### PR TITLE
feat(app-shell): extract chat and sidebar into shared @ora/app-shell package

### DIFF
--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ora</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/client/package.json
+++ b/apps/web/client/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@ora/web-client",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ora/app-shell": "workspace:*",
+    "@ora/ui": "workspace:*",
+    "@untitledui/icons": "^0.0.22",
+    "@tailwindcss/typography": "^0.5.19",
+    "@tailwindcss/vite": "^4.2.4",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "tailwindcss": "^4.2.4",
+    "tailwindcss-animate": "^1.0.7",
+    "tailwindcss-react-aria-components": "^2.0.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^6.0.1",
+    "vite": "^8.0.10"
+  }
+}

--- a/apps/web/client/public/favicon.svg
+++ b/apps/web/client/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="8" fill="#7F56D9" />
+  <path d="M9 12.5C9 11.1193 10.1193 10 11.5 10H20.5C21.8807 10 23 11.1193 23 12.5V17.5C23 18.8807 21.8807 20 20.5 20H14.5L11 23V20H11.5C10.1193 20 9 18.8807 9 17.5V12.5Z" fill="white" fill-opacity="0.95" />
+  <circle cx="13.5" cy="15" r="1.25" fill="#7F56D9" />
+  <circle cx="18.5" cy="15" r="1.25" fill="#7F56D9" />
+</svg>

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -1,0 +1,7 @@
+import { AppShell } from "@ora/app-shell";
+
+function App() {
+  return <AppShell />;
+}
+
+export default App;

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1,0 +1,77 @@
+@import "tailwindcss";
+@import "../../../../packages/ui/src/styles/theme.css";
+@import "../../../../packages/ui/src/styles/typography.css";
+
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-animate";
+@plugin "@tailwindcss/typography";
+
+@custom-variant dark (&:where(.dark-mode, .dark-mode *));
+@custom-variant label (& [data-label]);
+@custom-variant focus-input-within (&:has(input:focus));
+
+/* Scan the @ora/ui and @ora/app-shell package sources so Tailwind v4
+   generates the utility classes used inside the components. */
+@source "../../../../packages/ui/src";
+@source "../../../../packages/app-shell/src";
+
+@utility scrollbar-hide {
+    /* For Webkit-based browsers (Chrome, Safari and Opera) */
+    &::-webkit-scrollbar {
+        display: none;
+        -webkit-appearance: none;
+    }
+
+    /* For IE, Edge and Firefox */
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+}
+
+@utility transition-inherit-all {
+    transition-property: inherit;
+    transition-duration: inherit;
+    transition-timing-function: inherit;
+}
+
+:root {
+    font-family: var(--font-body);
+    color-scheme: light dark;
+}
+
+html,
+body {
+    margin: 0;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-variant-ligatures: contextual;
+    font-variant-ligatures: contextual;
+    -webkit-font-kerning: normal;
+    font-kerning: normal;
+}
+
+#root {
+    min-height: 100vh;
+}
+
+/* Hide the default expand arrow on Safari. */
+details summary::-webkit-details-marker {
+    display: none;
+}
+
+/* Hide default arrows from number inputs. */
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+/* Firefox */
+input[type="number"] {
+    -moz-appearance: textfield;
+}
+
+/* Hide the default clear button (X) from search inputs. */
+input[type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+}

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/web/client/tsconfig.app.json
+++ b/apps/web/client/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "../../../node_modules/.tmp/tsconfig.web-client.app.tsbuildinfo",
+    "types": ["vite/client"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/apps/web/client/tsconfig.json
+++ b/apps/web/client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/apps/web/client/tsconfig.node.json
+++ b/apps/web/client/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "../../../node_modules/.tmp/tsconfig.web-client.node.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/web/client/vite.config.ts
+++ b/apps/web/client/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import * as path from 'node:path'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    host: "0.0.0.0",
+    proxy: {
+      "/api": {
+        target: "http://localhost:21688",
+        changeOrigin: true,
+      },
+    },
+  },
+})

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@ora/app-shell",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@ora/ui": "workspace:*",
+    "@untitledui/icons": "^0.0.22"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/app-shell/src/app-shell.tsx
+++ b/packages/app-shell/src/app-shell.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { ChatView } from "./features/chat/chat-view";
+import { Sidebar } from "./features/sidebar/sidebar";
+import { CONVERSATIONS_STORAGE_KEY, useConversations } from "./hooks/use-conversations";
+import { CURRENT_USER } from "./lib/mock-data";
+import type { CurrentUser } from "./lib/types";
+
+interface AppShellProps {
+  user?: CurrentUser;
+}
+
+/** The main Ora application shell: sidebar + chat view with conversation state. */
+export function AppShell({ user = CURRENT_USER }: AppShellProps) {
+  const {
+    conversations,
+    activeId,
+    activeConversation,
+    isResponding,
+    newChat,
+    selectConversation,
+    sendMessage,
+    renameConversation,
+    removeConversation,
+  } = useConversations();
+
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+
+  const handleSignOut = () => {
+    try {
+      window.localStorage.removeItem(CONVERSATIONS_STORAGE_KEY);
+    } catch {
+      /* Storage may be unavailable; reload anyway. */
+    }
+    window.location.reload();
+  };
+
+  return (
+    <div className="flex h-dvh bg-primary text-primary">
+      <Sidebar
+        user={user}
+        conversations={conversations}
+        activeId={activeId}
+        collapsed={sidebarCollapsed}
+        onToggleCollapsed={() => setSidebarCollapsed((collapsed) => !collapsed)}
+        onNewChat={newChat}
+        onSelectConversation={selectConversation}
+        onRenameConversation={renameConversation}
+        onRemoveConversation={removeConversation}
+        onSignOut={handleSignOut}
+      />
+      <ChatView
+        active={activeConversation}
+        userName={user.name}
+        isResponding={isResponding}
+        onSend={sendMessage}
+        onNewChat={newChat}
+      />
+    </div>
+  );
+}

--- a/packages/app-shell/src/components/colored-avatar.tsx
+++ b/packages/app-shell/src/components/colored-avatar.tsx
@@ -1,0 +1,39 @@
+import { Avatar, cx } from "@ora/ui";
+import { getAvatarColor, getInitials } from "../lib/avatar";
+
+type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+
+// Mirrors the @ora/ui Avatar's internal initials text sizing so the colored
+// initials match the shell's scale when rendered via the `placeholder` slot.
+const INITIALS_TEXT: Record<AvatarSize, string> = {
+  xs: "text-xs",
+  sm: "text-sm",
+  md: "text-md",
+  lg: "text-lg",
+  xl: "text-xl",
+  "2xl": "text-display-xs",
+};
+
+interface ColoredAvatarProps {
+  name: string;
+  size?: AvatarSize;
+  className?: string;
+}
+
+/**
+ * A solid-color initials avatar (e.g. "Eric Wang" -> "EW") rendered on top of
+ * the @ora/ui Avatar shell. The background hue is picked deterministically
+ * from the name, and the initials use a darker shade of the same hue.
+ */
+export function ColoredAvatar({ name, size = "md", className }: ColoredAvatarProps) {
+  const { bg, fg } = getAvatarColor(name);
+  return (
+    <Avatar
+      size={size}
+      rounded
+      className={className}
+      contentClassName={bg}
+      placeholder={<span className={cx("font-semibold", INITIALS_TEXT[size], fg)}>{getInitials(name)}</span>}
+    />
+  );
+}

--- a/packages/app-shell/src/components/icon-button.tsx
+++ b/packages/app-shell/src/components/icon-button.tsx
@@ -1,0 +1,33 @@
+import type { FC } from "react";
+import { Button, cx } from "@ora/ui";
+
+interface IconButtonProps {
+  icon: FC<{ className?: string }>;
+  /** Accessible label for the button (it has no visible text). */
+  label: string;
+  onClick?: () => void;
+  color?: "tertiary" | "secondary" | "primary";
+  className?: string;
+  isDisabled?: boolean;
+}
+
+/**
+ * A compact square icon-only button built on the @ora/ui Button. Used for
+ * toolbar actions (new chat, toggle sidebar, copy, etc.) where a labeled
+ * button would be too heavy.
+ */
+export function IconButton({ icon: Icon, label, onClick, color = "tertiary", className, isDisabled }: IconButtonProps) {
+  return (
+    <Button
+      color={color}
+      size="sm"
+      aria-label={label}
+      onClick={onClick}
+      isDisabled={isDisabled}
+      noTextPadding
+      className={cx("size-8 shrink-0 p-0", className)}
+    >
+      <Icon className="size-[18px] text-fg-quaternary transition-inherit-all group-hover:text-fg-quaternary_hover" />
+    </Button>
+  );
+}

--- a/packages/app-shell/src/components/ora-mark.tsx
+++ b/packages/app-shell/src/components/ora-mark.tsx
@@ -1,0 +1,31 @@
+import { Avatar, cx } from "@ora/ui";
+import { AnnotationDots } from "@untitledui/icons";
+
+type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+
+const ICON_SIZE: Record<AvatarSize, string> = {
+  xs: "size-4",
+  sm: "size-5",
+  md: "size-6",
+  lg: "size-7",
+  xl: "size-8",
+  "2xl": "size-8",
+};
+
+interface OraMarkProps {
+  size?: AvatarSize;
+  className?: string;
+}
+
+/** The Ora brand mark: a brand-colored rounded square with a chat glyph. */
+export function OraMark({ size = "md", className }: OraMarkProps) {
+  return (
+    <Avatar
+      size={size}
+      rounded={false}
+      className={className}
+      contentClassName="bg-brand-solid"
+      placeholder={<AnnotationDots className={cx("text-white", ICON_SIZE[size])} />}
+    />
+  );
+}

--- a/packages/app-shell/src/features/chat/chat-view.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.tsx
@@ -1,0 +1,43 @@
+import { Edit01 } from "@untitledui/icons";
+import { IconButton } from "../../components/icon-button";
+import { Composer } from "./composer";
+import { EmptyState } from "./empty-state";
+import { MessageList } from "./message-list";
+import type { Conversation } from "../../lib/types";
+
+interface ChatViewProps {
+  active: Conversation | null;
+  userName: string;
+  isResponding: boolean;
+  onSend: (text: string) => void;
+  onNewChat: () => void;
+}
+
+/** The right pane: a centered empty composer, or a thread + composer. */
+export function ChatView({ active, userName, isResponding, onSend, onNewChat }: ChatViewProps) {
+  if (!active) {
+    return (
+      <main className="flex flex-1 flex-col bg-primary">
+        <EmptyState onSend={onSend} />
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex flex-1 flex-col bg-primary">
+      <header className="flex h-14 shrink-0 items-center gap-2 border-b border-secondary px-3">
+        <span className="truncate text-sm font-semibold text-primary">{active.title}</span>
+        <div className="flex-1" />
+        <IconButton icon={Edit01} label="New chat" onClick={onNewChat} />
+      </header>
+
+      <MessageList messages={active.messages} userName={userName} isResponding={isResponding} />
+
+      <div className="shrink-0 px-4 pb-4">
+        <div className="mx-auto w-full max-w-3xl">
+          <Composer onSend={onSend} isResponding={isResponding} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/packages/app-shell/src/features/chat/composer.tsx
+++ b/packages/app-shell/src/features/chat/composer.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { ArrowUp } from "@untitledui/icons";
+import { Button, TextArea } from "@ora/ui";
+
+interface ComposerProps {
+  onSend: (text: string) => void;
+  isResponding: boolean;
+  placeholder?: string;
+  autoFocus?: boolean;
+}
+
+/**
+ * The chat composer: a rounded input shell wrapping the @ora/ui TextArea with
+ * an inline send button. Enter sends, Shift+Enter inserts a newline, and the
+ * textarea auto-grows up to a max height.
+ */
+export function Composer({ onSend, isResponding, placeholder = "Message Ora…", autoFocus = false }: ComposerProps) {
+  const [value, setValue] = useState("");
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  const canSend = value.trim().length > 0 && !isResponding;
+
+  const submit = () => {
+    const text = value.trim();
+    if (!text || isResponding) return;
+    onSend(text);
+    setValue("");
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  // Auto-grow the textarea to fit its content, capped at a comfortable max.
+  useEffect(() => {
+    const el = textAreaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+  }, [value]);
+
+  return (
+    <div className="flex flex-col rounded-2xl bg-primary p-2 shadow-xs ring-1 ring-secondary transition focus-within:ring-2 focus-within:ring-brand">
+      <TextArea
+        textAreaRef={textAreaRef}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        value={value}
+        onChange={setValue}
+        onKeyDown={handleKeyDown}
+        textAreaClassName="resize-none rounded-none bg-transparent px-2 py-1.5 shadow-none ring-0 min-h-[28px] max-h-[200px]"
+      />
+      <div className="flex items-center justify-between pt-1">
+        <p className="px-2 text-xs text-quaternary">
+          Enter to send · <span className="text-tertiary">Shift+Enter for newline</span>
+        </p>
+        <Button
+          color="primary"
+          size="sm"
+          aria-label="Send message"
+          isDisabled={!canSend}
+          onClick={submit}
+          noTextPadding
+          className="size-8 rounded-full p-0"
+        >
+          <ArrowUp className="size-[18px] text-white" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-shell/src/features/chat/empty-state.tsx
+++ b/packages/app-shell/src/features/chat/empty-state.tsx
@@ -1,0 +1,41 @@
+import { OraMark } from "../../components/ora-mark";
+import { Composer } from "./composer";
+
+interface EmptyStateProps {
+  onSend: (text: string) => void;
+}
+
+const SUGGESTIONS = [
+  "Summarize the agent runtime refactor",
+  "Draft a layout for the web client",
+  "Explain how worktree cleanup works",
+  "Outline a test plan for session attach",
+];
+
+/** The centered landing view shown when no conversation is selected. */
+export function EmptyState({ onSend }: EmptyStateProps) {
+  return (
+    <div className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-10">
+      <div className="w-full max-w-2xl">
+        <div className="mb-6 flex flex-col items-center text-center">
+          <OraMark size="xl" className="mb-5" />
+          <h1 className="text-display-sm font-semibold text-primary">How can I help you today?</h1>
+          <p className="mt-2 text-md text-tertiary">Ask anything, or start from one of these.</p>
+        </div>
+        <Composer autoFocus onSend={onSend} isResponding={false} />
+        <div className="mt-4 flex flex-wrap justify-center gap-2">
+          {SUGGESTIONS.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              onClick={() => onSend(suggestion)}
+              className="rounded-full border border-secondary bg-primary px-3 py-1.5 text-sm text-secondary transition duration-100 hover:bg-primary_hover hover:text-secondary_hover"
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-shell/src/features/chat/message-bubble.tsx
+++ b/packages/app-shell/src/features/chat/message-bubble.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { Check, Copy07, ThumbsDown, ThumbsUp } from "@untitledui/icons";
+import { Button } from "@ora/ui";
+import { ColoredAvatar } from "../../components/colored-avatar";
+import { OraMark } from "../../components/ora-mark";
+import { formatClock } from "../../lib/format";
+import type { ChatMessage } from "../../lib/types";
+
+interface MessageBubbleProps {
+  message: ChatMessage;
+  userName: string;
+}
+
+/** Copies message content to the clipboard and briefly confirms with a check. */
+function useCopyMessage(content: string) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(content).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return { copied, copy };
+}
+
+/** A single chat message: avatar + content, with hover actions on replies. */
+export function MessageBubble({ message, userName }: MessageBubbleProps) {
+  const { copied, copy } = useCopyMessage(message.content);
+  const isUser = message.role === "user";
+
+  return (
+    <div className="group/message flex gap-3 py-4">
+      {isUser ? <ColoredAvatar name={userName} size="sm" /> : <OraMark size="sm" />}
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        {isUser ? (
+          <div className="w-fit max-w-full rounded-2xl bg-secondary px-3.5 py-2.5">
+            <p className="whitespace-pre-wrap break-words text-md text-primary">{message.content}</p>
+          </div>
+        ) : (
+          <p className="whitespace-pre-wrap break-words text-md text-primary">{message.content}</p>
+        )}
+
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-quaternary">{formatClock(message.createdAt)}</span>
+          {!isUser && (
+            <div className="flex items-center gap-0.5 opacity-0 transition duration-100 group-hover/message:opacity-100">
+              <Button color="tertiary" size="sm" aria-label="Copy" noTextPadding className="size-6 p-0" onClick={copy}>
+                {copied ? (
+                  <Check className="size-3.5 text-fg-success-secondary" />
+                ) : (
+                  <Copy07 className="size-3.5 text-fg-quaternary transition-inherit-all group-hover/message:text-fg-tertiary_hover" />
+                )}
+              </Button>
+              <Button color="tertiary" size="sm" aria-label="Good response" noTextPadding className="size-6 p-0">
+                <ThumbsUp className="size-3.5 text-fg-quaternary transition-inherit-all group-hover/message:text-fg-tertiary_hover" />
+              </Button>
+              <Button color="tertiary" size="sm" aria-label="Bad response" noTextPadding className="size-6 p-0">
+                <ThumbsDown className="size-3.5 text-fg-quaternary transition-inherit-all group-hover/message:text-fg-tertiary_hover" />
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <span className="sr-only">{isUser ? "You said" : "Assistant replied"}</span>
+    </div>
+  );
+}

--- a/packages/app-shell/src/features/chat/message-list.tsx
+++ b/packages/app-shell/src/features/chat/message-list.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+import { OraMark } from "../../components/ora-mark";
+import { MessageBubble } from "./message-bubble";
+import type { ChatMessage } from "../../lib/types";
+
+interface MessageListProps {
+  messages: ChatMessage[];
+  userName: string;
+  isResponding: boolean;
+}
+
+/** The scrollable message thread, kept pinned to the latest message. */
+export function MessageList({ messages, userName, isResponding }: MessageListProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Keep the latest message in view as the thread grows or the assistant "types".
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages.length, isResponding]);
+
+  return (
+    <div ref={scrollRef} className="scrollbar-hide flex-1 overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl px-4">
+        {messages.map((message) => (
+          <MessageBubble key={message.id} message={message} userName={userName} />
+        ))}
+        {isResponding && <TypingIndicator />}
+        <div className="h-4" />
+      </div>
+    </div>
+  );
+}
+
+/** Three bouncing dots shown while the assistant prepares a reply. */
+function TypingIndicator() {
+  return (
+    <div className="flex gap-3 py-4" aria-label="Assistant is typing">
+      <OraMark size="sm" />
+      <div className="flex items-center gap-1 py-2.5">
+        <span className="size-2 animate-bounce rounded-full bg-fg-quaternary" style={{ animationDelay: "0ms" }} />
+        <span className="size-2 animate-bounce rounded-full bg-fg-quaternary" style={{ animationDelay: "150ms" }} />
+        <span className="size-2 animate-bounce rounded-full bg-fg-quaternary" style={{ animationDelay: "300ms" }} />
+      </div>
+    </div>
+  );
+}

--- a/packages/app-shell/src/features/sidebar/conversation-item.tsx
+++ b/packages/app-shell/src/features/sidebar/conversation-item.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import { DotsVertical, MessageSquare02, Pencil01, Trash01 } from "@untitledui/icons";
+import { Button, Dropdown, Input, cx } from "@ora/ui";
+import type { Conversation } from "../../lib/types";
+
+interface ConversationItemProps {
+  conversation: Conversation;
+  active: boolean;
+  onSelect: () => void;
+  onRename: (title: string) => void;
+  onRemove: () => void;
+}
+
+/**
+ * A single sidebar conversation row: title, active highlight, and a hover
+ * affordance to rename or delete. Double-clicking the title enters rename mode.
+ */
+export function ConversationItem({ conversation, active, onSelect, onRename, onRemove }: ConversationItemProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(conversation.title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus and select the title text when entering rename mode.
+  useEffect(() => {
+    if (editing) inputRef.current?.select();
+  }, [editing]);
+
+  const startEdit = () => {
+    setDraft(conversation.title);
+    setEditing(true);
+  };
+
+  const commit = () => {
+    const next = draft.trim();
+    if (next && next !== conversation.title) onRename(next);
+    else setDraft(conversation.title);
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    setDraft(conversation.title);
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <Input
+        ref={inputRef}
+        size="sm"
+        aria-label="Rename conversation"
+        value={draft}
+        onChange={setDraft}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            commit();
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            cancel();
+          }
+        }}
+        onBlur={commit}
+      />
+    );
+  }
+
+  return (
+    <div className="group relative">
+      <button
+        type="button"
+        onClick={onSelect}
+        onDoubleClick={startEdit}
+        aria-current={active ? "true" : undefined}
+        className={cx(
+          "flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm font-medium transition duration-100 ease-linear",
+          active ? "bg-quaternary text-primary" : "text-secondary hover:bg-primary_hover hover:text-secondary_hover",
+        )}
+      >
+        <MessageSquare02 className="size-[18px] shrink-0 stroke-[1.75px] text-fg-quaternary" />
+        <span className="flex-1 truncate">{conversation.title}</span>
+      </button>
+
+      <div className={cx("absolute right-1 top-1/2 -translate-y-1/2", !active && "opacity-0 group-hover:opacity-100")}>
+        <Dropdown.Root>
+          <Button color="tertiary" size="sm" aria-label="Conversation options" noTextPadding className="size-7 p-0">
+            <DotsVertical className="size-4 text-fg-quaternary transition-inherit-all group-hover:text-fg-quaternary_hover" />
+          </Button>
+          <Dropdown.Popover className="w-48">
+            <Dropdown.Menu>
+              <Dropdown.Item label="Rename" icon={Pencil01} onAction={startEdit} />
+              <Dropdown.Item label="Delete" icon={Trash01} onAction={onRemove} />
+            </Dropdown.Menu>
+          </Dropdown.Popover>
+        </Dropdown.Root>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-shell/src/features/sidebar/sidebar.tsx
+++ b/packages/app-shell/src/features/sidebar/sidebar.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from "react";
+import { Edit01, Menu04, SearchMd } from "@untitledui/icons";
+import { Input } from "@ora/ui";
+import { IconButton } from "../../components/icon-button";
+import { ConversationItem } from "./conversation-item";
+import { UserProfile } from "./user-profile";
+import { groupConversationsByDate } from "../../lib/grouping";
+import type { Conversation, CurrentUser } from "../../lib/types";
+
+interface SidebarProps {
+  user: CurrentUser;
+  conversations: Conversation[];
+  activeId: string | null;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  onNewChat: () => void;
+  onSelectConversation: (id: string) => void;
+  onRenameConversation: (id: string, title: string) => void;
+  onRemoveConversation: (id: string) => void;
+  onSignOut: () => void;
+}
+
+/** The collapsible left rail: new chat, search, date-grouped history, user footer. */
+export function Sidebar({
+  user,
+  conversations,
+  activeId,
+  collapsed,
+  onToggleCollapsed,
+  onNewChat,
+  onSelectConversation,
+  onRenameConversation,
+  onRemoveConversation,
+  onSignOut,
+}: SidebarProps) {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return conversations;
+    return conversations.filter((c) => c.title.toLowerCase().includes(needle));
+  }, [conversations, query]);
+
+  const groups = useMemo(() => groupConversationsByDate(filtered, Date.now()), [filtered]);
+
+  if (collapsed) {
+    return (
+      <aside className="flex h-dvh w-16 shrink-0 flex-col items-center gap-2 border-r border-secondary bg-secondary py-2">
+        <IconButton icon={Edit01} label="New chat" onClick={onNewChat} />
+        <IconButton icon={Menu04} label="Open sidebar" onClick={onToggleCollapsed} />
+        <div className="flex-1" />
+        <UserProfile user={user} compact onSignOut={onSignOut} />
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="flex h-dvh w-72 shrink-0 flex-col border-r border-secondary bg-secondary">
+      <div className="flex items-center justify-between px-2 pt-2">
+        <IconButton icon={Edit01} label="New chat" onClick={onNewChat} />
+        <IconButton icon={Menu04} label="Collapse sidebar" onClick={onToggleCollapsed} />
+      </div>
+
+      <div className="px-2 pt-2">
+        <Input size="sm" icon={SearchMd} placeholder="Search conversations" value={query} onChange={setQuery} />
+      </div>
+
+      <nav className="scrollbar-hide mt-1 flex-1 overflow-y-auto px-2 py-1">
+        {groups.length === 0 ? (
+          <p className="px-2 py-6 text-center text-sm text-tertiary">No conversations found.</p>
+        ) : (
+          groups.map((group) => (
+            <section key={group.label} className="mb-1">
+              <p className="px-2 py-1 text-xs font-semibold text-quaternary">{group.label}</p>
+              <div className="space-y-px">
+                {group.conversations.map((conversation) => (
+                  <ConversationItem
+                    key={conversation.id}
+                    conversation={conversation}
+                    active={conversation.id === activeId}
+                    onSelect={() => onSelectConversation(conversation.id)}
+                    onRename={(title) => onRenameConversation(conversation.id, title)}
+                    onRemove={() => onRemoveConversation(conversation.id)}
+                  />
+                ))}
+              </div>
+            </section>
+          ))
+        )}
+      </nav>
+
+      <div className="border-t border-secondary p-2">
+        <UserProfile user={user} onSignOut={onSignOut} />
+      </div>
+    </aside>
+  );
+}

--- a/packages/app-shell/src/features/sidebar/user-profile.tsx
+++ b/packages/app-shell/src/features/sidebar/user-profile.tsx
@@ -1,0 +1,45 @@
+import { ChevronDown, Settings04, UserLeft01 } from "@untitledui/icons";
+import { Button, Dropdown } from "@ora/ui";
+import { ColoredAvatar } from "../../components/colored-avatar";
+import type { CurrentUser } from "../../lib/types";
+
+interface UserProfileProps {
+  user: CurrentUser;
+  /** Renders only the avatar — used when the sidebar is collapsed. */
+  compact?: boolean;
+  onSignOut?: () => void;
+}
+
+/**
+ * The sidebar footer user chip. Expanded it shows the colored avatar, name,
+ * and email; collapsed it shows just the avatar. Both open a small account
+ * menu (Settings / Log out).
+ */
+export function UserProfile({ user, compact = false, onSignOut }: UserProfileProps) {
+  const trigger = compact ? (
+    <Button color="tertiary" size="sm" aria-label={`${user.name} account`} noTextPadding className="size-9 p-0 rounded-full">
+      <ColoredAvatar name={user.name} size="sm" />
+    </Button>
+  ) : (
+    <Button color="tertiary" size="sm" aria-label={`${user.name} account`} noTextPadding className="w-full justify-start gap-2 p-1.5">
+      <ColoredAvatar name={user.name} size="sm" />
+      <span className="flex min-w-0 flex-1 flex-col text-left">
+        <span className="truncate text-sm font-semibold text-primary">{user.name}</span>
+        <span className="truncate text-xs text-tertiary">{user.email}</span>
+      </span>
+      <ChevronDown className="size-4 shrink-0 text-fg-quaternary" />
+    </Button>
+  );
+
+  return (
+    <Dropdown.Root>
+      {trigger}
+      <Dropdown.Popover className="w-60">
+        <Dropdown.Menu>
+          <Dropdown.Item label="Settings" icon={Settings04} />
+          <Dropdown.Item label="Log out" icon={UserLeft01} onAction={onSignOut} />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown.Root>
+  );
+}

--- a/packages/app-shell/src/hooks/use-conversations.ts
+++ b/packages/app-shell/src/hooks/use-conversations.ts
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ChatMessage, Conversation } from "../lib/types";
+import { createAssistantReply, createId, createSeedConversations, deriveTitle } from "../lib/mock-data";
+
+/** localStorage key under which the prototype persists its conversation state. */
+export const CONVERSATIONS_STORAGE_KEY = "ora.web-client.conversations.v1";
+const REPLY_DELAY_MS = 650;
+
+interface PersistedState {
+  conversations: Conversation[];
+  activeId: string | null;
+}
+
+/** Reads persisted state, seeding fresh conversations when storage is empty or corrupt. */
+function loadPersisted(now: number): PersistedState {
+  if (typeof window === "undefined") return { conversations: createSeedConversations(now), activeId: null };
+  try {
+    const raw = window.localStorage.getItem(CONVERSATIONS_STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as PersistedState;
+      if (Array.isArray(parsed.conversations)) return parsed;
+    }
+  } catch {
+    /* Ignore corrupt storage and fall back to seed data. */
+  }
+  return { conversations: createSeedConversations(now), activeId: null };
+}
+
+export interface UseConversations {
+  conversations: Conversation[];
+  activeId: string | null;
+  activeConversation: Conversation | null;
+  isResponding: boolean;
+  newChat: () => void;
+  selectConversation: (id: string) => void;
+  sendMessage: (text: string) => void;
+  renameConversation: (id: string, title: string) => void;
+  removeConversation: (id: string) => void;
+}
+
+/**
+ * Owns the conversation list and active selection for the prototype, mirroring
+ * state to `localStorage` and simulating an assistant reply after a short delay.
+ */
+export function useConversations(): UseConversations {
+  // Load once per mount; refs reset between StrictMode remounts, which is harmless.
+  const persistedRef = useRef<PersistedState | null>(null);
+  if (persistedRef.current === null) persistedRef.current = loadPersisted(Date.now());
+
+  const [conversations, setConversations] = useState<Conversation[]>(persistedRef.current.conversations);
+  const [activeId, setActiveId] = useState<string | null>(persistedRef.current.activeId);
+  const [isResponding, setIsResponding] = useState(false);
+
+  // Refs mirror state so stable callbacks and the reply timeout read fresh values.
+  const activeIdRef = useRef(activeId);
+  const isRespondingRef = useRef(isResponding);
+  const replyTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    activeIdRef.current = activeId;
+  }, [activeId]);
+  useEffect(() => {
+    isRespondingRef.current = isResponding;
+  }, [isResponding]);
+
+  // Persist on every change.
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(CONVERSATIONS_STORAGE_KEY, JSON.stringify({ conversations, activeId }));
+    } catch {
+      /* Storage may be unavailable (private mode); the prototype still works in-memory. */
+    }
+  }, [conversations, activeId]);
+
+  // Cancel a pending reply if the component unmounts mid-response.
+  useEffect(() => {
+    return () => {
+      if (replyTimeoutRef.current !== null) window.clearTimeout(replyTimeoutRef.current);
+    };
+  }, []);
+
+  const newChat = useCallback(() => {
+    activeIdRef.current = null;
+    setActiveId(null);
+  }, []);
+
+  const selectConversation = useCallback((id: string) => {
+    activeIdRef.current = id;
+    setActiveId(id);
+  }, []);
+
+  const sendMessage = useCallback((text: string) => {
+    const content = text.trim();
+    if (!content || isRespondingRef.current) return;
+
+    const now = Date.now();
+    const userMessage: ChatMessage = { id: createId(), role: "user", content, createdAt: now };
+
+    const currentActiveId = activeIdRef.current;
+    // Capture the id the reply must land in, whether we reuse or create a conversation.
+    const targetId = currentActiveId ?? createId();
+
+    if (currentActiveId) {
+      setConversations((prev) =>
+        prev.map((c) => (c.id === currentActiveId ? { ...c, messages: [...c.messages, userMessage], updatedAt: now } : c)),
+      );
+    } else {
+      const conversation: Conversation = {
+        id: targetId,
+        title: deriveTitle(content),
+        messages: [userMessage],
+        createdAt: now,
+        updatedAt: now,
+      };
+      activeIdRef.current = targetId;
+      setActiveId(targetId);
+      setConversations((prev) => [conversation, ...prev]);
+    }
+
+    setIsResponding(true);
+    isRespondingRef.current = true;
+
+    replyTimeoutRef.current = window.setTimeout(() => {
+      const replyAt = Date.now();
+      const assistantMessage: ChatMessage = {
+        id: createId(),
+        role: "assistant",
+        content: createAssistantReply(content),
+        createdAt: replyAt,
+      };
+      setConversations((prev) =>
+        prev.map((c) => (c.id === targetId ? { ...c, messages: [...c.messages, assistantMessage], updatedAt: replyAt } : c)),
+      );
+      setIsResponding(false);
+      isRespondingRef.current = false;
+      replyTimeoutRef.current = null;
+    }, REPLY_DELAY_MS);
+  }, []);
+
+  const renameConversation = useCallback((id: string, title: string) => {
+    const next = title.trim();
+    if (!next) return;
+    setConversations((prev) => prev.map((c) => (c.id === id ? { ...c, title: next } : c)));
+  }, []);
+
+  const removeConversation = useCallback((id: string) => {
+    setConversations((prev) => prev.filter((c) => c.id !== id));
+    if (activeIdRef.current === id) {
+      activeIdRef.current = null;
+      setActiveId(null);
+    }
+  }, []);
+
+  const activeConversation = useMemo(
+    () => conversations.find((c) => c.id === activeId) ?? null,
+    [conversations, activeId],
+  );
+
+  return {
+    conversations,
+    activeId,
+    activeConversation,
+    isResponding,
+    newChat,
+    selectConversation,
+    sendMessage,
+    renameConversation,
+    removeConversation,
+  };
+}

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -1,0 +1,1 @@
+export { AppShell } from "./app-shell";

--- a/packages/app-shell/src/lib/avatar.ts
+++ b/packages/app-shell/src/lib/avatar.ts
@@ -1,0 +1,47 @@
+/** A paired background + foreground for a colored initials avatar. */
+export interface AvatarColor {
+  /** Tailwind background utility for the avatar chip. */
+  bg: string;
+  /** Tailwind text utility for the initials, a darker shade of the same hue. */
+  fg: string;
+}
+
+// A fixed palette of solid backgrounds paired with a darker shade of the same
+// hue for the initials. The class strings are static so Tailwind v4 generates
+// them; the actual hue is selected deterministically from the name.
+const AVATAR_PALETTE: readonly AvatarColor[] = [
+  { bg: "bg-blue-500", fg: "text-blue-900" },
+  { bg: "bg-emerald-500", fg: "text-emerald-900" },
+  { bg: "bg-violet-500", fg: "text-violet-900" },
+  { bg: "bg-amber-500", fg: "text-amber-900" },
+  { bg: "bg-rose-500", fg: "text-rose-900" },
+  { bg: "bg-teal-500", fg: "text-teal-900" },
+  { bg: "bg-indigo-500", fg: "text-indigo-900" },
+  { bg: "bg-orange-500", fg: "text-orange-900" },
+];
+
+/**
+ * Picks a stable palette color for the given name so the same user always
+ * renders the same avatar color across sessions.
+ */
+export function getAvatarColor(name: string): AvatarColor {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length]!;
+}
+
+/**
+ * Extracts up to two initials from a display name.
+ * "Eric Wang" -> "EW", "Ada" -> "A", "" -> "".
+ */
+export function getInitials(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  const first = parts[0] ?? "";
+  // Use the last token for the second initial so "Eric Q. Wang" -> "EW".
+  const second = parts.length > 1 ? parts[parts.length - 1] : "";
+  return (first.charAt(0) + second.charAt(0)).toUpperCase();
+}

--- a/packages/app-shell/src/lib/format.ts
+++ b/packages/app-shell/src/lib/format.ts
@@ -1,0 +1,21 @@
+/** Formats an epoch-ms timestamp as a short local clock time, e.g. "3:45 PM". */
+export function formatClock(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/** Formats an epoch-ms timestamp as a short relative label, e.g. "2h ago". */
+export function formatRelativeTime(timestamp: number, now: number): string {
+  const elapsed = Math.max(0, now - timestamp);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (elapsed < minute) return "just now";
+  if (elapsed < hour) return `${Math.floor(elapsed / minute)}m ago`;
+  if (elapsed < day) return `${Math.floor(elapsed / hour)}h ago`;
+  if (elapsed < 7 * day) return `${Math.floor(elapsed / day)}d ago`;
+  return new Date(timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}

--- a/packages/app-shell/src/lib/grouping.ts
+++ b/packages/app-shell/src/lib/grouping.ts
@@ -1,0 +1,48 @@
+import type { Conversation } from "./types";
+
+/** A labeled bucket of conversations rendered as a sidebar section. */
+export interface ConversationGroup {
+  label: string;
+  conversations: Conversation[];
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/** Returns the epoch ms of midnight local time for the given timestamp. */
+function startOfDay(timestamp: number): number {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+/**
+ * Buckets conversations by recency of `updatedAt` into ChatGPT-style sidebar
+ * sections (Today, Yesterday, Previous 7 Days, …). Each bucket is sorted
+ * newest-first; empty buckets are omitted.
+ */
+export function groupConversationsByDate(
+  conversations: Conversation[],
+  now: number,
+): ConversationGroup[] {
+  const todayStart = startOfDay(now);
+  const buckets = [
+    { label: "Today", min: todayStart, max: todayStart + DAY, items: [] as Conversation[] },
+    { label: "Yesterday", min: todayStart - DAY, max: todayStart, items: [] as Conversation[] },
+    { label: "Previous 7 Days", min: todayStart - 7 * DAY, max: todayStart - DAY, items: [] as Conversation[] },
+    { label: "Previous 30 Days", min: todayStart - 30 * DAY, max: todayStart - 7 * DAY, items: [] as Conversation[] },
+    { label: "Older", min: Number.NEGATIVE_INFINITY, max: todayStart - 30 * DAY, items: [] as Conversation[] },
+  ];
+
+  for (const conversation of conversations) {
+    const bucket = buckets.find((b) => conversation.updatedAt >= b.min && conversation.updatedAt < b.max);
+    (bucket ?? buckets[buckets.length - 1]!).items.push(conversation);
+  }
+
+  for (const bucket of buckets) {
+    bucket.items.sort((a, z) => z.updatedAt - a.updatedAt);
+  }
+
+  return buckets
+    .filter((bucket) => bucket.items.length > 0)
+    .map(({ label, items }) => ({ label, conversations: items }));
+}

--- a/packages/app-shell/src/lib/mock-data.ts
+++ b/packages/app-shell/src/lib/mock-data.ts
@@ -1,0 +1,114 @@
+import type { ChatMessage, Conversation, CurrentUser, Role } from "./types";
+
+/** The signed-in user rendered in the sidebar footer. */
+export const CURRENT_USER: CurrentUser = {
+  name: "Eric Wang",
+  email: "eric@ora.dev",
+};
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** Generates a fresh id for client-created entities. */
+export function createId(): string {
+  return crypto.randomUUID();
+}
+
+/** Builds a message offset from a conversation's base time. */
+function message(role: Role, content: string, createdAt: number): ChatMessage {
+  return { id: createId(), role, content, createdAt };
+}
+
+/** Builds a seed conversation with messages spaced a few minutes apart. */
+function seedConversation(
+  id: string,
+  title: string,
+  base: number,
+  exchanges: Array<[user: string, assistant: string]>,
+): Conversation {
+  const messages: ChatMessage[] = [];
+  let cursor = base;
+  for (const [userText, assistantText] of exchanges) {
+    messages.push(message("user", userText, cursor));
+    cursor += 2 * MINUTE;
+    messages.push(message("assistant", assistantText, cursor));
+    cursor += 4 * MINUTE;
+  }
+  return {
+    id,
+    title,
+    messages,
+    createdAt: base,
+    updatedAt: messages[messages.length - 1]!.createdAt,
+  };
+}
+
+/**
+ * Seed conversations used on first load (before the user creates any of their
+ * own). Timestamps are computed relative to load time so the sidebar's date
+ * buckets stay meaningful as days pass.
+ */
+export function createSeedConversations(now: number): Conversation[] {
+  return [
+    seedConversation("seed-runtime", "Refactor the agent runtime", now - 2 * HOUR, [
+      [
+        "Can we split the agent loop out of the session handler?",
+        "Yes — extracting an `AgentLoop` trait behind the session handler keeps the transport concerns separate from the step orchestration. I'd start by moving `advance_step` and its retry policy into the new module.",
+      ],
+      [
+        "What about the streaming channel?",
+        "Keep it on the session side for now. The loop should accept an opaque `EventSink` so we can swap transports without touching the step logic.",
+      ],
+    ]),
+    seedConversation("seed-web-client", "Design the web client layout", now - 5 * HOUR, [
+      [
+        "Draft a layout for the web client.",
+        "A collapsible conversation sidebar on the left and a centered composer on the right mirrors the ChatGPT flow and keeps the focus on the conversation.",
+      ],
+    ]),
+    seedConversation("seed-worktree", "Investigate the worktree leak", now - 26 * HOUR, [
+      [
+        "We're leaking worktrees when a task is cancelled mid-flight.",
+        "The cancellation path drops the worktree handle before the agent finishes flushing. Moving cleanup into a `Drop` guard on the task context should close that gap.",
+      ],
+    ]),
+    seedConversation("seed-contracts", "Draft contracts for sessions", now - 4 * DAY, [
+      [
+        "What does the session contract need to expose?",
+        "Status, the owning task, and the agent session id. The terminal attach route stays a separate WebSocket concern.",
+      ],
+    ]),
+    seedConversation("seed-tauri", "Set up Tauri capabilities", now - 20 * DAY, [
+      [
+        "Which capabilities does the desktop shell need?",
+        "Filesystem scope for the project root and a window-event channel. Everything else stays behind the HTTP API so the web client can reuse it verbatim.",
+      ],
+    ]),
+  ];
+}
+
+const ASSISTANT_REPLIES: ReadonlyArray<(prompt: string) => string> = [
+  (prompt) => `Got it — here's how I'd approach "${truncate(prompt, 80)}": break it into the smallest reversible step, ship that, then iterate. Want me to draft the first change?`,
+  () => "Makes sense. I'll start by reproducing the current behavior with a small test, then make the change behind that test so we can verify it end-to-end.",
+  () => "Good question. The short answer is to keep the transport out of the orchestration layer — accept an event sink and let the caller decide how to render it. Want me to sketch the interface?",
+  () => "I can take that on. I'll open a worktree, make the change, and run the full suite before reporting back. Anything specific you want me to watch for?",
+  () => "Here's a first pass. It keeps the public API the same and moves the tricky bit into a small pure function so it's easy to unit-test in isolation.",
+];
+
+/** Returns a deterministic-ish canned reply for a user prompt (prototype only). */
+export function createAssistantReply(prompt: string): string {
+  const reply = ASSISTANT_REPLIES[Math.floor(prompt.length % ASSISTANT_REPLIES.length)]!;
+  return reply(prompt);
+}
+
+/** Derives a human-readable title from the first user message of a conversation. */
+export function deriveTitle(firstMessage: string): string {
+  const trimmed = firstMessage.trim().replace(/\s+/g, " ");
+  if (trimmed.length <= 42) return trimmed || "New chat";
+  return `${trimmed.slice(0, 42).trimEnd()}…`;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max).trimEnd()}…`;
+}

--- a/packages/app-shell/src/lib/types.ts
+++ b/packages/app-shell/src/lib/types.ts
@@ -1,0 +1,27 @@
+/** Roles a chat message can originate from. */
+export type Role = "user" | "assistant";
+
+/** A single message inside a conversation. */
+export interface ChatMessage {
+  id: string;
+  role: Role;
+  content: string;
+  /** Epoch milliseconds at which the message was created. */
+  createdAt: number;
+}
+
+/** A conversation thread, ordered oldest-to-newest by `messages[].createdAt`. */
+export interface Conversation {
+  id: string;
+  title: string;
+  messages: ChatMessage[];
+  createdAt: number;
+  /** Last activity, used for sidebar ordering and date grouping. */
+  updatedAt: number;
+}
+
+/** The signed-in user surfaced in the sidebar footer. */
+export interface CurrentUser {
+  name: string;
+  email: string;
+}

--- a/packages/app-shell/tsconfig.json
+++ b/packages/app-shell/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@react-aria/utils": "^3.0.0",
     "@react-stately/utils": "^3.0.0",
+    "@react-types/shared": "^3.36.0",
     "@untitledui/file-icons": "^0.0.9",
     "@untitledui/icons": "^0.0.22",
     "react-aria": "^3.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,61 @@ importers:
         specifier: ^8.0.10
         version: 8.0.11(@types/node@24.12.3)(jiti@2.7.0)
 
+  apps/web/client:
+    dependencies:
+      '@ora/app-shell':
+        specifier: workspace:*
+        version: link:../../../packages/app-shell
+      '@ora/ui':
+        specifier: workspace:*
+        version: link:../../../packages/ui
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.20(tailwindcss@4.3.0)
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.3.0(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
+      '@untitledui/icons':
+        specifier: ^0.0.22
+        version: 0.0.22(react@19.2.6)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.6(react@19.2.6)
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.3.0
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@4.3.0)
+      tailwindcss-react-aria-components:
+        specifier: ^2.0.1
+        version: 2.2.0(tailwindcss@4.3.0)
+    devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0))
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.11(@types/node@24.12.3)(jiti@2.7.0)
+
+  packages/app-shell:
+    dependencies:
+      '@ora/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@untitledui/icons':
+        specifier: ^0.0.22
+        version: 0.0.22(react@19.2.6)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.6(react@19.2.6)
+
   packages/contracts: {}
 
   packages/plugin-sdk:
@@ -101,6 +156,9 @@ importers:
       '@react-stately/utils':
         specifier: ^3.0.0
         version: 3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-types/shared':
+        specifier: ^3.36.0
+        version: 3.36.0(react@19.2.6)
       '@untitledui/file-icons':
         specifier: ^0.0.9
         version: 0.0.9(react@19.2.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'apps/*'
+  - 'apps/web/client'
   - 'packages/*'
 allowBuilds:
   msw: true


### PR DESCRIPTION
Move all feature components (chat, sidebar), shared components (colored-avatar, icon-button, ora-mark), hooks (use-conversations), and lib utilities from apps/web/client into packages/app-shell.

apps/web/client is now a thin entry layer that renders the AppShell component from @ora/app-shell.