### PR TITLE
refactor(task): move worktree provisioning into application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 name = "ora-application"
 version = "0.0.0"
 dependencies = [
+ "gitlancer",
  "ora-contracts",
  "ora-domain",
  "ora-logging",
@@ -1209,7 +1210,6 @@ version = "0.0.0"
 dependencies = [
  "axum",
  "futures-util",
- "gitlancer",
  "ora-application",
  "ora-contracts",
  "ora-db",

--- a/apps/web/server/Cargo.toml
+++ b/apps/web/server/Cargo.toml
@@ -9,7 +9,6 @@ path = "src/main.rs"
 
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
-gitlancer = { workspace = true }
 ora-application = { workspace = true }
 ora-db = { workspace = true }
 ora-contracts = { workspace = true }

--- a/apps/web/server/src/service/mod.rs
+++ b/apps/web/server/src/service/mod.rs
@@ -2,7 +2,6 @@ mod project;
 mod project_work_context;
 mod session;
 mod task;
-mod task_worktree;
 
 pub use project::ProjectApi;
 pub use project_work_context::ProjectWorkContextApi;

--- a/apps/web/server/src/service/task.rs
+++ b/apps/web/server/src/service/task.rs
@@ -1,8 +1,8 @@
 use crate::bootstrap::SystemClock;
-use crate::service::task_worktree::GitTaskWorktreeProvisioner;
 use ora_application::{
-    ApplicationError, CreateTaskHandler, DeleteTaskHandler, GetTaskHandler, ListTasksHandler,
-    UpdateTaskHandler, UuidTaskIdGenerator, UuidWorktreeIdGenerator,
+    ApplicationError, CreateTaskHandler, DeleteTaskHandler, GetTaskHandler,
+    GitTaskWorktreeProvisioner, ListTasksHandler, UpdateTaskHandler, UuidTaskIdGenerator,
+    UuidWorktreeIdGenerator,
 };
 use ora_contracts::{
     CreateTaskRequest, CreateTaskResponse, DeleteTaskRequest, DeleteTaskResponse, GetTaskRequest,

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
+gitlancer = { workspace = true }
 ora-contracts = { workspace = true }
 ora-domain = { workspace = true }
 ora-logging = { workspace = true }

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -24,9 +24,9 @@ pub use session::{
 };
 pub use task::{
     CreateTaskHandler, CreateTaskWorktreeRequest, DeleteTaskHandler, DeleteTaskWorktreeRequest,
-    GetTaskHandler, ListTasksHandler, TaskIdGenerator, TaskRepository, TaskRepositoryError,
-    TaskWorktreeDeletionMode, TaskWorktreeProvisioner, TaskWorktreeProvisionerError,
-    UpdateTaskHandler, UuidTaskIdGenerator,
+    GetTaskHandler, GitTaskWorktreeProvisioner, ListTasksHandler, TaskIdGenerator, TaskRepository,
+    TaskRepositoryError, TaskWorktreeDeletionMode, TaskWorktreeProvisioner,
+    TaskWorktreeProvisionerError, UpdateTaskHandler, UuidTaskIdGenerator,
 };
 pub use terminal::{
     AttachTerminalSessionHandler, CreateTerminalSessionHandler, HandleTerminalExitHandler,

--- a/crates/application/src/task/mod.rs
+++ b/crates/application/src/task/mod.rs
@@ -2,6 +2,7 @@ mod handlers;
 mod id_generator;
 mod mapper;
 mod ports;
+mod worktree_provisioner;
 
 #[cfg(test)]
 mod tests;
@@ -15,3 +16,4 @@ pub use ports::{
     TaskRepositoryError, TaskWorktreeDeletionMode, TaskWorktreeProvisioner,
     TaskWorktreeProvisionerError,
 };
+pub use worktree_provisioner::GitTaskWorktreeProvisioner;

--- a/crates/application/src/task/worktree_provisioner.rs
+++ b/crates/application/src/task/worktree_provisioner.rs
@@ -1,3 +1,7 @@
+use super::{
+    CreateTaskWorktreeRequest, DeleteTaskWorktreeRequest, TaskWorktreeDeletionMode,
+    TaskWorktreeProvisioner, TaskWorktreeProvisionerError,
+};
 use gitlancer::git::branch::ListBranchesRequest;
 use gitlancer::git::worktree::{
     CreateWorktreeRequest as GitCreateWorktreeRequest,
@@ -5,14 +9,10 @@ use gitlancer::git::worktree::{
     WorktreeDeletionMode as GitWorktreeDeletionMode,
 };
 use gitlancer::{BranchName, CliGitRunner, Git, RepoRoot, Repository, WorktreeRoot};
-use ora_application::{
-    CreateTaskWorktreeRequest, DeleteTaskWorktreeRequest, TaskWorktreeDeletionMode,
-    TaskWorktreeProvisioner, TaskWorktreeProvisionerError,
-};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Provisions and removes backend-owned task worktrees through the shared Git runtime.
+/// Provisions and removes application-owned task worktrees through the shared Git runtime.
 #[derive(Clone, Debug)]
 pub struct GitTaskWorktreeProvisioner {
     git: Git<CliGitRunner>,
@@ -49,7 +49,7 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
             })
     }
 
-    /// Creates one linked worktree and hides Git-specific diagnostics behind a stable application port.
+    /// Creates one linked worktree while keeping Git-specific diagnostics inside the application.
     fn create_task_worktree(
         &self,
         request: CreateTaskWorktreeRequest,
@@ -69,7 +69,7 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
             })
     }
 
-    /// Deletes one linked worktree and hides Git-specific diagnostics behind a stable application port.
+    /// Deletes one linked worktree while keeping Git-specific diagnostics inside the application.
     fn delete_task_worktree(
         &self,
         request: DeleteTaskWorktreeRequest,
@@ -104,7 +104,7 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
     }
 }
 
-/// Ensures the parent directory for a task-owned worktree exists before Git tries to populate it.
+/// Creates the parent eagerly because Git expects the worktree path's ancestor to exist.
 fn create_parent_directory(worktree_path: &Path) -> Result<(), TaskWorktreeProvisionerError> {
     match worktree_path.parent() {
         Some(parent_directory) => fs::create_dir_all(parent_directory).map_err(|_| {


### PR DESCRIPTION
Moves GitTaskWorktreeProvisioner and its gitlancer dependency from the web server into ora-application, leaving the server task service as a thin application-handler adapter. No behavior changes. Validation: cargo fmt --all -- --check; GNU cargo clippy --workspace -- -D warnings; GNU cargo test --workspace; TypeScript contract compilation and 7 contract tests. Closes #46.