### PR TITLE
fix(process): kill entire process tree instead of only the direct child

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,9 +1186,11 @@ dependencies = [
 name = "ora-process"
 version = "0.0.0"
 dependencies = [
+ "libc",
  "pretty_assertions",
  "tempfile",
  "tokio",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ora-process = { path = "crates/process" }
 ora-pty = { path = "crates/pty" }
 
 # External
+libc = "0.2"
 log = "0.4"
 portable-pty = "0.9"
 pretty_assertions = "1"
@@ -50,6 +51,7 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt", "registry"] }
 ts-rs = "12.0"
 uuid = { version = "1", features = ["v4"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [workspace.lints]
 rust = {}

--- a/crates/process/Cargo.toml
+++ b/crates/process/Cargo.toml
@@ -11,9 +11,16 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-tokio = { workspace = true, features = ["io-util", "process", "rt", "sync"] }
+libc = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "process", "rt-multi-thread", "time"] }
+
+[target.'cfg(windows)'.dev-dependencies]
+windows-sys = { workspace = true }

--- a/crates/process/src/lib.rs
+++ b/crates/process/src/lib.rs
@@ -1,6 +1,7 @@
 mod spec;
 mod tokio_process;
 mod traits;
+mod tree;
 
 pub use spec::{ProcessSpec, ProcessStdio};
 pub use tokio_process::{TokioManagedProcess, TokioProcessSpawner};

--- a/crates/process/src/tokio_process.rs
+++ b/crates/process/src/tokio_process.rs
@@ -7,6 +7,7 @@ use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 use tokio::runtime::Handle;
 use tokio::sync::{mpsc, oneshot, watch};
 
+use crate::tree::ProcessTree;
 use crate::{ManagedProcess, ProcessSpawner, ProcessSpec};
 
 /// Tokio-backed process spawner for real OS child processes.
@@ -42,8 +43,13 @@ impl ProcessSpawner for TokioProcessSpawner {
         command.stdout(spec.stdout_policy().as_stdio());
         command.stderr(spec.stderr_policy().as_stdio());
         command.kill_on_drop(spec.should_kill_on_drop());
+        ProcessTree::configure_command(&mut command);
 
         let mut child = command.spawn()?;
+        // Build the tree handle after spawn so the child can be enrolled in its tree-wide
+        // termination group on Windows. Doing it here (rather than lazily inside the lifecycle
+        // task) propagates any Job Object setup failure as a spawn error.
+        let tree = ProcessTree::from_spawned(&child)?;
         let id = child.id();
         let stdin = child.stdin.take();
         let stdout = child.stdout.take();
@@ -56,7 +62,9 @@ impl ProcessSpawner for TokioProcessSpawner {
         } else {
             (None, None)
         };
-        handle.spawn(run_process_lifecycle(child, kill_rx, drop_rx, exit_tx));
+        handle.spawn(run_process_lifecycle(
+            child, tree, kill_rx, drop_rx, exit_tx,
+        ));
 
         Ok(TokioManagedProcess {
             id,
@@ -159,15 +167,18 @@ impl ManagedProcess for TokioManagedProcess {
         }
     }
 
-    /// Forcefully terminates the child process.
+    /// Forcefully terminates the entire process tree rooted at the spawned child, on top of the
+    /// contract documented at [`crate::ManagedProcess::kill`].
     ///
-    /// Known limitation: only the direct child is terminated. Descendant processes spawned by the
-    /// child (for example a shell launching further tools) keep running, because tree-wide
-    /// termination requires Unix process groups / Windows Job Objects. This also applies to the
-    /// `kill_on_drop` path. Tree-wide termination is tracked as a follow-up task.
+    /// Tree-wide termination is realized with Unix process groups (the child runs in its own group
+    /// and the whole group is signalled) and Windows Job Objects (the child is enrolled in a job
+    /// created with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and the job is terminated). This also
+    /// applies to the `kill_on_drop` path: dropping the handle when the spec had
+    /// `kill_on_drop` enabled terminates the whole tree, not just the direct child.
     ///
-    /// Returns once the termination request is delivered to the OS; callers that need the final
-    /// exit status must still await [`ManagedProcess::wait`].
+    /// The `start_kill` contract still holds: this returns once the termination request has been
+    /// submitted to the OS rather than once the tree has fully exited; call [`Self::wait`] to reap
+    /// the direct child's final exit status.
     fn kill(&self) -> impl Future<Output = io::Result<()>> + Send + '_ {
         let kill_tx = self.kill_tx.clone();
         let exit_rx = self.exit_rx.clone();
@@ -222,6 +233,7 @@ impl WaitFailure {
 
 async fn run_process_lifecycle(
     mut child: Child,
+    tree: ProcessTree,
     mut kill_rx: mpsc::UnboundedReceiver<KillRequest>,
     mut drop_rx: Option<oneshot::Receiver<()>>,
     exit_tx: watch::Sender<Option<ExitState>>,
@@ -237,11 +249,13 @@ async fn run_process_lifecycle(
                         return;
                     }
                     request = kill_rx.recv(), if kill_rx_open => {
-                        handle_kill_request(&mut child, request, &mut kill_rx_open);
+                        handle_kill_request(&tree, request, &mut kill_rx_open);
                     }
                     _ = drop_signal => {
                         drop_rx = None;
-                        let _ = child.start_kill();
+                        // The user-facing handle was dropped with kill_on_drop enabled: terminate the
+                        // whole tree (descendants included), not just the direct child.
+                        let _ = tree.kill();
                     }
                 }
             }
@@ -252,7 +266,7 @@ async fn run_process_lifecycle(
                         return;
                     }
                     request = kill_rx.recv(), if kill_rx_open => {
-                        handle_kill_request(&mut child, request, &mut kill_rx_open);
+                        handle_kill_request(&tree, request, &mut kill_rx_open);
                     }
                 }
             }
@@ -260,10 +274,12 @@ async fn run_process_lifecycle(
     }
 }
 
-fn handle_kill_request(child: &mut Child, request: Option<KillRequest>, kill_rx_open: &mut bool) {
+fn handle_kill_request(tree: &ProcessTree, request: Option<KillRequest>, kill_rx_open: &mut bool) {
     match request {
         Some(KillRequest { ack }) => {
-            let _ = ack.send(child.start_kill());
+            // Acknowledge with the tree-wide termination result. `start_kill` semantics: the OS
+            // request has been submitted, callers still need to wait for the final exit status.
+            let _ = ack.send(tree.kill());
         }
         None => {
             *kill_rx_open = false;

--- a/crates/process/src/tokio_process.rs
+++ b/crates/process/src/tokio_process.rs
@@ -49,7 +49,22 @@ impl ProcessSpawner for TokioProcessSpawner {
         // Build the tree handle after spawn so the child can be enrolled in its tree-wide
         // termination group on Windows. Doing it here (rather than lazily inside the lifecycle
         // task) propagates any Job Object setup failure as a spawn error.
-        let tree = ProcessTree::from_spawned(&child)?;
+        let tree = match ProcessTree::from_spawned(&child) {
+            Ok(tree) => tree,
+            Err(error) => {
+                // The OS process already exists even though tree setup failed, and this function
+                // is about to return `Err` without handing the caller any handle to manage it.
+                // Terminate the direct child now, independent of the spec's drop policy: a
+                // keep_alive_on_drop child would otherwise survive `Child::drop` here (its
+                // `kill_on_drop` flag is false) and leak as an unmanaged process. Reap it on the
+                // runtime so it doesn't linger as a zombie either.
+                let _ = child.start_kill();
+                handle.spawn(async move {
+                    let _ = child.wait().await;
+                });
+                return Err(error);
+            }
+        };
         let id = child.id();
         let stdin = child.stdin.take();
         let stdout = child.stdout.take();

--- a/crates/process/src/traits.rs
+++ b/crates/process/src/traits.rs
@@ -48,6 +48,15 @@ pub trait ManagedProcess {
     /// Waits until the child exits and returns its platform exit status.
     fn wait(&self) -> impl Future<Output = io::Result<ExitStatus>> + Send + '_;
 
-    /// Forcefully terminates the child process.
+    /// Requests forceful termination of the entire process tree rooted at the spawned child,
+    /// including any descendant processes the child may have started (for example a shell that
+    /// launched further tools).
+    ///
+    /// This is a `start_kill` contract: the future resolves once the termination request has been
+    /// submitted to the OS, **not** once the tree has fully exited. Callers that need the final
+    /// exit status of the direct child must still await [`Self::wait`]. The future returns `Ok`
+    /// when the OS accepted the request or the tree was already gone; it returns `Err` only when
+    /// the OS refused the request for a reason the caller should surface (for example
+    /// permission loss).
     fn kill(&self) -> impl Future<Output = io::Result<()>> + Send + '_;
 }

--- a/crates/process/src/tree.rs
+++ b/crates/process/src/tree.rs
@@ -1,0 +1,232 @@
+//! Platform-specific process-tree termination for spawned child processes.
+//!
+//! Tree-wide termination is required because a child (for example a shell) may itself spawn nested
+//! processes. Killing only the direct child leaves those descendants orphaned and running. This
+//! module owns the OS resources and primitives used to request termination of the entire tree
+//! rooted at one spawned child:
+//!
+//! - On Unix the child is placed in its own process group (set via `Command::process_group(0)`);
+//!   the entire group is signalled with `kill(-pgid, SIGKILL)`.
+//! - On Windows the child is assigned to a Job Object created with
+//!   `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`; the whole job is terminated with
+//!   `TerminateJobObject`, and closing the job handle kills every process still in the job.
+//!
+//! [`ProcessTree::kill`] mirrors the `start_kill` contract used by [`crate::ManagedProcess::kill`]:
+//! it delivers the termination request to the OS and returns without waiting for any process to
+//! actually exit. Callers that need the final exit status must still reap the direct child via
+//! [`crate::ManagedProcess::wait`].
+
+use std::io;
+
+use tokio::process::{Child, Command};
+
+/// Owns the OS resources required to terminate an entire process tree rooted at one spawned
+/// child process.
+///
+/// Created from a freshly-spawned child and held by the lifecycle task so every kill path
+/// (explicit `kill()`, `kill_on_drop`, and lifecycle task teardown) goes through one entry point.
+/// Dropping this handle releases those resources; on Windows it also triggers OS-level cleanup of
+/// the tree via the Job Object's `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` limit.
+pub(crate) struct ProcessTree {
+    #[cfg(unix)]
+    pgid: i32,
+    #[cfg(windows)]
+    job: windows_sys::Win32::Foundation::HANDLE,
+}
+
+// SAFETY: On Windows the Job Object handle is owned exclusively by this struct and only ever
+// touched through the synchronous win32 APIs used here (no shared interior mutability), so moving
+// it across threads and dropping it on whichever thread the lifecycle task lands on is safe.
+// On Unix the only field is a plain `i32` process group id, which is intrinsically Send + Sync.
+#[cfg(windows)]
+unsafe impl Send for ProcessTree {}
+#[cfg(windows)]
+unsafe impl Sync for ProcessTree {}
+
+impl ProcessTree {
+    /// Applies platform-specific spawn configuration so the spawned child becomes the root of a
+    /// manageable process tree.
+    ///
+    /// On Unix this places the child in its own process group; on Windows the Job Object is
+    /// created after spawn, so nothing is configured here.
+    pub(crate) fn configure_command(command: &mut Command) {
+        #[cfg(unix)]
+        {
+            // A process group of 0 makes the child a process group leader with pgid == child pid.
+            // Descendants inherit the same pgid unless they explicitly leave it, which is rare and
+            // outside our control. This is the standard mechanism Rust's std documentation points
+            // to for tree-wide termination on Unix.
+            command.process_group(0);
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = command;
+        }
+    }
+
+    /// Builds a process-tree handle from a freshly-spawned child.
+    ///
+    /// On Windows this creates the Job Object with `KILL_ON_JOB_CLOSE` and assigns the running
+    /// child to it. There is a small race window between spawn and assignment where the child
+    /// could fork a subprocess that escapes the job; for Ora's agent runtimes this race is
+    /// acceptable and unavoidable without `CREATE_SUSPENDED` plumbing that the tokio `Command`
+    /// type does not expose.
+    pub(crate) fn from_spawned(child: &Child) -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            let pid = child
+                .id()
+                .ok_or_else(|| io::Error::other("spawned child has no platform pid"))?
+                as i32;
+            Ok(Self { pgid: pid })
+        }
+
+        #[cfg(windows)]
+        {
+            let pid = child
+                .id()
+                .ok_or_else(|| io::Error::other("spawned child has no platform pid"))?;
+            let job = create_kill_on_close_job()?;
+            // If assignment fails we must release the just-created job handle, otherwise it would
+            // leak and immediately kill the freshly-spawned child via KILL_ON_JOB_CLOSE.
+            if let Err(error) = assign_child_to_job(job, pid) {
+                close_handle(job);
+                return Err(error);
+            }
+            Ok(Self { job })
+        }
+    }
+
+    /// Delivers a tree-wide termination request to the OS without waiting for any process to
+    /// exit (a `start_kill` contract: the request has been submitted, not necessarily reaped).
+    ///
+    /// Returns `Ok(())` when the request was accepted by the OS or when the tree is already gone
+    /// (for example ESRCH on Unix when the process group no longer exists). Returns `Err` only when
+    /// the OS refused the request for a reason callers should surface (for example EPERM).
+    pub(crate) fn kill(&self) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            kill_process_group(self.pgid)
+        }
+
+        #[cfg(windows)]
+        {
+            terminate_job(self.job)
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ProcessTree {
+    fn drop(&mut self) {
+        // CloseHandle releasing our reference to the Job Object. Because the job was created with
+        // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, the OS kills every process still in the job once the
+        // last handle is closed. Even for keep_alive_on_drop processes this is the right thing to
+        // do during runtime teardown: thoroughly cleaning up the tree instead of orphaning it.
+        close_handle(self.job);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unix implementation: process-group signalling.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn kill_process_group(pgid: i32) -> io::Result<()> {
+    // A negative target delivers the signal to the entire process group identified by |pgid|.
+    // This relies on the child being its own group leader (see configure_command); the pid we
+    // captured at spawn equals the group id, so -pgid targets the whole tree.
+    let result = unsafe { libc::kill(-pgid, libc::SIGKILL) };
+    if result == 0 {
+        return Ok(());
+    }
+
+    let error = io::Error::last_os_error();
+    // ESRCH means the group is already gone, which is equivalent to "termination request
+    // delivered" from the caller's perspective. Any other failure should be surfaced.
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Windows implementation: Job Object with kill-on-close semantics.
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+fn create_kill_on_close_job() -> io::Result<windows_sys::Win32::Foundation::HANDLE> {
+    use windows_sys::Win32::System::JobObjects::{
+        CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JobObjectExtendedLimitInformation, SetInformationJobObject,
+    };
+
+    // CreateJobObjectW returns a null handle on failure (it does not use INVALID_HANDLE_VALUE).
+    let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if job.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+    info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+    let ok = unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const _ as *const std::ffi::c_void,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        )
+    };
+    if ok == 0 {
+        let error = io::Error::last_os_error();
+        close_handle(job);
+        return Err(error);
+    }
+
+    Ok(job)
+}
+
+#[cfg(windows)]
+fn assign_child_to_job(
+    job: windows_sys::Win32::Foundation::HANDLE,
+    child_pid: u32,
+) -> io::Result<()> {
+    use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
+    };
+
+    let child_handle = unsafe { OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, child_pid) };
+    if child_handle.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    // AssignProcessToJobObject can return ERROR_ACCESS_DENIED on systems without nested-job
+    // support, but Windows 8+ supports nested jobs, so success is the expected path.
+    let ok = unsafe { AssignProcessToJobObject(job, child_handle) };
+    close_handle(child_handle);
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn terminate_job(job: windows_sys::Win32::Foundation::HANDLE) -> io::Result<()> {
+    use windows_sys::Win32::System::JobObjects::TerminateJobObject;
+
+    let ok = unsafe { TerminateJobObject(job, 1) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn close_handle(handle: windows_sys::Win32::Foundation::HANDLE) {
+    let _ = unsafe { windows_sys::Win32::Foundation::CloseHandle(handle) };
+}

--- a/crates/process/src/tree.rs
+++ b/crates/process/src/tree.rs
@@ -25,8 +25,11 @@ use tokio::process::{Child, Command};
 ///
 /// Created from a freshly-spawned child and held by the lifecycle task so every kill path
 /// (explicit `kill()`, `kill_on_drop`, and lifecycle task teardown) goes through one entry point.
-/// Dropping this handle releases those resources; on Windows it also triggers OS-level cleanup of
-/// the tree via the Job Object's `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` limit.
+/// Dropping this handle is an *ordinary* release: on Windows it disarms
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` before closing the Job Object handle, so releasing this
+/// handle never terminates the tree on its own. Tree-wide termination only ever happens through
+/// the explicit [`ProcessTree::kill`] path (`TerminateJobObject`), which is unaffected by
+/// disarming since it acts immediately rather than on handle close.
 pub(crate) struct ProcessTree {
     #[cfg(unix)]
     pgid: i32,
@@ -120,10 +123,14 @@ impl ProcessTree {
 #[cfg(windows)]
 impl Drop for ProcessTree {
     fn drop(&mut self) {
-        // CloseHandle releasing our reference to the Job Object. Because the job was created with
-        // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, the OS kills every process still in the job once the
-        // last handle is closed. Even for keep_alive_on_drop processes this is the right thing to
-        // do during runtime teardown: thoroughly cleaning up the tree instead of orphaning it.
+        // This runs both on the direct child's normal exit and whenever the lifecycle task
+        // itself is torn down without an explicit kill (for example Tokio runtime shutdown),
+        // including for `keep_alive_on_drop` processes. Neither case should terminate whatever
+        // is still running in the job, so disarm JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE first: without
+        // this, closing the handle would kill every descendant still in the job even though
+        // nobody asked for that. Any real termination already happened synchronously through
+        // `kill()` (`TerminateJobObject`) before this Drop runs, so disarming here is safe.
+        let _ = disarm_kill_on_close(self.job);
         close_handle(self.job);
     }
 }
@@ -187,6 +194,34 @@ fn create_kill_on_close_job() -> io::Result<windows_sys::Win32::Foundation::HAND
     }
 
     Ok(job)
+}
+
+/// Clears the Job Object's limit flags so a subsequent `CloseHandle` no longer terminates
+/// whatever is still running in the job. Used for the ordinary (non-killing) release path in
+/// [`Drop for ProcessTree`](ProcessTree), never for the explicit `kill()` path.
+#[cfg(windows)]
+fn disarm_kill_on_close(job: windows_sys::Win32::Foundation::HANDLE) -> io::Result<()> {
+    use windows_sys::Win32::System::JobObjects::{
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+        SetInformationJobObject,
+    };
+
+    // Zeroed LimitFlags clears JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE (the only limit this job was
+    // ever configured with; see `create_kill_on_close_job`).
+    let info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+
+    let ok = unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const _ as *const std::ffi::c_void,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 #[cfg(windows)]

--- a/crates/process/tests/process.rs
+++ b/crates/process/tests/process.rs
@@ -284,3 +284,206 @@ fn long_running_command() -> ProcessSpec {
 fn long_running_command() -> ProcessSpec {
     shell_command("sleep 5")
 }
+
+// ---------------------------------------------------------------------------
+// Tree-wide termination
+// ---------------------------------------------------------------------------
+
+// Verifies the tree-kill contract from `ManagedProcess::kill`: when a spawned child starts a
+// grandchild (for example a shell launching a long-running tool), killing the managed process must
+// also terminate that grandchild. On Unix the grandchild inherits the child's process group, so a
+// group-wide `kill(-pgid, SIGKILL)` reaches it; on Windows the grandchild inherits membership in
+// the child's Job Object, so `TerminateJobObject` reaches it.
+//
+// Unix variant probes liveness with `libc::kill(0)`; the Windows variant uses
+// `OpenProcess` + `GetExitCodeProcess` against `STILL_ACTIVE`.
+#[cfg(unix)]
+#[tokio::test]
+async fn kill_terminates_descendants_started_by_the_child() {
+    use std::time::Duration;
+
+    let marker_dir = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("expected tempdir for pid marker: {error}"));
+    let marker_path = marker_dir.path().join("grandchild.pid");
+    let script = format!(
+        "sh -c 'sleep 30' & echo $! > {marker}; exec sleep 30",
+        marker = escape_shell_path(&marker_path)
+    );
+    let spawner = TokioProcessSpawner::new();
+    let process = spawner
+        .spawn(ProcessSpec::new("sh").args(["-c", script.as_str()]))
+        .unwrap_or_else(|error| panic!("expected process spawn to succeed: {error}"));
+
+    let grandchild_pid = wait_for_marker_pid(&marker_path).await;
+    assert_eq!(
+        unsafe { libc::kill(grandchild_pid, 0) },
+        0,
+        "grandchild should be alive before kill"
+    );
+
+    process
+        .kill()
+        .await
+        .unwrap_or_else(|error| panic!("expected process kill to succeed: {error}"));
+    // start_kill contract: kill returned even while the tree is still tearing down. Wait for the
+    // direct child so OS-driven SIGKILL delivery to the descendants has propagated.
+    let exit = process
+        .wait()
+        .await
+        .unwrap_or_else(|error| panic!("expected wait after kill to succeed: {error}"));
+    assert!(!exit.success());
+
+    // The grandchild was started in the same process group as the killed child (job control is
+    // off by default for non-interactive sh), so SIGKILL to the group should reach it as well.
+    // Poll for a short window: the grandchild becomes a reparented zombie until pid 1 reaps it,
+    // during which `kill -0` keeps returning success even though the process is already dead.
+    let mut reaped = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        if unsafe { libc::kill(grandchild_pid, 0) } != 0 {
+            reaped = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        reaped,
+        "grandchild should have been terminated as part of tree-wide kill"
+    );
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn kill_terminates_descendants_started_by_the_child() {
+    use std::time::Duration;
+
+    let marker_dir = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("expected tempdir for pid marker: {error}"));
+    let marker_path = marker_dir.path().join("grandchild.pid");
+    // powershell starts a detached ping (the grandchild), records its pid to the marker file, and
+    // then blocks in `Start-Sleep` so the powershell process itself stays alive until the kill
+    // arrives. `Start-Process` calls CreateProcess under the hood, so the grandchild inherits
+    // membership in the powershell process's Job Object.
+    let script = format!(
+        "$p = Start-Process -FilePath ping -ArgumentList '-n','30','127.0.0.1' -PassThru -WindowStyle Hidden; \
+         Out-File -FilePath '{marker}' -InputObject $p.Id -Encoding ASCII; \
+         Start-Sleep -Seconds 30",
+        marker = escape_powershell_path(&marker_path)
+    );
+    let spawner = TokioProcessSpawner::new();
+    let process = spawner
+        .spawn(ProcessSpec::new("powershell").args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            script.as_str(),
+        ]))
+        .unwrap_or_else(|error| panic!("expected process spawn to succeed: {error}"));
+
+    let grandchild_pid = wait_for_marker_pid(&marker_path).await;
+    assert!(
+        process_alive(grandchild_pid),
+        "grandchild should be alive before kill"
+    );
+
+    process
+        .kill()
+        .await
+        .unwrap_or_else(|error| panic!("expected process kill to succeed: {error}"));
+    // start_kill contract: kill returned even while the tree is still tearing down. Wait for the
+    // direct child so the Job Object termination has propagated to the descendants.
+    let exit = process
+        .wait()
+        .await
+        .unwrap_or_else(|error| panic!("expected wait after kill to succeed: {error}"));
+    assert!(!exit.success());
+
+    // `TerminateJobObject` kills every process in the job asynchronously. Poll for a short window
+    // until the grandchild's exit code is no longer `STILL_ACTIVE`.
+    let mut reaped = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if !process_alive(grandchild_pid) {
+            reaped = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        reaped,
+        "grandchild should have been terminated as part of tree-wide kill"
+    );
+}
+
+#[cfg(unix)]
+async fn wait_for_marker_pid(marker_path: &std::path::Path) -> i32 {
+    let pid = wait_for_marker_pid_contents(marker_path).await;
+    pid.parse::<i32>()
+        .unwrap_or_else(|error| panic!("grandchild marker held non-i32 pid {pid:?}: {error}"))
+}
+
+#[cfg(windows)]
+async fn wait_for_marker_pid(marker_path: &std::path::Path) -> u32 {
+    let pid = wait_for_marker_pid_contents(marker_path).await;
+    pid.parse::<u32>()
+        .unwrap_or_else(|error| panic!("grandchild marker held non-u32 pid {pid:?}: {error}"))
+}
+
+/// Polls for the numeric pid string written by the spawned grandchild. Returning the raw string lets
+/// the platform-specific callers parse into `i32` (Unix) or `u32` (Windows) without tripping the
+/// `expect_used` / `unwrap_used` clippy lints enforced workspace-wide.
+async fn wait_for_marker_pid_contents(marker_path: &std::path::Path) -> String {
+    use std::time::Duration;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(marker_path) {
+            let trimmed = contents.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "grandchild pid marker was never written"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[cfg(unix)]
+fn escape_shell_path(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\'', r"'\''")
+}
+
+// PowerShell single-quoted strings treat `'` as an escaped quote when doubled, so embedding the
+// marker path requires doubling every `'` and wrapping the whole result in `'...'`.
+#[cfg(windows)]
+fn escape_powershell_path(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\'', "''")
+}
+
+#[cfg(windows)]
+fn process_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // A null handle means the process is gone (or we don't have access). The grandchild was
+    // started by the test itself, so access is never the issue here.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        return false;
+    }
+
+    let mut exit_code: u32 = 0;
+    let ok = unsafe { GetExitCodeProcess(handle, &mut exit_code) };
+    let _ = unsafe { CloseHandle(handle) };
+    if ok == 0 {
+        return false;
+    }
+    // STILL_ACTIVE (0x103 = 259) is what GetExitCodeProcess reports until the process actually
+    // terminates; any other value means the OS has observed the exit.
+    exit_code == STILL_ACTIVE as u32
+}

--- a/crates/process/tests/process.rs
+++ b/crates/process/tests/process.rs
@@ -415,6 +415,236 @@ async fn kill_terminates_descendants_started_by_the_child() {
     );
 }
 
+// Verifies that the direct child exiting on its own (no `kill()` ever called) does not kill
+// descendants: only tree-wide `kill()` should terminate the tree. Regression test for the
+// Windows Job Object's `KILL_ON_JOB_CLOSE` limit firing whenever `ProcessTree` is dropped,
+// including on the direct child's normal exit.
+#[cfg(unix)]
+#[tokio::test]
+async fn natural_exit_does_not_kill_descendants_started_by_the_child() {
+    let marker_dir = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("expected tempdir for pid marker: {error}"));
+    let marker_path = marker_dir.path().join("grandchild.pid");
+    // No `exec sleep 30` here (unlike the kill test): the direct child backgrounds the
+    // grandchild, records its pid, and then exits on its own.
+    let script = format!(
+        "sh -c 'sleep 15' & echo $! > {marker}",
+        marker = escape_shell_path(&marker_path)
+    );
+    let spawner = TokioProcessSpawner::new();
+    let process = spawner
+        .spawn(ProcessSpec::new("sh").args(["-c", script.as_str()]))
+        .unwrap_or_else(|error| panic!("expected process spawn to succeed: {error}"));
+
+    let grandchild_pid = wait_for_marker_pid(&marker_path).await;
+    assert_eq!(
+        unsafe { libc::kill(grandchild_pid, 0) },
+        0,
+        "grandchild should be alive before parent exit"
+    );
+
+    let exit = process
+        .wait()
+        .await
+        .unwrap_or_else(|error| panic!("expected wait to succeed: {error}"));
+    assert!(exit.success(), "direct child should have exited normally");
+
+    // The handle (and the `ProcessTree` it owns) is dropped here. Nothing ever called kill(), so
+    // this must be an ordinary release that leaves the grandchild running.
+    drop(process);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert_eq!(
+        unsafe { libc::kill(grandchild_pid, 0) },
+        0,
+        "grandchild must survive the direct child's normal exit"
+    );
+
+    unsafe {
+        libc::kill(grandchild_pid, libc::SIGKILL);
+    }
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn natural_exit_does_not_kill_descendants_started_by_the_child() {
+    let marker_dir = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("expected tempdir for pid marker: {error}"));
+    let marker_path = marker_dir.path().join("grandchild.pid");
+    // No `Start-Sleep` here (unlike the kill test): the direct child starts the detached
+    // grandchild, records its pid, and then exits on its own.
+    let script = format!(
+        "$p = Start-Process -FilePath ping -ArgumentList '-n','15','127.0.0.1' -PassThru -WindowStyle Hidden; \
+         Out-File -FilePath '{marker}' -InputObject $p.Id -Encoding ASCII",
+        marker = escape_powershell_path(&marker_path)
+    );
+    let spawner = TokioProcessSpawner::new();
+    let process = spawner
+        .spawn(ProcessSpec::new("powershell").args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            script.as_str(),
+        ]))
+        .unwrap_or_else(|error| panic!("expected process spawn to succeed: {error}"));
+
+    let grandchild_pid = wait_for_marker_pid(&marker_path).await;
+    assert!(
+        process_alive(grandchild_pid),
+        "grandchild should be alive before parent exit"
+    );
+
+    let exit = process
+        .wait()
+        .await
+        .unwrap_or_else(|error| panic!("expected wait to succeed: {error}"));
+    assert!(exit.success(), "direct child should have exited normally");
+
+    // The handle (and the `ProcessTree` it owns, along with the Job Object handle) is dropped
+    // here. Nothing ever called kill(), so this must be an ordinary release that does not fire
+    // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE against the grandchild still in the job.
+    drop(process);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert!(
+        process_alive(grandchild_pid),
+        "grandchild must survive the direct child's normal exit"
+    );
+
+    kill_pid(grandchild_pid);
+}
+
+// Verifies that a `keep_alive_on_drop` process (and its descendants) survives the lifecycle
+// task itself being torn down (for example Tokio runtime shutdown), not just the user-facing
+// handle being dropped. This exercises `Drop for ProcessTree` directly, since runtime teardown
+// cancels the pending lifecycle task future without running any of its async body.
+#[cfg(unix)]
+#[test]
+fn keep_alive_on_drop_survives_runtime_teardown() {
+    let marker_dir = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("expected tempdir for pid marker: {error}"));
+    let marker_path = marker_dir.path().join("grandchild.pid");
+    let script = format!(
+        "sh -c 'sleep 30' & echo $! > {marker}; exec sleep 30",
+        marker = escape_shell_path(&marker_path)
+    );
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|error| panic!("expected tokio runtime to build: {error}"));
+
+    let (direct_pid, grandchild_pid) = runtime.block_on(async {
+        let spawner = TokioProcessSpawner::new();
+        let process = spawner
+            .spawn(
+                ProcessSpec::new("sh")
+                    .args(["-c", script.as_str()])
+                    .keep_alive_on_drop(),
+            )
+            .unwrap_or_else(|error| panic!("expected process spawn to succeed: {error}"));
+        let direct_pid = process
+            .id()
+            .unwrap_or_else(|| panic!("expected direct child pid")) as i32;
+
+        let grandchild_pid = wait_for_marker_pid(&marker_path).await;
+        assert_eq!(
+            unsafe { libc::kill(grandchild_pid, 0) },
+            0,
+            "grandchild should be alive before teardown"
+        );
+
+        // Mirrors real usage: the caller drops the handle because it no longer needs to observe
+        // this process. keep_alive_on_drop means this alone must not affect the child or its
+        // descendants; the lifecycle task keeps running past this point.
+        drop(process);
+        (direct_pid, grandchild_pid)
+    });
+
+    // The direct child is still asleep (30s), so the lifecycle task is still parked on
+    // `child.wait()` when the runtime tears down: its future is dropped without running any more
+    // of its async body, so only `Drop for ProcessTree` gets a chance to run.
+    runtime.shutdown_timeout(Duration::from_secs(5));
+
+    assert_eq!(
+        unsafe { libc::kill(direct_pid, 0) },
+        0,
+        "direct child should survive runtime teardown for a keep_alive_on_drop process"
+    );
+    assert_eq!(
+        unsafe { libc::kill(grandchild_pid, 0) },
+        0,
+        "descendant should survive runtime teardown for a keep_alive_on_drop process"
+    );
+
+    unsafe {
+        libc::kill(direct_pid, libc::SIGKILL);
+        libc::kill(grandchild_pid, libc::SIGKILL);
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn keep_alive_on_drop_survives_runtime_teardown() {
+    let marker_dir = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("expected tempdir for pid marker: {error}"));
+    let marker_path = marker_dir.path().join("grandchild.pid");
+    let script = format!(
+        "$p = Start-Process -FilePath ping -ArgumentList '-n','30','127.0.0.1' -PassThru -WindowStyle Hidden; \
+         Out-File -FilePath '{marker}' -InputObject $p.Id -Encoding ASCII; \
+         Start-Sleep -Seconds 30",
+        marker = escape_powershell_path(&marker_path)
+    );
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|error| panic!("expected tokio runtime to build: {error}"));
+
+    let (direct_pid, grandchild_pid) = runtime.block_on(async {
+        let spawner = TokioProcessSpawner::new();
+        let process = spawner
+            .spawn(
+                ProcessSpec::new("powershell")
+                    .args(["-NoProfile", "-NonInteractive", "-Command", script.as_str()])
+                    .keep_alive_on_drop(),
+            )
+            .unwrap_or_else(|error| panic!("expected process spawn to succeed: {error}"));
+        let direct_pid = process
+            .id()
+            .unwrap_or_else(|| panic!("expected direct child pid"));
+
+        let grandchild_pid = wait_for_marker_pid(&marker_path).await;
+        assert!(
+            process_alive(grandchild_pid),
+            "grandchild should be alive before teardown"
+        );
+
+        // Mirrors real usage: the caller drops the handle because it no longer needs to observe
+        // this process. keep_alive_on_drop means this alone must not affect the child or its
+        // descendants; the lifecycle task keeps running past this point.
+        drop(process);
+        (direct_pid, grandchild_pid)
+    });
+
+    // The direct child is still asleep (30s), so the lifecycle task is still parked on
+    // `child.wait()` when the runtime tears down: its future is dropped without running any more
+    // of its async body, so only `Drop for ProcessTree` gets a chance to run.
+    runtime.shutdown_timeout(Duration::from_secs(5));
+
+    assert!(
+        process_alive(direct_pid),
+        "direct child should survive runtime teardown for a keep_alive_on_drop process"
+    );
+    assert!(
+        process_alive(grandchild_pid),
+        "descendant should survive runtime teardown for a keep_alive_on_drop process"
+    );
+
+    kill_pid(direct_pid);
+    kill_pid(grandchild_pid);
+}
+
 #[cfg(unix)]
 async fn wait_for_marker_pid(marker_path: &std::path::Path) -> i32 {
     let pid = wait_for_marker_pid_contents(marker_path).await;
@@ -486,4 +716,19 @@ fn process_alive(pid: u32) -> bool {
     // STILL_ACTIVE (0x103 = 259) is what GetExitCodeProcess reports until the process actually
     // terminates; any other value means the OS has observed the exit.
     exit_code == STILL_ACTIVE as u32
+}
+
+// Test cleanup helper: some regression tests deliberately keep processes alive past the point a
+// normal `kill()` path would reach, so the test is responsible for terminating them itself.
+#[cfg(windows)]
+fn kill_pid(pid: u32) {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_TERMINATE, TerminateProcess};
+
+    let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if handle.is_null() {
+        return;
+    }
+    let _ = unsafe { TerminateProcess(handle, 1) };
+    let _ = unsafe { CloseHandle(handle) };
 }


### PR DESCRIPTION
## Summary

Makes `ManagedProcess::kill` terminate the **entire process tree** instead of only the direct child, and fixes a Windows regression where an ordinary drop could kill still-running descendants.

## Commits

### `feat(process): kill entire process tree instead of only the direct child`
- Previously `kill` terminated only the direct child, leaving descendants (e.g. a shell's nested tools) orphaned.
- **Unix:** the child is placed in its own process group via `Command::process_group(0)`; the whole group is signalled with `kill(-pgid, SIGKILL)`.
- **Windows:** the child is enrolled in a Job Object created with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, terminated via `TerminateJobObject`.
- The `kill_on_drop` path goes through the same tree-wide termination.
- `start_kill` contract preserved: `kill` resolves once the termination request is submitted to the OS, not once the tree has fully exited — callers needing the final exit status must still `await wait`. Trait docs now make this explicit.
- Promotes `tokio` `macros` from dev- to prod-dependencies (lib uses `tokio::select!` in the lifecycle task).

### `fix(process): stop Windows Job Object from killing descendants on ordinary drop`
- `ProcessTree`'s `Drop` unconditionally closed the kill-on-close Job Object handle, so a direct child exiting normally (or the lifecycle task torn down at runtime shutdown) would kill still-running descendants even for `keep_alive_on_drop` processes. The kill-on-close limit is now disarmed before closing, so only the explicit `kill()` path (`TerminateJobObject`) terminates the tree.
- Fixes a leak where a Job Object setup failure after spawn (`ProcessTree::from_spawned`) propagated as a `spawn()` error while leaving the already-started child running with no handle — the direct child is now explicitly killed and reaped on that error path.

## Testing

Verified on Linux:
- `cargo test -p ora-process` — 10/10 pass (incl. tree-wide kill, natural-exit-keeps-descendants, keep-alive-on-drop, unowned-stdin cases)
- `cargo clippy -p ora-process --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
