### PR TITLE
feat: add ora-acp crate — stable ACP v1 client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "agent-client-protocol-schema"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06679e1542356341f4550ccfb16338b64f37f6af70de2105446ef6fbb078234c"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +34,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anyhow"
@@ -150,6 +174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +256,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +314,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -342,6 +436,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -386,7 +504,7 @@ dependencies = [
  "anyhow",
  "bumpalo",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "rustc-hash",
  "serde",
  "unicode-width",
@@ -435,6 +553,12 @@ dependencies = [
  "swc_ecma_parser",
  "text_lines",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -630,6 +754,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -669,6 +799,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hstr"
@@ -790,6 +926,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +1038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +1062,17 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1113,6 +1290,19 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ora-acp"
+version = "0.0.0"
+dependencies = [
+ "agent-client-protocol-schema",
+ "ora-acp",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
 
 [[package]]
 name = "ora-application"
@@ -1560,6 +1750,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1920,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,11 +2011,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -1788,6 +2056,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1931,6 +2231,33 @@ checksum = "ae36a4951ca7bd1cfd991c241584a9824a70f6aff1e7d4f693fb3f2465e4030e"
 dependencies = [
  "quote",
  "swc_macros_common",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -2509,6 +2836,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,7 +3012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2692,7 +3025,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -2757,10 +3090,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2887,7 +3273,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -2918,7 +3304,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2937,7 +3323,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "apps/web/server",
+    "crates/acp",
     "crates/application",
     "crates/contracts",
     "crates/db",
@@ -25,6 +26,7 @@ edition = "2024"
 
 [workspace.dependencies]
 # Internal
+ora-acp = { path = "crates/acp" }
 ora-application = { path = "crates/application" }
 ora-contracts = { path = "crates/contracts" }
 ora-db = { path = "crates/db" }
@@ -37,6 +39,7 @@ ora-process = { path = "crates/process" }
 ora-pty = { path = "crates/pty" }
 
 # External
+agent-client-protocol-schema = "1.4"
 log = "0.4"
 portable-pty = "0.9"
 pretty_assertions = "1"

--- a/crates/acp/Cargo.toml
+++ b/crates/acp/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "ora-acp"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+name = "ora_acp"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[features]
+# Exposes `FakeAcpTransport`, the in-memory test double. Off by default so it
+# never ships in a production build; enabled for this crate's own tests/examples
+# via the self dev-dependency below, and available to downstream test code that
+# opts in.
+test-util = []
+
+[dependencies]
+# Stable ACP v1 wire types. No `unstable_*` features: the crate exposes only
+# the stable protocol surface (see specs/acp-protocol).
+agent-client-protocol-schema = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+# Self dev-dependency: turns on `test-util` when building this crate's own tests
+# and examples, so `cargo test` needs no extra flags.
+ora-acp = { path = ".", features = ["test-util"] }
+pretty_assertions = { workspace = true }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt",
+    "sync",
+    "process",
+    "io-util",
+    "time",
+] }

--- a/crates/acp/examples/mock_agent.rs
+++ b/crates/acp/examples/mock_agent.rs
@@ -1,0 +1,161 @@
+//! Runnable end-to-end example driving `AcpConnection` against an in-process
+//! mock agent.
+//!
+//! The `ScriptedAgent` here implements [`AcpTransport`] — the same seam a future
+//! duplex driver in `plugin-manager` will implement. It reacts to the frames the
+//! connection sends and enqueues canned agent responses, including streaming
+//! `session/update` notifications and a reverse `fs/read_text_file` request, so
+//! the whole bidirectional flow runs without any real process or pipe.
+//!
+//! Run with:
+//!   cargo run -p ora-acp --example mock_agent
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use ora_acp::schema::{
+    InitializeRequest, ProtocolVersion, ReadTextFileResponse, RequestId,
+};
+use ora_acp::{AcpConnection, AcpError, AcpFrame, AcpTransport};
+use serde_json::{Value, json};
+
+/// A minimal in-process agent: whatever the client sends, it scripts the reply.
+#[derive(Default)]
+struct ScriptedAgent {
+    outbox: Mutex<VecDeque<AcpFrame>>,
+}
+
+impl ScriptedAgent {
+    fn queue(&self, frame: AcpFrame) {
+        if let Ok(mut outbox) = self.outbox.lock() {
+            outbox.push_back(frame);
+        }
+    }
+
+    /// Turns one inbound client request into the agent's scripted response frames.
+    fn react(&self, id: RequestId, method: &str) {
+        match method {
+            "initialize" => self.queue(AcpFrame::Success {
+                id,
+                result: json!({
+                    "protocolVersion": 1,
+                    "agentCapabilities": { "loadSession": true }
+                }),
+            }),
+            "session/new" => self.queue(AcpFrame::Success {
+                id,
+                result: json!({ "sessionId": "sess-1" }),
+            }),
+            "session/prompt" => {
+                // Stream two thinking chunks...
+                self.queue(update_frame("Let me check that file."));
+                self.queue(update_frame(" Reading it now..."));
+                // ...then reverse-call the client to read a file...
+                self.queue(AcpFrame::Request {
+                    id: RequestId::Str("rev-1".to_string()),
+                    method: "fs/read_text_file".to_string(),
+                    params: json!({ "sessionId": "sess-1", "path": "/etc/hostname" }),
+                });
+                // ...and finish the turn.
+                self.queue(AcpFrame::Success {
+                    id,
+                    result: json!({ "stopReason": "end_turn" }),
+                });
+            }
+            other => {
+                eprintln!("mock agent: unhandled method {other}");
+                self.queue(AcpFrame::Failure {
+                    id,
+                    error: ora_acp::schema::ProtocolError::method_not_found(),
+                });
+            }
+        }
+    }
+}
+
+fn update_frame(text: &str) -> AcpFrame {
+    AcpFrame::Notification {
+        method: "session/update".to_string(),
+        params: json!({
+            "sessionId": "sess-1",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": text }
+            }
+        }),
+    }
+}
+
+impl AcpTransport for ScriptedAgent {
+    async fn send(&self, frame: AcpFrame) -> Result<(), AcpError> {
+        match frame {
+            // A client request: script the agent's reply.
+            AcpFrame::Request { id, method, .. } => self.react(id, &method),
+            // The client answering our reverse request: just acknowledge it.
+            AcpFrame::Success { id, .. } => println!("  <- client answered reverse request {id:?}"),
+            AcpFrame::Failure { id, .. } => println!("  <- client rejected reverse request {id:?}"),
+            // A notification (e.g. session/cancel): nothing to reply.
+            AcpFrame::Notification { .. } => {}
+        }
+        Ok(())
+    }
+
+    async fn recv(&self) -> Result<Option<AcpFrame>, AcpError> {
+        let mut outbox = self
+            .outbox
+            .lock()
+            .map_err(|_| AcpError::Transport("outbox poisoned".to_string()))?;
+        Ok(outbox.pop_front())
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // The reverse-request handler: the app answers agent -> client calls here.
+    let connection =
+        AcpConnection::new(ScriptedAgent::default()).with_request_handler(|request| {
+            use ora_acp::schema::AgentRequest;
+            match request {
+                AgentRequest::ReadTextFileRequest(_) => {
+                    let response = ReadTextFileResponse::new("mock-host\n");
+                    Ok(serde_json::to_value(response).unwrap_or(Value::Null))
+                }
+                _ => Err(ora_acp::schema::ProtocolError::method_not_found()),
+            }
+        });
+
+    // 1. Handshake.
+    let init = connection
+        .initialize(InitializeRequest::new(ProtocolVersion::LATEST))
+        .await?;
+    println!(
+        "initialized: protocol v{}, load_session={}",
+        init.protocol_version.as_u16(),
+        init.agent_capabilities.load_session
+    );
+
+    // 2. Open a session.
+    let session = connection
+        .new_session(serde_json::from_value(json!({ "cwd": "/work", "mcpServers": [] }))?)
+        .await?;
+    println!("session created: {}", session.session_id);
+
+    // 3. Prompt — drives streaming updates and a reverse file read.
+    let prompt = serde_json::from_value(json!({
+        "sessionId": session.session_id.to_string(),
+        "prompt": [{ "type": "text", "text": "What is the hostname?" }]
+    }))?;
+    println!("prompting...");
+    let turn = connection.prompt(prompt).await?;
+
+    for (index, update) in turn.updates.iter().enumerate() {
+        let text = serde_json::to_value(&update.update)
+            .ok()
+            .and_then(|value| value.get("content")?.get("text")?.as_str().map(str::to_string))
+            .unwrap_or_default();
+        println!("  update #{index}: {text}");
+    }
+    println!("turn finished: stop_reason={:?}", turn.response.stop_reason);
+
+    Ok(())
+}

--- a/crates/acp/examples/opencode_agent.rs
+++ b/crates/acp/examples/opencode_agent.rs
@@ -1,0 +1,198 @@
+//! Real end-to-end example: drive a live `opencode acp` agent over stdio.
+//!
+//! This spawns `opencode acp` (a standards-compliant ACP server) as a child
+//! process and implements [`AcpTransport`] over newline-delimited JSON-RPC on its
+//! stdin/stdout — a slice of what a future `plugin-manager` duplex driver does.
+//! It then runs the ACP handshake and opens a session against the real agent,
+//! proving the crate interoperates with a third-party ACP implementation.
+//!
+//! Prompting is intentionally skipped: it would require a configured model and
+//! credentials. `initialize` + `session/new` exercise the wire protocol without
+//! hitting an LLM.
+//!
+//! Run with:
+//!   cargo run -p ora-acp --example opencode_agent
+//!
+//! Requires `opencode` on PATH (tested with 1.17.x).
+
+use std::process::Stdio;
+use std::sync::Mutex;
+
+use ora_acp::schema::{InitializeRequest, ProtocolError, ProtocolVersion, RequestId};
+use ora_acp::{AcpConnection, AcpError, AcpFrame, AcpTransport};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{ChildStdin, ChildStdout};
+use tokio::sync::Mutex as AsyncMutex;
+
+/// A stdio JSON-RPC transport bound to a child ACP agent process.
+struct StdioTransport {
+    stdin: AsyncMutex<ChildStdin>,
+    stdout: AsyncMutex<Lines<BufReader<ChildStdout>>>,
+    // Keeps the child alive for the transport's lifetime.
+    _child: Mutex<tokio::process::Child>,
+}
+
+impl StdioTransport {
+    fn spawn() -> Result<Self, AcpError> {
+        let mut child = tokio::process::Command::new("opencode")
+            .arg("acp")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|error| AcpError::Transport(format!("failed to spawn opencode: {error}")))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| AcpError::Transport("no child stdin".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| AcpError::Transport("no child stdout".to_string()))?;
+
+        Ok(Self {
+            stdin: AsyncMutex::new(stdin),
+            stdout: AsyncMutex::new(BufReader::new(stdout).lines()),
+            _child: Mutex::new(child),
+        })
+    }
+}
+
+/// Serializes an outbound frame to a JSON-RPC 2.0 wire object.
+fn frame_to_wire(frame: &AcpFrame) -> Value {
+    match frame {
+        AcpFrame::Request { id, method, params } => json!({
+            "jsonrpc": "2.0", "id": id, "method": method, "params": params
+        }),
+        AcpFrame::Notification { method, params } => json!({
+            "jsonrpc": "2.0", "method": method, "params": params
+        }),
+        AcpFrame::Success { id, result } => json!({
+            "jsonrpc": "2.0", "id": id, "result": result
+        }),
+        AcpFrame::Failure { id, error } => json!({
+            "jsonrpc": "2.0", "id": id, "error": error
+        }),
+    }
+}
+
+/// Parses one inbound JSON-RPC wire line into a frame.
+fn wire_to_frame(line: &str) -> Result<AcpFrame, AcpError> {
+    let value: Value = serde_json::from_str(line)
+        .map_err(|error| AcpError::Transport(format!("bad json from agent: {error}")))?;
+
+    let id = value.get("id").cloned();
+    let method = value.get("method").and_then(Value::as_str);
+
+    match (id, method) {
+        // Response: id + result / error.
+        (Some(id), None) => {
+            let id: RequestId = serde_json::from_value(id)
+                .map_err(|error| AcpError::Transport(format!("bad id: {error}")))?;
+            if let Some(error) = value.get("error") {
+                let error: ProtocolError = serde_json::from_value(error.clone())
+                    .map_err(|error| AcpError::Transport(format!("bad error: {error}")))?;
+                Ok(AcpFrame::Failure { id, error })
+            } else {
+                let result = value.get("result").cloned().unwrap_or(Value::Null);
+                Ok(AcpFrame::Success { id, result })
+            }
+        }
+        // Reverse request: id + method.
+        (Some(id), Some(method)) => {
+            let id: RequestId = serde_json::from_value(id)
+                .map_err(|error| AcpError::Transport(format!("bad id: {error}")))?;
+            Ok(AcpFrame::Request {
+                id,
+                method: method.to_string(),
+                params: value.get("params").cloned().unwrap_or(Value::Null),
+            })
+        }
+        // Notification: method, no id.
+        (None, Some(method)) => Ok(AcpFrame::Notification {
+            method: method.to_string(),
+            params: value.get("params").cloned().unwrap_or(Value::Null),
+        }),
+        (None, None) => Err(AcpError::Transport("frame has neither id nor method".to_string())),
+    }
+}
+
+impl AcpTransport for StdioTransport {
+    async fn send(&self, frame: AcpFrame) -> Result<(), AcpError> {
+        let line = frame_to_wire(&frame).to_string();
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|error| AcpError::Transport(format!("write failed: {error}")))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|error| AcpError::Transport(format!("write newline failed: {error}")))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|error| AcpError::Transport(format!("flush failed: {error}")))
+    }
+
+    async fn recv(&self) -> Result<Option<AcpFrame>, AcpError> {
+        let mut stdout = self.stdout.lock().await;
+        loop {
+            let next = stdout
+                .next_line()
+                .await
+                .map_err(|error| AcpError::Transport(format!("read failed: {error}")))?;
+            match next {
+                None => return Ok(None),
+                Some(line) if line.trim().is_empty() => continue,
+                Some(line) => return Ok(Some(wire_to_frame(&line)?)),
+            }
+        }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let transport = StdioTransport::spawn()?;
+    let connection = AcpConnection::new(transport).with_request_handler(|_request| {
+        // The agent shouldn't need reverse calls during handshake/session setup.
+        Err(ProtocolError::method_not_found())
+    });
+
+    // Guard the whole exchange with a timeout so a stuck agent can't hang the example.
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        println!("→ initialize");
+        let init = connection
+            .initialize(InitializeRequest::new(ProtocolVersion::LATEST))
+            .await?;
+        println!(
+            "← initialized by opencode: protocol v{}, load_session={}, auth_methods={}",
+            init.protocol_version.as_u16(),
+            init.agent_capabilities.load_session,
+            init.auth_methods.len()
+        );
+
+        println!("→ session/new");
+        let session = connection
+            .new_session(serde_json::from_value(json!({
+                "cwd": std::env::current_dir()?.to_string_lossy(),
+                "mcpServers": []
+            }))?)
+            .await?;
+        println!("← session created by opencode: {}", session.session_id);
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })
+    .await;
+
+    match outcome {
+        Ok(Ok(())) => {
+            println!("\nInteroperability confirmed against a live opencode ACP agent.");
+            Ok(())
+        }
+        Ok(Err(error)) => Err(error),
+        Err(_) => Err("timed out talking to opencode".into()),
+    }
+}

--- a/crates/acp/examples/opencode_agent.rs
+++ b/crates/acp/examples/opencode_agent.rs
@@ -33,10 +33,28 @@ struct StdioTransport {
     _child: Mutex<tokio::process::Child>,
 }
 
+/// Builds a command targeting the `opencode` CLI in a cross-platform way.
+///
+/// On Windows the CLI is a `opencode.cmd` shim that `Command::new` cannot launch
+/// directly, so it is invoked through `cmd /C`.
+fn opencode_command() -> tokio::process::Command {
+    #[cfg(windows)]
+    {
+        let mut command = tokio::process::Command::new("cmd");
+        command.args(["/C", "opencode"]);
+        command
+    }
+    #[cfg(not(windows))]
+    {
+        tokio::process::Command::new("opencode")
+    }
+}
+
 impl StdioTransport {
     fn spawn() -> Result<Self, AcpError> {
-        let mut child = tokio::process::Command::new("opencode")
+        let mut child = opencode_command()
             .arg("acp")
+            .kill_on_drop(true)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())

--- a/crates/acp/examples/opencode_chat.rs
+++ b/crates/acp/examples/opencode_chat.rs
@@ -1,0 +1,219 @@
+//! Have a real conversation with a live `opencode acp` agent.
+//!
+//! Spawns `opencode acp`, runs the ACP handshake, opens a session, sends one
+//! prompt, and prints the agent's streamed reply — a full round trip through the
+//! `AcpConnection` against a third-party ACP agent backed by a real LLM.
+//!
+//! A throwaway `opencode.json` pins a free model in a temp working directory, so
+//! this neither touches your global opencode config nor costs anything.
+//!
+//! Run with:
+//!   cargo run -p ora-acp --example opencode_chat -- "your message here"
+//!
+//! Requires `opencode` on PATH with a configured provider (e.g. OpenRouter).
+
+use std::process::Stdio;
+use std::sync::Mutex;
+
+use ora_acp::schema::{InitializeRequest, ProtocolError, ProtocolVersion, RequestId};
+use ora_acp::{AcpConnection, AcpError, AcpFrame, AcpTransport};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{ChildStdin, ChildStdout};
+use tokio::sync::Mutex as AsyncMutex;
+
+const FREE_MODEL: &str = "opencode/deepseek-v4-flash-free";
+
+struct StdioTransport {
+    stdin: AsyncMutex<ChildStdin>,
+    stdout: AsyncMutex<Lines<BufReader<ChildStdout>>>,
+    _child: Mutex<tokio::process::Child>,
+}
+
+impl StdioTransport {
+    fn spawn(cwd: &std::path::Path) -> Result<Self, AcpError> {
+        let mut child = tokio::process::Command::new("opencode")
+            .arg("acp")
+            .arg("--cwd")
+            .arg(cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|error| AcpError::Transport(format!("failed to spawn opencode: {error}")))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| AcpError::Transport("no child stdin".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| AcpError::Transport("no child stdout".to_string()))?;
+
+        Ok(Self {
+            stdin: AsyncMutex::new(stdin),
+            stdout: AsyncMutex::new(BufReader::new(stdout).lines()),
+            _child: Mutex::new(child),
+        })
+    }
+}
+
+fn frame_to_wire(frame: &AcpFrame) -> Value {
+    match frame {
+        AcpFrame::Request { id, method, params } => {
+            json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params })
+        }
+        AcpFrame::Notification { method, params } => {
+            json!({ "jsonrpc": "2.0", "method": method, "params": params })
+        }
+        AcpFrame::Success { id, result } => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+        AcpFrame::Failure { id, error } => json!({ "jsonrpc": "2.0", "id": id, "error": error }),
+    }
+}
+
+fn wire_to_frame(line: &str) -> Result<AcpFrame, AcpError> {
+    let value: Value = serde_json::from_str(line)
+        .map_err(|error| AcpError::Transport(format!("bad json from agent: {error}")))?;
+    let id = value.get("id").cloned();
+    let method = value.get("method").and_then(Value::as_str);
+
+    match (id, method) {
+        (Some(id), None) => {
+            let id: RequestId = serde_json::from_value(id)
+                .map_err(|error| AcpError::Transport(format!("bad id: {error}")))?;
+            if let Some(error) = value.get("error") {
+                let error: ProtocolError = serde_json::from_value(error.clone())
+                    .map_err(|error| AcpError::Transport(format!("bad error: {error}")))?;
+                Ok(AcpFrame::Failure { id, error })
+            } else {
+                Ok(AcpFrame::Success {
+                    id,
+                    result: value.get("result").cloned().unwrap_or(Value::Null),
+                })
+            }
+        }
+        (Some(id), Some(method)) => {
+            let id: RequestId = serde_json::from_value(id)
+                .map_err(|error| AcpError::Transport(format!("bad id: {error}")))?;
+            Ok(AcpFrame::Request {
+                id,
+                method: method.to_string(),
+                params: value.get("params").cloned().unwrap_or(Value::Null),
+            })
+        }
+        (None, Some(method)) => Ok(AcpFrame::Notification {
+            method: method.to_string(),
+            params: value.get("params").cloned().unwrap_or(Value::Null),
+        }),
+        (None, None) => Err(AcpError::Transport("frame has neither id nor method".to_string())),
+    }
+}
+
+impl AcpTransport for StdioTransport {
+    async fn send(&self, frame: AcpFrame) -> Result<(), AcpError> {
+        let line = frame_to_wire(&frame).to_string();
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(line.as_bytes())
+            .await
+            .and(stdin.write_all(b"\n").await)
+            .map_err(|error| AcpError::Transport(format!("write failed: {error}")))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|error| AcpError::Transport(format!("flush failed: {error}")))
+    }
+
+    async fn recv(&self) -> Result<Option<AcpFrame>, AcpError> {
+        let mut stdout = self.stdout.lock().await;
+        loop {
+            match stdout
+                .next_line()
+                .await
+                .map_err(|error| AcpError::Transport(format!("read failed: {error}")))?
+            {
+                None => return Ok(None),
+                Some(line) if line.trim().is_empty() => continue,
+                Some(line) => return Ok(Some(wire_to_frame(&line)?)),
+            }
+        }
+    }
+}
+
+/// Pulls the text out of an `agent_message_chunk` update; empty for other kinds.
+fn chunk_text(update: &Value) -> String {
+    if update.get("sessionUpdate").and_then(Value::as_str) != Some("agent_message_chunk") {
+        return String::new();
+    }
+    update
+        .get("content")
+        .and_then(|content| content.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let message = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "Reply with a short one-sentence greeting.".to_string());
+
+    // Temp working dir pinning a free model, so we neither touch global config nor pay.
+    let workdir = std::env::temp_dir().join(format!("ora-acp-chat-{}", std::process::id()));
+    std::fs::create_dir_all(&workdir)?;
+    std::fs::write(
+        workdir.join("opencode.json"),
+        json!({ "$schema": "https://opencode.ai/config.json", "model": FREE_MODEL }).to_string(),
+    )?;
+
+    let transport = StdioTransport::spawn(&workdir)?;
+    // Auto-reject reverse calls; a plain chat prompt shouldn't need tools.
+    let connection = AcpConnection::new(transport)
+        .with_request_handler(|_request| Err(ProtocolError::method_not_found()));
+
+    let reply = tokio::time::timeout(std::time::Duration::from_secs(120), async {
+        connection
+            .initialize(InitializeRequest::new(ProtocolVersion::LATEST))
+            .await?;
+        let session = connection
+            .new_session(serde_json::from_value(json!({
+                "cwd": workdir.to_string_lossy(),
+                "mcpServers": []
+            }))?)
+            .await?;
+
+        println!("you    > {message}");
+        let prompt = serde_json::from_value(json!({
+            "sessionId": session.session_id.to_string(),
+            "prompt": [{ "type": "text", "text": message }]
+        }))?;
+        let turn = connection.prompt(prompt).await?;
+
+        let text: String = turn
+            .updates
+            .iter()
+            .map(|notification| {
+                serde_json::to_value(&notification.update)
+                    .map(|value| chunk_text(&value))
+                    .unwrap_or_default()
+            })
+            .collect();
+        Ok::<_, Box<dyn std::error::Error>>((text, turn.response.stop_reason))
+    })
+    .await;
+
+    // Best-effort cleanup of the temp workdir.
+    let _ = std::fs::remove_dir_all(&workdir);
+
+    match reply {
+        Ok(Ok((text, stop_reason))) => {
+            println!("opencode> {}", text.trim());
+            println!("\n[stop_reason: {stop_reason:?}]");
+            Ok(())
+        }
+        Ok(Err(error)) => Err(error),
+        Err(_) => Err("timed out waiting for opencode".into()),
+    }
+}

--- a/crates/acp/examples/opencode_chat.rs
+++ b/crates/acp/examples/opencode_chat.rs
@@ -30,12 +30,30 @@ struct StdioTransport {
     _child: Mutex<tokio::process::Child>,
 }
 
+/// Builds a command targeting the `opencode` CLI in a cross-platform way.
+///
+/// On Windows the CLI is a `opencode.cmd` shim that `Command::new` cannot launch
+/// directly, so it is invoked through `cmd /C`.
+fn opencode_command() -> tokio::process::Command {
+    #[cfg(windows)]
+    {
+        let mut command = tokio::process::Command::new("cmd");
+        command.args(["/C", "opencode"]);
+        command
+    }
+    #[cfg(not(windows))]
+    {
+        tokio::process::Command::new("opencode")
+    }
+}
+
 impl StdioTransport {
     fn spawn(cwd: &std::path::Path) -> Result<Self, AcpError> {
-        let mut child = tokio::process::Command::new("opencode")
+        let mut child = opencode_command()
             .arg("acp")
             .arg("--cwd")
             .arg(cwd)
+            .kill_on_drop(true)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())

--- a/crates/acp/src/connection.rs
+++ b/crates/acp/src/connection.rs
@@ -1,0 +1,291 @@
+//! The `AcpConnection`: a connection-level driver for the stable ACP client surface.
+//!
+//! One `AcpConnection` corresponds to one connection to an agent over a transport.
+//! It drives both connection-level methods (`initialize`, `authenticate`, `logout`)
+//! and the session-scoped methods that carry a `SessionId` in their payload
+//! (`session/new`, `session/prompt`, `session/cancel`, ...) — a single connection
+//! can host multiple sessions. It owns ACP-layer id correlation, streaming
+//! `session/update` aggregation, capability gating, and inbound reverse-request
+//! routing, and speaks only standard ACP methods — no invented wire semantics.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use agent_client_protocol_schema::v1::{
+    AgentCapabilities, AgentRequest, CancelNotification, Error as ProtocolError, InitializeRequest,
+    InitializeResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
+    NewSessionResponse, PromptRequest, PromptResponse, RequestId, SessionNotification,
+};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::dispatch::decode_agent_request;
+use crate::error::{AcpError, SessionError};
+use crate::frame::AcpFrame;
+use crate::transport::AcpTransport;
+
+/// Method name constants for the outbound (client -> agent) calls this crate drives.
+const METHOD_INITIALIZE: &str = "initialize";
+const METHOD_SESSION_NEW: &str = "session/new";
+const METHOD_SESSION_LOAD: &str = "session/load";
+const METHOD_SESSION_PROMPT: &str = "session/prompt";
+const METHOD_SESSION_CANCEL: &str = "session/cancel";
+const METHOD_SESSION_UPDATE: &str = "session/update";
+
+/// The result of one prompt turn: the ordered interim updates plus the final response.
+#[derive(Debug)]
+pub struct PromptTurn {
+    /// `session/update` notifications observed during the turn, in arrival order.
+    pub updates: Vec<SessionNotification>,
+    /// The final `session/prompt` response, carrying the `stop_reason`.
+    pub response: PromptResponse,
+}
+
+/// A handler for inbound agent -> client requests (`fs/*`, `session/request_permission`, `terminal/*`).
+///
+/// Returns the JSON-RPC `result` payload for the reverse request (built by the app,
+/// e.g. `serde_json::to_value(ReadTextFileResponse::new(..))`), or a protocol error to
+/// reject it. A `Value` is used rather than the official `ClientResponse` enum because
+/// that enum is `#[non_exhaustive]` and cannot be constructed outside the schema crate.
+type RequestHandler = Box<dyn Fn(AgentRequest) -> Result<Value, ProtocolError> + Send + Sync>;
+
+/// Drives the client side of one ACP connection over a transport.
+pub struct AcpConnection<T> {
+    transport: T,
+    next_id: AtomicI64,
+    capabilities: Mutex<Option<AgentCapabilities>>,
+    request_handler: Option<RequestHandler>,
+}
+
+impl<T: AcpTransport> AcpConnection<T> {
+    /// Creates a session over the given transport.
+    #[must_use]
+    pub fn new(transport: T) -> Self {
+        Self {
+            transport,
+            next_id: AtomicI64::new(1),
+            capabilities: Mutex::new(None),
+            request_handler: None,
+        }
+    }
+
+    /// Registers the handler invoked for inbound reverse requests.
+    #[must_use]
+    pub fn with_request_handler<H>(mut self, handler: H) -> Self
+    where
+        H: Fn(AgentRequest) -> Result<Value, ProtocolError> + Send + Sync + 'static,
+    {
+        self.request_handler = Some(Box::new(handler));
+        self
+    }
+
+    /// Returns a reference to the underlying transport.
+    #[must_use]
+    pub fn transport(&self) -> &T {
+        &self.transport
+    }
+
+    /// Returns the capabilities negotiated at `initialize`, if any.
+    #[must_use]
+    pub fn capabilities(&self) -> Option<AgentCapabilities> {
+        self.capabilities
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+    }
+
+    /// Negotiates protocol capabilities. Records the agent's advertised capabilities.
+    ///
+    /// # Errors
+    ///
+    /// Propagates transport, protocol, and decode failures.
+    pub async fn initialize(
+        &self,
+        request: InitializeRequest,
+    ) -> Result<InitializeResponse, AcpError> {
+        let response: InitializeResponse = self.request(METHOD_INITIALIZE, &request).await?;
+        if let Ok(mut guard) = self.capabilities.lock() {
+            *guard = Some(response.agent_capabilities.clone());
+        }
+        Ok(response)
+    }
+
+    /// Creates a new session (`session/new`).
+    ///
+    /// # Errors
+    ///
+    /// Propagates transport, protocol, and decode failures.
+    pub async fn new_session(
+        &self,
+        request: NewSessionRequest,
+    ) -> Result<NewSessionResponse, AcpError> {
+        self.request(METHOD_SESSION_NEW, &request).await
+    }
+
+    /// Loads an existing session (`session/load`). Gated on the agent's `load_session` capability.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SessionError::CapabilityUnavailable`] without sending a frame when the
+    /// agent did not advertise `load_session`; otherwise propagates transport/protocol failures.
+    pub async fn load_session(
+        &self,
+        request: LoadSessionRequest,
+    ) -> Result<LoadSessionResponse, AcpError> {
+        if !self.agent_supports_load_session() {
+            return Err(
+                SessionError::CapabilityUnavailable(METHOD_SESSION_LOAD.to_string()).into(),
+            );
+        }
+        self.request(METHOD_SESSION_LOAD, &request).await
+    }
+
+    /// Sends a prompt and drives the turn, aggregating interim updates until the response.
+    ///
+    /// # Errors
+    ///
+    /// Propagates transport, protocol, and decode failures.
+    pub async fn prompt(&self, request: PromptRequest) -> Result<PromptTurn, AcpError> {
+        let id = self.next_request_id();
+        let params = encode(&request)?;
+        self.transport
+            .send(AcpFrame::Request {
+                id: id.clone(),
+                method: METHOD_SESSION_PROMPT.to_string(),
+                params,
+            })
+            .await?;
+
+        let mut updates = Vec::new();
+        let result = self.run_until_response(&id, &mut updates).await?;
+        let response = decode(result)?;
+        Ok(PromptTurn { updates, response })
+    }
+
+    /// Sends a `session/cancel` notification. No response is expected.
+    ///
+    /// # Errors
+    ///
+    /// Propagates transport and encoding failures.
+    pub async fn cancel(&self, notification: CancelNotification) -> Result<(), AcpError> {
+        let params = encode(&notification)?;
+        self.transport
+            .send(AcpFrame::Notification {
+                method: METHOD_SESSION_CANCEL.to_string(),
+                params,
+            })
+            .await
+    }
+
+    /// Issues a request/response call, discarding any interim notifications.
+    async fn request<Req, Res>(&self, method: &str, request: &Req) -> Result<Res, AcpError>
+    where
+        Req: Serialize,
+        Res: DeserializeOwned,
+    {
+        let id = self.next_request_id();
+        let params = encode(request)?;
+        self.transport
+            .send(AcpFrame::Request {
+                id: id.clone(),
+                method: method.to_string(),
+                params,
+            })
+            .await?;
+
+        let mut updates = Vec::new();
+        let result = self.run_until_response(&id, &mut updates).await?;
+        decode(result)
+    }
+
+    /// Pumps inbound frames until the response with `id` arrives.
+    ///
+    /// Interim `session/update` notifications are aggregated into `updates`; inbound
+    /// reverse requests are routed to the handler; responses with an unknown id are ignored.
+    async fn run_until_response(
+        &self,
+        id: &RequestId,
+        updates: &mut Vec<SessionNotification>,
+    ) -> Result<Value, AcpError> {
+        loop {
+            match self.transport.recv().await? {
+                None => return Err(SessionError::TransportClosed.into()),
+                Some(AcpFrame::Notification { method, params }) => {
+                    if method == METHOD_SESSION_UPDATE
+                        && let Ok(notification) =
+                            serde_json::from_value::<SessionNotification>(params)
+                    {
+                        updates.push(notification);
+                    }
+                }
+                Some(AcpFrame::Request {
+                    id: request_id,
+                    method: _,
+                    params,
+                }) => {
+                    self.handle_inbound_request(request_id, &params).await?;
+                }
+                Some(AcpFrame::Success {
+                    id: response_id,
+                    result,
+                }) => {
+                    if response_id == *id {
+                        return Ok(result);
+                    }
+                }
+                Some(AcpFrame::Failure {
+                    id: response_id,
+                    error,
+                }) => {
+                    if response_id == *id {
+                        return Err(AcpError::Protocol(error));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Routes one inbound reverse request to the handler and sends back the correlated response.
+    async fn handle_inbound_request(&self, id: RequestId, params: &Value) -> Result<(), AcpError> {
+        let response = match &self.request_handler {
+            None => AcpFrame::Failure {
+                id,
+                error: ProtocolError::method_not_found(),
+            },
+            Some(handler) => match decode_agent_request(params) {
+                Err(_) => AcpFrame::Failure {
+                    id,
+                    error: ProtocolError::invalid_params(),
+                },
+                Ok(request) => match handler(request) {
+                    Ok(result) => AcpFrame::Success { id, result },
+                    Err(error) => AcpFrame::Failure { id, error },
+                },
+            },
+        };
+        self.transport.send(response).await
+    }
+
+    fn next_request_id(&self) -> RequestId {
+        RequestId::Number(self.next_id.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn agent_supports_load_session(&self) -> bool {
+        self.capabilities
+            .lock()
+            .ok()
+            .and_then(|guard| guard.as_ref().map(|caps| caps.load_session))
+            .unwrap_or(false)
+    }
+}
+
+/// Encodes a typed request into JSON params.
+fn encode<T: Serialize>(value: &T) -> Result<Value, AcpError> {
+    serde_json::to_value(value).map_err(|error| SessionError::Encode(error.to_string()).into())
+}
+
+/// Decodes a JSON result into the expected typed response.
+fn decode<T: DeserializeOwned>(value: Value) -> Result<T, AcpError> {
+    serde_json::from_value(value).map_err(|error| SessionError::Decode(error.to_string()).into())
+}

--- a/crates/acp/src/dispatch.rs
+++ b/crates/acp/src/dispatch.rs
@@ -1,0 +1,46 @@
+//! Decoding inbound frames onto the official routing enums.
+//!
+//! Reverse requests (agent -> client) are decoded into the schema crate's
+//! `AgentRequest` enum; the session then routes them to a handler.
+
+use agent_client_protocol_schema::v1::AgentRequest;
+use serde_json::Value;
+
+use crate::error::{AcpError, SessionError};
+
+/// Decodes an inbound reverse-request `params` payload into the official [`AgentRequest`] enum.
+///
+/// # Errors
+///
+/// Returns [`AcpError::Session`] with [`SessionError::Decode`] when the payload does
+/// not match any known agent -> client request variant.
+pub fn decode_agent_request(params: &Value) -> Result<AgentRequest, AcpError> {
+    serde_json::from_value(params.clone())
+        .map_err(|error| SessionError::Decode(error.to_string()).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_agent_request;
+    use agent_client_protocol_schema::v1::AgentRequest;
+    use serde_json::json;
+
+    #[test]
+    fn decodes_request_permission_reverse_request() {
+        let params = json!({
+            "sessionId": "sess-1",
+            "toolCall": { "toolCallId": "call-1" },
+            "options": [
+                { "optionId": "allow", "name": "Allow", "kind": "allow_once" }
+            ]
+        });
+
+        let request = decode_agent_request(&params)
+            .unwrap_or_else(|error| panic!("expected decode to succeed: {error}"));
+
+        assert!(
+            matches!(request, AgentRequest::RequestPermissionRequest(_)),
+            "expected RequestPermissionRequest, got {request:?}"
+        );
+    }
+}

--- a/crates/acp/src/error.rs
+++ b/crates/acp/src/error.rs
@@ -1,0 +1,75 @@
+//! Error model for the ACP client, layered by protocol phase.
+//!
+//! The three layers are kept distinct on purpose (see specs/acp-protocol):
+//! transport/seam failures, session state-machine failures, and protocol-level
+//! JSON-RPC errors returned by the peer.
+
+use agent_client_protocol_schema::v1::Error as ProtocolError;
+
+/// Top-level error returned by the ACP client, separated by the phase that failed.
+#[derive(Debug, thiserror::Error)]
+pub enum AcpError {
+    /// A failure at the transport seam (the pipe or its implementation).
+    #[error("acp transport failure: {0}")]
+    Transport(String),
+
+    /// A failure in the session state machine (correlation, encoding, gating).
+    #[error("acp session error: {0}")]
+    Session(#[from] SessionError),
+
+    /// A JSON-RPC error object returned by the peer, carried verbatim.
+    #[error("acp protocol error {}: {}", .0.code, .0.message)]
+    Protocol(ProtocolError),
+}
+
+impl AcpError {
+    /// Returns the peer's protocol error when this is a protocol-level failure.
+    ///
+    /// Lets callers recover the original JSON-RPC `code`/`message` without matching
+    /// on the enum shape directly.
+    #[must_use]
+    pub fn as_protocol(&self) -> Option<&ProtocolError> {
+        match self {
+            Self::Protocol(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+/// Failures produced by the session driver itself, before or instead of a peer response.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    /// A method was called whose capability the peer did not advertise.
+    #[error("capability unavailable for method: {0}")]
+    CapabilityUnavailable(String),
+
+    /// The transport closed before the awaited response arrived.
+    #[error("transport closed before response")]
+    TransportClosed,
+
+    /// A typed request could not be encoded into JSON params.
+    #[error("failed to encode params: {0}")]
+    Encode(String),
+
+    /// A peer payload could not be decoded into the expected type.
+    #[error("failed to decode payload: {0}")]
+    Decode(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AcpError;
+    use agent_client_protocol_schema::v1::Error as ProtocolError;
+
+    #[test]
+    fn protocol_variant_preserves_peer_code_and_message() {
+        let peer = ProtocolError::new(-32601, "missing method");
+        let error = AcpError::Protocol(peer);
+
+        let protocol = error
+            .as_protocol()
+            .unwrap_or_else(|| panic!("expected a protocol-level error"));
+        assert_eq!(protocol.code, (-32601).into());
+        assert_eq!(protocol.message, "missing method");
+    }
+}

--- a/crates/acp/src/frame.rs
+++ b/crates/acp/src/frame.rs
@@ -1,0 +1,44 @@
+//! The typed ACP frame moved across the transport seam.
+//!
+//! A frame is one JSON-RPC message (request, response, or notification) carrying
+//! already-structured payloads (`RequestId`, `serde_json::Value` params/results,
+//! the official protocol `Error`) rather than raw bytes. Outer envelope framing
+//! and pipe I/O belong to the transport implementation, not to this type.
+
+use agent_client_protocol_schema::v1::{Error as ProtocolError, RequestId};
+use serde_json::Value;
+
+/// One ACP-layer JSON-RPC message.
+#[derive(Debug, Clone)]
+pub enum AcpFrame {
+    /// A request carrying a correlation id, method name, and params.
+    Request {
+        /// The ACP-layer id used to correlate the matching response.
+        id: RequestId,
+        /// The ACP method name (e.g. `session/prompt`).
+        method: String,
+        /// Method-specific params.
+        params: Value,
+    },
+    /// A successful response correlated to a prior request id.
+    Success {
+        /// The id of the request this answers.
+        id: RequestId,
+        /// Method-specific result payload.
+        result: Value,
+    },
+    /// A failed response correlated to a prior request id.
+    Failure {
+        /// The id of the request this answers.
+        id: RequestId,
+        /// The protocol-level JSON-RPC error.
+        error: ProtocolError,
+    },
+    /// A notification, which carries no id and expects no response.
+    Notification {
+        /// The ACP method name (e.g. `session/update`).
+        method: String,
+        /// Method-specific params.
+        params: Value,
+    },
+}

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -1,0 +1,37 @@
+//! Client-side support for the stable Agent Client Protocol (ACP) v1.
+//!
+//! Wire types come from the official [`agent_client_protocol_schema`] crate and
+//! are re-exported here; this crate adds the transport seam ([`AcpTransport`]),
+//! id correlation, streaming aggregation, capability gating, and inbound-request
+//! routing ([`AcpConnection`]) that the app needs, without depending on any concrete
+//! pipe. Only the stable protocol surface is exposed — no `unstable_*` features.
+
+mod connection;
+mod dispatch;
+mod error;
+mod frame;
+mod transport;
+
+pub use connection::{AcpConnection, PromptTurn};
+pub use error::{AcpError, SessionError};
+pub use frame::AcpFrame;
+pub use transport::AcpTransport;
+#[cfg(feature = "test-util")]
+pub use transport::FakeAcpTransport;
+
+/// Re-exported stable ACP v1 wire types, sourced from `agent-client-protocol-schema`.
+///
+/// These are re-exports, not redefinitions: the crate never declares its own copy
+/// of a protocol message type.
+pub mod schema {
+    pub use agent_client_protocol_schema::ProtocolVersion;
+    pub use agent_client_protocol_schema::v1::{
+        AgentCapabilities, AgentNotification, AgentRequest, AgentResponse, CancelNotification,
+        ClientCapabilities, ClientNotification, ClientRequest, ClientResponse, ContentBlock,
+        Error as ProtocolError, ErrorCode, InitializeRequest, InitializeResponse,
+        LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse,
+        PromptRequest, PromptResponse, ReadTextFileRequest, ReadTextFileResponse, RequestId,
+        RequestPermissionRequest, RequestPermissionResponse, SessionId, SessionNotification,
+        SessionUpdate, StopReason, WriteTextFileRequest, WriteTextFileResponse,
+    };
+}

--- a/crates/acp/src/transport.rs
+++ b/crates/acp/src/transport.rs
@@ -1,0 +1,81 @@
+//! The transport seam that decouples ACP semantics from the concrete pipe.
+//!
+//! `AcpTransport` moves typed [`AcpFrame`]s in both directions. The real
+//! implementation (a future duplex driver in `plugin-manager`, or a WebSocket /
+//! gRPC bridge) lives outside this crate; here we only define the seam and a
+//! test double.
+
+use std::future::Future;
+
+use crate::error::AcpError;
+use crate::frame::AcpFrame;
+
+/// A bidirectional channel for ACP frames.
+///
+/// Outbound frames flow client -> agent via [`send`](AcpTransport::send); inbound
+/// frames (agent -> client responses, notifications, and reverse requests such as
+/// `fs/read_text_file`) are pulled via [`recv`](AcpTransport::recv).
+pub trait AcpTransport {
+    /// Sends one frame toward the agent.
+    fn send(&self, frame: AcpFrame) -> impl Future<Output = Result<(), AcpError>> + Send;
+
+    /// Receives the next inbound frame, or `None` once the transport is closed.
+    fn recv(&self) -> impl Future<Output = Result<Option<AcpFrame>, AcpError>> + Send;
+}
+
+/// An in-memory [`AcpTransport`] for tests: scripts inbound frames and captures outbound ones.
+///
+/// Only compiled when the `test-util` feature is enabled, so it stays out of
+/// production builds.
+#[cfg(feature = "test-util")]
+#[derive(Default)]
+pub struct FakeAcpTransport {
+    inbound: std::sync::Mutex<std::collections::VecDeque<AcpFrame>>,
+    outbound: std::sync::Mutex<Vec<AcpFrame>>,
+}
+
+#[cfg(feature = "test-util")]
+impl FakeAcpTransport {
+    /// Creates an empty fake transport.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enqueues one scripted inbound frame; `recv` returns them in this order.
+    pub fn push_inbound(&self, frame: AcpFrame) -> &Self {
+        if let Ok(mut inbound) = self.inbound.lock() {
+            inbound.push_back(frame);
+        }
+        self
+    }
+
+    /// Returns a snapshot of the frames the session has sent so far.
+    #[must_use]
+    pub fn sent(&self) -> Vec<AcpFrame> {
+        self.outbound
+            .lock()
+            .map(|outbound| outbound.clone())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(feature = "test-util")]
+impl AcpTransport for FakeAcpTransport {
+    async fn send(&self, frame: AcpFrame) -> Result<(), AcpError> {
+        let mut outbound = self
+            .outbound
+            .lock()
+            .map_err(|_| AcpError::Transport("outbound lock poisoned".to_string()))?;
+        outbound.push(frame);
+        Ok(())
+    }
+
+    async fn recv(&self) -> Result<Option<AcpFrame>, AcpError> {
+        let mut inbound = self
+            .inbound
+            .lock()
+            .map_err(|_| AcpError::Transport("inbound lock poisoned".to_string()))?;
+        Ok(inbound.pop_front())
+    }
+}

--- a/crates/acp/tests/connection.rs
+++ b/crates/acp/tests/connection.rs
@@ -1,0 +1,321 @@
+//! Behavioural tests for the ACP client, driven entirely through `FakeAcpTransport`.
+
+use ora_acp::schema::{
+    AgentRequest, ErrorCode, InitializeRequest, LoadSessionRequest, NewSessionRequest,
+    PromptRequest, ProtocolVersion, ReadTextFileResponse, RequestId, SessionUpdate, StopReason,
+};
+use ora_acp::{AcpConnection, AcpError, AcpFrame, AcpTransport, FakeAcpTransport, SessionError};
+use serde_json::{Value, json};
+
+fn from_json<T: serde::de::DeserializeOwned>(value: Value) -> T {
+    serde_json::from_value(value.clone())
+        .unwrap_or_else(|error| panic!("failed to build value from {value}: {error}"))
+}
+
+fn prompt_request() -> PromptRequest {
+    from_json(json!({
+        "sessionId": "s1",
+        "prompt": [{ "type": "text", "text": "hello" }]
+    }))
+}
+
+fn new_session_request() -> NewSessionRequest {
+    from_json(json!({ "cwd": "/work", "mcpServers": [] }))
+}
+
+fn initialize_request() -> InitializeRequest {
+    InitializeRequest::new(ProtocolVersion::LATEST)
+}
+
+fn load_session_request() -> LoadSessionRequest {
+    from_json(json!({ "sessionId": "s1", "cwd": "/work", "mcpServers": [] }))
+}
+
+fn ok_response(id: i64, result: Value) -> AcpFrame {
+    AcpFrame::Success {
+        id: RequestId::Number(id),
+        result,
+    }
+}
+
+fn update_frame(text: &str) -> AcpFrame {
+    AcpFrame::Notification {
+        method: "session/update".to_string(),
+        params: json!({
+            "sessionId": "s1",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": text }
+            }
+        }),
+    }
+}
+
+// --- acp-transport ---
+
+#[tokio::test]
+async fn fake_transport_orders_inbound_and_captures_outbound() {
+    let transport = FakeAcpTransport::new();
+    transport
+        .push_inbound(update_frame("first"))
+        .push_inbound(update_frame("second"));
+
+    let first = transport
+        .recv()
+        .await
+        .unwrap_or_else(|error| panic!("recv failed: {error}"));
+    assert!(matches!(first, Some(AcpFrame::Notification { .. })));
+
+    transport
+        .send(AcpFrame::Notification {
+            method: "out".to_string(),
+            params: json!({}),
+        })
+        .await
+        .unwrap_or_else(|error| panic!("send failed: {error}"));
+
+    assert_eq!(transport.sent().len(), 1);
+    // One inbound frame consumed, one still queued.
+    assert!(transport.recv().await.is_ok());
+}
+
+// --- acp-protocol ---
+
+#[test]
+fn prompt_request_round_trips_through_official_type() {
+    let input = json!({
+        "sessionId": "s1",
+        "prompt": [{ "type": "text", "text": "hello" }]
+    });
+    let typed: PromptRequest = from_json(input);
+    let reparsed: PromptRequest = from_json(
+        serde_json::to_value(&typed).unwrap_or_else(|error| panic!("serialize failed: {error}")),
+    );
+    assert_eq!(typed, reparsed);
+}
+
+// --- acp-session: 1:1 methods + id correlation ---
+
+#[tokio::test]
+async fn initialize_sends_handshake_and_records_capabilities() {
+    let transport: FakeAcpTransport = FakeAcpTransport::new();
+    transport.push_inbound(ok_response(
+        1,
+        json!({
+            "protocolVersion": 1,
+            "agentCapabilities": { "loadSession": true }
+        }),
+    ));
+
+    let request = initialize_request();
+    let expected_params =
+        serde_json::to_value(&request).unwrap_or_else(|error| panic!("serialize: {error}"));
+
+    let session = AcpConnection::new(transport);
+    // No capabilities are known before the handshake completes.
+    assert!(session.capabilities().is_none());
+
+    let response = session
+        .initialize(request)
+        .await
+        .unwrap_or_else(|error| panic!("initialize failed: {error}"));
+
+    // The response is decoded from the official InitializeResponse type.
+    assert!(response.agent_capabilities.load_session);
+
+    // The outbound frame is the standard `initialize` request carrying the caller's params.
+    let sent = session.transport().sent();
+    match &sent[0] {
+        AcpFrame::Request { method, params, id } => {
+            assert_eq!(method, "initialize");
+            assert_eq!(params, &expected_params);
+            assert_eq!(*id, RequestId::Number(1));
+        }
+        other => panic!("expected an initialize request frame, got {other:?}"),
+    }
+
+    // Negotiated capabilities are recorded on the connection for later gating.
+    let recorded = session
+        .capabilities()
+        .unwrap_or_else(|| panic!("expected capabilities to be recorded"));
+    assert!(recorded.load_session);
+}
+
+#[tokio::test]
+async fn prompt_sends_standard_method_with_unchanged_params() {
+    let transport = FakeAcpTransport::new();
+    transport.push_inbound(ok_response(1, json!({ "stopReason": "end_turn" })));
+
+    let request = prompt_request();
+    let expected_params =
+        serde_json::to_value(&request).unwrap_or_else(|error| panic!("serialize: {error}"));
+
+    let session = AcpConnection::new(transport);
+    let turn = session
+        .prompt(request)
+        .await
+        .unwrap_or_else(|error| panic!("prompt failed: {error}"));
+
+    assert!(matches!(turn.response.stop_reason, StopReason::EndTurn));
+
+    let sent = session.transport().sent();
+    match &sent[0] {
+        AcpFrame::Request { method, params, .. } => {
+            assert_eq!(method, "session/prompt");
+            assert_eq!(params, &expected_params);
+        }
+        other => panic!("expected a request frame, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn response_with_unknown_id_is_ignored() {
+    let transport = FakeAcpTransport::new();
+    transport.push_inbound(ok_response(999, json!({ "sessionId": "other" })));
+    transport.push_inbound(ok_response(1, json!({ "sessionId": "s1" })));
+
+    let session = AcpConnection::new(transport);
+    let response = session
+        .new_session(new_session_request())
+        .await
+        .unwrap_or_else(|error| panic!("new_session failed: {error}"));
+
+    assert_eq!(response.session_id.to_string(), "s1");
+}
+
+// --- acp-session: streaming aggregation ---
+
+#[tokio::test]
+async fn updates_are_aggregated_in_order_before_response() {
+    let transport = FakeAcpTransport::new();
+    transport.push_inbound(update_frame("one"));
+    transport.push_inbound(update_frame("two"));
+    transport.push_inbound(ok_response(1, json!({ "stopReason": "end_turn" })));
+
+    let session = AcpConnection::new(transport);
+    let turn = session
+        .prompt(prompt_request())
+        .await
+        .unwrap_or_else(|error| panic!("prompt failed: {error}"));
+
+    assert_eq!(turn.updates.len(), 2);
+    assert_eq!(chunk_text(&turn.updates[0].update), "one");
+    assert_eq!(chunk_text(&turn.updates[1].update), "two");
+    assert!(matches!(turn.response.stop_reason, StopReason::EndTurn));
+}
+
+fn chunk_text(update: &SessionUpdate) -> String {
+    let value = serde_json::to_value(update).unwrap_or(Value::Null);
+    value
+        .get("content")
+        .and_then(|content| content.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+// --- acp-session: capability gating ---
+
+#[tokio::test]
+async fn load_session_is_gated_without_capability_and_sends_no_frame() {
+    let transport = FakeAcpTransport::new();
+    let session = AcpConnection::new(transport);
+
+    let error = match session.load_session(load_session_request()).await {
+        Ok(_) => panic!("expected load_session to be gated"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        AcpError::Session(SessionError::CapabilityUnavailable(_))
+    ));
+    assert!(session.transport().sent().is_empty());
+}
+
+#[tokio::test]
+async fn load_session_is_allowed_after_capability_negotiated() {
+    let transport = FakeAcpTransport::new();
+    transport.push_inbound(ok_response(
+        1,
+        json!({ "protocolVersion": 1, "agentCapabilities": { "loadSession": true } }),
+    ));
+    transport.push_inbound(ok_response(2, json!({})));
+
+    let session = AcpConnection::new(transport);
+    session
+        .initialize(initialize_request())
+        .await
+        .unwrap_or_else(|error| panic!("initialize failed: {error}"));
+    session
+        .load_session(load_session_request())
+        .await
+        .unwrap_or_else(|error| panic!("load_session failed: {error}"));
+
+    assert_eq!(session.transport().sent().len(), 2);
+}
+
+// --- acp-session: inbound request routing + e2e ---
+
+#[tokio::test]
+async fn end_to_end_prompt_with_updates_and_reverse_request() {
+    let transport = FakeAcpTransport::new();
+    transport.push_inbound(update_frame("thinking"));
+    transport.push_inbound(update_frame("still thinking"));
+    transport.push_inbound(AcpFrame::Request {
+        id: RequestId::Str("r1".to_string()),
+        method: "fs/read_text_file".to_string(),
+        params: json!({ "sessionId": "s1", "path": "/f" }),
+    });
+    transport.push_inbound(ok_response(1, json!({ "stopReason": "end_turn" })));
+
+    let session = AcpConnection::new(transport).with_request_handler(|request| match request {
+        AgentRequest::ReadTextFileRequest(_) => Ok(serde_json::to_value(
+            ReadTextFileResponse::new("file contents"),
+        )
+        .unwrap_or(Value::Null)),
+        _ => Err(ora_acp::schema::ProtocolError::method_not_found()),
+    });
+
+    let turn = session
+        .prompt(prompt_request())
+        .await
+        .unwrap_or_else(|error| panic!("prompt failed: {error}"));
+
+    assert_eq!(turn.updates.len(), 2);
+    assert!(matches!(turn.response.stop_reason, StopReason::EndTurn));
+
+    let sent = session.transport().sent();
+    // sent[0] is the prompt; sent[1] is the response correlated to the reverse request.
+    match &sent[1] {
+        AcpFrame::Success { id, .. } => assert_eq!(*id, RequestId::Str("r1".to_string())),
+        other => panic!("expected a success response to r1, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unhandled_reverse_request_gets_protocol_error() {
+    let transport = FakeAcpTransport::new();
+    transport.push_inbound(AcpFrame::Request {
+        id: RequestId::Str("r1".to_string()),
+        method: "fs/read_text_file".to_string(),
+        params: json!({ "sessionId": "s1", "path": "/f" }),
+    });
+    transport.push_inbound(ok_response(1, json!({ "stopReason": "end_turn" })));
+
+    // No handler registered.
+    let session = AcpConnection::new(transport);
+    session
+        .prompt(prompt_request())
+        .await
+        .unwrap_or_else(|error| panic!("prompt failed: {error}"));
+
+    let sent = session.transport().sent();
+    match &sent[1] {
+        AcpFrame::Failure { id, error } => {
+            assert_eq!(*id, RequestId::Str("r1".to_string()));
+            assert_eq!(error.code, ErrorCode::MethodNotFound);
+        }
+        other => panic!("expected a failure response, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## What

Adds `crates/acp` (`ora-acp`), the client-side driver for the stable **Agent Client Protocol (ACP) v1**. Wire types are re-exported from the official `agent-client-protocol-schema` crate rather than redeclared.

- **`AcpTransport`** — bidirectional seam over typed ACP frames. The real duplex implementation lands later in `plugin-manager`; this crate only defines the seam.
- **`AcpConnection`** — connection-level driver with 1:1 protocol methods (`initialize`, `session/new`, `session/load`, `session/prompt`, `session/cancel`), ACP-layer id correlation, streaming `session/update` aggregation, capability gating, and inbound reverse-request routing (`fs/*`, `session/request_permission`, `terminal/*`).
- **`AcpError`** — layered by phase (Transport / Session / Protocol).
- **`FakeAcpTransport`** — in-memory test double, gated behind the `test-util` feature so it never ships in production builds.

## Why this shape

- **Depend on official types, don't rewrite them** — preserves interoperability with real ACP agents; the toolchain already supports the crate (rustc ≥ 1.88, edition 2024).
- **Two-layer tunneling** — the outer ora-RPC envelope (plugin-manager's job) carries a standard ACP frame as an opaque, notification-style payload; all id correlation happens once, at the inner ACP layer inside this crate.
- **No facade / no business mapping** — those belong to the `application` layer and are explicitly out of scope here.

## Testing

- 12 tests (unit + integration) driven through `FakeAcpTransport`: id correlation, streaming aggregation, capability gating, reverse-request routing, e2e prompt turn.
- Examples exercise real interop with a live `opencode acp` agent: `mock_agent` (in-memory), `opencode_agent` (handshake), `opencode_chat` (full conversation through a real LLM). Cross-platform process spawning (Windows via `cmd /C`).
- `cargo fmt` / `clippy --all-targets` / `test` clean; whole workspace builds.

## Scope / not included

- No `plugin-manager` (duplex driver) or `application` (facade) changes.
- No frontend TS bindings.
- No `unstable_*` ACP surface (NES, elicitation, providers, MCP-over-ACP, session fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)