### PR TITLE
fix(process): drop unowned stdin before wait to prevent hang

### DIFF
--- a/crates/process/src/tokio_process.rs
+++ b/crates/process/src/tokio_process.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::io;
 use std::process::ExitStatus;
+use std::sync::{Mutex, PoisonError};
 
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 use tokio::runtime::Handle;
@@ -59,7 +60,7 @@ impl ProcessSpawner for TokioProcessSpawner {
 
         Ok(TokioManagedProcess {
             id,
-            stdin,
+            stdin: Mutex::new(stdin),
             stdout,
             stderr,
             exit_rx,
@@ -73,7 +74,7 @@ impl ProcessSpawner for TokioProcessSpawner {
 #[derive(Debug)]
 pub struct TokioManagedProcess {
     id: Option<u32>,
-    stdin: Option<ChildStdin>,
+    stdin: Mutex<Option<ChildStdin>>,
     stdout: Option<ChildStdout>,
     stderr: Option<ChildStderr>,
     exit_rx: watch::Receiver<Option<ExitState>>,
@@ -99,7 +100,12 @@ impl ManagedProcess for TokioManagedProcess {
     }
 
     fn take_stdin(&mut self) -> Option<Self::Stdin> {
-        self.stdin.take()
+        // A poisoned mutex only means some prior holder panicked while locked;
+        // the guard is still usable, so recover it instead of poisoning the caller.
+        self.stdin
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take()
     }
 
     fn take_stdout(&mut self) -> Option<Self::Stdout> {
@@ -118,6 +124,19 @@ impl ManagedProcess for TokioManagedProcess {
     }
 
     fn wait(&self) -> impl Future<Output = io::Result<ExitStatus>> + Send + '_ {
+        // If the caller never took ownership of stdin, close the write end before
+        // waiting so stdin-driven children (cat, more, grep, ...) observe EOF and
+        // exit instead of hanging forever. tokio's native Child::wait does this
+        // automatically; moving stdin off the Child and onto this handle lost that
+        // protection, so we restore it here. The take is idempotent: a caller that
+        // already took stdin to write finds None here and nothing is dropped.
+        drop(
+            self.stdin
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .take(),
+        );
+
         let mut exit_rx = self.exit_rx.clone();
 
         async move {

--- a/crates/process/tests/process.rs
+++ b/crates/process/tests/process.rs
@@ -177,6 +177,24 @@ async fn can_wait_and_kill_without_exclusive_process_access() {
     assert!(!exit.success());
 }
 
+#[tokio::test]
+async fn wait_closes_unowned_stdin_so_stdin_readers_exit() {
+    let spawner = TokioProcessSpawner::new();
+    let process = spawner
+        .spawn(stdin_echo_command())
+        .unwrap_or_else(|error| panic!("expected process spawn to succeed: {error}"));
+
+    // Deliberately do NOT take_stdin. A stdin-driven child (cat/more) must still
+    // exit because wait() closes the unowned write end, mirroring tokio's native
+    // Child::wait. Without the fix this hangs until the timeout elapses.
+    let exit = tokio::time::timeout(Duration::from_secs(5), process.wait())
+        .await
+        .expect("expected wait to return after closing stdin, but it hung");
+    let exit = exit.unwrap_or_else(|error| panic!("expected process wait to succeed: {error}"));
+
+    assert!(exit.success());
+}
+
 fn spawn_with<S: ProcessSpawner>(spawner: &S, spec: ProcessSpec) -> io::Result<S::Process> {
     spawner.spawn(spec)
 }


### PR DESCRIPTION
Moving child.stdin off the Child and onto the handle removed tokio's native "wait drops the unowned stdin" anti-deadlock protection. A stdin-driven child (cat, more, grep, ...) that the caller only waits on — without take_stdin and closing the writer — never observes EOF, so wait() hangs forever and the crate's exit-management contract breaks.

Store stdin in a shared Mutex<Option<ChildStdin>> and have wait() take-and-drop any stdin the caller never claimed before entering the wait loop. The take is idempotent, so callers that already took stdin to write are unaffected; kill, try_wait, and Drop paths need no change.

Adds a regression test that spawns cat/more without take_stdin and asserts wait() returns within a timeout.