### PR TITLE
fix(contracts): restore file-system contract export wiring lost in re…

### DIFF
--- a/crates/contracts/src/file_system.rs
+++ b/crates/contracts/src/file_system.rs
@@ -52,6 +52,16 @@ pub struct ListDirectoryResponse {
     pub entries: Vec<FileSystemEntry>,
 }
 
+/// Exports every TypeScript binding declared in this module into the target directory.
+pub(crate) fn export(config: &ts_rs::Config) -> Result<(), ts_rs::ExportError> {
+    FileSystemEntryKind::export(config)?;
+    FileSystemEntry::export(config)?;
+    FileSystemBreadcrumb::export(config)?;
+    ListDirectoryRequest::export(config)?;
+    ListDirectoryResponse::export(config)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -62,6 +62,7 @@ pub fn export_typescript_bindings_to(
 
     acp::export(&config)?;
     agent::export(&config)?;
+    file_system::export(&config)?;
     project::export(&config)?;
     project_work_context::export(&config)?;
     session::export(&config)?;

--- a/packages/contracts/src/client.ts
+++ b/packages/contracts/src/client.ts
@@ -32,9 +32,6 @@ export type ContractsClient = {
       ? (typeof endpoints)[Operation]["memberName"]
       : never]: ClientOperation<Operation>;
   };
-  fileSystem: {
-    listDirectory: ClientOperation<"listDirectory">;
-  };
 };
 
 export function createContractsClient(transport: ContractTransport): ContractsClient {

--- a/packages/contracts/src/endpoints.ts
+++ b/packages/contracts/src/endpoints.ts
@@ -422,6 +422,8 @@ export const endpoints = {
   },
   listDirectory: {
     operationName: "listDirectory",
+    namespace: "fileSystem",
+    memberName: "listDirectory",
     method: "GET",
     pathTemplate: "/api/file-system/directory",
     requestType: "ListDirectoryRequest",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,6 +2,7 @@ export * as acp from "./acp/index.js";
 export * from "./agent.js";
 export * from "./client.js";
 export * from "./endpoints.js";
+export * from "./file-system.js";
 export * from "./project-work-context.js";
 export * from "./project.js";
 export * from "./session.js";

--- a/xtask/src/export_contracts.rs
+++ b/xtask/src/export_contracts.rs
@@ -428,6 +428,7 @@ mod tests {
         let generated_files = [
             "agent.ts",
             "endpoints.ts",
+            "file-system.ts",
             "project.ts",
             "project-work-context.ts",
             "session.ts",


### PR DESCRIPTION
…base

The rebase onto main landed this branch's file_system contracts on top of an upstream refactor that moved `export_typescript_bindings_to` from a central type list to per-module `export()` functions. `file_system` never got its own `export()`, so `packages/contracts/src/file-system.ts` stopped being regenerated and silently drifted from the Rust definitions.

Restore the wiring and the two downstream pieces that went stale with it:

- Add `file_system::export()` and call it from `export_typescript_bindings_to`
- Regenerate `endpoints.ts`, which was missing the `namespace`/`memberName` metadata every other endpoint already carried
- Re-add the `file-system.js` re-export dropped from the package entrypoint
- Drop the explicit `fileSystem` block from `ContractsClient`; the upstream mapped type derives it from the manifest, and declaring it alongside the mapped type failed `tsc` with TS7061
- Cover `file-system.ts` in the xtask export test so this cannot regress