### PR TITLE
feat(plugin-protocol): add protocol foundations (stack 1/7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ packages/contracts/.test-dist/
 /.data
 .tmp
 *.tsbuildinfo
+**/.test-dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ora-plugin-protocol"
+version = "0.0.0"
+dependencies = [
+ "pretty_assertions",
+ "semver",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "ts-rs",
+ "uuid",
+]
+
+[[package]]
 name = "ora-process"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/domain",
     "crates/gitlancer",
     "crates/logging",
+    "crates/plugin-protocol",
     "crates/process",
     "crates/pty",
     "xtask",
@@ -30,6 +31,7 @@ ora-db = { path = "crates/db" }
 ora-domain = { path = "crates/domain" }
 gitlancer = { path = "crates/gitlancer" }
 ora-logging = { path = "crates/logging" }
+ora-plugin-protocol = { path = "crates/plugin-protocol" }
 ora-process = { path = "crates/process" }
 ora-pty = { path = "crates/pty" }
 
@@ -43,6 +45,7 @@ r2d2 = "0.8"
 rusqlite = "0.37"
 serde = "1.0"
 serde_json = "1.0"
+semver = "1"
 serde_with = { version = "3" }
 tempfile = "3"
 thiserror = "2"

--- a/crates/plugin-protocol/Cargo.toml
+++ b/crates/plugin-protocol/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ora-plugin-protocol"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+name = "ora_plugin_protocol"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+ts-rs = { workspace = true, features = ["format"] }
+uuid = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/plugin-protocol/fixtures/v1/agent-contract-golden.json
+++ b/crates/plugin-protocol/fixtures/v1/agent-contract-golden.json
@@ -1,0 +1,91 @@
+{
+  "fixtureVersion": 1,
+  "contractVersion": 1,
+  "methods": [
+    {
+      "method": "agent.discoverInstallations",
+      "semantics": "idempotent",
+      "streaming": false,
+      "safetyControl": false
+    },
+    {
+      "method": "agent.getConfigurationSummary",
+      "semantics": "idempotent",
+      "streaming": false,
+      "safetyControl": false
+    },
+    {
+      "method": "agent.listSkills",
+      "semantics": "idempotent",
+      "streaming": false,
+      "safetyControl": false
+    },
+    {
+      "method": "agent.listMcpServers",
+      "semantics": "idempotent",
+      "streaming": false,
+      "safetyControl": false
+    },
+    {
+      "method": "agent.listConversations",
+      "semantics": "idempotent",
+      "streaming": false,
+      "safetyControl": false
+    },
+    {
+      "method": "agent.startConversation",
+      "semantics": "nonIdempotent",
+      "streaming": true,
+      "safetyControl": false
+    },
+    {
+      "method": "agent.sendMessage",
+      "semantics": "nonIdempotent",
+      "streaming": true,
+      "safetyControl": false
+    },
+    {
+      "method": "agent.cancelConversation",
+      "semantics": "idempotent",
+      "streaming": false,
+      "safetyControl": true
+    }
+  ],
+  "representativeValues": [
+    {
+      "name": "agentScope.global",
+      "value": {
+        "type": "global"
+      }
+    },
+    {
+      "name": "agentScope.project",
+      "value": {
+        "projectHandle": "project-1",
+        "type": "project",
+        "workingDirectory": "D:\\work"
+      }
+    },
+    {
+      "name": "agentEvent.textDelta",
+      "value": {
+        "channel": "assistant",
+        "kind": "textDelta",
+        "text": "你好"
+      }
+    },
+    {
+      "name": "cancelConversation.accepted",
+      "value": {
+        "disposition": "accepted"
+      }
+    },
+    {
+      "name": "businessError.authenticationRequired",
+      "value": {
+        "kind": "authenticationRequired",
+        "retryable": false
+      }
+    }
+  ]
+}

--- a/crates/plugin-protocol/fixtures/v1/frame-golden.json
+++ b/crates/plugin-protocol/fixtures/v1/frame-golden.json
@@ -1,0 +1,53 @@
+{
+  "fixtureVersion": 1,
+  "wireVersion": 1,
+  "maximumPayloadBytes": 8388608,
+  "valid": [
+    {
+      "frameType": "request",
+      "payloadUtf8": "{\"jsonrpc\":\"2.0\",\"id\":\"h:1\",\"method\":\"ping\",\"params\":{}}",
+      "payloadLen": 56,
+      "headerHex": "0000003801",
+      "frameHex": "00000038017b226a736f6e727063223a22322e30222c226964223a22683a31222c226d6574686f64223a2270696e67222c22706172616d73223a7b7d7d"
+    },
+    {
+      "frameType": "response",
+      "payloadUtf8": "{\"jsonrpc\":\"2.0\",\"id\":\"h:1\",\"result\":\"ok\"}",
+      "payloadLen": 42,
+      "headerHex": "0000002a02",
+      "frameHex": "0000002a027b226a736f6e727063223a22322e30222c226964223a22683a31222c22726573756c74223a226f6b227d"
+    },
+    {
+      "frameType": "notification",
+      "payloadUtf8": "{\"jsonrpc\":\"2.0\",\"method\":\"$/exit\"}",
+      "payloadLen": 35,
+      "headerHex": "0000002303",
+      "frameHex": "00000023037b226a736f6e727063223a22322e30222c226d6574686f64223a22242f65786974227d"
+    },
+    {
+      "frameType": "notification",
+      "payloadUtf8": "{\"jsonrpc\":\"2.0\",\"method\":\"$/stream\",\"params\":{\"id\":\"h:1\",\"seq\":1,\"value\":{\"kind\":\"textDelta\",\"text\":\"你好\"}}}",
+      "payloadLen": 112,
+      "headerHex": "0000007003",
+      "frameHex": "00000070037b226a736f6e727063223a22322e30222c226d6574686f64223a22242f73747265616d222c22706172616d73223a7b226964223a22683a31222c22736571223a312c2276616c7565223a7b226b696e64223a227465787444656c7461222c2274657874223a22e4bda0e5a5bd227d7d7d"
+    }
+  ],
+  "invalid": [
+    {
+      "frameHex": "0000000001",
+      "reason": "zeroLength"
+    },
+    {
+      "frameHex": "ffffffff01",
+      "reason": "negativeLength"
+    },
+    {
+      "frameHex": "0080000101",
+      "reason": "payloadTooLarge"
+    },
+    {
+      "frameHex": "000000027f",
+      "reason": "unknownType"
+    }
+  ]
+}

--- a/crates/plugin-protocol/src/agent/dto.rs
+++ b/crates/plugin-protocol/src/agent/dto.rs
@@ -1,0 +1,518 @@
+use super::leaf::{
+    AgentConfigurationKey, AgentConversationId, AgentCursor, AgentInstallationId, AgentPageLimit,
+    AgentPrompt, AgentResourceId, AgentToolCallId, AgentTurnId, ClientRequestId, FiniteJsonNumber,
+    HostResolvedAbsolutePath, JsonSafeU64, ProjectHandle, Rfc3339Timestamp, WorktreeHandle,
+    deserialize_optional_non_null,
+};
+use crate::AgentProviderId;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+/// The Host-issued invocation scope, resolved for every request rather than process-global state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentScope {
+    Global {},
+    Project {
+        project_handle: ProjectHandle,
+        working_directory: HostResolvedAbsolutePath,
+    },
+    Worktree {
+        project_handle: ProjectHandle,
+        worktree_handle: WorktreeHandle,
+        working_directory: HostResolvedAbsolutePath,
+    },
+}
+
+macro_rules! page_request {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        #[ts(export_to = "agent-contract.ts")]
+        pub struct $name {
+            pub provider_id: AgentProviderId,
+            pub installation_id: AgentInstallationId,
+            pub scope: AgentScope,
+            #[serde(
+                default,
+                skip_serializing_if = "Option::is_none",
+                deserialize_with = "deserialize_optional_non_null"
+            )]
+            #[ts(optional)]
+            pub cursor: Option<AgentCursor>,
+            pub limit: AgentPageLimit,
+        }
+    };
+}
+
+/// Requests discovery of provider installations in a Host-resolved scope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct DiscoverInstallationsRequest {
+    pub provider_id: AgentProviderId,
+    pub scope: AgentScope,
+}
+
+/// Requests a redacted configuration summary for one installation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct GetConfigurationSummaryRequest {
+    pub provider_id: AgentProviderId,
+    pub installation_id: AgentInstallationId,
+    pub scope: AgentScope,
+}
+
+page_request!(ListSkillsRequest);
+page_request!(ListMcpServersRequest);
+page_request!(ListConversationsRequest);
+
+/// Starts a conversation and carries the first non-idempotent prompt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct StartConversationRequest {
+    pub provider_id: AgentProviderId,
+    pub installation_id: AgentInstallationId,
+    pub scope: AgentScope,
+    pub client_request_id: ClientRequestId,
+    pub prompt: AgentPrompt,
+}
+
+/// Sends a non-idempotent prompt to an existing conversation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct SendMessageRequest {
+    pub provider_id: AgentProviderId,
+    pub installation_id: AgentInstallationId,
+    pub conversation_id: AgentConversationId,
+    pub scope: AgentScope,
+    pub client_request_id: ClientRequestId,
+    pub prompt: AgentPrompt,
+}
+
+/// Requests the safety-controlled termination of one active conversation turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct CancelConversationRequest {
+    pub provider_id: AgentProviderId,
+    pub installation_id: AgentInstallationId,
+    pub conversation_id: AgentConversationId,
+    pub scope: AgentScope,
+}
+
+/// Returns provider installations and non-fatal discovery diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct DiscoverInstallationsResponse {
+    pub installations: Vec<AgentInstallation>,
+    pub diagnostics: Vec<AgentDiscoveryDiagnostic>,
+}
+
+/// A safe display projection of one external Agent installation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentInstallation {
+    pub installation_id: AgentInstallationId,
+    pub display_name: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub version: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub location_display: Option<String>,
+    pub availability: AgentAvailability,
+}
+
+/// Distinguishes an available installation from a display-only unavailable result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentAvailability {
+    Available {},
+    Unavailable { reason: String },
+}
+
+/// A non-fatal discovery diagnostic with a bounded display message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentDiscoveryDiagnostic {
+    pub kind: AgentDiscoveryDiagnosticKind,
+    pub message: String,
+}
+
+/// The closed v1 set of discovery diagnostic categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentDiscoveryDiagnosticKind {
+    NotFound,
+    PermissionDenied,
+    ProbeFailed,
+}
+
+/// Returns configuration display items without secret values.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct GetConfigurationSummaryResponse {
+    pub items: Vec<AgentConfigurationItem>,
+}
+
+/// One redacted or display-safe configuration item.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentConfigurationItem {
+    pub key: AgentConfigurationKey,
+    pub display_name: String,
+    pub source: AgentResourceSource,
+    pub value: AgentConfigurationValue,
+}
+
+/// The only configuration value shapes allowed to cross the Agent contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentConfigurationValue {
+    Unset {},
+    Redacted {},
+    Boolean { value: bool },
+    Number { value: FiniteJsonNumber },
+    String { value: String },
+    StringList { value: Vec<String> },
+}
+
+/// A bounded page of safe skill summaries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct ListSkillsResponse {
+    pub items: Vec<AgentSkillSummary>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub next_cursor: Option<AgentCursor>,
+}
+
+/// A display-safe skill descriptor without executable content.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentSkillSummary {
+    pub id: AgentResourceId,
+    pub display_name: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub description: Option<String>,
+    pub source: AgentResourceSource,
+}
+
+/// A bounded page of safe MCP server summaries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct ListMcpServersResponse {
+    pub items: Vec<AgentMcpServerSummary>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub next_cursor: Option<AgentCursor>,
+}
+
+/// A display-only MCP server projection that excludes command, environment, and token data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentMcpServerSummary {
+    pub id: AgentResourceId,
+    pub display_name: String,
+    pub transport: AgentMcpTransport,
+    pub enabled: bool,
+    pub source: AgentResourceSource,
+}
+
+/// Identifies where a display resource originated without exposing a path authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentResourceSource {
+    User {},
+    Project {},
+    Worktree {},
+    BuiltIn {},
+    Unknown {
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "deserialize_optional_non_null"
+        )]
+        #[ts(optional)]
+        display: Option<String>,
+    },
+}
+
+/// The safe display categories for MCP transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentMcpTransport {
+    Stdio,
+    Http,
+    Sse,
+    Unknown,
+}
+
+/// A bounded page of conversation summaries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct ListConversationsResponse {
+    pub items: Vec<AgentConversationSummary>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub next_cursor: Option<AgentCursor>,
+}
+
+/// A display-safe conversation descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentConversationSummary {
+    pub conversation_id: AgentConversationId,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub title: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub updated_at: Option<Rfc3339Timestamp>,
+}
+
+/// The closed stream-event union for conversation methods.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentEvent {
+    ConversationStarted {
+        conversation_id: AgentConversationId,
+    },
+    TextDelta {
+        channel: AgentOutputChannel,
+        text: String,
+    },
+    Status {
+        phase: String,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "deserialize_optional_non_null"
+        )]
+        #[ts(optional)]
+        message: Option<String>,
+    },
+    ToolCall {
+        call_id: AgentToolCallId,
+        name: String,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "deserialize_optional_non_null"
+        )]
+        #[ts(optional)]
+        summary: Option<String>,
+    },
+    ToolResult {
+        call_id: AgentToolCallId,
+        is_error: bool,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "deserialize_optional_non_null"
+        )]
+        #[ts(optional)]
+        summary: Option<String>,
+    },
+    Usage {
+        usage: AgentUsage,
+    },
+}
+
+/// Identifies which display channel produced a streamed text delta.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentOutputChannel {
+    Assistant,
+    Reasoning,
+    Tool,
+}
+
+/// Optional bounded usage counters; validation requires at least one present field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentUsage {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub input_tokens: Option<JsonSafeU64>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub output_tokens: Option<JsonSafeU64>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub cost_micros: Option<JsonSafeU64>,
+}
+
+/// The terminal result returned by both streaming conversation methods.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentTurnResult {
+    pub conversation_id: AgentConversationId,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub turn_id: Option<AgentTurnId>,
+    pub finish_reason: AgentFinishReason,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional)]
+    pub usage: Option<AgentUsage>,
+}
+
+/// The only successful terminal reasons in Agent Contract v1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentFinishReason {
+    Completed,
+    Cancelled,
+    Limit,
+}
+
+/// Proves whether a safety cancellation stopped work or observed it already stopped.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct CancelConversationResponse {
+    pub disposition: CancelDisposition,
+}
+
+/// The exact success dispositions for the business safety method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "agent-contract.ts")]
+pub enum CancelDisposition {
+    Accepted,
+    AlreadyStopped,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AgentResourceSource, AgentScope, ListSkillsResponse};
+    use pretty_assertions::assert_eq;
+
+    /// Rejects explicit null for fields whose contract allows omission only.
+    #[test]
+    fn rejects_null_optional_fields() {
+        assert_eq!(
+            serde_json::from_str::<ListSkillsResponse>(r#"{"items":[],"nextCursor":null}"#)
+                .is_err(),
+            true
+        );
+        assert_eq!(
+            serde_json::from_str::<AgentResourceSource>(r#"{"type":"unknown","display":null}"#)
+                .is_err(),
+            true
+        );
+    }
+
+    /// Rejects unknown fields recursively in discriminated object unions.
+    #[test]
+    fn rejects_unknown_scope_fields() {
+        assert_eq!(
+            serde_json::from_str::<AgentScope>(r#"{"type":"global","cwd":"D:\\x"}"#).is_err(),
+            true
+        );
+    }
+}

--- a/crates/plugin-protocol/src/agent/leaf.rs
+++ b/crates/plugin-protocol/src/agent/leaf.rs
@@ -1,0 +1,436 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Display, Formatter};
+use std::marker::PhantomData;
+use std::str::FromStr;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use ts_rs::TS;
+use uuid::Uuid;
+
+pub const JSON_SAFE_U64_MAX: u64 = 9_007_199_254_740_991;
+pub const MAX_OPAQUE_ID_BYTES: usize = 256;
+pub const MAX_CONFIGURATION_KEY_BYTES: usize = 512;
+pub const MAX_WORKING_DIRECTORY_BYTES: usize = 32 * 1024;
+pub const MAX_AGENT_PROMPT_BYTES: usize = 1024 * 1024;
+
+/// Reports why a leaf Agent DTO cannot enter the closed v1 contract.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AgentLeafError {
+    #[error("{kind} must not be empty")]
+    Empty { kind: &'static str },
+    #[error("{kind} exceeds its {maximum}-byte limit")]
+    TooLong { kind: &'static str, maximum: usize },
+    #[error("{kind} has an invalid v1 format")]
+    InvalidFormat { kind: &'static str },
+    #[error("JSON integer {value} exceeds the JavaScript safe-integer range")]
+    JsonIntegerOutOfRange { value: u64 },
+    #[error("Agent page limit must be in 1..=100, got {value}")]
+    PageLimitOutOfRange { value: u64 },
+    #[error("finite JSON number is required")]
+    NonFiniteNumber,
+}
+
+macro_rules! agent_string_leaf {
+    ($name:ident, $kind:literal, $validator:expr) => {
+        #[doc = concat!("A validated ", $kind, " encoded as a transparent JSON string.")]
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, TS)]
+        #[serde(transparent)]
+        #[ts(export_to = "agent-contract.ts")]
+        pub struct $name(String);
+
+        impl $name {
+            #[doc = concat!("Validates and constructs a ", $kind, ".")]
+            pub fn parse(value: impl Into<String>) -> Result<Self, AgentLeafError> {
+                let value = value.into();
+                ($validator)(&value)?;
+                Ok(Self(value))
+            }
+
+            #[doc = concat!("Returns the validated ", $kind, " text.")]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = AgentLeafError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Self::parse(value)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::parse(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+agent_string_leaf!(
+    AgentInstallationId,
+    "Agent installation id",
+    validate_opaque_id
+);
+agent_string_leaf!(
+    AgentConversationId,
+    "Agent conversation id",
+    validate_opaque_id
+);
+agent_string_leaf!(AgentTurnId, "Agent turn id", validate_opaque_id);
+agent_string_leaf!(AgentCursor, "Agent cursor", validate_opaque_id);
+agent_string_leaf!(AgentResourceId, "Agent resource id", validate_opaque_id);
+agent_string_leaf!(AgentToolCallId, "Agent tool-call id", validate_opaque_id);
+agent_string_leaf!(ProjectHandle, "project handle", validate_opaque_id);
+agent_string_leaf!(WorktreeHandle, "worktree handle", validate_opaque_id);
+agent_string_leaf!(
+    AgentConfigurationKey,
+    "Agent configuration key",
+    validate_configuration_key
+);
+agent_string_leaf!(
+    ClientRequestId,
+    "client request id",
+    validate_client_request_id
+);
+agent_string_leaf!(
+    HostResolvedAbsolutePath,
+    "Host-resolved absolute path",
+    validate_windows_absolute_path
+);
+agent_string_leaf!(AgentPrompt, "Agent prompt", validate_prompt);
+agent_string_leaf!(Rfc3339Timestamp, "RFC 3339 timestamp", validate_rfc3339);
+
+/// A JavaScript-safe unsigned integer encoded as a JSON number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, TS)]
+#[serde(transparent)]
+#[ts(export_to = "agent-contract.ts")]
+#[ts(type = "number")]
+pub struct JsonSafeU64(u64);
+
+impl JsonSafeU64 {
+    /// Constructs a count that round-trips through JavaScript number without precision loss.
+    pub fn new(value: u64) -> Result<Self, AgentLeafError> {
+        if value > JSON_SAFE_U64_MAX {
+            return Err(AgentLeafError::JsonIntegerOutOfRange { value });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Returns the next value or fails closed at the protocol maximum.
+    pub fn checked_increment(self) -> Result<Self, AgentLeafError> {
+        let next = self
+            .0
+            .checked_add(1)
+            .ok_or(AgentLeafError::JsonIntegerOutOfRange { value: u64::MAX })?;
+        Self::new(next)
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonSafeU64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = u64::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A page size constrained to the Agent v1 maximum of one hundred items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, TS)]
+#[serde(transparent)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentPageLimit(u8);
+
+impl AgentPageLimit {
+    /// Validates the inclusive page limit boundary.
+    pub fn new(value: u64) -> Result<Self, AgentLeafError> {
+        if !(1..=100).contains(&value) {
+            return Err(AgentLeafError::PageLimitOutOfRange { value });
+        }
+        Ok(Self(value as u8))
+    }
+
+    pub fn get(self) -> u8 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentPageLimit {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = u64::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A finite floating-point value that can be represented by JSON.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, TS)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct FiniteJsonNumber(f64);
+
+impl FiniteJsonNumber {
+    /// Rejects NaN and infinities before a configuration value reaches serialization.
+    pub fn new(value: f64) -> Result<Self, AgentLeafError> {
+        if !value.is_finite() {
+            return Err(AgentLeafError::NonFiniteNumber);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> f64 {
+        self.0
+    }
+}
+
+impl Serialize for FiniteJsonNumber {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_f64(self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for FiniteJsonNumber {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = f64::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Deserializes an optional field while rejecting an explicitly supplied JSON null.
+pub(crate) fn deserialize_optional_non_null<'de, D, T>(
+    deserializer: D,
+) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    struct NonNullOptionVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> serde::de::Visitor<'de> for NonNullOptionVisitor<T>
+    where
+        T: Deserialize<'de>,
+    {
+        type Value = Option<T>;
+
+        fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("an omitted field or a non-null value")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Err(E::custom("explicit null is not allowed"))
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Err(E::custom("explicit null is not allowed"))
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            T::deserialize(deserializer).map(Some)
+        }
+    }
+
+    deserializer.deserialize_option(NonNullOptionVisitor(PhantomData))
+}
+
+/// Validates opaque plugin-produced identities without accepting path-like text.
+fn validate_opaque_id(value: &str) -> Result<(), AgentLeafError> {
+    validate_nonempty_length(value, "opaque Agent identity", MAX_OPAQUE_ID_BYTES)?;
+    if value.trim() != value
+        || value.chars().any(|character| {
+            character == '\0'
+                || character == '/'
+                || character == '\\'
+                || character == ':'
+                || character.is_control()
+        })
+    {
+        return Err(invalid("opaque Agent identity"));
+    }
+    Ok(())
+}
+
+/// Applies the dedicated, wider ASCII grammar for configuration keys.
+fn validate_configuration_key(value: &str) -> Result<(), AgentLeafError> {
+    validate_nonempty_length(
+        value,
+        "Agent configuration key",
+        MAX_CONFIGURATION_KEY_BYTES,
+    )?;
+    if !value.is_ascii()
+        || !value.as_bytes()[0].is_ascii_alphanumeric()
+        || value
+            .bytes()
+            .any(|byte| !(byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')))
+    {
+        return Err(invalid("Agent configuration key"));
+    }
+    Ok(())
+}
+
+/// Requires the Host-issued UUID to remain canonical lower-case hyphenated text.
+fn validate_client_request_id(value: &str) -> Result<(), AgentLeafError> {
+    validate_nonempty_length(value, "client request id", 36)?;
+    let parsed = Uuid::parse_str(value).map_err(|_| invalid("client request id"))?;
+    if parsed.hyphenated().to_string() != value {
+        return Err(invalid("client request id"));
+    }
+    Ok(())
+}
+
+/// Accepts canonical absolute Windows drive, UNC, and extended-length paths from the Host.
+fn validate_windows_absolute_path(value: &str) -> Result<(), AgentLeafError> {
+    validate_nonempty_length(
+        value,
+        "Host-resolved absolute path",
+        MAX_WORKING_DIRECTORY_BYTES,
+    )?;
+    if value.contains('\0') || !is_windows_absolute(value) {
+        return Err(invalid("Host-resolved absolute path"));
+    }
+    Ok(())
+}
+
+/// Preserves prompt whitespace while applying the v1 byte and NUL bounds.
+fn validate_prompt(value: &str) -> Result<(), AgentLeafError> {
+    validate_nonempty_length(value, "Agent prompt", MAX_AGENT_PROMPT_BYTES)?;
+    if value.contains('\0') {
+        return Err(invalid("Agent prompt"));
+    }
+    Ok(())
+}
+
+/// Uses the RFC 3339 parser and retains the authored offset form.
+fn validate_rfc3339(value: &str) -> Result<(), AgentLeafError> {
+    validate_nonempty_length(value, "RFC 3339 timestamp", 64)?;
+    if !value.is_ascii() || OffsetDateTime::parse(value, &Rfc3339).is_err() {
+        return Err(invalid("RFC 3339 timestamp"));
+    }
+    Ok(())
+}
+
+/// Recognizes Windows absolute path prefixes without consulting ambient filesystem state.
+fn is_windows_absolute(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    (bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/'))
+        || value.starts_with("\\\\")
+        || value.starts_with("//")
+}
+
+/// Applies a non-empty UTF-8 byte limit shared by Agent leaf types.
+fn validate_nonempty_length(
+    value: &str,
+    kind: &'static str,
+    maximum: usize,
+) -> Result<(), AgentLeafError> {
+    if value.is_empty() {
+        return Err(AgentLeafError::Empty { kind });
+    }
+    if value.len() > maximum {
+        return Err(AgentLeafError::TooLong { kind, maximum });
+    }
+    Ok(())
+}
+
+/// Builds a stable leaf-format failure without attacker-controlled detail.
+fn invalid(kind: &'static str) -> AgentLeafError {
+    AgentLeafError::InvalidFormat { kind }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AgentConfigurationKey, AgentInstallationId, AgentPageLimit, AgentPrompt, ClientRequestId,
+        FiniteJsonNumber, HostResolvedAbsolutePath, JSON_SAFE_U64_MAX, JsonSafeU64,
+        Rfc3339Timestamp,
+    };
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    /// Verifies leaf newtypes serialize as primitives rather than `{ value }` wrappers.
+    #[test]
+    fn serializes_leaf_types_as_json_primitives() {
+        let installation = AgentInstallationId::parse("install-1")
+            .unwrap_or_else(|error| panic!("expected installation id: {error}"));
+        let prompt = AgentPrompt::parse(" keep whitespace \n")
+            .unwrap_or_else(|error| panic!("expected prompt: {error}"));
+        let installation_json = serde_json::to_value(installation)
+            .unwrap_or_else(|error| panic!("expected installation serialization: {error}"));
+        let prompt_json = serde_json::to_value(prompt)
+            .unwrap_or_else(|error| panic!("expected prompt serialization: {error}"));
+        let count =
+            JsonSafeU64::new(1).unwrap_or_else(|error| panic!("expected safe count: {error}"));
+        let count_json = serde_json::to_value(count)
+            .unwrap_or_else(|error| panic!("expected count serialization: {error}"));
+        assert_eq!(installation_json, json!("install-1"));
+        assert_eq!(prompt_json, json!(" keep whitespace \n"));
+        assert_eq!(count_json, json!(1));
+    }
+
+    /// Covers the explicit numeric, UUID, path, key, and timestamp boundaries.
+    #[test]
+    fn validates_agent_leaf_boundaries() {
+        assert!(JsonSafeU64::new(JSON_SAFE_U64_MAX).is_ok());
+        assert!(JsonSafeU64::new(JSON_SAFE_U64_MAX + 1).is_err());
+        assert!(AgentPageLimit::new(1).is_ok());
+        assert!(AgentPageLimit::new(100).is_ok());
+        assert!(AgentPageLimit::new(101).is_err());
+        assert!(FiniteJsonNumber::new(f64::INFINITY).is_err());
+        assert_eq!(
+            AgentConfigurationKey::parse("agent.model-name").is_ok(),
+            true
+        );
+        assert!(AgentConfigurationKey::parse("agent/model").is_err());
+        assert_eq!(
+            ClientRequestId::parse("550e8400-e29b-41d4-a716-446655440000").is_ok(),
+            true
+        );
+        assert_eq!(
+            HostResolvedAbsolutePath::parse("D:\\workspace").is_ok(),
+            true
+        );
+        assert_eq!(
+            HostResolvedAbsolutePath::parse("relative\\workspace").is_err(),
+            true
+        );
+        assert_eq!(
+            Rfc3339Timestamp::parse("2026-07-16T12:00:00Z").is_ok(),
+            true
+        );
+    }
+}

--- a/crates/plugin-protocol/src/agent/method.rs
+++ b/crates/plugin-protocol/src/agent/method.rs
@@ -1,0 +1,334 @@
+use super::dto::{
+    CancelConversationRequest, CancelConversationResponse, DiscoverInstallationsRequest,
+    DiscoverInstallationsResponse, GetConfigurationSummaryRequest, GetConfigurationSummaryResponse,
+    ListConversationsRequest, ListConversationsResponse, ListMcpServersRequest,
+    ListMcpServersResponse, ListSkillsRequest, ListSkillsResponse, SendMessageRequest,
+    StartConversationRequest,
+};
+use super::leaf::deserialize_optional_non_null;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use ts_rs::TS;
+
+pub const METHOD_DISCOVER_INSTALLATIONS: &str = "agent.discoverInstallations";
+pub const METHOD_GET_CONFIGURATION_SUMMARY: &str = "agent.getConfigurationSummary";
+pub const METHOD_LIST_SKILLS: &str = "agent.listSkills";
+pub const METHOD_LIST_MCP_SERVERS: &str = "agent.listMcpServers";
+pub const METHOD_LIST_CONVERSATIONS: &str = "agent.listConversations";
+pub const METHOD_START_CONVERSATION: &str = "agent.startConversation";
+pub const METHOD_SEND_MESSAGE: &str = "agent.sendMessage";
+pub const METHOD_CANCEL_CONVERSATION: &str = "agent.cancelConversation";
+
+/// The exact Agent v1 method registry represented as a closed enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentMethod {
+    #[serde(rename = "agent.discoverInstallations")]
+    DiscoverInstallations,
+    #[serde(rename = "agent.getConfigurationSummary")]
+    GetConfigurationSummary,
+    #[serde(rename = "agent.listSkills")]
+    ListSkills,
+    #[serde(rename = "agent.listMcpServers")]
+    ListMcpServers,
+    #[serde(rename = "agent.listConversations")]
+    ListConversations,
+    #[serde(rename = "agent.startConversation")]
+    StartConversation,
+    #[serde(rename = "agent.sendMessage")]
+    SendMessage,
+    #[serde(rename = "agent.cancelConversation")]
+    CancelConversation,
+}
+
+impl AgentMethod {
+    /// Returns the exact wire method string owned by the generated registry.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DiscoverInstallations => METHOD_DISCOVER_INSTALLATIONS,
+            Self::GetConfigurationSummary => METHOD_GET_CONFIGURATION_SUMMARY,
+            Self::ListSkills => METHOD_LIST_SKILLS,
+            Self::ListMcpServers => METHOD_LIST_MCP_SERVERS,
+            Self::ListConversations => METHOD_LIST_CONVERSATIONS,
+            Self::StartConversation => METHOD_START_CONVERSATION,
+            Self::SendMessage => METHOD_SEND_MESSAGE,
+            Self::CancelConversation => METHOD_CANCEL_CONVERSATION,
+        }
+    }
+
+    /// Resolves only methods present in Agent Contract v1.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            METHOD_DISCOVER_INSTALLATIONS => Some(Self::DiscoverInstallations),
+            METHOD_GET_CONFIGURATION_SUMMARY => Some(Self::GetConfigurationSummary),
+            METHOD_LIST_SKILLS => Some(Self::ListSkills),
+            METHOD_LIST_MCP_SERVERS => Some(Self::ListMcpServers),
+            METHOD_LIST_CONVERSATIONS => Some(Self::ListConversations),
+            METHOD_START_CONVERSATION => Some(Self::StartConversation),
+            METHOD_SEND_MESSAGE => Some(Self::SendMessage),
+            METHOD_CANCEL_CONVERSATION => Some(Self::CancelConversation),
+            _ => None,
+        }
+    }
+
+    /// Returns method-level idempotency, streaming, and safety metadata.
+    pub const fn metadata(self) -> AgentMethodMetadata {
+        match self {
+            Self::DiscoverInstallations
+            | Self::GetConfigurationSummary
+            | Self::ListSkills
+            | Self::ListMcpServers
+            | Self::ListConversations => AgentMethodMetadata {
+                method: self,
+                semantics: InvocationSemantics::Idempotent,
+                streaming: false,
+                safety_control: false,
+            },
+            Self::StartConversation | Self::SendMessage => AgentMethodMetadata {
+                method: self,
+                semantics: InvocationSemantics::NonIdempotent,
+                streaming: true,
+                safety_control: false,
+            },
+            Self::CancelConversation => AgentMethodMetadata {
+                method: self,
+                semantics: InvocationSemantics::Idempotent,
+                streaming: false,
+                safety_control: true,
+            },
+        }
+    }
+}
+
+/// Declares whether a Written request may have an unknowable business outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "agent-contract.ts")]
+pub enum InvocationSemantics {
+    Idempotent,
+    NonIdempotent,
+}
+
+/// Immutable metadata used by both Rust routing and generated SDK drift checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentMethodMetadata {
+    pub method: AgentMethod,
+    pub semantics: InvocationSemantics,
+    pub streaming: bool,
+    pub safety_control: bool,
+}
+
+/// Every method in deterministic contract order.
+pub const ALL_AGENT_METHODS: [AgentMethod; 8] = [
+    AgentMethod::DiscoverInstallations,
+    AgentMethod::GetConfigurationSummary,
+    AgentMethod::ListSkills,
+    AgentMethod::ListMcpServers,
+    AgentMethod::ListConversations,
+    AgentMethod::StartConversation,
+    AgentMethod::SendMessage,
+    AgentMethod::CancelConversation,
+];
+
+/// A typed outbound Agent request; arbitrary method strings cannot be represented.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentRequest {
+    DiscoverInstallations(DiscoverInstallationsRequest),
+    GetConfigurationSummary(GetConfigurationSummaryRequest),
+    ListSkills(ListSkillsRequest),
+    ListMcpServers(ListMcpServersRequest),
+    ListConversations(ListConversationsRequest),
+    StartConversation(StartConversationRequest),
+    SendMessage(SendMessageRequest),
+    CancelConversation(CancelConversationRequest),
+}
+
+impl AgentRequest {
+    /// Parses params through the exact DTO selected by the closed Agent method registry.
+    pub fn from_method_params(
+        method: AgentMethod,
+        params: Value,
+    ) -> Result<Self, serde_json::Error> {
+        match method {
+            AgentMethod::DiscoverInstallations => {
+                serde_json::from_value(params).map(Self::DiscoverInstallations)
+            }
+            AgentMethod::GetConfigurationSummary => {
+                serde_json::from_value(params).map(Self::GetConfigurationSummary)
+            }
+            AgentMethod::ListSkills => serde_json::from_value(params).map(Self::ListSkills),
+            AgentMethod::ListMcpServers => serde_json::from_value(params).map(Self::ListMcpServers),
+            AgentMethod::ListConversations => {
+                serde_json::from_value(params).map(Self::ListConversations)
+            }
+            AgentMethod::StartConversation => {
+                serde_json::from_value(params).map(Self::StartConversation)
+            }
+            AgentMethod::SendMessage => serde_json::from_value(params).map(Self::SendMessage),
+            AgentMethod::CancelConversation => {
+                serde_json::from_value(params).map(Self::CancelConversation)
+            }
+        }
+    }
+
+    /// Returns the fixed registry method corresponding to this typed request.
+    pub const fn method(&self) -> AgentMethod {
+        match self {
+            Self::DiscoverInstallations(_) => AgentMethod::DiscoverInstallations,
+            Self::GetConfigurationSummary(_) => AgentMethod::GetConfigurationSummary,
+            Self::ListSkills(_) => AgentMethod::ListSkills,
+            Self::ListMcpServers(_) => AgentMethod::ListMcpServers,
+            Self::ListConversations(_) => AgentMethod::ListConversations,
+            Self::StartConversation(_) => AgentMethod::StartConversation,
+            Self::SendMessage(_) => AgentMethod::SendMessage,
+            Self::CancelConversation(_) => AgentMethod::CancelConversation,
+        }
+    }
+
+    /// Serializes the exact params object for the JSON-RPC request envelope.
+    pub fn to_params_value(&self) -> Result<Value, serde_json::Error> {
+        match self {
+            Self::DiscoverInstallations(value) => serde_json::to_value(value),
+            Self::GetConfigurationSummary(value) => serde_json::to_value(value),
+            Self::ListSkills(value) => serde_json::to_value(value),
+            Self::ListMcpServers(value) => serde_json::to_value(value),
+            Self::ListConversations(value) => serde_json::to_value(value),
+            Self::StartConversation(value) => serde_json::to_value(value),
+            Self::SendMessage(value) => serde_json::to_value(value),
+            Self::CancelConversation(value) => serde_json::to_value(value),
+        }
+    }
+}
+
+/// A typed successful Agent terminal response for non-streaming methods.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentResponse {
+    DiscoverInstallations(DiscoverInstallationsResponse),
+    GetConfigurationSummary(GetConfigurationSummaryResponse),
+    ListSkills(ListSkillsResponse),
+    ListMcpServers(ListMcpServersResponse),
+    ListConversations(ListConversationsResponse),
+    CancelConversation(CancelConversationResponse),
+}
+
+impl AgentResponse {
+    /// Serializes the typed terminal payload without inventing an application-level union shape.
+    pub fn to_result_value(&self) -> Result<Value, serde_json::Error> {
+        match self {
+            Self::DiscoverInstallations(value) => serde_json::to_value(value),
+            Self::GetConfigurationSummary(value) => serde_json::to_value(value),
+            Self::ListSkills(value) => serde_json::to_value(value),
+            Self::ListMcpServers(value) => serde_json::to_value(value),
+            Self::ListConversations(value) => serde_json::to_value(value),
+            Self::CancelConversation(value) => serde_json::to_value(value),
+        }
+    }
+}
+
+/// The closed business failure set exposed to plugin authors and Host consumers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "agent-contract.ts")]
+pub enum AgentBusinessFailureKind {
+    AgentUnavailable,
+    AuthenticationRequired,
+    InvalidAgentConfiguration,
+    InstallationNotFound,
+    ConversationNotFound,
+    UnsupportedAgentCapability,
+    InvalidState,
+    PermissionDenied,
+    CursorExpired,
+    AgentProcessFailed,
+    ProviderFailure,
+}
+
+/// The exact `-32000` error data shape; details are the only bounded extension bag.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentBusinessErrorData {
+    pub kind: AgentBusinessFailureKind,
+    pub retryable: bool,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[ts(optional, type = "Record<string, JsonValue>")]
+    pub details: Option<Map<String, Value>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ALL_AGENT_METHODS, AgentMethod, InvocationSemantics};
+    use pretty_assertions::assert_eq;
+
+    /// Freezes method spelling, order, streaming, idempotency, and safety classification together.
+    #[test]
+    fn exposes_closed_agent_method_registry() {
+        let registry = ALL_AGENT_METHODS.map(|method| {
+            let metadata = method.metadata();
+            (
+                method.as_str(),
+                metadata.semantics,
+                metadata.streaming,
+                metadata.safety_control,
+            )
+        });
+        assert_eq!(
+            registry,
+            [
+                (
+                    "agent.discoverInstallations",
+                    InvocationSemantics::Idempotent,
+                    false,
+                    false
+                ),
+                (
+                    "agent.getConfigurationSummary",
+                    InvocationSemantics::Idempotent,
+                    false,
+                    false
+                ),
+                (
+                    "agent.listSkills",
+                    InvocationSemantics::Idempotent,
+                    false,
+                    false
+                ),
+                (
+                    "agent.listMcpServers",
+                    InvocationSemantics::Idempotent,
+                    false,
+                    false
+                ),
+                (
+                    "agent.listConversations",
+                    InvocationSemantics::Idempotent,
+                    false,
+                    false
+                ),
+                (
+                    "agent.startConversation",
+                    InvocationSemantics::NonIdempotent,
+                    true,
+                    false
+                ),
+                (
+                    "agent.sendMessage",
+                    InvocationSemantics::NonIdempotent,
+                    true,
+                    false
+                ),
+                (
+                    "agent.cancelConversation",
+                    InvocationSemantics::Idempotent,
+                    false,
+                    true
+                ),
+            ]
+        );
+        assert_eq!(AgentMethod::from_wire("agent.unknown"), None);
+    }
+}

--- a/crates/plugin-protocol/src/agent/mod.rs
+++ b/crates/plugin-protocol/src/agent/mod.rs
@@ -1,0 +1,3 @@
+mod leaf;
+
+pub use leaf::*;

--- a/crates/plugin-protocol/src/agent/mod.rs
+++ b/crates/plugin-protocol/src/agent/mod.rs
@@ -1,3 +1,5 @@
+mod dto;
 mod leaf;
 
+pub use dto::*;
 pub use leaf::*;

--- a/crates/plugin-protocol/src/agent/mod.rs
+++ b/crates/plugin-protocol/src/agent/mod.rs
@@ -1,5 +1,7 @@
 mod dto;
 mod leaf;
+mod method;
 
 pub use dto::*;
 pub use leaf::*;
+pub use method::*;

--- a/crates/plugin-protocol/src/agent/mod.rs
+++ b/crates/plugin-protocol/src/agent/mod.rs
@@ -1,7 +1,9 @@
 mod dto;
 mod leaf;
 mod method;
+mod validation;
 
 pub use dto::*;
 pub use leaf::*;
 pub use method::*;
+pub use validation::*;

--- a/crates/plugin-protocol/src/agent/validation.rs
+++ b/crates/plugin-protocol/src/agent/validation.rs
@@ -1,0 +1,415 @@
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+
+use super::{
+    AgentAvailability, AgentBusinessErrorData, AgentConfigurationValue,
+    AgentDiscoveryDiagnosticKind, AgentEvent, AgentRequest, AgentResourceSource, AgentResponse,
+    AgentTurnResult, AgentUsage, DiscoverInstallationsResponse, GetConfigurationSummaryResponse,
+    ListConversationsResponse, ListMcpServersResponse, ListSkillsResponse,
+};
+use crate::InitializeLimits;
+
+const MAX_DISPLAY_NAME_BYTES: usize = 512;
+const MAX_DESCRIPTION_BYTES: usize = 4 * 1024;
+const MAX_STATUS_PHASE_BYTES: usize = 512;
+const MAX_DISCOVERY_INSTALLATIONS: usize = 128;
+const MAX_DISCOVERY_DIAGNOSTICS: usize = 64;
+const MAX_CONFIGURATION_ITEMS: usize = 256;
+const MAX_STRING_LIST_ITEMS: usize = 128;
+
+/// Stable reasons why a typed Agent value still violates cross-field or container constraints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AgentContractValidationError {
+    #[error("Agent value exceeds its negotiated encoded byte limit")]
+    EncodedLimit,
+    #[error("Agent collection exceeds its item limit")]
+    ItemLimit,
+    #[error("Agent collection contains a duplicate identity")]
+    DuplicateIdentity,
+    #[error("Agent display value violates its byte or NUL constraint")]
+    InvalidDisplayValue,
+    #[error("Agent usage must contain at least one counter")]
+    EmptyUsage,
+    #[error("empty discovery must include a notFound diagnostic")]
+    MissingNotFoundDiagnostic,
+    #[error("Agent response does not match the request method")]
+    MethodMismatch,
+    #[error("Agent request exceeds a negotiated dynamic limit")]
+    RequestLimit,
+}
+
+impl AgentRequest {
+    /// Applies negotiated prompt and page limits that cannot be encoded by fixed leaf newtypes.
+    pub fn validate_with_limits(
+        &self,
+        limits: &InitializeLimits,
+    ) -> Result<(), AgentContractValidationError> {
+        match self {
+            Self::ListSkills(request) => validate_page_request(request.limit.get(), limits),
+            Self::ListMcpServers(request) => validate_page_request(request.limit.get(), limits),
+            Self::ListConversations(request) => validate_page_request(request.limit.get(), limits),
+            Self::StartConversation(request) => {
+                validate_prompt(request.prompt.as_str(), limits.max_agent_prompt_bytes)
+            }
+            Self::SendMessage(request) => {
+                validate_prompt(request.prompt.as_str(), limits.max_agent_prompt_bytes)
+            }
+            Self::DiscoverInstallations(_)
+            | Self::GetConfigurationSummary(_)
+            | Self::CancelConversation(_) => Ok(()),
+        }
+    }
+}
+
+impl AgentEvent {
+    /// Validates event display leaves, usage invariants, and the negotiated encoded byte cap.
+    pub fn validate_with_limits(
+        &self,
+        limits: &InitializeLimits,
+    ) -> Result<(), AgentContractValidationError> {
+        match self {
+            Self::ConversationStarted { .. } => {}
+            Self::TextDelta { text, .. } => {
+                validate_display(text, limits.max_agent_event_bytes as usize)?;
+            }
+            Self::Status { phase, message } => {
+                validate_display(phase, MAX_STATUS_PHASE_BYTES)?;
+                validate_optional_display(message.as_deref(), MAX_DESCRIPTION_BYTES)?;
+            }
+            Self::ToolCall { name, summary, .. } => {
+                validate_display(name, MAX_DISPLAY_NAME_BYTES)?;
+                validate_optional_display(summary.as_deref(), MAX_DESCRIPTION_BYTES)?;
+            }
+            Self::ToolResult { summary, .. } => {
+                validate_optional_display(summary.as_deref(), MAX_DESCRIPTION_BYTES)?;
+            }
+            Self::Usage { usage } => validate_usage(usage)?,
+        }
+        validate_encoded_limit(self, limits.max_agent_event_bytes)
+    }
+}
+
+impl AgentTurnResult {
+    /// Validates terminal usage and the negotiated result byte cap.
+    pub fn validate_with_limits(
+        &self,
+        limits: &InitializeLimits,
+    ) -> Result<(), AgentContractValidationError> {
+        if let Some(usage) = &self.usage {
+            validate_usage(usage)?;
+        }
+        validate_encoded_limit(self, limits.max_agent_result_bytes)
+    }
+}
+
+impl AgentBusinessErrorData {
+    /// Bounds the only extension bag by the same negotiated terminal-result budget.
+    pub fn validate_with_limits(
+        &self,
+        limits: &InitializeLimits,
+    ) -> Result<(), AgentContractValidationError> {
+        validate_encoded_limit(self, limits.max_agent_result_bytes)
+    }
+}
+
+impl AgentResponse {
+    /// Validates the method-specific container, uniqueness, display, and encoded-size contract.
+    pub fn validate_for_request(
+        &self,
+        request: &AgentRequest,
+        limits: &InitializeLimits,
+    ) -> Result<(), AgentContractValidationError> {
+        match (request, self) {
+            (AgentRequest::DiscoverInstallations(_), Self::DiscoverInstallations(response)) => {
+                validate_discovery(response)?
+            }
+            (AgentRequest::GetConfigurationSummary(_), Self::GetConfigurationSummary(response)) => {
+                validate_configuration(response)?
+            }
+            (AgentRequest::ListSkills(request), Self::ListSkills(response)) => {
+                validate_skills(response, page_cap(request.limit.get(), limits))?;
+            }
+            (AgentRequest::ListMcpServers(request), Self::ListMcpServers(response)) => {
+                validate_mcp_servers(response, page_cap(request.limit.get(), limits))?;
+            }
+            (AgentRequest::ListConversations(request), Self::ListConversations(response)) => {
+                validate_conversations(response, page_cap(request.limit.get(), limits))?;
+            }
+            (AgentRequest::CancelConversation(_), Self::CancelConversation(_)) => {}
+            _ => return Err(AgentContractValidationError::MethodMismatch),
+        }
+        let value = self
+            .to_result_value()
+            .map_err(|_| AgentContractValidationError::InvalidDisplayValue)?;
+        validate_encoded_limit(&value, limits.max_agent_result_bytes)
+    }
+}
+
+fn validate_discovery(
+    response: &DiscoverInstallationsResponse,
+) -> Result<(), AgentContractValidationError> {
+    if response.installations.len() > MAX_DISCOVERY_INSTALLATIONS
+        || response.diagnostics.len() > MAX_DISCOVERY_DIAGNOSTICS
+    {
+        return Err(AgentContractValidationError::ItemLimit);
+    }
+    let mut ids = BTreeSet::new();
+    for installation in &response.installations {
+        if !ids.insert(&installation.installation_id) {
+            return Err(AgentContractValidationError::DuplicateIdentity);
+        }
+        validate_display(&installation.display_name, MAX_DISPLAY_NAME_BYTES)?;
+        validate_optional_display(installation.version.as_deref(), MAX_DISPLAY_NAME_BYTES)?;
+        validate_optional_display(
+            installation.location_display.as_deref(),
+            MAX_DESCRIPTION_BYTES,
+        )?;
+        if let AgentAvailability::Unavailable { reason } = &installation.availability {
+            validate_display(reason, MAX_DESCRIPTION_BYTES)?;
+        }
+    }
+    for diagnostic in &response.diagnostics {
+        validate_display(&diagnostic.message, MAX_DESCRIPTION_BYTES)?;
+    }
+    if response.installations.is_empty()
+        && !response
+            .diagnostics
+            .iter()
+            .any(|item| item.kind == AgentDiscoveryDiagnosticKind::NotFound)
+    {
+        return Err(AgentContractValidationError::MissingNotFoundDiagnostic);
+    }
+    Ok(())
+}
+
+fn validate_configuration(
+    response: &GetConfigurationSummaryResponse,
+) -> Result<(), AgentContractValidationError> {
+    if response.items.len() > MAX_CONFIGURATION_ITEMS {
+        return Err(AgentContractValidationError::ItemLimit);
+    }
+    let mut keys = BTreeSet::new();
+    for item in &response.items {
+        if !keys.insert(&item.key) {
+            return Err(AgentContractValidationError::DuplicateIdentity);
+        }
+        validate_display(&item.display_name, MAX_DISPLAY_NAME_BYTES)?;
+        validate_source(&item.source)?;
+        match &item.value {
+            AgentConfigurationValue::String { value } => {
+                validate_display(value, MAX_DESCRIPTION_BYTES)?;
+            }
+            AgentConfigurationValue::StringList { value } => {
+                if value.len() > MAX_STRING_LIST_ITEMS {
+                    return Err(AgentContractValidationError::ItemLimit);
+                }
+                for element in value {
+                    validate_display(element, MAX_DESCRIPTION_BYTES)?;
+                }
+            }
+            AgentConfigurationValue::Unset {}
+            | AgentConfigurationValue::Redacted {}
+            | AgentConfigurationValue::Boolean { .. }
+            | AgentConfigurationValue::Number { .. } => {}
+        }
+    }
+    Ok(())
+}
+
+fn validate_skills(
+    response: &ListSkillsResponse,
+    maximum_items: usize,
+) -> Result<(), AgentContractValidationError> {
+    if response.items.len() > maximum_items {
+        return Err(AgentContractValidationError::ItemLimit);
+    }
+    let mut ids = BTreeSet::new();
+    for item in &response.items {
+        if !ids.insert(&item.id) {
+            return Err(AgentContractValidationError::DuplicateIdentity);
+        }
+        validate_display(&item.display_name, MAX_DISPLAY_NAME_BYTES)?;
+        validate_optional_display(item.description.as_deref(), MAX_DESCRIPTION_BYTES)?;
+        validate_source(&item.source)?;
+    }
+    Ok(())
+}
+
+fn validate_mcp_servers(
+    response: &ListMcpServersResponse,
+    maximum_items: usize,
+) -> Result<(), AgentContractValidationError> {
+    if response.items.len() > maximum_items {
+        return Err(AgentContractValidationError::ItemLimit);
+    }
+    let mut ids = BTreeSet::new();
+    for item in &response.items {
+        if !ids.insert(&item.id) {
+            return Err(AgentContractValidationError::DuplicateIdentity);
+        }
+        validate_display(&item.display_name, MAX_DISPLAY_NAME_BYTES)?;
+        validate_source(&item.source)?;
+    }
+    Ok(())
+}
+
+fn validate_conversations(
+    response: &ListConversationsResponse,
+    maximum_items: usize,
+) -> Result<(), AgentContractValidationError> {
+    if response.items.len() > maximum_items {
+        return Err(AgentContractValidationError::ItemLimit);
+    }
+    let mut ids = BTreeSet::new();
+    for item in &response.items {
+        if !ids.insert(&item.conversation_id) {
+            return Err(AgentContractValidationError::DuplicateIdentity);
+        }
+        validate_optional_display(item.title.as_deref(), MAX_DESCRIPTION_BYTES)?;
+    }
+    Ok(())
+}
+
+fn validate_source(source: &AgentResourceSource) -> Result<(), AgentContractValidationError> {
+    if let AgentResourceSource::Unknown { display } = source {
+        validate_optional_display(display.as_deref(), MAX_DESCRIPTION_BYTES)?;
+    }
+    Ok(())
+}
+
+fn validate_usage(usage: &AgentUsage) -> Result<(), AgentContractValidationError> {
+    if usage.input_tokens.is_none() && usage.output_tokens.is_none() && usage.cost_micros.is_none()
+    {
+        return Err(AgentContractValidationError::EmptyUsage);
+    }
+    Ok(())
+}
+
+fn validate_page_request(
+    requested: u8,
+    limits: &InitializeLimits,
+) -> Result<(), AgentContractValidationError> {
+    if u32::from(requested) > limits.max_page_items {
+        return Err(AgentContractValidationError::RequestLimit);
+    }
+    Ok(())
+}
+
+fn validate_prompt(prompt: &str, maximum_bytes: u32) -> Result<(), AgentContractValidationError> {
+    if prompt.len() > maximum_bytes as usize {
+        return Err(AgentContractValidationError::RequestLimit);
+    }
+    Ok(())
+}
+
+fn page_cap(requested: u8, limits: &InitializeLimits) -> usize {
+    usize::from(requested).min(limits.max_page_items as usize)
+}
+
+fn validate_optional_display(
+    value: Option<&str>,
+    maximum_bytes: usize,
+) -> Result<(), AgentContractValidationError> {
+    value.map_or(Ok(()), |value| validate_display(value, maximum_bytes))
+}
+
+fn validate_display(value: &str, maximum_bytes: usize) -> Result<(), AgentContractValidationError> {
+    if value.len() > maximum_bytes || value.contains('\0') {
+        return Err(AgentContractValidationError::InvalidDisplayValue);
+    }
+    Ok(())
+}
+
+fn validate_encoded_limit<T>(
+    value: &T,
+    maximum_bytes: u32,
+) -> Result<(), AgentContractValidationError>
+where
+    T: Serialize,
+{
+    let encoded =
+        serde_json::to_vec(value).map_err(|_| AgentContractValidationError::InvalidDisplayValue)?;
+    if encoded.len() > maximum_bytes as usize {
+        return Err(AgentContractValidationError::EncodedLimit);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AgentContractValidationError;
+    use crate::{
+        AgentAvailability, AgentInstallation, AgentInstallationId, AgentPageLimit, AgentProviderId,
+        AgentRequest, AgentResponse, AgentScope, DiscoverInstallationsRequest,
+        DiscoverInstallationsResponse, InitializeLimits, ListSkillsRequest, ListSkillsResponse,
+    };
+    use pretty_assertions::assert_eq;
+
+    fn provider_id() -> AgentProviderId {
+        AgentProviderId::parse("example")
+            .unwrap_or_else(|error| panic!("expected provider id: {error}"))
+    }
+
+    /// Enforces canonical empty discovery and duplicate installation identity rules.
+    #[test]
+    fn validates_discovery_container_invariants() {
+        let request = AgentRequest::DiscoverInstallations(DiscoverInstallationsRequest {
+            provider_id: provider_id(),
+            scope: AgentScope::Global {},
+        });
+        let empty = AgentResponse::DiscoverInstallations(DiscoverInstallationsResponse {
+            installations: Vec::new(),
+            diagnostics: Vec::new(),
+        });
+        assert_eq!(
+            empty.validate_for_request(&request, &InitializeLimits::v1_defaults()),
+            Err(AgentContractValidationError::MissingNotFoundDiagnostic)
+        );
+
+        let installation = AgentInstallation {
+            installation_id: AgentInstallationId::parse("installation-1")
+                .unwrap_or_else(|error| panic!("expected installation id: {error}")),
+            display_name: "Agent".to_owned(),
+            version: None,
+            location_display: None,
+            availability: AgentAvailability::Available {},
+        };
+        let duplicate = AgentResponse::DiscoverInstallations(DiscoverInstallationsResponse {
+            installations: vec![installation.clone(), installation],
+            diagnostics: Vec::new(),
+        });
+        assert_eq!(
+            duplicate.validate_for_request(&request, &InitializeLimits::v1_defaults()),
+            Err(AgentContractValidationError::DuplicateIdentity)
+        );
+    }
+
+    /// Applies both the caller's page limit and a tightened initialize limit.
+    #[test]
+    fn validates_dynamic_page_limits() {
+        let limits = InitializeLimits::new(8, 4096, 4096, 4096, 4, 1)
+            .unwrap_or_else(|error| panic!("expected limits: {error}"));
+        let request = AgentRequest::ListSkills(ListSkillsRequest {
+            provider_id: provider_id(),
+            installation_id: AgentInstallationId::parse("installation-1")
+                .unwrap_or_else(|error| panic!("expected installation id: {error}")),
+            scope: AgentScope::Global {},
+            cursor: None,
+            limit: AgentPageLimit::new(2)
+                .unwrap_or_else(|error| panic!("expected page limit: {error}")),
+        });
+        assert_eq!(
+            request.validate_with_limits(&limits),
+            Err(AgentContractValidationError::RequestLimit)
+        );
+        assert_eq!(
+            AgentResponse::ListSkills(ListSkillsResponse {
+                items: Vec::new(),
+                next_cursor: None,
+            })
+            .validate_for_request(&request, &limits),
+            Ok(())
+        );
+    }
+}

--- a/crates/plugin-protocol/src/fixtures.rs
+++ b/crates/plugin-protocol/src/fixtures.rs
@@ -1,0 +1,234 @@
+use crate::{ALL_AGENT_METHODS, FrameType, MAX_FRAME_BYTES, encode_frame};
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::path::Path;
+
+/// The checked-in canonical Frame v1 fixture schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameGoldenFixture {
+    pub fixture_version: u32,
+    pub wire_version: u32,
+    pub maximum_payload_bytes: usize,
+    pub valid: Vec<FrameGoldenVector>,
+    pub invalid: Vec<InvalidFrameGoldenVector>,
+}
+
+/// One exact valid Frame vector shared by Rust and TypeScript.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameGoldenVector {
+    pub frame_type: String,
+    pub payload_utf8: String,
+    pub payload_len: usize,
+    pub header_hex: String,
+    pub frame_hex: String,
+}
+
+/// One invalid byte vector and its stable rejection category.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InvalidFrameGoldenVector {
+    pub frame_hex: String,
+    pub reason: String,
+}
+
+/// A generated projection of the closed Agent method registry and representative DTO shapes.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentContractGoldenFixture {
+    pub fixture_version: u32,
+    pub contract_version: u32,
+    pub methods: Vec<AgentMethodGolden>,
+    pub representative_values: Vec<NamedGoldenValue>,
+}
+
+/// Method metadata that SDK behavior interfaces must match at compile time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentMethodGolden {
+    pub method: String,
+    pub semantics: String,
+    pub streaming: bool,
+    pub safety_control: bool,
+}
+
+/// A named JSON value used for cross-language encode/decode checks.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NamedGoldenValue {
+    pub name: String,
+    pub value: Value,
+}
+
+/// Builds the canonical valid and invalid Frame vectors from the production encoder.
+pub fn canonical_frame_golden_fixture() -> FrameGoldenFixture {
+    let payloads = [
+        (
+            FrameType::Request,
+            r#"{"jsonrpc":"2.0","id":"h:1","method":"ping","params":{}}"#,
+        ),
+        (
+            FrameType::Response,
+            r#"{"jsonrpc":"2.0","id":"h:1","result":"ok"}"#,
+        ),
+        (
+            FrameType::Notification,
+            r#"{"jsonrpc":"2.0","method":"$/exit"}"#,
+        ),
+        (
+            FrameType::Notification,
+            r#"{"jsonrpc":"2.0","method":"$/stream","params":{"id":"h:1","seq":1,"value":{"kind":"textDelta","text":"你好"}}}"#,
+        ),
+    ];
+    let valid = payloads
+        .into_iter()
+        .map(|(frame_type, payload)| {
+            let encoded = encode_frame(frame_type, payload.as_bytes(), MAX_FRAME_BYTES)
+                .unwrap_or_else(|error| panic!("canonical frame must encode: {error}"));
+            FrameGoldenVector {
+                frame_type: frame_type_name(frame_type).to_string(),
+                payload_utf8: payload.to_string(),
+                payload_len: payload.len(),
+                header_hex: encode_hex(&encoded[..5]),
+                frame_hex: encode_hex(&encoded),
+            }
+        })
+        .collect();
+
+    FrameGoldenFixture {
+        fixture_version: 1,
+        wire_version: 1,
+        maximum_payload_bytes: MAX_FRAME_BYTES,
+        valid,
+        invalid: vec![
+            invalid_vector([0x00, 0x00, 0x00, 0x00, 0x01], "zeroLength"),
+            invalid_vector([0xff, 0xff, 0xff, 0xff, 0x01], "negativeLength"),
+            invalid_vector([0x00, 0x80, 0x00, 0x01, 0x01], "payloadTooLarge"),
+            invalid_vector([0x00, 0x00, 0x00, 0x02, 0x7f], "unknownType"),
+        ],
+    }
+}
+
+/// Builds deterministic Agent registry metadata plus representative discriminated unions.
+pub fn canonical_agent_contract_golden_fixture() -> AgentContractGoldenFixture {
+    let methods = ALL_AGENT_METHODS
+        .into_iter()
+        .map(|method| {
+            let metadata = method.metadata();
+            AgentMethodGolden {
+                method: method.as_str().to_string(),
+                semantics: match metadata.semantics {
+                    crate::InvocationSemantics::Idempotent => "idempotent",
+                    crate::InvocationSemantics::NonIdempotent => "nonIdempotent",
+                }
+                .to_string(),
+                streaming: metadata.streaming,
+                safety_control: metadata.safety_control,
+            }
+        })
+        .collect();
+
+    AgentContractGoldenFixture {
+        fixture_version: 1,
+        contract_version: 1,
+        methods,
+        representative_values: vec![
+            named("agentScope.global", json!({"type": "global"})),
+            named(
+                "agentScope.project",
+                json!({
+                    "type": "project",
+                    "projectHandle": "project-1",
+                    "workingDirectory": "D:\\work"
+                }),
+            ),
+            named(
+                "agentEvent.textDelta",
+                json!({"kind": "textDelta", "channel": "assistant", "text": "你好"}),
+            ),
+            named(
+                "cancelConversation.accepted",
+                json!({"disposition": "accepted"}),
+            ),
+            named(
+                "businessError.authenticationRequired",
+                json!({"kind": "authenticationRequired", "retryable": false}),
+            ),
+        ],
+    }
+}
+
+/// Writes both canonical fixture files for Rust, TypeScript, and E2E consumers.
+pub fn export_protocol_fixtures_to(
+    output_directory: impl AsRef<Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output_directory = output_directory.as_ref();
+    std::fs::create_dir_all(output_directory)?;
+    let frame = serde_json::to_vec_pretty(&canonical_frame_golden_fixture())?;
+    let agent = serde_json::to_vec_pretty(&canonical_agent_contract_golden_fixture())?;
+    std::fs::write(output_directory.join("frame-golden.json"), frame)?;
+    std::fs::write(output_directory.join("agent-contract-golden.json"), agent)?;
+    Ok(())
+}
+
+/// Converts a fixed invalid header vector into the checked-in hex representation.
+fn invalid_vector<const N: usize>(bytes: [u8; N], reason: &str) -> InvalidFrameGoldenVector {
+    InvalidFrameGoldenVector {
+        frame_hex: encode_hex(&bytes),
+        reason: reason.to_string(),
+    }
+}
+
+/// Returns the lowercase fixture spelling for one numeric frame type.
+fn frame_type_name(frame_type: FrameType) -> &'static str {
+    match frame_type {
+        FrameType::Request => "request",
+        FrameType::Response => "response",
+        FrameType::Notification => "notification",
+    }
+}
+
+/// Encodes bytes without separators so concatenation remains machine-checkable.
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// Builds one named representative JSON entry.
+fn named(name: &str, value: Value) -> NamedGoldenValue {
+    NamedGoldenValue {
+        name: name.to_string(),
+        value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_agent_contract_golden_fixture, canonical_frame_golden_fixture};
+    use pretty_assertions::assert_eq;
+
+    /// Freezes the human-readable payload lengths and exact five-byte headers from the design.
+    #[test]
+    fn canonical_frame_vectors_match_design() {
+        let fixture = canonical_frame_golden_fixture();
+        assert_eq!(
+            fixture
+                .valid
+                .iter()
+                .map(|vector| (vector.payload_len, vector.header_hex.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (56, "0000003801"),
+                (42, "0000002a02"),
+                (35, "0000002303"),
+                (112, "0000007003"),
+            ]
+        );
+    }
+
+    /// Keeps every closed Rust Agent method in the shared fixture.
+    #[test]
+    fn canonical_agent_fixture_contains_all_methods() {
+        assert_eq!(canonical_agent_contract_golden_fixture().methods.len(), 8);
+    }
+}

--- a/crates/plugin-protocol/src/frame.rs
+++ b/crates/plugin-protocol/src/frame.rs
@@ -1,0 +1,294 @@
+/// Wire v1 frame header size: signed big-endian length plus signed type byte.
+pub const FRAME_HEADER_BYTES: usize = 5;
+/// Absolute wire v1 payload cap applied before any payload allocation.
+pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+/// Identifies the JSON-RPC envelope shape carried by one wire frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(i8)]
+pub enum FrameType {
+    Request = 1,
+    Response = 2,
+    Notification = 3,
+}
+
+impl TryFrom<i8> for FrameType {
+    type Error = FrameError;
+
+    fn try_from(value: i8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Request),
+            2 => Ok(Self::Response),
+            3 => Ok(Self::Notification),
+            value => Err(FrameError::UnknownType { value }),
+        }
+    }
+}
+
+/// An owned, fully validated wire frame whose payload still awaits JSON validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Frame {
+    pub frame_type: FrameType,
+    pub payload: Vec<u8>,
+}
+
+/// Classifies framing failures without attempting byte-stream resynchronization.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum FrameError {
+    #[error("frame payload length must be positive, got {length}")]
+    NonPositiveLength { length: i32 },
+    #[error("frame payload length {length} exceeds limit {maximum}")]
+    PayloadTooLarge { length: usize, maximum: usize },
+    #[error("unknown signed frame type {value}")]
+    UnknownType { value: i8 },
+    #[error("frame decoder ended with a partial {part}")]
+    PartialFrame { part: PartialFramePart },
+    #[error("frame payload limit must be in 1..={hard_maximum}, got {configured}")]
+    InvalidMaximum {
+        configured: usize,
+        hard_maximum: usize,
+    },
+}
+
+/// Identifies which frame component was incomplete when the stream reached EOF.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartialFramePart {
+    Header,
+    Payload,
+}
+
+impl std::fmt::Display for PartialFramePart {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Header => formatter.write_str("header"),
+            Self::Payload => formatter.write_str("payload"),
+        }
+    }
+}
+
+/// Encodes a frame into the exact 5-byte-header wire representation.
+pub fn encode_frame(
+    frame_type: FrameType,
+    payload: &[u8],
+    maximum_payload_bytes: usize,
+) -> Result<Vec<u8>, FrameError> {
+    validate_maximum(maximum_payload_bytes)?;
+    let length = validate_payload_length(payload.len(), maximum_payload_bytes)?;
+    let mut encoded = Vec::with_capacity(FRAME_HEADER_BYTES + payload.len());
+    encoded.extend_from_slice(&length.to_be_bytes());
+    encoded.push(frame_type as i8 as u8);
+    encoded.extend_from_slice(payload);
+    Ok(encoded)
+}
+
+/// Incrementally decodes arbitrary pipe chunks without buffering more than one payload.
+#[derive(Debug)]
+pub struct FrameDecoder {
+    maximum_payload_bytes: usize,
+    state: DecoderState,
+}
+
+#[derive(Debug)]
+enum DecoderState {
+    Header {
+        bytes: [u8; FRAME_HEADER_BYTES],
+        filled: usize,
+    },
+    Payload {
+        frame_type: FrameType,
+        expected: usize,
+        bytes: Vec<u8>,
+    },
+}
+
+impl FrameDecoder {
+    /// Builds a decoder with a Host-selected limit no larger than the wire hard cap.
+    pub fn new(maximum_payload_bytes: usize) -> Result<Self, FrameError> {
+        validate_maximum(maximum_payload_bytes)?;
+        Ok(Self {
+            maximum_payload_bytes,
+            state: empty_header_state(),
+        })
+    }
+
+    /// Consumes one arbitrary byte chunk and returns every complete frame in order.
+    pub fn decode_chunk(&mut self, mut chunk: &[u8]) -> Result<Vec<Frame>, FrameError> {
+        let mut frames = Vec::new();
+        while !chunk.is_empty() {
+            match &mut self.state {
+                DecoderState::Header { bytes, filled } => {
+                    let remaining = FRAME_HEADER_BYTES - *filled;
+                    let copied = remaining.min(chunk.len());
+                    bytes[*filled..*filled + copied].copy_from_slice(&chunk[..copied]);
+                    *filled += copied;
+                    chunk = &chunk[copied..];
+                    if *filled == FRAME_HEADER_BYTES {
+                        let length = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                        if length <= 0 {
+                            return Err(FrameError::NonPositiveLength { length });
+                        }
+                        let expected = usize::try_from(length)
+                            .map_err(|_| FrameError::NonPositiveLength { length })?;
+                        validate_payload_length(expected, self.maximum_payload_bytes)?;
+                        let frame_type = FrameType::try_from(bytes[4] as i8)?;
+                        self.state = DecoderState::Payload {
+                            frame_type,
+                            expected,
+                            bytes: Vec::with_capacity(expected),
+                        };
+                    }
+                }
+                DecoderState::Payload {
+                    frame_type,
+                    expected,
+                    bytes,
+                } => {
+                    let remaining = *expected - bytes.len();
+                    let copied = remaining.min(chunk.len());
+                    bytes.extend_from_slice(&chunk[..copied]);
+                    chunk = &chunk[copied..];
+                    if bytes.len() == *expected {
+                        let payload = std::mem::take(bytes);
+                        frames.push(Frame {
+                            frame_type: *frame_type,
+                            payload,
+                        });
+                        self.state = empty_header_state();
+                    }
+                }
+            }
+        }
+        Ok(frames)
+    }
+
+    /// Validates that EOF occurred exactly on a frame boundary.
+    pub fn finish(self) -> Result<(), FrameError> {
+        match self.state {
+            DecoderState::Header { filled: 0, .. } => Ok(()),
+            DecoderState::Header { .. } => Err(FrameError::PartialFrame {
+                part: PartialFramePart::Header,
+            }),
+            DecoderState::Payload { .. } => Err(FrameError::PartialFrame {
+                part: PartialFramePart::Payload,
+            }),
+        }
+    }
+}
+
+/// Creates a zeroed decoder header after construction and every complete frame.
+fn empty_header_state() -> DecoderState {
+    DecoderState::Header {
+        bytes: [0; FRAME_HEADER_BYTES],
+        filled: 0,
+    }
+}
+
+/// Rejects configuration values that would create a second, incompatible wire profile.
+fn validate_maximum(maximum_payload_bytes: usize) -> Result<(), FrameError> {
+    if !(1..=MAX_FRAME_BYTES).contains(&maximum_payload_bytes) {
+        return Err(FrameError::InvalidMaximum {
+            configured: maximum_payload_bytes,
+            hard_maximum: MAX_FRAME_BYTES,
+        });
+    }
+    Ok(())
+}
+
+/// Checks the signed wire length and Host policy before payload allocation or encoding.
+fn validate_payload_length(length: usize, maximum: usize) -> Result<i32, FrameError> {
+    if length == 0 {
+        return Err(FrameError::NonPositiveLength { length: 0 });
+    }
+    if length > maximum {
+        return Err(FrameError::PayloadTooLarge { length, maximum });
+    }
+    i32::try_from(length).map_err(|_| FrameError::PayloadTooLarge { length, maximum })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Frame, FrameDecoder, FrameError, FrameType, MAX_FRAME_BYTES, PartialFramePart, encode_frame,
+    };
+    use pretty_assertions::assert_eq;
+
+    const REQUEST: &[u8] = br#"{"jsonrpc":"2.0","id":"h:1","method":"ping","params":{}}"#;
+
+    /// Confirms the canonical request vector has an exact five-byte big-endian header.
+    #[test]
+    fn encodes_canonical_golden_vector() {
+        let encoded = encode_frame(FrameType::Request, REQUEST, MAX_FRAME_BYTES)
+            .unwrap_or_else(|error| panic!("expected frame encoding to succeed: {error}"));
+        assert_eq!(&encoded[..5], &[0x00, 0x00, 0x00, 0x38, 0x01]);
+        assert_eq!(&encoded[5..], REQUEST);
+    }
+
+    /// Exercises every split position plus coalesced frames with one decoder implementation.
+    #[test]
+    fn decodes_arbitrary_splits_and_coalesced_frames() {
+        let encoded = encode_frame(FrameType::Request, REQUEST, MAX_FRAME_BYTES)
+            .unwrap_or_else(|error| panic!("expected frame encoding to succeed: {error}"));
+        let expected = vec![Frame {
+            frame_type: FrameType::Request,
+            payload: REQUEST.to_vec(),
+        }];
+
+        for cut in 0..=encoded.len() {
+            let mut decoder = FrameDecoder::new(MAX_FRAME_BYTES)
+                .unwrap_or_else(|error| panic!("expected decoder construction: {error}"));
+            let mut actual = decoder
+                .decode_chunk(&encoded[..cut])
+                .unwrap_or_else(|error| panic!("expected first chunk: {error}"));
+            actual.extend(
+                decoder
+                    .decode_chunk(&encoded[cut..])
+                    .unwrap_or_else(|error| panic!("expected second chunk: {error}")),
+            );
+            assert_eq!(actual, expected);
+            assert_eq!(decoder.finish(), Ok(()));
+        }
+
+        let mut decoder = FrameDecoder::new(MAX_FRAME_BYTES)
+            .unwrap_or_else(|error| panic!("expected decoder construction: {error}"));
+        let mut doubled = encoded.clone();
+        doubled.extend_from_slice(&encoded);
+        assert_eq!(
+            decoder.decode_chunk(&doubled),
+            Ok([expected.clone(), expected].concat())
+        );
+    }
+
+    /// Rejects invalid signed lengths and types before allocating a payload buffer.
+    #[test]
+    fn rejects_invalid_headers_and_partial_eof() {
+        let cases = [
+            (
+                [0x00, 0x00, 0x00, 0x00, 0x01],
+                FrameError::NonPositiveLength { length: 0 },
+            ),
+            (
+                [0xff, 0xff, 0xff, 0xff, 0x01],
+                FrameError::NonPositiveLength { length: -1 },
+            ),
+            (
+                [0x00, 0x00, 0x00, 0x02, 0x7f],
+                FrameError::UnknownType { value: 127 },
+            ),
+        ];
+        for (header, expected) in cases {
+            let mut decoder = FrameDecoder::new(MAX_FRAME_BYTES)
+                .unwrap_or_else(|error| panic!("expected decoder construction: {error}"));
+            assert_eq!(decoder.decode_chunk(&header), Err(expected));
+        }
+
+        let mut decoder = FrameDecoder::new(MAX_FRAME_BYTES)
+            .unwrap_or_else(|error| panic!("expected decoder construction: {error}"));
+        assert_eq!(decoder.decode_chunk(&[0, 0]), Ok(Vec::new()));
+        assert_eq!(
+            decoder.finish(),
+            Err(FrameError::PartialFrame {
+                part: PartialFramePart::Header,
+            })
+        );
+    }
+}

--- a/crates/plugin-protocol/src/identity.rs
+++ b/crates/plugin-protocol/src/identity.rs
@@ -1,0 +1,314 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+use ts_rs::TS;
+use uuid::Uuid;
+
+const SHA256_HEX_LENGTH: usize = 64;
+
+/// Reports why a protocol identity cannot be represented by its v1 canonical form.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum IdentityError {
+    #[error("{kind} must not be empty")]
+    Empty { kind: &'static str },
+    #[error("{kind} exceeds its {maximum}-byte limit")]
+    TooLong { kind: &'static str, maximum: usize },
+    #[error("{kind} has an invalid v1 format")]
+    InvalidFormat { kind: &'static str },
+}
+
+macro_rules! validated_string {
+    ($name:ident, $kind:literal, $validator:expr, $export:literal) => {
+        #[doc = concat!("A validated ", $kind, " serialized as a transparent JSON string.")]
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, TS)]
+        #[serde(transparent)]
+        #[ts(export_to = $export)]
+        pub struct $name(String);
+
+        impl $name {
+            #[doc = concat!("Validates and constructs a canonical ", $kind, ".")]
+            pub fn parse(value: impl Into<String>) -> Result<Self, IdentityError> {
+                let value = value.into();
+                ($validator)(&value)?;
+                Ok(Self(value))
+            }
+
+            #[doc = concat!("Returns the canonical ", $kind, " text.")]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            #[doc = concat!("Consumes the ", $kind, " and returns its canonical text.")]
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = IdentityError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Self::parse(value)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::parse(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+validated_string!(PluginId, "plugin id", validate_plugin_id, "plugin-types.ts");
+validated_string!(
+    AgentProviderId,
+    "Agent provider id",
+    validate_agent_provider_id,
+    "agent-contract.ts"
+);
+validated_string!(
+    PluginVersion,
+    "plugin version",
+    validate_semver,
+    "plugin-types.ts"
+);
+validated_string!(
+    PluginRelativePath,
+    "plugin relative path",
+    validate_plugin_relative_path,
+    "plugin-types.ts"
+);
+validated_string!(
+    ContentDigest,
+    "content digest",
+    validate_content_digest,
+    "plugin-types.ts"
+);
+validated_string!(
+    ContentOwnerId,
+    "content owner id",
+    validate_content_owner,
+    "plugin-types.ts"
+);
+validated_string!(
+    OperationId,
+    "operation id",
+    validate_uuid,
+    "plugin-types.ts"
+);
+validated_string!(
+    CandidateAuditId,
+    "candidate audit id",
+    validate_uuid,
+    "plugin-types.ts"
+);
+
+/// A global Agent provider identity that never relies on delimiter concatenation.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "agent-contract.ts")]
+pub struct AgentProviderKey {
+    pub plugin_id: PluginId,
+    pub provider_id: AgentProviderId,
+}
+
+/// Validates the canonical dotted plugin identity grammar and Windows-safe labels.
+fn validate_plugin_id(value: &str) -> Result<(), IdentityError> {
+    validate_length(value, "plugin id", 128)?;
+    if !value.is_ascii() || value.bytes().any(|byte| byte.is_ascii_uppercase()) {
+        return Err(invalid("plugin id"));
+    }
+
+    let labels = value.split('.').collect::<Vec<_>>();
+    if labels.len() < 2
+        || labels.iter().any(|label| {
+            label.is_empty()
+                || label.len() > 63
+                || label.starts_with('-')
+                || label.ends_with('-')
+                || label.bytes().any(|byte| {
+                    !(byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+                })
+                || is_windows_device_name(label)
+        })
+    {
+        return Err(invalid("plugin id"));
+    }
+    Ok(())
+}
+
+/// Validates a plugin-local provider id without applying the dotted plugin-id grammar.
+fn validate_agent_provider_id(value: &str) -> Result<(), IdentityError> {
+    validate_length(value, "Agent provider id", 63)?;
+    if !value.is_ascii()
+        || value.starts_with('-')
+        || value.ends_with('-')
+        || value
+            .bytes()
+            .any(|byte| !(byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'))
+    {
+        return Err(invalid("Agent provider id"));
+    }
+    Ok(())
+}
+
+/// Uses the SemVer parser and requires its canonical rendering to match the input.
+fn validate_semver(value: &str) -> Result<(), IdentityError> {
+    validate_length(value, "plugin version", 256)?;
+    let parsed = semver::Version::parse(value).map_err(|_| invalid("plugin version"))?;
+    if parsed.to_string() != value {
+        return Err(invalid("plugin version"));
+    }
+    Ok(())
+}
+
+/// Validates a portable plugin-relative path before any filesystem join occurs.
+fn validate_plugin_relative_path(value: &str) -> Result<(), IdentityError> {
+    validate_length(value, "plugin relative path", 512)?;
+    if value.contains('\0') {
+        return Err(invalid("plugin relative path"));
+    }
+    if value.starts_with('/')
+        || value.starts_with('\\')
+        || value.contains(':')
+        || value.ends_with('/')
+        || value.ends_with('\\')
+    {
+        return Err(invalid("plugin relative path"));
+    }
+
+    let segments = value.split(['/', '\\']);
+    for segment in segments {
+        if segment.is_empty()
+            || matches!(segment, "." | "..")
+            || segment.ends_with('.')
+            || segment.ends_with(' ')
+            || is_windows_device_name(segment)
+        {
+            return Err(invalid("plugin relative path"));
+        }
+    }
+    Ok(())
+}
+
+/// Validates the display digest form retained in receipts and state.
+fn validate_content_digest(value: &str) -> Result<(), IdentityError> {
+    validate_sha256_prefixed(value, "sha256:", "content digest")
+}
+
+/// Validates the path-safe content owner form used beneath plugin-data.
+fn validate_content_owner(value: &str) -> Result<(), IdentityError> {
+    validate_sha256_prefixed(value, "sha256-", "content owner id")
+}
+
+/// Validates canonical lowercase UUID text used for operation and audit identities.
+fn validate_uuid(value: &str) -> Result<(), IdentityError> {
+    validate_length(value, "UUID identity", 36)?;
+    let parsed = Uuid::parse_str(value).map_err(|_| invalid("UUID identity"))?;
+    if parsed.hyphenated().to_string() != value {
+        return Err(invalid("UUID identity"));
+    }
+    Ok(())
+}
+
+/// Validates a lower-hex SHA-256 string with an exact protocol prefix.
+fn validate_sha256_prefixed(
+    value: &str,
+    prefix: &str,
+    kind: &'static str,
+) -> Result<(), IdentityError> {
+    let Some(hex) = value.strip_prefix(prefix) else {
+        return Err(invalid(kind));
+    };
+    if hex.len() != SHA256_HEX_LENGTH
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(invalid(kind));
+    }
+    Ok(())
+}
+
+/// Applies a non-empty UTF-8 byte limit shared by all string identities.
+fn validate_length(value: &str, kind: &'static str, maximum: usize) -> Result<(), IdentityError> {
+    if value.is_empty() {
+        return Err(IdentityError::Empty { kind });
+    }
+    if value.len() > maximum {
+        return Err(IdentityError::TooLong { kind, maximum });
+    }
+    Ok(())
+}
+
+/// Recognizes Windows reserved DOS device names, including extension forms.
+fn is_windows_device_name(value: &str) -> bool {
+    let base = value
+        .split('.')
+        .next()
+        .unwrap_or(value)
+        .to_ascii_uppercase();
+    matches!(base.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || (base.len() == 4
+            && (base.starts_with("COM") || base.starts_with("LPT"))
+            && matches!(base.as_bytes()[3], b'1'..=b'9'))
+}
+
+/// Builds a stable invalid-format error without exposing parser-specific details.
+fn invalid(kind: &'static str) -> IdentityError {
+    IdentityError::InvalidFormat { kind }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AgentProviderId, ContentDigest, ContentOwnerId, PluginId, PluginRelativePath};
+    use pretty_assertions::assert_eq;
+
+    /// Covers canonical and rejected plugin/provider identities from the v1 grammar.
+    #[test]
+    fn validates_plugin_and_provider_identities() {
+        assert!(PluginId::parse("ora.claude-code").is_ok());
+        assert!(PluginId::parse("Ora.claude-code").is_err());
+        assert!(PluginId::parse("ora.con").is_err());
+        assert!(AgentProviderId::parse("claude-code").is_ok());
+        assert!(AgentProviderId::parse("-claude").is_err());
+        assert!(AgentProviderId::parse("claude.code").is_err());
+        assert!(AgentProviderId::parse("中文").is_err());
+    }
+
+    /// Rejects path traversal, alternate streams, devices, and ambiguous path segments.
+    #[test]
+    fn validates_plugin_relative_paths() {
+        assert!(PluginRelativePath::parse("dist/index.js").is_ok());
+        assert!(PluginRelativePath::parse("../index.js").is_err());
+        assert!(PluginRelativePath::parse("C:\\index.js").is_err());
+        assert!(PluginRelativePath::parse("dist/con.js").is_err());
+        assert_eq!(
+            PluginRelativePath::parse("dist/file.js:secret").is_err(),
+            true
+        );
+    }
+
+    /// Keeps receipt and path-safe owner digest encodings deliberately distinct.
+    #[test]
+    fn validates_digest_encodings() {
+        let hex = "a".repeat(64);
+        assert!(ContentDigest::parse(format!("sha256:{hex}")).is_ok());
+        assert!(ContentOwnerId::parse(format!("sha256-{hex}")).is_ok());
+        assert_eq!(
+            ContentOwnerId::parse(format!("sha256:{hex}")).is_err(),
+            true
+        );
+    }
+}

--- a/crates/plugin-protocol/src/json_rpc.rs
+++ b/crates/plugin-protocol/src/json_rpc.rs
@@ -1,0 +1,389 @@
+use crate::{
+    Frame, FrameType, JSON_SAFE_U64_MAX, StrictJsonError, deserialize_optional_non_null,
+    parse_strict_json,
+};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::{Map, Value};
+use std::collections::BTreeSet;
+use std::fmt::{Display, Formatter};
+
+pub const JSON_RPC_VERSION: &str = "2.0";
+pub const ERROR_PARSE: i32 = -32700;
+pub const ERROR_INVALID_REQUEST: i32 = -32600;
+pub const ERROR_METHOD_NOT_FOUND: i32 = -32601;
+pub const ERROR_INVALID_PARAMS: i32 = -32602;
+pub const ERROR_INTERNAL: i32 = -32603;
+pub const ERROR_AGENT_BUSINESS: i32 = -32000;
+pub const ERROR_SERVER_BUSY: i32 = -32010;
+pub const ERROR_REQUEST_CANCELLED: i32 = -32800;
+
+/// A bounded JSON-RPC id accepted for direction-violation diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RpcId(String);
+
+impl RpcId {
+    /// Validates the generic non-empty JSON-RPC string id boundary.
+    pub fn parse(value: impl Into<String>) -> Result<Self, JsonRpcParseError> {
+        let value = value.into();
+        if value.is_empty() || value.len() > 128 {
+            return Err(JsonRpcParseError::InvalidId);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for RpcId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for RpcId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A Host-created request id with the exact `h:<JsonSafeU64>` spelling.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct HostRequestId(RpcId);
+
+impl HostRequestId {
+    /// Constructs a Host id directly from a JavaScript-safe monotonic counter.
+    pub fn from_sequence(sequence: u64) -> Result<Self, JsonRpcParseError> {
+        if sequence > JSON_SAFE_U64_MAX {
+            return Err(JsonRpcParseError::InvalidHostRequestId);
+        }
+        Ok(Self(RpcId(format!("h:{sequence}"))))
+    }
+
+    /// Validates a response id received from the plugin.
+    pub fn parse(value: impl Into<String>) -> Result<Self, JsonRpcParseError> {
+        let value = value.into();
+        let Some(sequence) = value.strip_prefix("h:") else {
+            return Err(JsonRpcParseError::InvalidHostRequestId);
+        };
+        if sequence.is_empty()
+            || (sequence.len() > 1 && sequence.starts_with('0'))
+            || !sequence.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            return Err(JsonRpcParseError::InvalidHostRequestId);
+        }
+        let sequence = sequence
+            .parse::<u64>()
+            .map_err(|_| JsonRpcParseError::InvalidHostRequestId)?;
+        Self::from_sequence(sequence)
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl<'de> Deserialize<'de> for HostRequestId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A parsed strict JSON-RPC envelope whose variant must match the enclosing frame type.
+#[derive(Debug, Clone, PartialEq)]
+pub enum JsonRpcEnvelope {
+    Request(JsonRpcRequest),
+    Response(JsonRpcResponse),
+    Notification(JsonRpcNotification),
+}
+
+/// A well-formed Request envelope; method-specific params are validated by the closed registry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsonRpcRequest {
+    pub id: RpcId,
+    pub method: String,
+    pub params: Option<Value>,
+}
+
+/// A terminal Response envelope with exactly one of result or error.
+#[derive(Debug, Clone, PartialEq)]
+pub enum JsonRpcResponse {
+    Success {
+        id: HostRequestId,
+        result: Value,
+    },
+    Error {
+        id: HostRequestId,
+        error: JsonRpcError,
+    },
+}
+
+/// A well-formed Notification envelope.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsonRpcNotification {
+    pub method: String,
+    pub params: Option<Value>,
+}
+
+/// The exact JSON-RPC error object shape with an optional object data payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    pub data: Option<Map<String, Value>>,
+}
+
+/// Classifies strict profile failures without embedding the rejected payload in diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum JsonRpcParseError {
+    #[error(transparent)]
+    Json(#[from] StrictJsonError),
+    #[error("JSON-RPC envelope must be an object and batch is unsupported")]
+    EnvelopeNotObject,
+    #[error("JSON-RPC version must equal 2.0")]
+    InvalidVersion,
+    #[error("JSON-RPC envelope has fields incompatible with its frame type")]
+    FrameEnvelopeMismatch,
+    #[error("JSON-RPC envelope contains an unknown top-level field")]
+    UnknownField,
+    #[error("JSON-RPC id must be a non-empty string no longer than 128 bytes")]
+    InvalidId,
+    #[error("Plugin response id must use canonical h:<JsonSafeU64> form")]
+    InvalidHostRequestId,
+    #[error("JSON-RPC method must be a non-empty string no longer than 256 bytes")]
+    InvalidMethod,
+    #[error("JSON-RPC params, when present, must be a non-null object")]
+    InvalidParamsShape,
+    #[error("JSON-RPC response must contain exactly one of result or error")]
+    InvalidResponseShape,
+    #[error("JSON-RPC error object is invalid")]
+    InvalidErrorShape,
+}
+
+/// Parses one complete frame according to the strict Ora JSON-RPC profile.
+pub fn parse_json_rpc_frame(
+    frame: &Frame,
+    maximum_json_depth: usize,
+) -> Result<JsonRpcEnvelope, JsonRpcParseError> {
+    let value = parse_strict_json(&frame.payload, maximum_json_depth)?;
+    let object = value
+        .as_object()
+        .ok_or(JsonRpcParseError::EnvelopeNotObject)?;
+    validate_jsonrpc_version(object)?;
+    match frame.frame_type {
+        FrameType::Request => parse_request(object).map(JsonRpcEnvelope::Request),
+        FrameType::Response => parse_response(object).map(JsonRpcEnvelope::Response),
+        FrameType::Notification => parse_notification(object).map(JsonRpcEnvelope::Notification),
+    }
+}
+
+/// Serializes one Host request envelope with exact top-level fields.
+pub fn encode_json_rpc_request<P>(
+    id: &HostRequestId,
+    method: &str,
+    params: &P,
+) -> Result<Vec<u8>, serde_json::Error>
+where
+    P: Serialize,
+{
+    #[derive(Serialize)]
+    struct Request<'a, P> {
+        jsonrpc: &'static str,
+        id: &'a HostRequestId,
+        method: &'a str,
+        params: &'a P,
+    }
+
+    serde_json::to_vec(&Request {
+        jsonrpc: JSON_RPC_VERSION,
+        id,
+        method,
+        params,
+    })
+}
+
+/// Serializes one Host notification, omitting params for the exact exit shape when absent.
+pub fn encode_json_rpc_notification<P>(
+    method: &str,
+    params: Option<&P>,
+) -> Result<Vec<u8>, serde_json::Error>
+where
+    P: Serialize,
+{
+    #[derive(Serialize)]
+    struct Notification<'a, P> {
+        jsonrpc: &'static str,
+        method: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        params: Option<&'a P>,
+    }
+
+    serde_json::to_vec(&Notification {
+        jsonrpc: JSON_RPC_VERSION,
+        method,
+        params,
+    })
+}
+
+/// Parses the Request profile while retaining arbitrary ids for the required fatal diagnostic.
+fn parse_request(object: &Map<String, Value>) -> Result<JsonRpcRequest, JsonRpcParseError> {
+    require_allowed_fields(object, &["jsonrpc", "id", "method", "params"])?;
+    if object.contains_key("result") || object.contains_key("error") {
+        return Err(JsonRpcParseError::FrameEnvelopeMismatch);
+    }
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or(JsonRpcParseError::InvalidId)
+        .and_then(RpcId::parse)?;
+    let method = parse_method(object)?;
+    let params = parse_optional_params(object)?;
+    Ok(JsonRpcRequest { id, method, params })
+}
+
+/// Parses the Response profile and enforces Host-owned id correlation syntax.
+fn parse_response(object: &Map<String, Value>) -> Result<JsonRpcResponse, JsonRpcParseError> {
+    require_allowed_fields(object, &["jsonrpc", "id", "result", "error"])?;
+    if object.contains_key("method") || object.contains_key("params") {
+        return Err(JsonRpcParseError::FrameEnvelopeMismatch);
+    }
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or(JsonRpcParseError::InvalidHostRequestId)
+        .and_then(HostRequestId::parse)?;
+    match (object.get("result"), object.get("error")) {
+        (Some(result), None) => Ok(JsonRpcResponse::Success {
+            id,
+            result: result.clone(),
+        }),
+        (None, Some(error)) => {
+            let error = serde_json::from_value::<JsonRpcError>(error.clone())
+                .map_err(|_| JsonRpcParseError::InvalidErrorShape)?;
+            Ok(JsonRpcResponse::Error { id, error })
+        }
+        _ => Err(JsonRpcParseError::InvalidResponseShape),
+    }
+}
+
+/// Parses the Notification profile, leaving method-direction policy to the session router.
+fn parse_notification(
+    object: &Map<String, Value>,
+) -> Result<JsonRpcNotification, JsonRpcParseError> {
+    require_allowed_fields(object, &["jsonrpc", "method", "params"])?;
+    if object.contains_key("id") || object.contains_key("result") || object.contains_key("error") {
+        return Err(JsonRpcParseError::FrameEnvelopeMismatch);
+    }
+    let method = parse_method(object)?;
+    let params = parse_optional_params(object)?;
+    Ok(JsonRpcNotification { method, params })
+}
+
+/// Enforces the exact JSON-RPC version before shape-specific parsing.
+fn validate_jsonrpc_version(object: &Map<String, Value>) -> Result<(), JsonRpcParseError> {
+    if object.get("jsonrpc").and_then(Value::as_str) != Some(JSON_RPC_VERSION) {
+        return Err(JsonRpcParseError::InvalidVersion);
+    }
+    Ok(())
+}
+
+/// Applies the common method string bounds.
+fn parse_method(object: &Map<String, Value>) -> Result<String, JsonRpcParseError> {
+    let method = object
+        .get("method")
+        .and_then(Value::as_str)
+        .ok_or(JsonRpcParseError::InvalidMethod)?;
+    if method.is_empty() || method.len() > 256 {
+        return Err(JsonRpcParseError::InvalidMethod);
+    }
+    Ok(method.to_string())
+}
+
+/// Rejects explicit null and non-object params in the closed v1 method registry.
+fn parse_optional_params(object: &Map<String, Value>) -> Result<Option<Value>, JsonRpcParseError> {
+    match object.get("params") {
+        None => Ok(None),
+        Some(value) if value.is_object() => Ok(Some(value.clone())),
+        Some(_) => Err(JsonRpcParseError::InvalidParamsShape),
+    }
+}
+
+/// Rejects unknown envelope fields before they can create shape ambiguity.
+fn require_allowed_fields(
+    object: &Map<String, Value>,
+    allowed: &[&str],
+) -> Result<(), JsonRpcParseError> {
+    let allowed = allowed.iter().copied().collect::<BTreeSet<_>>();
+    if object.keys().any(|key| !allowed.contains(key.as_str())) {
+        return Err(JsonRpcParseError::UnknownField);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        HostRequestId, JsonRpcEnvelope, JsonRpcParseError, JsonRpcResponse,
+        encode_json_rpc_request, parse_json_rpc_frame,
+    };
+    use crate::{Frame, FrameType};
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    /// Parses a strict response and rejects type/envelope mismatch or result/error ambiguity.
+    #[test]
+    fn parses_strict_response_envelopes() {
+        let response = Frame {
+            frame_type: FrameType::Response,
+            payload: br#"{"jsonrpc":"2.0","id":"h:1","result":{"ok":true}}"#.to_vec(),
+        };
+        assert_eq!(
+            parse_json_rpc_frame(&response, 64),
+            Ok(JsonRpcEnvelope::Response(JsonRpcResponse::Success {
+                id: HostRequestId::from_sequence(1)
+                    .unwrap_or_else(|error| panic!("expected Host id: {error}")),
+                result: json!({"ok": true}),
+            }))
+        );
+
+        let mismatch = Frame {
+            frame_type: FrameType::Notification,
+            payload: response.payload,
+        };
+        assert_eq!(
+            parse_json_rpc_frame(&mismatch, 64),
+            Err(JsonRpcParseError::UnknownField)
+        );
+    }
+
+    /// Emits canonical Host request ids and compact JSON without newline framing.
+    #[test]
+    fn encodes_host_request() {
+        let id = HostRequestId::from_sequence(7)
+            .unwrap_or_else(|error| panic!("expected Host id: {error}"));
+        let encoded = encode_json_rpc_request(&id, "agent.listSkills", &json!({"limit": 10}))
+            .unwrap_or_else(|error| panic!("expected request encoding: {error}"));
+        assert_eq!(
+            encoded,
+            br#"{"jsonrpc":"2.0","id":"h:7","method":"agent.listSkills","params":{"limit":10}}"#
+                .to_vec()
+        );
+    }
+}

--- a/crates/plugin-protocol/src/json_rpc.rs
+++ b/crates/plugin-protocol/src/json_rpc.rs
@@ -244,10 +244,12 @@ where
 
 /// Parses the Request profile while retaining arbitrary ids for the required fatal diagnostic.
 fn parse_request(object: &Map<String, Value>) -> Result<JsonRpcRequest, JsonRpcParseError> {
-    require_allowed_fields(object, &["jsonrpc", "id", "method", "params"])?;
+    // Classify cross-shape fields before the allow-list so mismatch stays distinguishable from
+    // unknown keys; later layers may treat the two failures differently.
     if object.contains_key("result") || object.contains_key("error") {
         return Err(JsonRpcParseError::FrameEnvelopeMismatch);
     }
+    require_allowed_fields(object, &["jsonrpc", "id", "method", "params"])?;
     let id = object
         .get("id")
         .and_then(Value::as_str)
@@ -260,10 +262,11 @@ fn parse_request(object: &Map<String, Value>) -> Result<JsonRpcRequest, JsonRpcP
 
 /// Parses the Response profile and enforces Host-owned id correlation syntax.
 fn parse_response(object: &Map<String, Value>) -> Result<JsonRpcResponse, JsonRpcParseError> {
-    require_allowed_fields(object, &["jsonrpc", "id", "result", "error"])?;
+    // See parse_request: check incompatible envelope fields before UnknownField.
     if object.contains_key("method") || object.contains_key("params") {
         return Err(JsonRpcParseError::FrameEnvelopeMismatch);
     }
+    require_allowed_fields(object, &["jsonrpc", "id", "result", "error"])?;
     let id = object
         .get("id")
         .and_then(Value::as_str)
@@ -287,10 +290,11 @@ fn parse_response(object: &Map<String, Value>) -> Result<JsonRpcResponse, JsonRp
 fn parse_notification(
     object: &Map<String, Value>,
 ) -> Result<JsonRpcNotification, JsonRpcParseError> {
-    require_allowed_fields(object, &["jsonrpc", "method", "params"])?;
+    // See parse_request: check incompatible envelope fields before UnknownField.
     if object.contains_key("id") || object.contains_key("result") || object.contains_key("error") {
         return Err(JsonRpcParseError::FrameEnvelopeMismatch);
     }
+    require_allowed_fields(object, &["jsonrpc", "method", "params"])?;
     let method = parse_method(object)?;
     let params = parse_optional_params(object)?;
     Ok(JsonRpcNotification { method, params })
@@ -325,7 +329,10 @@ fn parse_optional_params(object: &Map<String, Value>) -> Result<Option<Value>, J
     }
 }
 
-/// Rejects unknown envelope fields before they can create shape ambiguity.
+/// Rejects top-level keys outside the closed field set for the current envelope shape.
+///
+/// Callers must classify cross-shape incompatibilities as [`JsonRpcParseError::FrameEnvelopeMismatch`]
+/// before invoking this helper so unknown-key failures stay distinct.
 fn require_allowed_fields(
     object: &Map<String, Value>,
     allowed: &[&str],
@@ -369,7 +376,7 @@ mod tests {
         };
         assert_eq!(
             parse_json_rpc_frame(&mismatch, 64),
-            Err(JsonRpcParseError::UnknownField)
+            Err(JsonRpcParseError::FrameEnvelopeMismatch)
         );
     }
 
@@ -384,6 +391,62 @@ mod tests {
             encoded,
             br#"{"jsonrpc":"2.0","id":"h:7","method":"agent.listSkills","params":{"limit":10}}"#
                 .to_vec()
+        );
+    }
+
+    /// Keeps cross-shape fields as FrameEnvelopeMismatch rather than collapsing to UnknownField.
+    #[test]
+    fn classifies_cross_shape_fields_as_envelope_mismatch() {
+        let request_with_result = Frame {
+            frame_type: FrameType::Request,
+            payload: br#"{"jsonrpc":"2.0","id":"p:1","method":"agent.listSkills","result":true}"#
+                .to_vec(),
+        };
+        assert_eq!(
+            parse_json_rpc_frame(&request_with_result, 64),
+            Err(JsonRpcParseError::FrameEnvelopeMismatch)
+        );
+
+        let response_with_params = Frame {
+            frame_type: FrameType::Response,
+            payload: br#"{"jsonrpc":"2.0","id":"h:1","result":true,"params":{}}"#.to_vec(),
+        };
+        assert_eq!(
+            parse_json_rpc_frame(&response_with_params, 64),
+            Err(JsonRpcParseError::FrameEnvelopeMismatch)
+        );
+
+        let notification_with_error = Frame {
+            frame_type: FrameType::Notification,
+            payload: br#"{"jsonrpc":"2.0","method":"$/exit","error":{"code":1,"message":"x"}}"#
+                .to_vec(),
+        };
+        assert_eq!(
+            parse_json_rpc_frame(&notification_with_error, 64),
+            Err(JsonRpcParseError::FrameEnvelopeMismatch)
+        );
+    }
+
+    /// Keeps truly unknown top-level keys as UnknownField after mismatch checks.
+    #[test]
+    fn classifies_unknown_top_level_fields_separately() {
+        let unknown_on_request = Frame {
+            frame_type: FrameType::Request,
+            payload: br#"{"jsonrpc":"2.0","id":"p:1","method":"agent.listSkills","extra":1}"#
+                .to_vec(),
+        };
+        assert_eq!(
+            parse_json_rpc_frame(&unknown_on_request, 64),
+            Err(JsonRpcParseError::UnknownField)
+        );
+
+        let unknown_on_response = Frame {
+            frame_type: FrameType::Response,
+            payload: br#"{"jsonrpc":"2.0","id":"h:1","result":true,"extra":1}"#.to_vec(),
+        };
+        assert_eq!(
+            parse_json_rpc_frame(&unknown_on_response, 64),
+            Err(JsonRpcParseError::UnknownField)
         );
     }
 }

--- a/crates/plugin-protocol/src/lib.rs
+++ b/crates/plugin-protocol/src/lib.rs
@@ -1,7 +1,9 @@
+mod frame;
 mod identity;
 mod manifest;
 mod strict_json;
 
+pub use frame::*;
 pub use identity::*;
 pub use manifest::*;
 pub use strict_json::*;

--- a/crates/plugin-protocol/src/lib.rs
+++ b/crates/plugin-protocol/src/lib.rs
@@ -1,8 +1,10 @@
+mod agent;
 mod frame;
 mod identity;
 mod manifest;
 mod strict_json;
 
+pub use agent::*;
 pub use frame::*;
 pub use identity::*;
 pub use manifest::*;

--- a/crates/plugin-protocol/src/lib.rs
+++ b/crates/plugin-protocol/src/lib.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod fixtures;
 mod frame;
 mod identity;
 mod json_rpc;
@@ -7,9 +8,200 @@ mod manifest;
 mod strict_json;
 
 pub use agent::*;
+pub use fixtures::*;
 pub use frame::*;
 pub use identity::*;
 pub use json_rpc::*;
 pub use lifecycle::*;
 pub use manifest::*;
 pub use strict_json::*;
+
+use std::path::Path;
+use ts_rs::{Config, ExportError, TS};
+
+/// Exports author-visible manifest and Agent DTOs to the public SDK package.
+pub fn export_public_typescript_bindings_to(
+    output_directory: impl AsRef<Path>,
+) -> Result<(), ExportError> {
+    write_typescript_bindings(output_directory.as_ref(), false)
+}
+
+/// Exports Host-private lifecycle DTOs consumed by the bundled bootstrap runtime.
+pub fn export_runtime_typescript_bindings_to(
+    output_directory: impl AsRef<Path>,
+) -> Result<(), ExportError> {
+    write_typescript_bindings(output_directory.as_ref(), true)
+}
+
+/// Renders one self-contained module so ts-rs never creates fragile cross-file merge imports.
+fn write_typescript_bindings(
+    output_directory: &Path,
+    include_lifecycle: bool,
+) -> Result<(), ExportError> {
+    std::fs::create_dir_all(output_directory)?;
+    let mut source = String::from(
+        "// Generated from ora-plugin-protocol. Do not edit.\n\n\
+         export type JsonValue = null | boolean | number | string | readonly JsonValue[] | { readonly [key: string]: JsonValue };\n\n",
+    );
+    let config = Config::new();
+
+    macro_rules! push_declarations {
+        ($($type:ty),+ $(,)?) => {
+            $(
+                source.push_str("export ");
+                source.push_str(&<$type>::decl(&config));
+                source.push_str("\n\n");
+            )+
+        };
+    }
+
+    push_declarations!(
+        PluginId,
+        AgentProviderId,
+        PluginVersion,
+        PluginRelativePath,
+        ContentDigest,
+        ContentOwnerId,
+        OperationId,
+        CandidateAuditId,
+        AgentProviderKey,
+        PluginPackageManifest,
+        PackageModuleType,
+        PluginManifest,
+        PluginKind,
+        AgentEngines,
+        WorkbenchEngines,
+        EngineRange,
+        AgentContributions,
+        AgentContribution,
+        WorkbenchContributions,
+        WorkbenchContribution,
+        AgentInstallationId,
+        AgentConversationId,
+        AgentTurnId,
+        AgentCursor,
+        AgentResourceId,
+        AgentToolCallId,
+        ProjectHandle,
+        WorktreeHandle,
+        AgentConfigurationKey,
+        ClientRequestId,
+        HostResolvedAbsolutePath,
+        AgentPrompt,
+        Rfc3339Timestamp,
+        JsonSafeU64,
+        AgentPageLimit,
+        FiniteJsonNumber,
+        AgentScope,
+        DiscoverInstallationsRequest,
+        GetConfigurationSummaryRequest,
+        ListSkillsRequest,
+        ListMcpServersRequest,
+        ListConversationsRequest,
+        StartConversationRequest,
+        SendMessageRequest,
+        CancelConversationRequest,
+        DiscoverInstallationsResponse,
+        AgentInstallation,
+        AgentAvailability,
+        AgentDiscoveryDiagnostic,
+        AgentDiscoveryDiagnosticKind,
+        GetConfigurationSummaryResponse,
+        AgentConfigurationItem,
+        AgentConfigurationValue,
+        ListSkillsResponse,
+        AgentSkillSummary,
+        ListMcpServersResponse,
+        AgentMcpServerSummary,
+        AgentResourceSource,
+        AgentMcpTransport,
+        ListConversationsResponse,
+        AgentConversationSummary,
+        AgentEvent,
+        AgentOutputChannel,
+        AgentUsage,
+        AgentTurnResult,
+        AgentFinishReason,
+        CancelConversationResponse,
+        CancelDisposition,
+        AgentMethod,
+        InvocationSemantics,
+        AgentBusinessFailureKind,
+        AgentBusinessErrorData,
+    );
+
+    if include_lifecycle {
+        push_declarations!(
+            InitializeParams,
+            InitializePlugin,
+            InitializePaths,
+            DeclaredAgent,
+            InitializeLimits,
+            InitializeResult,
+            InitializeResultPlugin,
+            ActivationReason,
+            ActivateParams,
+            ActivateResult,
+            DeactivationReason,
+            DeactivateParams,
+            CancelRequestParams,
+            StreamParams,
+        );
+    }
+
+    let trimmed_length = source.trim_end().len();
+    source.truncate(trimmed_length);
+    source.push('\n');
+    std::fs::write(output_directory.join("plugin-protocol.ts"), source)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{export_public_typescript_bindings_to, export_runtime_typescript_bindings_to};
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Verifies SDK protocol bindings are written only to the caller-selected package directory.
+    #[test]
+    fn exports_public_and_private_typescript_bindings() {
+        let output_directory = TempDir::new().unwrap_or_else(|error| {
+            panic!("failed to create protocol export directory: {error}");
+        });
+
+        export_public_typescript_bindings_to(output_directory.path()).unwrap_or_else(|error| {
+            panic!("expected protocol export to succeed: {error}");
+        });
+
+        let public_files = fs::read_dir(output_directory.path())
+            .unwrap_or_else(|error| panic!("failed to read protocol exports: {error}"))
+            .map(|entry| {
+                entry
+                    .unwrap_or_else(|error| panic!("failed to read protocol entry: {error}"))
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(public_files, vec!["plugin-protocol.ts".to_string()]);
+        let public_source = fs::read_to_string(output_directory.path().join("plugin-protocol.ts"))
+            .unwrap_or_else(|error| panic!("failed to read public protocol export: {error}"));
+        assert!(!public_source.contains("InitializeParams"));
+        assert!(public_source.contains("AgentEvent"));
+        assert!(!public_source.ends_with("\n\n"));
+
+        let runtime_directory = TempDir::new().unwrap_or_else(|error| {
+            panic!("failed to create runtime export directory: {error}");
+        });
+        export_runtime_typescript_bindings_to(runtime_directory.path()).unwrap_or_else(|error| {
+            panic!("expected runtime protocol export to succeed: {error}");
+        });
+        let runtime_source =
+            fs::read_to_string(runtime_directory.path().join("plugin-protocol.ts"))
+                .unwrap_or_else(|error| panic!("failed to read runtime protocol export: {error}"));
+        assert!(runtime_source.contains("InitializeParams"));
+        assert!(!runtime_source.ends_with("\n\n"));
+    }
+}

--- a/crates/plugin-protocol/src/lib.rs
+++ b/crates/plugin-protocol/src/lib.rs
@@ -1,11 +1,13 @@
 mod agent;
 mod frame;
 mod identity;
+mod lifecycle;
 mod manifest;
 mod strict_json;
 
 pub use agent::*;
 pub use frame::*;
 pub use identity::*;
+pub use lifecycle::*;
 pub use manifest::*;
 pub use strict_json::*;

--- a/crates/plugin-protocol/src/lib.rs
+++ b/crates/plugin-protocol/src/lib.rs
@@ -1,0 +1,7 @@
+mod identity;
+mod manifest;
+mod strict_json;
+
+pub use identity::*;
+pub use manifest::*;
+pub use strict_json::*;

--- a/crates/plugin-protocol/src/lib.rs
+++ b/crates/plugin-protocol/src/lib.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod frame;
 mod identity;
+mod json_rpc;
 mod lifecycle;
 mod manifest;
 mod strict_json;
@@ -8,6 +9,7 @@ mod strict_json;
 pub use agent::*;
 pub use frame::*;
 pub use identity::*;
+pub use json_rpc::*;
 pub use lifecycle::*;
 pub use manifest::*;
 pub use strict_json::*;

--- a/crates/plugin-protocol/src/lifecycle.rs
+++ b/crates/plugin-protocol/src/lifecycle.rs
@@ -1,0 +1,488 @@
+use crate::{
+    AGENT_CONTRACT_VERSION_V1, AgentContribution, AgentProviderId, ContentOwnerId,
+    HostResolvedAbsolutePath, MAX_AGENT_PROMPT_BYTES, MAX_FRAME_BYTES, PluginId, PluginKind,
+    PluginVersion,
+};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::BTreeSet;
+use ts_rs::TS;
+
+pub const WIRE_VERSION_V1: u32 = 1;
+pub const METHOD_INITIALIZE: &str = "$/initialize";
+pub const METHOD_ACTIVATE: &str = "$/activate";
+pub const METHOD_DEACTIVATE: &str = "$/deactivate";
+pub const METHOD_EXIT: &str = "$/exit";
+pub const METHOD_CANCEL_REQUEST: &str = "$/cancelRequest";
+pub const METHOD_STREAM: &str = "$/stream";
+
+/// Host-private initialize parameters sent before plugin entry import.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct InitializeParams {
+    pub wire_version: u32,
+    pub host_version: PluginVersion,
+    pub runtime_version: PluginVersion,
+    pub session_id: String,
+    pub plugin: InitializePlugin,
+    pub paths: InitializePaths,
+    pub declared_agents: Vec<DeclaredAgent>,
+    pub limits: InitializeLimits,
+}
+
+impl InitializeParams {
+    /// Validates cross-field lifecycle invariants before the bootstrap confirms initialization.
+    pub fn validate(&self) -> Result<(), LifecycleContractError> {
+        if self.wire_version != WIRE_VERSION_V1 {
+            return Err(LifecycleContractError::WireVersionMismatch {
+                actual: self.wire_version,
+            });
+        }
+        if self.session_id.is_empty() || self.session_id.len() > 128 {
+            return Err(LifecycleContractError::InvalidSessionId);
+        }
+        if self.plugin.kind != PluginKind::Agent
+            || self.plugin.plugin_api != crate::PLUGIN_API_VERSION_V1
+        {
+            return Err(LifecycleContractError::PluginApiMismatch);
+        }
+        self.limits.validate()?;
+        validate_entry_descendant(&self.paths)?;
+        validate_declared_agents(&self.declared_agents)
+    }
+}
+
+/// Immutable identity echoed across the private bootstrap handshake.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct InitializePlugin {
+    pub id: PluginId,
+    pub version: PluginVersion,
+    pub kind: PluginKind,
+    pub plugin_api: u32,
+    pub content_owner: ContentOwnerId,
+}
+
+/// Host-derived managed paths that the plugin response cannot replace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct InitializePaths {
+    pub extension_path: HostResolvedAbsolutePath,
+    pub entry_path: HostResolvedAbsolutePath,
+    pub storage_path: HostResolvedAbsolutePath,
+}
+
+/// A provider descriptor declared by the immutable manifest.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct DeclaredAgent {
+    pub id: AgentProviderId,
+    pub contract_version: u32,
+}
+
+impl From<&AgentContribution> for DeclaredAgent {
+    fn from(contribution: &AgentContribution) -> Self {
+        Self {
+            id: contribution.id.clone(),
+            contract_version: contribution.contract_version,
+        }
+    }
+}
+
+/// The exact seven initialize limits installed by both Host and bootstrap.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "lifecycle.ts")]
+pub struct InitializeLimits {
+    pub max_frame_bytes: u32,
+    pub max_pending_requests: u32,
+    pub max_agent_event_bytes: u32,
+    pub max_agent_result_bytes: u32,
+    pub max_agent_prompt_bytes: u32,
+    pub max_active_turns: u32,
+    pub max_page_items: u32,
+}
+
+impl InitializeLimits {
+    /// Constructs limits only when every dynamic cap is positive and no larger than wire v1.
+    pub fn new(
+        max_pending_requests: u32,
+        max_agent_event_bytes: u32,
+        max_agent_result_bytes: u32,
+        max_agent_prompt_bytes: u32,
+        max_active_turns: u32,
+        max_page_items: u32,
+    ) -> Result<Self, LifecycleContractError> {
+        let limits = Self {
+            max_frame_bytes: MAX_FRAME_BYTES as u32,
+            max_pending_requests,
+            max_agent_event_bytes,
+            max_agent_result_bytes,
+            max_agent_prompt_bytes,
+            max_active_turns,
+            max_page_items,
+        };
+        limits.validate()?;
+        Ok(limits)
+    }
+
+    /// Provides the design defaults while preserving the same validation path as configuration.
+    pub fn v1_defaults() -> Self {
+        Self {
+            max_frame_bytes: MAX_FRAME_BYTES as u32,
+            max_pending_requests: 128,
+            max_agent_event_bytes: 256 * 1024,
+            max_agent_result_bytes: 1024 * 1024,
+            max_agent_prompt_bytes: MAX_AGENT_PROMPT_BYTES as u32,
+            max_active_turns: 64,
+            max_page_items: 100,
+        }
+    }
+
+    /// Applies the exact frame constant and six configurable hard-cap boundaries.
+    pub fn validate(&self) -> Result<(), LifecycleContractError> {
+        if self.max_frame_bytes != MAX_FRAME_BYTES as u32 {
+            return Err(LifecycleContractError::InvalidLimit {
+                field: "maxFrameBytes",
+                value: self.max_frame_bytes,
+                maximum: MAX_FRAME_BYTES as u32,
+            });
+        }
+        validate_limit("maxPendingRequests", self.max_pending_requests, 128)?;
+        validate_limit("maxAgentEventBytes", self.max_agent_event_bytes, 256 * 1024)?;
+        validate_limit(
+            "maxAgentResultBytes",
+            self.max_agent_result_bytes,
+            1024 * 1024,
+        )?;
+        validate_limit(
+            "maxAgentPromptBytes",
+            self.max_agent_prompt_bytes,
+            MAX_AGENT_PROMPT_BYTES as u32,
+        )?;
+        validate_limit("maxActiveTurns", self.max_active_turns, 64)?;
+        validate_limit("maxPageItems", self.max_page_items, 100)?;
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for InitializeLimits {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct RawInitializeLimits {
+            max_frame_bytes: u32,
+            max_pending_requests: u32,
+            max_agent_event_bytes: u32,
+            max_agent_result_bytes: u32,
+            max_agent_prompt_bytes: u32,
+            max_active_turns: u32,
+            max_page_items: u32,
+        }
+
+        let raw = RawInitializeLimits::deserialize(deserializer)?;
+        let limits = Self {
+            max_frame_bytes: raw.max_frame_bytes,
+            max_pending_requests: raw.max_pending_requests,
+            max_agent_event_bytes: raw.max_agent_event_bytes,
+            max_agent_result_bytes: raw.max_agent_result_bytes,
+            max_agent_prompt_bytes: raw.max_agent_prompt_bytes,
+            max_active_turns: raw.max_active_turns,
+            max_page_items: raw.max_page_items,
+        };
+        limits.validate().map_err(serde::de::Error::custom)?;
+        Ok(limits)
+    }
+}
+
+/// Bootstrap identity echo returned before plugin code can execute.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct InitializeResult {
+    pub wire_version: u32,
+    pub runtime_version: PluginVersion,
+    pub session_id: String,
+    pub plugin: InitializeResultPlugin,
+}
+
+/// The minimal plugin identity echoed by initialize.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct InitializeResultPlugin {
+    pub id: PluginId,
+    pub version: PluginVersion,
+}
+
+/// The only reasons that can trigger the activate lifecycle method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "lifecycle.ts")]
+pub enum ActivationReason {
+    LazyInvocation,
+    ManualStart,
+}
+
+/// Exact activate params shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct ActivateParams {
+    pub reason: ActivationReason,
+}
+
+/// Provider descriptors installed only after successful activation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct ActivateResult {
+    pub providers: Vec<DeclaredAgent>,
+}
+
+impl ActivateResult {
+    /// Requires the activated provider set to equal the manifest set after canonical sorting.
+    pub fn validate_declared_providers(
+        &self,
+        declared: &[DeclaredAgent],
+    ) -> Result<(), LifecycleContractError> {
+        let mut expected = declared.to_vec();
+        expected.sort();
+        let mut actual = self.providers.clone();
+        actual.sort();
+        if actual != expected || actual.windows(2).any(|pair| pair[0].id == pair[1].id) {
+            return Err(LifecycleContractError::ProviderMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// The reasons for a bounded deactivate request after successful activation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "lifecycle.ts")]
+pub enum DeactivationReason {
+    ManualStop,
+    Disable,
+    Uninstall,
+    Shutdown,
+    GrantChanged,
+}
+
+/// Exact deactivate params shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct DeactivateParams {
+    pub reason: DeactivationReason,
+}
+
+/// Transport cancellation params sent only from Host requester to Plugin responder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct CancelRequestParams {
+    pub id: String,
+}
+
+/// A typed stream notification tied to one Host request and strict sequence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "lifecycle.ts")]
+pub struct StreamParams {
+    pub id: String,
+    pub seq: crate::JsonSafeU64,
+    pub value: crate::AgentEvent,
+}
+
+/// Stable lifecycle DTO validation failures used by handshake diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LifecycleContractError {
+    #[error("wireVersion must equal 1, got {actual}")]
+    WireVersionMismatch { actual: u32 },
+    #[error("sessionId must contain 1..=128 UTF-8 bytes")]
+    InvalidSessionId,
+    #[error("initialize plugin kind/pluginApi does not identify Agent v1")]
+    PluginApiMismatch,
+    #[error("declared Agent descriptors are empty, duplicated, or not contractVersion=1")]
+    InvalidDeclaredAgents,
+    #[error("entryPath must be a normalized strict descendant of extensionPath")]
+    InvalidEntryPath,
+    #[error("initialize limit {field} must be in 1..={maximum}, got {value}")]
+    InvalidLimit {
+        field: &'static str,
+        value: u32,
+        maximum: u32,
+    },
+    #[error("activate providers do not exactly match manifest declarations")]
+    ProviderMismatch,
+}
+
+/// Enforces positive, no-greater-than-hard-cap dynamic limits.
+fn validate_limit(
+    field: &'static str,
+    value: u32,
+    maximum: u32,
+) -> Result<(), LifecycleContractError> {
+    if value == 0 || value > maximum {
+        return Err(LifecycleContractError::InvalidLimit {
+            field,
+            value,
+            maximum,
+        });
+    }
+    Ok(())
+}
+
+/// Rejects duplicate or non-v1 provider descriptors before plugin import.
+fn validate_declared_agents(agents: &[DeclaredAgent]) -> Result<(), LifecycleContractError> {
+    if agents.is_empty() || agents.len() > 64 {
+        return Err(LifecycleContractError::InvalidDeclaredAgents);
+    }
+    let mut ids = BTreeSet::new();
+    if agents.iter().any(|agent| {
+        agent.contract_version != AGENT_CONTRACT_VERSION_V1 || !ids.insert(agent.id.clone())
+    }) {
+        return Err(LifecycleContractError::InvalidDeclaredAgents);
+    }
+    Ok(())
+}
+
+/// Prevents an authored entry path from escaping the Host-resolved extension directory.
+fn validate_entry_descendant(paths: &InitializePaths) -> Result<(), LifecycleContractError> {
+    let extension = paths
+        .extension_path
+        .as_str()
+        .replace('/', "\\")
+        .trim_end_matches('\\')
+        .to_ascii_lowercase();
+    let entry = paths
+        .entry_path
+        .as_str()
+        .replace('/', "\\")
+        .to_ascii_lowercase();
+    let has_relative_segment = |path: &str| {
+        path.split('\\')
+            .any(|component| matches!(component, "." | ".."))
+    };
+    if has_relative_segment(&extension)
+        || has_relative_segment(&entry)
+        || !entry.starts_with(&format!("{extension}\\"))
+    {
+        return Err(LifecycleContractError::InvalidEntryPath);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ActivateResult, DeclaredAgent, InitializeLimits, InitializeParams, InitializePaths,
+        InitializePlugin, LifecycleContractError, WIRE_VERSION_V1,
+    };
+    use crate::{
+        AgentProviderId, ContentOwnerId, HostResolvedAbsolutePath, PluginId, PluginKind,
+        PluginVersion,
+    };
+    use pretty_assertions::assert_eq;
+
+    /// Requires the exact seven-field initialize limits and rejects values above hard caps.
+    #[test]
+    fn validates_initialize_limits() {
+        assert_eq!(InitializeLimits::v1_defaults().validate(), Ok(()));
+        let invalid = serde_json::from_str::<InitializeLimits>(
+            r#"{"maxFrameBytes":8388608,"maxPendingRequests":129,"maxAgentEventBytes":262144,"maxAgentResultBytes":1048576,"maxAgentPromptBytes":1048576,"maxActiveTurns":64,"maxPageItems":100}"#,
+        );
+        assert!(invalid.is_err());
+    }
+
+    /// Compares activated providers as a sorted deep-equal set and still rejects duplicates.
+    #[test]
+    fn validates_activation_provider_set() {
+        let provider = DeclaredAgent {
+            id: AgentProviderId::parse("claude-code")
+                .unwrap_or_else(|error| panic!("expected provider id: {error}")),
+            contract_version: 1,
+        };
+        assert_eq!(
+            ActivateResult {
+                providers: vec![provider.clone()],
+            }
+            .validate_declared_providers(std::slice::from_ref(&provider)),
+            Ok(())
+        );
+        assert_eq!(
+            ActivateResult {
+                providers: vec![provider.clone(), provider.clone()],
+            }
+            .validate_declared_providers(&[provider]),
+            Err(LifecycleContractError::ProviderMismatch)
+        );
+    }
+
+    /// Applies nested limit validation and normalized entry containment at the Host boundary.
+    #[test]
+    fn validates_initialize_cross_field_invariants() {
+        let mut params = initialize_params(r"D:\plugins\ora.runtime\dist\index.js");
+        assert_eq!(params.validate(), Ok(()));
+        params.limits.max_active_turns = 0;
+        assert_eq!(
+            params.validate(),
+            Err(LifecycleContractError::InvalidLimit {
+                field: "maxActiveTurns",
+                value: 0,
+                maximum: 64,
+            })
+        );
+        assert_eq!(
+            initialize_params(r"D:\plugins\ora.runtime\..\other\index.js").validate(),
+            Err(LifecycleContractError::InvalidEntryPath)
+        );
+        assert_eq!(
+            initialize_params(r"D:\plugins\other\index.js").validate(),
+            Err(LifecycleContractError::InvalidEntryPath)
+        );
+    }
+
+    /// Builds a complete initialize value so validation tests exercise the public entry point.
+    fn initialize_params(entry_path: &str) -> InitializeParams {
+        InitializeParams {
+            wire_version: WIRE_VERSION_V1,
+            host_version: PluginVersion::parse("1.0.0")
+                .unwrap_or_else(|error| panic!("host version: {error}")),
+            runtime_version: PluginVersion::parse("1.0.0")
+                .unwrap_or_else(|error| panic!("runtime version: {error}")),
+            session_id: "session-1".to_owned(),
+            plugin: InitializePlugin {
+                id: PluginId::parse("ora.runtime")
+                    .unwrap_or_else(|error| panic!("plugin id: {error}")),
+                version: PluginVersion::parse("0.1.0")
+                    .unwrap_or_else(|error| panic!("plugin version: {error}")),
+                kind: PluginKind::Agent,
+                plugin_api: crate::PLUGIN_API_VERSION_V1,
+                content_owner: ContentOwnerId::parse(format!("sha256-{}", "a".repeat(64)))
+                    .unwrap_or_else(|error| panic!("content owner: {error}")),
+            },
+            paths: InitializePaths {
+                extension_path: HostResolvedAbsolutePath::parse(r"D:\plugins\ora.runtime")
+                    .unwrap_or_else(|error| panic!("extension path: {error}")),
+                entry_path: HostResolvedAbsolutePath::parse(entry_path)
+                    .unwrap_or_else(|error| panic!("entry path: {error}")),
+                storage_path: HostResolvedAbsolutePath::parse(r"D:\plugin-data\ora.runtime")
+                    .unwrap_or_else(|error| panic!("storage path: {error}")),
+            },
+            declared_agents: vec![DeclaredAgent {
+                id: AgentProviderId::parse("example")
+                    .unwrap_or_else(|error| panic!("provider id: {error}")),
+                contract_version: 1,
+            }],
+            limits: InitializeLimits::v1_defaults(),
+        }
+    }
+}

--- a/crates/plugin-protocol/src/manifest.rs
+++ b/crates/plugin-protocol/src/manifest.rs
@@ -1,0 +1,405 @@
+use crate::{
+    AgentProviderId, PluginId, PluginRelativePath, PluginVersion, StrictJsonError,
+    parse_strict_json,
+};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::BTreeSet;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+use ts_rs::TS;
+
+pub const MANIFEST_VERSION_V1: u32 = 1;
+pub const PLUGIN_API_VERSION_V1: u32 = 1;
+pub const AGENT_CONTRACT_VERSION_V1: u32 = 1;
+pub const MAX_MANIFEST_BYTES: usize = 256 * 1024;
+pub const MAX_MANIFEST_JSON_DEPTH: usize = 64;
+pub const MAX_CONTRIBUTIONS: usize = 64;
+
+/// A parsed package.json containing standard package metadata and strict Ora metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "plugin-types.ts")]
+pub struct PluginPackageManifest {
+    pub name: String,
+    pub version: PluginVersion,
+    #[serde(rename = "type", default)]
+    #[ts(optional)]
+    pub module_type: Option<PackageModuleType>,
+    pub ora: PluginManifest,
+}
+
+/// The only package module mode supported by the materialized Agent v1 format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "plugin-types.ts")]
+pub enum PackageModuleType {
+    Module,
+}
+
+/// The closed v1 plugin-kind union; fields illegal for a kind cannot be represented.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+#[ts(export_to = "plugin-types.ts")]
+pub enum PluginManifest {
+    Agent {
+        manifest_version: u32,
+        id: PluginId,
+        display_name: String,
+        main: PluginRelativePath,
+        engines: AgentEngines,
+        contributes: AgentContributions,
+    },
+    Workbench {
+        manifest_version: u32,
+        id: PluginId,
+        display_name: String,
+        engines: WorkbenchEngines,
+        contributes: WorkbenchContributions,
+    },
+}
+
+impl PluginManifest {
+    /// Returns the canonical identity shared by directories, state, catalog, and registry.
+    pub fn id(&self) -> &PluginId {
+        match self {
+            Self::Agent { id, .. } | Self::Workbench { id, .. } => id,
+        }
+    }
+
+    /// Returns the user-facing name after manifest budget validation.
+    pub fn display_name(&self) -> &str {
+        match self {
+            Self::Agent { display_name, .. } | Self::Workbench { display_name, .. } => display_name,
+        }
+    }
+
+    /// Returns the closed plugin kind without exposing kind-specific optional fields.
+    pub fn kind(&self) -> PluginKind {
+        match self {
+            Self::Agent { .. } => PluginKind::Agent,
+            Self::Workbench { .. } => PluginKind::Workbench,
+        }
+    }
+
+    /// Returns Agent contributions only for the executable Agent variant.
+    pub fn agent_contributions(&self) -> Option<&AgentContributions> {
+        match self {
+            Self::Agent { contributes, .. } => Some(contributes),
+            Self::Workbench { .. } => None,
+        }
+    }
+}
+
+/// The manifest kind known to management and support-policy decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "plugin-types.ts")]
+pub enum PluginKind {
+    Agent,
+    Workbench,
+}
+
+/// Compatibility requirements for an executable Agent plugin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "plugin-types.ts")]
+pub struct AgentEngines {
+    pub ora: EngineRange,
+    pub plugin_api: u32,
+    pub bun: EngineRange,
+}
+
+/// Compatibility requirements for a catalog-only Workbench v1 plugin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "plugin-types.ts")]
+pub struct WorkbenchEngines {
+    pub ora: EngineRange,
+}
+
+/// A validated SemVer requirement string retained exactly as authored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(transparent)]
+#[ts(export_to = "plugin-types.ts")]
+pub struct EngineRange(String);
+
+impl EngineRange {
+    /// Parses the whitespace-separated comparator form used by Ora manifests.
+    pub fn parse(value: impl Into<String>) -> Result<Self, ManifestParseError> {
+        let value = value.into();
+        if value.is_empty() || value.len() > 256 || !value.is_ascii() {
+            return Err(ManifestParseError::InvalidEngineRange);
+        }
+        parse_version_requirement(&value)?;
+        Ok(Self(value))
+    }
+
+    /// Returns the exact authored range for diagnostics and generated types.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Tests a canonical SemVer against this range without defining a compatibility shim.
+    pub fn matches(&self, version: &PluginVersion) -> bool {
+        let requirement = parse_version_requirement(&self.0);
+        let version = semver::Version::parse(version.as_str());
+        matches!((requirement, version), (Ok(requirement), Ok(version)) if requirement.matches(&version))
+    }
+}
+
+impl Display for EngineRange {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl FromStr for EngineRange {
+    type Err = ManifestParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for EngineRange {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Agent contributions statically declared by the immutable manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "plugin-types.ts")]
+pub struct AgentContributions {
+    pub agents: Vec<AgentContribution>,
+}
+
+/// One plugin-local provider registration allowed by Agent Contract v1.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "plugin-types.ts")]
+pub struct AgentContribution {
+    pub id: AgentProviderId,
+    pub display_name: String,
+    pub contract_version: u32,
+}
+
+/// Workbench v1 deliberately exposes only a non-executable placeholder contribution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "plugin-types.ts")]
+pub struct WorkbenchContributions {
+    pub workbench: WorkbenchContribution,
+}
+
+/// The exact non-executable Workbench v1 schema marker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export_to = "plugin-types.ts")]
+pub struct WorkbenchContribution {
+    pub schema_version: u32,
+}
+
+/// Classifies manifest parsing and v1 schema failures before compatibility checks.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ManifestParseError {
+    #[error("package.json exceeds its {maximum}-byte limit")]
+    TooLarge { maximum: usize },
+    #[error(transparent)]
+    Json(#[from] StrictJsonError),
+    #[error("manifest envelope is missing a non-negative integer ora.manifestVersion")]
+    MissingManifestVersion,
+    #[error("manifest schema version {manifest_version} is not supported")]
+    UnsupportedManifestVersion { manifest_version: u64 },
+    #[error("known manifest v1 schema is invalid: {message}")]
+    InvalidSchema { message: String },
+    #[error("manifest engine range is invalid")]
+    InvalidEngineRange,
+    #[error("manifest violates v1 invariant: {message}")]
+    InvalidInvariant { message: String },
+}
+
+/// Parses package.json with duplicate-key/depth protection and validates v1 invariants.
+pub fn parse_plugin_manifest(bytes: &[u8]) -> Result<PluginPackageManifest, ManifestParseError> {
+    if bytes.len() > MAX_MANIFEST_BYTES {
+        return Err(ManifestParseError::TooLarge {
+            maximum: MAX_MANIFEST_BYTES,
+        });
+    }
+    let value = parse_strict_json(bytes, MAX_MANIFEST_JSON_DEPTH)?;
+    let manifest_version = value
+        .get("ora")
+        .and_then(|ora| ora.get("manifestVersion"))
+        .and_then(serde_json::Value::as_u64)
+        .ok_or(ManifestParseError::MissingManifestVersion)?;
+    if manifest_version != u64::from(MANIFEST_VERSION_V1) {
+        return Err(ManifestParseError::UnsupportedManifestVersion { manifest_version });
+    }
+    let manifest = serde_json::from_value::<PluginPackageManifest>(value).map_err(|error| {
+        ManifestParseError::InvalidSchema {
+            message: error.to_string(),
+        }
+    })?;
+    validate_manifest_invariants(&manifest)?;
+    Ok(manifest)
+}
+
+/// Enforces semantic constraints that cannot be represented by serde object shapes alone.
+fn validate_manifest_invariants(package: &PluginPackageManifest) -> Result<(), ManifestParseError> {
+    if package.name.is_empty() || package.name.len() > 512 {
+        return Err(invariant("package name must contain 1..=512 UTF-8 bytes"));
+    }
+    if package.ora.display_name().chars().count() > 128 || package.ora.display_name().is_empty() {
+        return Err(invariant(
+            "displayName must contain 1..=128 Unicode scalar values",
+        ));
+    }
+
+    match &package.ora {
+        PluginManifest::Agent {
+            manifest_version,
+            engines,
+            contributes,
+            ..
+        } => {
+            require_v1_manifest_version(*manifest_version)?;
+            if package.module_type != Some(PackageModuleType::Module) {
+                return Err(invariant("Agent v1 requires top-level type=module"));
+            }
+            if engines.plugin_api != PLUGIN_API_VERSION_V1 {
+                return Err(invariant("Agent v1 requires engines.pluginApi=1"));
+            }
+            if contributes.agents.is_empty() || contributes.agents.len() > MAX_CONTRIBUTIONS {
+                return Err(invariant("Agent contribution count must be in 1..=64"));
+            }
+            let mut ids = BTreeSet::new();
+            for contribution in &contributes.agents {
+                if contribution.contract_version != AGENT_CONTRACT_VERSION_V1 {
+                    return Err(invariant("Agent contribution contractVersion must equal 1"));
+                }
+                if contribution.display_name.is_empty()
+                    || contribution.display_name.chars().count() > 128
+                {
+                    return Err(invariant(
+                        "Agent displayName must contain 1..=128 Unicode scalar values",
+                    ));
+                }
+                if !ids.insert(contribution.id.clone()) {
+                    return Err(invariant("Agent contribution ids must be unique"));
+                }
+            }
+        }
+        PluginManifest::Workbench {
+            manifest_version,
+            contributes,
+            ..
+        } => {
+            require_v1_manifest_version(*manifest_version)?;
+            if contributes.workbench.schema_version != 1 {
+                return Err(invariant("Workbench v1 schemaVersion must equal 1"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Keeps schema-version equality explicit even after envelope routing.
+fn require_v1_manifest_version(manifest_version: u32) -> Result<(), ManifestParseError> {
+    if manifest_version != MANIFEST_VERSION_V1 {
+        return Err(invariant("manifestVersion must equal 1"));
+    }
+    Ok(())
+}
+
+/// Parses Ora's whitespace comparator spelling through semver's comma-separated grammar.
+fn parse_version_requirement(value: &str) -> Result<semver::VersionReq, ManifestParseError> {
+    let normalized = value.split_whitespace().collect::<Vec<_>>().join(", ");
+    semver::VersionReq::parse(&normalized).map_err(|_| ManifestParseError::InvalidEngineRange)
+}
+
+/// Builds a stable invariant error for catalog diagnostics.
+fn invariant(message: impl Into<String>) -> ManifestParseError {
+    ManifestParseError::InvalidInvariant {
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ManifestParseError, PluginKind, parse_plugin_manifest};
+    use pretty_assertions::assert_eq;
+
+    const AGENT_MANIFEST: &str = r#"{
+        "name":"@ora-plugins/claude-code",
+        "version":"0.1.0",
+        "type":"module",
+        "ora":{
+            "manifestVersion":1,
+            "id":"ora.claude-code",
+            "displayName":"Claude Code",
+            "kind":"agent",
+            "main":"dist/index.js",
+            "engines":{"ora":">=0.1.0 <0.2.0","pluginApi":1,"bun":">=1.0.0 <2.0.0"},
+            "contributes":{"agents":[{"id":"claude-code","displayName":"Claude Code","contractVersion":1}]}
+        }
+    }"#;
+
+    /// Parses the exact Agent v1 shape and preserves kind-specific data in the enum.
+    #[test]
+    fn parses_agent_manifest() {
+        let manifest = parse_plugin_manifest(AGENT_MANIFEST.as_bytes())
+            .unwrap_or_else(|error| panic!("expected Agent manifest to parse: {error}"));
+        assert_eq!(manifest.ora.kind(), PluginKind::Agent);
+        assert_eq!(manifest.ora.id().as_str(), "ora.claude-code");
+    }
+
+    /// Routes unknown schema versions separately from known-v1 strict-field errors.
+    #[test]
+    fn distinguishes_unknown_version_from_invalid_v1() {
+        let unknown = AGENT_MANIFEST.replace("\"manifestVersion\":1", "\"manifestVersion\":2");
+        assert_eq!(
+            parse_plugin_manifest(unknown.as_bytes()),
+            Err(ManifestParseError::UnsupportedManifestVersion {
+                manifest_version: 2,
+            })
+        );
+
+        let invalid = AGENT_MANIFEST.replace(
+            "\"displayName\":\"Claude Code\",\n            \"kind\"",
+            "\"displayName\":\"Claude Code\",\n            \"future\":true,\n            \"kind\"",
+        );
+        assert_eq!(
+            matches!(
+                parse_plugin_manifest(invalid.as_bytes()),
+                Err(ManifestParseError::InvalidSchema { .. })
+            ),
+            true
+        );
+    }
+
+    /// Rejects duplicate providers rather than allowing activation to select one implicitly.
+    #[test]
+    fn rejects_duplicate_agent_contributions() {
+        let duplicate = AGENT_MANIFEST.replace(
+            "}]}",
+            "},{\"id\":\"claude-code\",\"displayName\":\"Duplicate\",\"contractVersion\":1}]}",
+        );
+        assert_eq!(
+            matches!(
+                parse_plugin_manifest(duplicate.as_bytes()),
+                Err(ManifestParseError::InvalidInvariant { .. })
+            ),
+            true
+        );
+    }
+}

--- a/crates/plugin-protocol/src/strict_json.rs
+++ b/crates/plugin-protocol/src/strict_json.rs
@@ -1,0 +1,215 @@
+use serde::de::{DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde_json::{Map, Number, Value};
+use std::fmt::Formatter;
+
+const DUPLICATE_KEY_MARKER: &str = "ora_duplicate_key:";
+const DEPTH_LIMIT_MARKER: &str = "ora_depth_limit";
+
+/// Classifies strict JSON failures before a value can enter an authorization decision.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum StrictJsonError {
+    #[error("JSON contains duplicate object key `{key}`")]
+    DuplicateKey { key: String },
+    #[error("JSON exceeds the maximum nesting depth of {maximum}")]
+    DepthLimitExceeded { maximum: usize },
+    #[error("invalid JSON: {message}")]
+    Invalid { message: String },
+}
+
+/// Parses one JSON value while rejecting duplicate keys, excessive nesting, and trailing bytes.
+pub fn parse_strict_json(bytes: &[u8], maximum_depth: usize) -> Result<Value, StrictJsonError> {
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let value = StrictValueSeed {
+        depth: 0,
+        maximum_depth,
+    }
+    .deserialize(&mut deserializer)
+    .map_err(|error| classify_error(error, maximum_depth))?;
+    deserializer
+        .end()
+        .map_err(|error| StrictJsonError::Invalid {
+            message: error.to_string(),
+        })?;
+    Ok(value)
+}
+
+struct StrictValueSeed {
+    depth: usize,
+    maximum_depth: usize,
+}
+
+impl<'de> DeserializeSeed<'de> for StrictValueSeed {
+    type Value = Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(StrictValueVisitor {
+            depth: self.depth,
+            maximum_depth: self.maximum_depth,
+        })
+    }
+}
+
+struct StrictValueVisitor {
+    depth: usize,
+    maximum_depth: usize,
+}
+
+impl<'de> Visitor<'de> for StrictValueVisitor {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a valid JSON value without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(Value::Number(Number::from(value)))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Value::Number(Number::from(value)))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Number::from_f64(value)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("JSON number must be finite"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.visit_string(value.to_string())
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(Value::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        StrictValueSeed {
+            depth: self.depth,
+            maximum_depth: self.maximum_depth,
+        }
+        .deserialize(deserializer)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let child_depth = self.checked_child_depth::<A::Error>()?;
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0).min(1024));
+        while let Some(value) = sequence.next_element_seed(StrictValueSeed {
+            depth: child_depth,
+            maximum_depth: self.maximum_depth,
+        })? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let child_depth = self.checked_child_depth::<A::Error>()?;
+        let mut values = Map::new();
+        while let Some(key) = object.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(serde::de::Error::custom(format!(
+                    "{DUPLICATE_KEY_MARKER}{key}"
+                )));
+            }
+            let value = object.next_value_seed(StrictValueSeed {
+                depth: child_depth,
+                maximum_depth: self.maximum_depth,
+            })?;
+            values.insert(key, value);
+        }
+        Ok(Value::Object(values))
+    }
+}
+
+impl StrictValueVisitor {
+    /// Advances object/array nesting while keeping the parser's depth budget explicit.
+    fn checked_child_depth<E>(&self) -> Result<usize, E>
+    where
+        E: serde::de::Error,
+    {
+        let child_depth = self.depth.saturating_add(1);
+        if child_depth > self.maximum_depth {
+            return Err(E::custom(DEPTH_LIMIT_MARKER));
+        }
+        Ok(child_depth)
+    }
+}
+
+/// Converts private serde marker messages into stable strict-parser classifications.
+fn classify_error(error: serde_json::Error, maximum_depth: usize) -> StrictJsonError {
+    let message = error.to_string();
+    if let Some(marker_start) = message.find(DUPLICATE_KEY_MARKER) {
+        let key_start = marker_start + DUPLICATE_KEY_MARKER.len();
+        let key = message[key_start..]
+            .split(" at line ")
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        return StrictJsonError::DuplicateKey { key };
+    }
+    if message.contains(DEPTH_LIMIT_MARKER) {
+        return StrictJsonError::DepthLimitExceeded {
+            maximum: maximum_depth,
+        };
+    }
+    StrictJsonError::Invalid { message }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StrictJsonError, parse_strict_json};
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    /// Rejects duplicate keys before serde can silently keep only the last value.
+    #[test]
+    fn rejects_duplicate_keys_at_any_depth() {
+        assert_eq!(
+            parse_strict_json(br#"{"outer":{"id":1,"id":2}}"#, 64),
+            Err(StrictJsonError::DuplicateKey {
+                key: "id".to_string(),
+            })
+        );
+    }
+
+    /// Applies the configured nesting boundary to both objects and arrays.
+    #[test]
+    fn enforces_nesting_depth() {
+        assert_eq!(parse_strict_json(br#"{"a":[1]}"#, 2), Ok(json!({"a": [1]})));
+        assert_eq!(
+            parse_strict_json(br#"{"a":[{"b":1}]}"#, 2),
+            Err(StrictJsonError::DepthLimitExceeded { maximum: 2 })
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ora-plugin-protocol` foundations: identity/manifest, binary frame codec, agent DTOs, lifecycle handshake, strict JSON-RPC, method registry, validation + golden fixtures.
- Includes a small unrelated `.gitignore` tweak from the branch root (1 line).

## Stack
- **1/7** (this PR) → 2 process → 3 manager → 4 runtime → 5 sdk/ts → 6 assets/pack → 7 e2e
- Supersedes monolithic draft [#72](https://github.com/ora-space/desktop/pull/72) (please close #72 after this stack is up).

## Test plan
- [ ] `cargo test -p ora-plugin-protocol`
- [ ] `cargo fmt --all -- --check`

Made with [Cursor](https://cursor.com)