### PR TITLE
refactor(contracts): drop ts-rs `export` attribute to stop test-generated bindings

### DIFF
--- a/crates/contracts/src/project.rs
+++ b/crates/contracts/src/project.rs
@@ -4,7 +4,7 @@ use ts_rs::TS;
 /// Describes the public project payload shared across adapter responses.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct Project {
     pub id: String,
     pub name: String,
@@ -14,7 +14,7 @@ pub struct Project {
 /// Carries the app-facing payload for project creation requests.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct CreateProjectRequest {
     pub name: String,
     pub root_path: String,
@@ -23,7 +23,7 @@ pub struct CreateProjectRequest {
 /// Returns the created project after a successful create request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct CreateProjectResponse {
     pub project: Project,
 }
@@ -31,7 +31,7 @@ pub struct CreateProjectResponse {
 /// Identifies which project to fetch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct GetProjectRequest {
     pub project_id: String,
 }
@@ -39,7 +39,7 @@ pub struct GetProjectRequest {
 /// Returns one project payload after a successful fetch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct GetProjectResponse {
     pub project: Project,
 }
@@ -47,13 +47,13 @@ pub struct GetProjectResponse {
 /// Requests the full visible project list.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct ListProjectsRequest {}
 
 /// Returns the visible project list.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct ListProjectsResponse {
     pub projects: Vec<Project>,
 }
@@ -61,7 +61,7 @@ pub struct ListProjectsResponse {
 /// Carries the full replacement payload for project updates in the first slice.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct UpdateProjectRequest {
     pub project_id: String,
     pub name: String,
@@ -71,7 +71,7 @@ pub struct UpdateProjectRequest {
 /// Returns the updated project after a successful update request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct UpdateProjectResponse {
     pub project: Project,
 }
@@ -79,7 +79,7 @@ pub struct UpdateProjectResponse {
 /// Identifies which project to delete.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct DeleteProjectRequest {
     pub project_id: String,
 }
@@ -87,7 +87,7 @@ pub struct DeleteProjectRequest {
 /// Returns the deleted project identifier after a successful delete request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project.ts")]
+#[ts(export_to = "project.ts")]
 pub struct DeleteProjectResponse {
     pub project_id: String,
 }

--- a/crates/contracts/src/project_work_context.rs
+++ b/crates/contracts/src/project_work_context.rs
@@ -4,7 +4,7 @@ use ts_rs::TS;
 /// Describes which client surface owns one project work context.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project-work-context.ts")]
+#[ts(export_to = "project-work-context.ts")]
 pub enum ProjectWorkContextSurface {
     Web,
     Tauri,
@@ -13,7 +13,7 @@ pub enum ProjectWorkContextSurface {
 /// Describes the public project work context payload shared across adapter responses.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project-work-context.ts")]
+#[ts(export_to = "project-work-context.ts")]
 pub struct ProjectWorkContext {
     pub id: String,
     pub surface: ProjectWorkContextSurface,
@@ -25,7 +25,7 @@ pub struct ProjectWorkContext {
 /// Carries the payload used to open or switch a client window into a project.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project-work-context.ts")]
+#[ts(export_to = "project-work-context.ts")]
 pub struct OpenProjectWorkContextRequest {
     pub surface: ProjectWorkContextSurface,
     pub window_id: String,
@@ -35,7 +35,7 @@ pub struct OpenProjectWorkContextRequest {
 /// Returns the active project work context after a successful open or switch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project-work-context.ts")]
+#[ts(export_to = "project-work-context.ts")]
 pub struct OpenProjectWorkContextResponse {
     pub context: ProjectWorkContext,
 }
@@ -43,7 +43,7 @@ pub struct OpenProjectWorkContextResponse {
 /// Carries the payload used to renew an existing project work context lease.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project-work-context.ts")]
+#[ts(export_to = "project-work-context.ts")]
 pub struct RenewProjectWorkContextRequest {
     pub surface: ProjectWorkContextSurface,
     pub window_id: String,
@@ -52,7 +52,7 @@ pub struct RenewProjectWorkContextRequest {
 /// Returns the active project work context after a successful lease renewal.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "project-work-context.ts")]
+#[ts(export_to = "project-work-context.ts")]
 pub struct RenewProjectWorkContextResponse {
     pub context: ProjectWorkContext,
 }

--- a/crates/contracts/src/session.rs
+++ b/crates/contracts/src/session.rs
@@ -4,7 +4,7 @@ use ts_rs::TS;
 /// Describes whether the public session view is still running.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub enum SessionStatus {
     Running,
     Stopped,
@@ -13,7 +13,7 @@ pub enum SessionStatus {
 /// Describes the initial PTY dimensions used only during terminal session startup.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct TerminalSessionStartup {
     pub cols: u16,
     pub rows: u16,
@@ -22,7 +22,7 @@ pub struct TerminalSessionStartup {
 /// Describes the public session payload shared across adapter responses.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct Session {
     pub id: String,
     pub task_id: String,
@@ -34,7 +34,7 @@ pub struct Session {
 /// Carries the app-facing payload for session creation requests.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct CreateSessionRequest {
     pub task_id: String,
     pub agent_id: String,
@@ -47,7 +47,7 @@ pub struct CreateSessionRequest {
 /// Returns the created session after a successful create request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct CreateSessionResponse {
     pub session: Session,
 }
@@ -55,7 +55,7 @@ pub struct CreateSessionResponse {
 /// Identifies which session to fetch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct GetSessionRequest {
     pub session_id: String,
 }
@@ -63,7 +63,7 @@ pub struct GetSessionRequest {
 /// Returns one session payload after a successful fetch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct GetSessionResponse {
     pub session: Session,
 }
@@ -71,13 +71,13 @@ pub struct GetSessionResponse {
 /// Requests the full visible session list.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct ListSessionsRequest {}
 
 /// Returns the visible session list.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct ListSessionsResponse {
     pub sessions: Vec<Session>,
 }
@@ -85,7 +85,7 @@ pub struct ListSessionsResponse {
 /// Carries the full replacement payload for session updates in the first slice.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct UpdateSessionRequest {
     pub session_id: String,
     pub task_id: String,
@@ -97,7 +97,7 @@ pub struct UpdateSessionRequest {
 /// Returns the updated session after a successful update request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct UpdateSessionResponse {
     pub session: Session,
 }
@@ -105,7 +105,7 @@ pub struct UpdateSessionResponse {
 /// Identifies which session to delete.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct DeleteSessionRequest {
     pub session_id: String,
 }
@@ -113,7 +113,7 @@ pub struct DeleteSessionRequest {
 /// Returns the deleted session identifier after a successful delete request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub struct DeleteSessionResponse {
     pub session_id: String,
 }
@@ -121,7 +121,7 @@ pub struct DeleteSessionResponse {
 /// Describes one client-to-server terminal control message.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub enum TerminalClientMessage {
     Input { data: String },
     Resize { cols: u16, rows: u16 },
@@ -131,7 +131,7 @@ pub enum TerminalClientMessage {
 /// Describes one server-to-client terminal stream message.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "camelCase")]
-#[ts(export, export_to = "session.ts")]
+#[ts(export_to = "session.ts")]
 pub enum TerminalServerMessage {
     Ready {
         #[serde(rename = "sessionId")]

--- a/crates/contracts/src/task.rs
+++ b/crates/contracts/src/task.rs
@@ -4,7 +4,7 @@ use ts_rs::TS;
 /// Describes the public task status shared across adapter boundaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub enum TaskStatus {
     Todo,
     Doing,
@@ -14,7 +14,7 @@ pub enum TaskStatus {
 /// Describes the public task payload shared across adapter responses.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct Task {
     pub id: String,
     pub project_id: String,
@@ -25,7 +25,7 @@ pub struct Task {
 /// Carries the app-facing payload for task creation requests.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct CreateTaskRequest {
     pub project_id: String,
     pub title: String,
@@ -35,7 +35,7 @@ pub struct CreateTaskRequest {
 /// Returns the created task after a successful create request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct CreateTaskResponse {
     pub task: Task,
 }
@@ -43,7 +43,7 @@ pub struct CreateTaskResponse {
 /// Identifies which task to fetch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct GetTaskRequest {
     pub task_id: String,
 }
@@ -51,7 +51,7 @@ pub struct GetTaskRequest {
 /// Returns one task payload after a successful fetch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct GetTaskResponse {
     pub task: Task,
 }
@@ -59,13 +59,13 @@ pub struct GetTaskResponse {
 /// Requests the full visible task list.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct ListTasksRequest {}
 
 /// Returns the visible task list.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct ListTasksResponse {
     pub tasks: Vec<Task>,
 }
@@ -73,7 +73,7 @@ pub struct ListTasksResponse {
 /// Carries the full replacement payload for task updates in the first slice.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct UpdateTaskRequest {
     pub task_id: String,
     pub project_id: String,
@@ -84,7 +84,7 @@ pub struct UpdateTaskRequest {
 /// Returns the updated task after a successful update request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct UpdateTaskResponse {
     pub task: Task,
 }
@@ -92,7 +92,7 @@ pub struct UpdateTaskResponse {
 /// Identifies which task to delete.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct DeleteTaskRequest {
     pub task_id: String,
 }
@@ -100,7 +100,7 @@ pub struct DeleteTaskRequest {
 /// Returns the deleted task identifier after a successful delete request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export, export_to = "task.ts")]
+#[ts(export_to = "task.ts")]
 pub struct DeleteTaskResponse {
     pub task_id: String,
 }


### PR DESCRIPTION
The `#[ts(export, export_to = "...")]` markers caused ts-rs to synthesize `export_bindings_*` tests that wrote TypeScript files into `crates/contracts/bindings/` on every `cargo test` run, duplicating the canonical output produced by `cargo xtask export-contracts` into `packages/contracts/src/`.

Removed the `export` flag from all contract DTOs (project, session, task, project-work-context), keeping only `export_to` so `TS::export()` still resolves the correct filename when invoked programmatically via xtask. This mirrors the existing pattern in `crates/plugin-protocol/src/json_rpc.rs`.

`cargo build`, `cargo test -p ora-contracts`, and
`cargo xtask export-contracts` all pass; `crates/contracts/bindings/` is no longer recreated.