### PR TITLE
test: add stdio add-plugin fixture and rust harness

### DIFF
--- a/test/fixture/main.ts
+++ b/test/fixture/main.ts
@@ -1,0 +1,26 @@
+/**
+ * 加法插件入口（fixture）。
+ *
+ * 启动即执行：向宿主索取输入数字（getNums），求和后把结果回传（returnNums）。
+ * 加法业务逻辑与 add-plugin 中的 `add` 保持一致，只是去掉了 VS Code 风格的
+ * activate/deactivate/registerCommand 那套插件生命周期机制——宿主(test_add.rs)
+ * 直接把本文件当作一个一次性进程拉起来跑通即可。
+ */
+
+// ⚠️ './ora-sdk' 是仅供本测试的占位实现；真实 SDK 就绪后把此路径换成真实包名
+//    （前提是其导出的 getNums/returnNums 名称与签名一致，否则需在此适配）。
+import { getNums, returnNums } from './ora-sdk';
+
+/** 纯函数：两个整数相加。 */
+function add(a: number, b: number): number {
+  return a + b;
+}
+
+async function main(): Promise<void> {
+  const [a, b] = await getNums();
+  returnNums(add(a, b));
+  // 结果已回传，显式退出，让宿主的读循环收到 EOF 并结束。
+  process.exit(0);
+}
+
+void main();

--- a/test/fixture/ora-sdk.ts
+++ b/test/fixture/ora-sdk.ts
@@ -1,0 +1,83 @@
+/**
+ * ORA SDK（fixture 占位实现）—— ⚠️ 仅供 test_add 这个测试使用，不是正式 SDK。
+ *
+ * 这个文件是为了让 test_add.rs 能直接拉起 main.ts 跑通一次加法而临时造的占位，
+ * 只实现了本测试需要的 getNums / returnNums，签名也是为「加法」量身定的
+ * （getNums 固定返回两个整数）。它【不是】通用的 ora-sdk，也不打算覆盖真实
+ * 协议的全部能力。
+ *
+ * 等真实的 ora-sdk 包就绪后，把 main.ts 里的
+ *     import { getNums, returnNums } from './ora-sdk';
+ * 换成真实包路径即可——但前提是真实包导出的函数名与签名和这里一致；
+ * 若不一致（大概率如此，真实 SDK 是通用的、不会内建加法专用的取数接口），
+ * 需要在 main.ts 里做一层适配，或由真实包提供同形状的适配器。
+ *
+ * 和 add-plugin 里的 ora-sdk 一样，插件业务逻辑只依赖这里暴露的函数，
+ * 完全不关心底层通信细节。区别在于：这里用的是「启动即跑」模型
+ * （getNums 取输入 / returnNums 返回结果），而不是 VS Code 风格的
+ * registerCommand 命令注册模型——因为本 fixture 只需要打通宿主(Rust)
+ * 直接拉起 main.ts 并跑通一次加法的最小链路。
+ *
+ * 线路协议：以换行分隔的 JSON，一行一条消息。
+ *   - 插件 → 宿主 (stdout)：{"type":"getNums"}
+ *                          {"type":"returnNums","result":<number>}
+ *   - 宿主 → 插件 (stdin) ：{"a":<number>,"b":<number>}
+ *
+ * 注意：stdout 被协议独占，任何调试输出都必须走 stderr（console.error），
+ * 否则会污染协议流。
+ */
+
+import { createInterface } from 'node:readline';
+
+// 逐行读取 stdin。node:readline 在 bun 下同样可用。
+const rl = createInterface({ input: process.stdin });
+
+// 已到达但还没被 await 消费的行，做一个简单缓冲，避免丢消息。
+const buffered: string[] = [];
+// 正在等待下一行的消费者（同一时刻最多一个）。
+let waiter: ((line: string) => void) | null = null;
+
+rl.on('line', (line) => {
+  if (waiter) {
+    const resolve = waiter;
+    waiter = null;
+    resolve(line);
+  } else {
+    buffered.push(line);
+  }
+});
+
+/** 取宿主发来的下一行；已有缓冲则立即返回，否则挂起等待。 */
+function nextLine(): Promise<string> {
+  const queued = buffered.shift();
+  if (queued !== undefined) {
+    return Promise.resolve(queued);
+  }
+  return new Promise((resolve) => {
+    waiter = resolve;
+  });
+}
+
+/** 向宿主发送一条协议消息（stdout，一行一条）。 */
+function send(message: unknown): void {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+/**
+ * 向宿主索取本次运行的两个整型输入。
+ * 发出 getNums 请求后阻塞等待宿主回传 {"a":..,"b":..}。
+ */
+export async function getNums(): Promise<[number, number]> {
+  send({ type: 'getNums' });
+  const line = await nextLine();
+  const message = JSON.parse(line) as { a: number; b: number };
+  return [message.a, message.b];
+}
+
+/**
+ * 把计算结果回传给宿主。
+ * 发完即结束，调用方应随后退出进程（宿主据此判定一次运行完成）。
+ */
+export function returnNums(result: number): void {
+  send({ type: 'returnNums', result });
+}

--- a/test/fixture/tsconfig.json
+++ b/test/fixture/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    // 引入 Node 类型，让 `process`、`node:readline` 等在类型层可被识别。
+    // 运行时用的是 bun 内置实现，这里仅为类型检查提供声明。
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/test/test_add.rs
+++ b/test/test_add.rs
@@ -1,0 +1,122 @@
+//! 直接把 fixture/main.ts 当作插件进程拉起来，跑通加法链路的宿主端测试套件。
+//!
+//! 本文件只依赖标准库，用 rustc 的内置测试框架编译运行（无需接入 cargo workspace）：
+//!
+//!     rustc --test test/test_add.rs -o /tmp/test_add && /tmp/test_add
+//!
+//! 需要从仓库根目录运行（默认按相对路径定位 fixture/main.ts），
+//! 也可以设置环境变量 ORA_MAIN_TS 指定 main.ts 的绝对路径。
+//!
+//! 协议（与 fixture/ora-sdk.ts 对齐，换行分隔 JSON）：
+//!   - 插件 → 宿主 (stdout)：{"type":"getNums"} / {"type":"returnNums","result":N}
+//!   - 宿主 → 插件 (stdin) ：{"a":..,"b":..}
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// 定位 fixture/main.ts：优先取 ORA_MAIN_TS 环境变量，否则相对本源文件推导。
+fn resolve_main_ts() -> PathBuf {
+    if let Some(path) = std::env::var_os("ORA_MAIN_TS") {
+        return PathBuf::from(path);
+    }
+    // file!() 形如 "test/test_add.rs"，其父目录即 test/。
+    let source_dir = PathBuf::from(file!())
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    source_dir.join("fixture").join("main.ts")
+}
+
+/// 从 {"type":"returnNums","result":15} 这类消息中抽出 result 的数值。
+fn parse_result(line: &str) -> i64 {
+    const KEY: &str = "\"result\":";
+    let start = line.find(KEY).expect("returnNums 消息缺少 result 字段") + KEY.len();
+    let rest = &line[start..];
+    // result 后面跟着 } 或 ,（本协议里是 }），取到分隔符为止。
+    let end = rest
+        .find(|c: char| c == '}' || c == ',')
+        .unwrap_or(rest.len());
+    rest[..end].trim().parse().expect("result 不是合法整数")
+}
+
+/// 拉起一次 main.ts，喂入 (a, b)，走完协议后返回插件回传的结果。
+///
+/// 每次调用都是独立的一次性子进程，方便并行跑多个用例互不干扰。
+fn run_add(a: i64, b: i64) -> i64 {
+    let main_ts = resolve_main_ts();
+    assert!(
+        main_ts.exists(),
+        "找不到 main.ts：{}（请从仓库根目录运行，或设置 ORA_MAIN_TS）",
+        main_ts.display()
+    );
+
+    let mut child = Command::new("bun")
+        .arg(&main_ts)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("拉起 bun 失败：请确认已安装 bun");
+
+    let mut child_stdin = child.stdin.take().expect("拿不到子进程 stdin");
+    let child_stdout = child.stdout.take().expect("拿不到子进程 stdout");
+    let mut reader = BufReader::new(child_stdout);
+
+    let mut result: Option<i64> = None;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = reader.read_line(&mut line).expect("读取子进程 stdout 失败");
+        if read == 0 {
+            break; // EOF：子进程已退出
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if trimmed.contains("\"getNums\"") {
+            // 回应输入：把两个整数以 JSON 写回子进程 stdin。
+            writeln!(child_stdin, "{{\"a\":{a},\"b\":{b}}}").expect("写入子进程 stdin 失败");
+            child_stdin.flush().expect("flush 子进程 stdin 失败");
+        } else if trimmed.contains("\"returnNums\"") {
+            result = Some(parse_result(trimmed));
+            break;
+        }
+    }
+
+    let _ = child.wait();
+    result.expect("没有收到 returnNums 结果")
+}
+
+#[test]
+fn adds_two_positive_integers() {
+    assert_eq!(run_add(3, 4), 7);
+}
+
+#[test]
+fn adds_with_zero() {
+    assert_eq!(run_add(0, 0), 0);
+    assert_eq!(run_add(0, 9), 9);
+}
+
+#[test]
+fn adds_negative_operand() {
+    assert_eq!(run_add(-5, 2), -3);
+}
+
+#[test]
+fn adds_two_negative_integers() {
+    assert_eq!(run_add(-10, -20), -30);
+}
+
+#[test]
+fn addition_is_commutative() {
+    assert_eq!(run_add(7, 3), run_add(3, 7));
+}
+
+#[test]
+fn adds_large_integers() {
+    assert_eq!(run_add(1_000_000, 2_000_000), 3_000_000);
+}


### PR DESCRIPTION
Closes #21

## 概述

新增一个最小的插件 fixture 与宿主端测试,打通「Rust 宿主直接拉起 TS 插件进程、跑通一次加法」的链路。

## 改动

- `test/fixture/main.ts` — 插件入口,启动即 `getNums` 取两个整型输入,求和后经 `returnNums` 回传。
- `test/fixture/ora-sdk.ts` — 仅供测试的占位 SDK,实现基于 stdio 的换行分隔 JSON 协议。
- `test/fixture/tsconfig.json` — 引入 @types/node。
- `test/test_add.rs` — 纯 std 的 `rustc --test` 套件,spawn `bun main.ts` 驱动协议、断言多组加法结果。

## 运行

```bash
rustc --test test/test_add.rs -o /tmp/test_add && /tmp/test_add
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)