### PR TITLE
fix: avoid task worktree prefix collisions

### DIFF
--- a/apps/web/server/src/service/task_worktree.rs
+++ b/apps/web/server/src/service/task_worktree.rs
@@ -1,3 +1,4 @@
+use gitlancer::git::branch::ListBranchesRequest;
 use gitlancer::git::worktree::{
     CreateWorktreeRequest as GitCreateWorktreeRequest,
     DeleteWorktreeRequest as GitDeleteWorktreeRequest, FindWorktreeRequest,
@@ -29,6 +30,25 @@ impl GitTaskWorktreeProvisioner {
 }
 
 impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
+    /// Checks local refs so orphaned task branches also participate in id collision avoidance.
+    fn task_branch_exists(&self, branch_name: &str) -> Result<bool, TaskWorktreeProvisionerError> {
+        self.git
+            .list_branches(ListBranchesRequest {
+                repository: &self.repository,
+            })
+            .map(|response| {
+                response
+                    .branches
+                    .iter()
+                    .any(|branch| branch.as_str() == branch_name)
+            })
+            .map_err(|_| {
+                TaskWorktreeProvisionerError::OperationFailed(
+                    "failed to inspect task branches".to_string(),
+                )
+            })
+    }
+
     /// Creates one linked worktree and hides Git-specific diagnostics behind a stable application port.
     fn create_task_worktree(
         &self,

--- a/crates/application/src/task/handlers.rs
+++ b/crates/application/src/task/handlers.rs
@@ -15,7 +15,12 @@ use ora_domain::{
     Worktree as DomainWorktree, WorktreeActivity as DomainWorktreeActivity, WorktreeId,
 };
 use ora_logging::{ora_error, ora_info};
+use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
+
+const TASK_BRANCH_PREFIX_LEN: usize = 8;
+const MAX_TASK_ID_GENERATION_ATTEMPTS: usize = 3;
 
 /// Handles task creation without depending on transport-specific concerns.
 pub struct CreateTaskHandler<
@@ -102,7 +107,9 @@ where
         &self,
         request: CreateTaskRequest,
     ) -> Result<CreateTaskResponse, ApplicationError> {
-        let task_id = self.task_id_generator.generate_task_id();
+        let task_id = self
+            .select_available_task_id()
+            .inspect_err(|error| log_task_failure("create_task", None, error))?;
         let branch_name = branch_name_for_task(&task_id);
         let worktree_path = worktree_path_for_task(&self.work_dir, &task_id);
         self.worktree_provisioner
@@ -160,6 +167,33 @@ where
 
         Ok(CreateTaskResponse {
             task: map_task(task),
+        })
+    }
+
+    /// Generates a task id whose branch prefix does not collide with existing task worktree folders.
+    fn select_available_task_id(&self) -> Result<TaskId, ApplicationError> {
+        for _ in 0..MAX_TASK_ID_GENERATION_ATTEMPTS {
+            let task_id = self.task_id_generator.generate_task_id();
+            let branch_prefix = task_branch_prefix(&task_id);
+
+            if task_branch_prefix_exists_in_work_dir(&self.work_dir, &branch_prefix)? {
+                continue;
+            }
+
+            let branch_name = branch_name_for_task(&task_id);
+            let branch_exists = self
+                .worktree_provisioner
+                .task_branch_exists(&branch_name)
+                .map_err(ApplicationError::from_task_worktree_provisioner_error)?;
+            if !branch_exists {
+                return Ok(task_id);
+            }
+        }
+
+        Err(ApplicationError::TaskWorktree {
+            message: format!(
+                "failed to generate a task branch prefix without collision after {MAX_TASK_ID_GENERATION_ATTEMPTS} attempts"
+            ),
         })
     }
 
@@ -598,13 +632,123 @@ fn map_contract_task_status(status: TaskStatus) -> DomainTaskStatus {
 
 /// Derives the stable task branch name from the first eight characters of the generated task id.
 fn branch_name_for_task(task_id: &TaskId) -> String {
-    format!(
-        "ora/{}",
-        task_id.to_string().chars().take(8).collect::<String>()
-    )
+    format!("ora/{}", task_branch_prefix(task_id))
+}
+
+/// Derives the short branch prefix used to keep task branch names readable.
+fn task_branch_prefix(task_id: &TaskId) -> String {
+    task_id
+        .to_string()
+        .chars()
+        .take(TASK_BRANCH_PREFIX_LEN)
+        .collect()
 }
 
 /// Derives the owned linked-worktree path from the configured worktree root and full task id.
 fn worktree_path_for_task(work_dir: &Path, task_id: &TaskId) -> PathBuf {
     work_dir.join(task_id.to_string())
+}
+
+/// Checks existing task worktree folders before branch creation because branch names use short ids.
+fn task_branch_prefix_exists_in_work_dir(
+    work_dir: &Path,
+    branch_prefix: &str,
+) -> Result<bool, ApplicationError> {
+    let entries = match fs::read_dir(work_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(_) => {
+            return Err(ApplicationError::TaskWorktree {
+                message: "failed to inspect task worktree directory".to_string(),
+            });
+        }
+    };
+
+    for entry in entries {
+        let entry = entry.map_err(|_| ApplicationError::TaskWorktree {
+            message: "failed to inspect task worktree directory".to_string(),
+        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|_| ApplicationError::TaskWorktree {
+                message: "failed to inspect task worktree directory".to_string(),
+            })?;
+
+        if file_type.is_dir()
+            && entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(branch_prefix)
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+#[cfg(test)]
+mod task_branch_prefix_tests {
+    use super::task_branch_prefix_exists_in_work_dir;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::path::PathBuf;
+
+    /// Verifies an absent worktree root is treated as the first task creation, not an inspection failure.
+    #[test]
+    fn reports_no_collision_when_work_dir_does_not_exist() {
+        let work_dir = unique_test_work_dir("missing");
+
+        assert_eq!(
+            task_branch_prefix_exists_in_work_dir(&work_dir, "12345678"),
+            Ok(false)
+        );
+    }
+
+    /// Verifies only directories with the requested prefix reserve a task branch prefix.
+    #[test]
+    fn detects_matching_directory_prefixes() {
+        let work_dir = unique_test_work_dir("matching-directory");
+        fs::create_dir_all(work_dir.join("12345678-existing"))
+            .unwrap_or_else(|error| panic!("failed to create collision fixture: {error}"));
+
+        assert_eq!(
+            task_branch_prefix_exists_in_work_dir(&work_dir, "12345678"),
+            Ok(true)
+        );
+
+        fs::remove_dir_all(&work_dir)
+            .unwrap_or_else(|error| panic!("failed to remove collision fixture: {error}"));
+    }
+
+    /// Verifies ordinary files and unrelated directories do not reserve a task branch prefix.
+    #[test]
+    fn ignores_files_and_unrelated_directories() {
+        let work_dir = unique_test_work_dir("unrelated-entries");
+        fs::create_dir_all(work_dir.join("87654321-existing"))
+            .unwrap_or_else(|error| panic!("failed to create unrelated directory: {error}"));
+        fs::write(work_dir.join("12345678-file"), b"not a worktree")
+            .unwrap_or_else(|error| panic!("failed to create ordinary file: {error}"));
+
+        assert_eq!(
+            task_branch_prefix_exists_in_work_dir(&work_dir, "12345678"),
+            Ok(false)
+        );
+
+        fs::remove_dir_all(&work_dir)
+            .unwrap_or_else(|error| panic!("failed to remove unrelated entries: {error}"));
+    }
+
+    /// Builds an isolated filesystem location for branch-prefix unit tests.
+    fn unique_test_work_dir(name: &str) -> PathBuf {
+        let work_dir = std::env::temp_dir().join(format!(
+            "ora-application-prefix-unit-{name}-{}",
+            std::process::id()
+        ));
+        if work_dir.exists() {
+            fs::remove_dir_all(&work_dir)
+                .unwrap_or_else(|error| panic!("failed to reset unit-test work dir: {error}"));
+        }
+        work_dir
+    }
 }

--- a/crates/application/src/task/ports.rs
+++ b/crates/application/src/task/ports.rs
@@ -37,6 +37,9 @@ pub trait TaskIdGenerator {
 /// Implementations are expected to provision and remove backend-managed task worktrees
 /// while hiding Git and filesystem details from the application layer.
 pub trait TaskWorktreeProvisioner {
+    /// Reports whether the repository already contains the task branch, including orphaned branches without worktree folders.
+    fn task_branch_exists(&self, branch_name: &str) -> Result<bool, TaskWorktreeProvisionerError>;
+
     /// Creates the linked worktree requested by the task-create flow.
     fn create_task_worktree(
         &self,

--- a/crates/application/src/task/tests.rs
+++ b/crates/application/src/task/tests.rs
@@ -18,6 +18,7 @@ use ora_logging::{with_recorded_trace_logging, with_trace_logging};
 use pretty_assertions::assert_eq;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -92,6 +93,222 @@ fn creates_tasks_with_owned_worktrees_and_clock_values() {
             )]
         );
     });
+}
+
+/// Verifies task creation regenerates ids when the short branch prefix already exists as a worktree folder.
+#[test]
+fn regenerates_task_ids_when_branch_prefix_folder_exists() {
+    with_trace_logging(|| {
+        let work_dir = unique_test_work_dir("task-prefix-collision");
+        fs::create_dir_all(work_dir.join("12345678-existing-worktree"))
+            .unwrap_or_else(|error| panic!("failed to create prefix collision fixture: {error}"));
+        let task_repository = Rc::new(FakeTaskRepository::default());
+        let worktree_repository = Rc::new(FakeWorktreeRepository::default());
+        let provisioner = Rc::new(FakeTaskWorktreeProvisioner::default());
+        let handler = CreateTaskHandler::new(
+            task_repository.clone(),
+            worktree_repository,
+            SequenceTaskIdGenerator::new(vec![
+                "12345678-1234-5678-90ab-1234567890ab",
+                "87654321-1234-5678-90ab-1234567890ab",
+            ]),
+            FixedWorktreeIdGenerator::new("worktree-1"),
+            provisioner.clone(),
+            work_dir.clone(),
+            FixedClock::new(1_700_000_000_000),
+        );
+
+        let response = handler
+            .handle(CreateTaskRequest {
+                project_id: "project-1".to_string(),
+                title: "Ship handlers".to_string(),
+                status: ContractTaskStatus::Doing,
+            })
+            .unwrap_or_else(|error| panic!("create handler failed: {error}"));
+
+        assert_eq!(
+            response,
+            CreateTaskResponse {
+                task: ContractTask {
+                    id: "87654321-1234-5678-90ab-1234567890ab".to_string(),
+                    project_id: "project-1".to_string(),
+                    title: "Ship handlers".to_string(),
+                    status: ContractTaskStatus::Doing,
+                },
+            }
+        );
+        assert_eq!(
+            provisioner.created_requests(),
+            vec![CreateTaskWorktreeRequest {
+                branch_name: "ora/87654321".to_string(),
+                worktree_path: work_dir.join("87654321-1234-5678-90ab-1234567890ab"),
+            }]
+        );
+        assert_eq!(
+            task_repository
+                .visible_tasks()
+                .into_iter()
+                .map(|task| task.id)
+                .collect::<Vec<_>>(),
+            vec![TaskId::new("87654321-1234-5678-90ab-1234567890ab")]
+        );
+
+        fs::remove_dir_all(&work_dir)
+            .unwrap_or_else(|error| panic!("failed to remove prefix collision fixture: {error}"));
+    });
+}
+
+/// Verifies an orphaned task branch reserves its short prefix even after the worktree folder is deleted.
+#[test]
+fn regenerates_task_ids_when_orphaned_branch_exists() {
+    with_trace_logging(|| {
+        let work_dir = unique_test_work_dir("orphaned-task-branch");
+        let provisioner = Rc::new(FakeTaskWorktreeProvisioner::with_existing_branches(vec![
+            "ora/12345678",
+        ]));
+        let handler = CreateTaskHandler::new(
+            Rc::new(FakeTaskRepository::default()),
+            Rc::new(FakeWorktreeRepository::default()),
+            SequenceTaskIdGenerator::new(vec![
+                "12345678-1234-5678-90ab-1234567890ab",
+                "87654321-1234-5678-90ab-1234567890ab",
+            ]),
+            FixedWorktreeIdGenerator::new("worktree-1"),
+            provisioner.clone(),
+            work_dir.clone(),
+            FixedClock::new(1_700_000_000_000),
+        );
+
+        let response = handler
+            .handle(CreateTaskRequest {
+                project_id: "project-1".to_string(),
+                title: "Ship handlers".to_string(),
+                status: ContractTaskStatus::Doing,
+            })
+            .unwrap_or_else(|error| panic!("create handler failed: {error}"));
+
+        assert_eq!(
+            response,
+            CreateTaskResponse {
+                task: ContractTask {
+                    id: "87654321-1234-5678-90ab-1234567890ab".to_string(),
+                    project_id: "project-1".to_string(),
+                    title: "Ship handlers".to_string(),
+                    status: ContractTaskStatus::Doing,
+                },
+            }
+        );
+        assert_eq!(
+            provisioner.created_requests(),
+            vec![CreateTaskWorktreeRequest {
+                branch_name: "ora/87654321".to_string(),
+                worktree_path: work_dir.join("87654321-1234-5678-90ab-1234567890ab"),
+            }]
+        );
+    });
+}
+
+/// Verifies first-time task creation succeeds before the configured worktree root exists.
+#[test]
+fn creates_task_when_work_dir_does_not_exist() {
+    with_trace_logging(|| {
+        let work_dir = unique_test_work_dir("missing-work-dir");
+        let provisioner = Rc::new(FakeTaskWorktreeProvisioner::default());
+        let handler = CreateTaskHandler::new(
+            Rc::new(FakeTaskRepository::default()),
+            Rc::new(FakeWorktreeRepository::default()),
+            FixedTaskIdGenerator::new(TASK_ID),
+            FixedWorktreeIdGenerator::new("worktree-1"),
+            provisioner.clone(),
+            work_dir.clone(),
+            FixedClock::new(1_700_000_000_000),
+        );
+
+        let response = handler
+            .handle(CreateTaskRequest {
+                project_id: "project-1".to_string(),
+                title: "Ship handlers".to_string(),
+                status: ContractTaskStatus::Doing,
+            })
+            .unwrap_or_else(|error| panic!("create handler failed: {error}"));
+
+        assert_eq!(
+            response,
+            CreateTaskResponse {
+                task: ContractTask {
+                    id: TASK_ID.to_string(),
+                    project_id: "project-1".to_string(),
+                    title: "Ship handlers".to_string(),
+                    status: ContractTaskStatus::Doing,
+                },
+            }
+        );
+        assert_eq!(
+            provisioner.created_requests(),
+            vec![CreateTaskWorktreeRequest {
+                branch_name: "ora/12345678".to_string(),
+                worktree_path: work_dir.join(TASK_ID),
+            }]
+        );
+    });
+}
+
+/// Verifies repeated branch-prefix collisions return a stable error and emit the shared failure event.
+#[test]
+fn reports_task_worktree_error_when_task_id_retries_are_exhausted() {
+    let work_dir = unique_test_work_dir("task-prefix-exhaustion");
+    fs::create_dir_all(work_dir.join("12345678-existing-worktree"))
+        .unwrap_or_else(|error| panic!("failed to create prefix collision fixture: {error}"));
+    let recorder = EventRecorder::default();
+
+    with_recorded_trace_logging(recorder.layer(), || {
+        let handler = CreateTaskHandler::new(
+            Rc::new(FakeTaskRepository::default()),
+            Rc::new(FakeWorktreeRepository::default()),
+            FixedTaskIdGenerator::new(TASK_ID),
+            FixedWorktreeIdGenerator::new("worktree-1"),
+            Rc::new(FakeTaskWorktreeProvisioner::default()),
+            work_dir.clone(),
+            FixedClock::new(1_700_000_000_000),
+        );
+
+        assert_eq!(
+            handler
+                .handle(CreateTaskRequest {
+                    project_id: "project-1".to_string(),
+                    title: "Ship handlers".to_string(),
+                    status: ContractTaskStatus::Doing,
+                })
+                .unwrap_err(),
+            ApplicationError::TaskWorktree {
+                message:
+                    "failed to generate a task branch prefix without collision after 3 attempts"
+                        .to_string(),
+            }
+        );
+    });
+
+    assert_eq!(
+        recorder.events(),
+        vec![LoggedEvent {
+            level: "ERROR".to_string(),
+            target: "ora_application::task::handlers".to_string(),
+            fields: BTreeMap::from([
+                ("error.kind".to_string(), "task_worktree".to_string()),
+                (
+                    "error.message".to_string(),
+                    "task worktree operation failed: failed to generate a task branch prefix without collision after 3 attempts"
+                        .to_string(),
+                ),
+                ("message".to_string(), "task operation failed".to_string()),
+                ("method".to_string(), "log_task_failure".to_string()),
+                ("operation".to_string(), "create_task".to_string()),
+            ]),
+        }]
+    );
+
+    fs::remove_dir_all(&work_dir)
+        .unwrap_or_else(|error| panic!("failed to remove prefix collision fixture: {error}"));
 }
 
 /// Verifies get handlers return the shared contract projection for existing tasks.
@@ -669,6 +886,7 @@ impl WorktreeRepository for Rc<FakeWorktreeRepository> {
 
 #[derive(Debug, Default)]
 struct FakeTaskWorktreeProvisioner {
+    existing_branches: RefCell<Vec<String>>,
     created_requests: RefCell<Vec<CreateTaskWorktreeRequest>>,
     deleted_requests: RefCell<Vec<DeleteTaskWorktreeRequest>>,
     next_create_error: RefCell<Option<TaskWorktreeProvisionerError>>,
@@ -676,6 +894,14 @@ struct FakeTaskWorktreeProvisioner {
 }
 
 impl FakeTaskWorktreeProvisioner {
+    /// Builds a fake provisioner seeded with repository-local branches.
+    fn with_existing_branches(branches: Vec<&str>) -> Self {
+        Self {
+            existing_branches: RefCell::new(branches.into_iter().map(str::to_string).collect()),
+            ..Self::default()
+        }
+    }
+
     /// Configures the next create request to fail with a deterministic error.
     fn fail_next_create(&self, error: TaskWorktreeProvisionerError) {
         self.next_create_error.replace(Some(error));
@@ -709,6 +935,14 @@ impl FakeTaskWorktreeProvisioner {
 }
 
 impl TaskWorktreeProvisioner for Rc<FakeTaskWorktreeProvisioner> {
+    fn task_branch_exists(&self, branch_name: &str) -> Result<bool, TaskWorktreeProvisionerError> {
+        Ok(self
+            .existing_branches
+            .borrow()
+            .iter()
+            .any(|branch| branch == branch_name))
+    }
+
     fn create_task_worktree(
         &self,
         request: CreateTaskWorktreeRequest,
@@ -747,6 +981,28 @@ impl TaskIdGenerator for FixedTaskIdGenerator {
     }
 }
 
+struct SequenceTaskIdGenerator {
+    task_ids: RefCell<Vec<TaskId>>,
+}
+
+impl SequenceTaskIdGenerator {
+    /// Builds an identifier generator that returns ids in the provided order.
+    fn new(task_ids: Vec<&str>) -> Self {
+        Self {
+            task_ids: RefCell::new(task_ids.into_iter().rev().map(TaskId::new).collect()),
+        }
+    }
+}
+
+impl TaskIdGenerator for SequenceTaskIdGenerator {
+    fn generate_task_id(&self) -> TaskId {
+        self.task_ids
+            .borrow_mut()
+            .pop()
+            .unwrap_or_else(|| panic!("sequence task id generator exhausted"))
+    }
+}
+
 struct FixedWorktreeIdGenerator {
     worktree_id: WorktreeId,
 }
@@ -781,6 +1037,18 @@ impl Clock for FixedClock {
     fn now_timestamp_millis(&self) -> i64 {
         self.timestamp_millis
     }
+}
+
+/// Builds a process-scoped temp path for tests that need filesystem-backed worktree roots.
+fn unique_test_work_dir(name: &str) -> PathBuf {
+    let work_dir =
+        std::env::temp_dir().join(format!("ora-application-{name}-{}", std::process::id()));
+    if work_dir.exists() {
+        fs::remove_dir_all(&work_dir)
+            .unwrap_or_else(|error| panic!("failed to reset test work dir: {error}"));
+    }
+
+    work_dir
 }
 
 /// Captures one emitted event in a comparison-friendly structure for logging assertions.

--- a/openspec/specs/task-worktree-provisioning/spec.md
+++ b/openspec/specs/task-worktree-provisioning/spec.md
@@ -15,6 +15,14 @@ The system SHALL treat linked worktree provisioning as part of task creation. Wh
 - **WHEN** the backend generates a new task identifier during task creation
 - **THEN** it derives the Git branch name from a short task-id prefix and the worktree directory from the full task identifier under the configured worktree root
 
+#### Scenario: Short branch-prefix collisions regenerate the task identity
+- **WHEN** the generated short task-id prefix is already used by a task worktree directory or a local `ora/<prefix>` branch
+- **THEN** the backend generates another task identifier before provisioning, because the collision applies to the shortened branch name rather than the full-identifier worktree directory
+
+#### Scenario: Orphaned task branches still reserve their prefix
+- **WHEN** a task worktree directory has been removed but its local `ora/<prefix>` branch remains
+- **THEN** the backend treats that prefix as unavailable and generates another task identifier
+
 ### Requirement: Task creation SHALL keep Git and persistence state aligned
 The system SHALL avoid exposing partially created task workspaces. If linked-worktree provisioning fails, the backend SHALL return a failure without persisting task or worktree rows. If persistence fails after the Git worktree is created, the backend SHALL attempt compensating cleanup of that linked worktree before returning a failure.
 


### PR DESCRIPTION
Closes #20


- Generate task ids with a retry loop when the branch prefix collides with existing task worktree folders


