### PR TITLE
refactor(web): remove bootstrap project configuration

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -128,15 +128,6 @@ tasks:
   ############# Run Development Servers #############
   ###################################################
 
-  run:prepare:
-    desc: Ensure the local .data workspace and rustun repository exist
-    cmds:
-      - mkdir -p .data
-      - |
-        if [ ! -d .data/rustun ]; then
-          git clone https://github.com/ora-space/rustun.git .data/rustun
-        fi
-
   run:web-frontend:
     desc: Run the web frontend against the real HTTP backend
     env:
@@ -165,8 +156,5 @@ tasks:
     desc: Run the web server backend in development mode
     env:
       ORA_DATA_DIR: .data
-      ORA_PROJECT_NAME: rustun
-      ORA_PROJECT_PATH: .data/rustun
     cmds:
-      - task: run:prepare
       - cargo run --bin ora_web_server

--- a/apps/web/server/src/bootstrap.rs
+++ b/apps/web/server/src/bootstrap.rs
@@ -1,15 +1,9 @@
 use crate::app_state::AppState;
-use crate::config::{ProjectConfig, RuntimeConfig};
+use crate::config::RuntimeConfig;
 use crate::error::WebBootstrapError;
 use crate::service::{FileSystemApi, ProjectWorkContextApi};
-use ora_application::{
-    Clock, OpenProjectWorkContextHandler, ProjectIdGenerator, ProjectRepository,
-    ProjectRepositoryError, UuidProjectIdGenerator, UuidProjectWorkContextIdGenerator,
-};
+use ora_application::Clock;
 use ora_backend::{Backend, BackendBootstrapError, BackendPaths};
-use ora_contracts::{OpenProjectWorkContextRequest, ProjectWorkContextSurface};
-use ora_db::RepositoryPool;
-use ora_domain::{AuditFields, Project};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -18,24 +12,22 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub fn build_app_state(runtime_config: &RuntimeConfig) -> Result<AppState, WebBootstrapError> {
     let backend = build_backend(
         runtime_config.database().path(),
-        runtime_config.project().work_dir(),
+        runtime_config.worktree().root(),
         runtime_config.file_system().home_directory(),
     )?;
     let pool = backend.repository_pool();
     let clock = SystemClock;
-
-    reconcile_configured_project(&pool, runtime_config.project(), clock)?;
 
     Ok(AppState::new(
         backend,
         Arc::new(FileSystemApi::new(
             runtime_config.file_system().home_directory().to_path_buf(),
         )),
-        Arc::new(ProjectWorkContextApi::new(pool.clone(), clock)),
+        Arc::new(ProjectWorkContextApi::new(pool, clock)),
     ))
 }
 
-/// Builds application state for tests that need SQLite-backed handlers without project reconciliation.
+/// Builds application state for tests from explicit filesystem paths.
 #[cfg(test)]
 pub(crate) fn build_app_state_for_database(
     database_path: &Path,
@@ -55,62 +47,8 @@ pub(crate) fn build_app_state_for_database(
         Arc::new(FileSystemApi::new(
             project_root.parent().unwrap_or(project_root).to_path_buf(),
         )),
-        Arc::new(ProjectWorkContextApi::new(pool.clone(), clock)),
+        Arc::new(ProjectWorkContextApi::new(pool, clock)),
     ))
-}
-
-/// Ensures the configured workspace project exists in persistent storage before readiness.
-fn reconcile_configured_project(
-    pool: &RepositoryPool,
-    project_config: &ProjectConfig,
-    clock: SystemClock,
-) -> Result<(), WebBootstrapError> {
-    let repository = ora_db::SqliteProjectRepository::new(pool.clone());
-    let context_repository = ora_db::SqliteProjectWorkContextRepository::new(pool.clone());
-    let configured_project_path = project_config.path().to_string_lossy().to_string();
-    let existing_project = repository
-        .find_project_by_name(project_config.name())
-        .map_err(project_bootstrap_error)?;
-
-    let project_id = match existing_project {
-        Some(existing_project) if existing_project.root_path == configured_project_path => {
-            Ok(existing_project.id)
-        }
-        Some(existing_project) => Err(WebBootstrapError::ProjectBootstrap {
-            message: format!(
-                "configured project root differs from immutable stored root: {}",
-                existing_project.root_path
-            ),
-        }),
-        None => {
-            let now = clock.now_timestamp_millis();
-
-            repository
-                .create_project(Project::new(
-                    UuidProjectIdGenerator::new().generate_project_id(),
-                    project_config.name(),
-                    configured_project_path,
-                    AuditFields::new(now, now, false),
-                ))
-                .map(|project| project.id)
-                .map_err(project_bootstrap_error)
-        }
-    }?;
-    let handler = OpenProjectWorkContextHandler::new(
-        repository,
-        context_repository,
-        UuidProjectWorkContextIdGenerator::new(),
-        clock,
-    );
-
-    handler
-        .handle(OpenProjectWorkContextRequest {
-            surface: ProjectWorkContextSurface::Web,
-            window_id: "main".to_string(),
-            project_id: project_id.to_string(),
-        })
-        .map(|_| ())
-        .map_err(project_work_context_bootstrap_error)
 }
 
 /// Opens the shared backend while preserving the server's existing bootstrap error variants.
@@ -134,27 +72,9 @@ fn web_backend_bootstrap_error(error: BackendBootstrapError) -> WebBootstrapErro
             WebBootstrapError::DataDirectoryCreate(source)
         }
         BackendBootstrapError::Database(source) => WebBootstrapError::DatabaseBootstrap(source),
-        BackendBootstrapError::AgentRuntime(_) => WebBootstrapError::ProjectBootstrap {
-            message: "failed to initialize agent runtime".to_string(),
-        },
-    }
-}
-
-/// Converts repository-owned bootstrap failures into one stable startup error variant.
-fn project_bootstrap_error(error: ProjectRepositoryError) -> WebBootstrapError {
-    match error {
-        ProjectRepositoryError::OperationFailed(message) => {
-            WebBootstrapError::ProjectBootstrap { message }
+        BackendBootstrapError::AgentRuntime(source) => {
+            WebBootstrapError::BackendRuntimeBootstrap(source)
         }
-    }
-}
-
-/// Converts project work context bootstrap failures into one stable startup error variant.
-fn project_work_context_bootstrap_error(
-    error: ora_application::ApplicationError,
-) -> WebBootstrapError {
-    WebBootstrapError::ProjectBootstrap {
-        message: error.to_string(),
     }
 }
 
@@ -182,10 +102,9 @@ mod tests {
         DatabaseBootstrapper, DatabaseLocation, SqliteProjectRepository,
         SqliteProjectWorkContextRepository, default_migration_catalog,
     };
+    use ora_domain::ProjectWorkContextSurface;
     use pretty_assertions::assert_eq;
     use std::path::Path;
-    use std::thread;
-    use std::time::Duration;
     use tempfile::TempDir;
 
     /// Verifies bootstrap fails cleanly when the configured database path points to a directory.
@@ -204,13 +123,12 @@ mod tests {
         assert!(matches!(error, WebBootstrapError::DatabaseBootstrap(_)));
     }
 
-    /// Verifies runtime bootstrap creates the configured project when no visible row exists yet.
+    /// Verifies runtime bootstrap becomes usable without creating a project or synthetic context.
     #[test]
-    fn creates_configured_project_during_bootstrap() {
+    fn starts_with_an_empty_project_catalog() {
         let temp_dir = TempDir::new().unwrap();
-        let data_dir = temp_dir.path().join("bootstrap-create");
-        let project_path = temp_dir.path().join("workspace").join("ora");
-        let runtime_config = runtime_config(&data_dir, "Ora", &project_path);
+        let data_dir = temp_dir.path().join("empty-bootstrap");
+        let runtime_config = runtime_config(&data_dir);
         let database_path = data_dir.join("ora.sqlite3");
 
         build_app_state(&runtime_config)
@@ -219,108 +137,19 @@ mod tests {
         let repository = bootstrapped_project_repository(&database_path);
         let context_repository = bootstrapped_project_work_context_repository(&database_path);
 
-        assert_eq!(
-            repository
-                .find_project_by_name("Ora")
-                .unwrap()
-                .map(|project| (
-                    project.name,
-                    project.root_path,
-                    project.audit_fields.is_deleted,
-                )),
-            Some((
-                "Ora".to_string(),
-                project_path.to_string_lossy().to_string(),
-                false,
-            ))
-        );
-        let project = repository
-            .find_project_by_name("Ora")
-            .unwrap()
-            .unwrap_or_else(|| panic!("expected configured project to exist after bootstrap"));
-
+        assert_eq!(repository.list_projects().unwrap(), Vec::new());
         assert_eq!(
             context_repository
-                .find_project_work_context(ora_domain::ProjectWorkContextSurface::Web, "main")
-                .unwrap()
-                .map(|context| (context.surface, context.window_id, context.project_id)),
-            Some((
-                ora_domain::ProjectWorkContextSurface::Web,
-                "main".to_string(),
-                project.id,
-            ))
+                .find_project_work_context(ProjectWorkContextSurface::Web, "main")
+                .unwrap(),
+            None
         );
-    }
-
-    /// Verifies runtime bootstrap leaves an already reconciled configured project unchanged.
-    #[test]
-    fn keeps_configured_project_unchanged_when_name_and_path_match() {
-        let temp_dir = TempDir::new().unwrap();
-        let data_dir = temp_dir.path().join("bootstrap-noop");
-        let project_path = temp_dir.path().join("workspace").join("ora");
-        let runtime_config = runtime_config(&data_dir, "Ora", &project_path);
-        let database_path = data_dir.join("ora.sqlite3");
-
-        build_app_state(&runtime_config)
-            .unwrap_or_else(|error| panic!("expected first runtime bootstrap to succeed: {error}"));
-        let repository = bootstrapped_project_repository(&database_path);
-        let original_project = repository
-            .find_project_by_name("Ora")
-            .unwrap()
-            .unwrap_or_else(|| panic!("expected configured project to exist after bootstrap"));
-
-        build_app_state(&runtime_config).unwrap_or_else(|error| {
-            panic!("expected second runtime bootstrap to succeed: {error}")
-        });
-        let repository = bootstrapped_project_repository(&database_path);
-
-        assert_eq!(
-            repository.find_project_by_name("Ora").unwrap(),
-            Some(original_project)
-        );
-    }
-
-    /// Verifies runtime bootstrap rejects path drift because project roots are immutable.
-    #[test]
-    fn rejects_configured_project_path_when_storage_drifts() {
-        let temp_dir = TempDir::new().unwrap();
-        let data_dir = temp_dir.path().join("bootstrap-update");
-        let original_project_path = temp_dir.path().join("workspace").join("ora");
-        let original_runtime_config = runtime_config(&data_dir, "Ora", &original_project_path);
-        let database_path = data_dir.join("ora.sqlite3");
-
-        build_app_state(&original_runtime_config)
-            .unwrap_or_else(|error| panic!("expected first runtime bootstrap to succeed: {error}"));
-        let repository = bootstrapped_project_repository(&database_path);
-        let original_project = repository
-            .find_project_by_name("Ora")
-            .unwrap()
-            .unwrap_or_else(|| panic!("expected configured project to exist after bootstrap"));
-
-        thread::sleep(Duration::from_millis(2));
-
-        let updated_project_path = temp_dir.path().join("workspace").join("ora-renamed");
-        let updated_runtime_config = runtime_config(&data_dir, "Ora", &updated_project_path);
-        let error = match build_app_state(&updated_runtime_config) {
-            Ok(_) => panic!("expected immutable project root mismatch to fail bootstrap"),
-            Err(error) => error,
-        };
-        assert!(error.to_string().contains("immutable stored root"));
-        let repository = bootstrapped_project_repository(&database_path);
-        let stored_project = repository
-            .find_project_by_name("Ora")
-            .unwrap()
-            .unwrap_or_else(|| panic!("expected configured project to remain stored"));
-
-        assert_eq!(stored_project, original_project);
     }
 
     /// Builds one runtime configuration without mutating process environment during tests.
-    fn runtime_config(data_dir: &Path, project_name: &str, project_path: &Path) -> RuntimeConfig {
+    fn runtime_config(data_dir: &Path) -> RuntimeConfig {
         RuntimeConfig::from_reader(|key| match key {
             "ORA_DATA_DIR" => Some(data_dir.to_string_lossy().to_string()),
-            "ORA_PROJECT_NAME" => Some(project_name.to_string()),
-            "ORA_PROJECT_PATH" => Some(project_path.to_string_lossy().to_string()),
             "HOME" => Some(data_dir.to_string_lossy().to_string()),
             _ => None,
         })

--- a/apps/web/server/src/config.rs
+++ b/apps/web/server/src/config.rs
@@ -6,8 +6,6 @@ use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 const DATA_DIR_ENV_VAR: &str = "ORA_DATA_DIR";
-const PROJECT_NAME_ENV_VAR: &str = "ORA_PROJECT_NAME";
-const PROJECT_PATH_ENV_VAR: &str = "ORA_PROJECT_PATH";
 const HOST_ENV_VAR: &str = "ORA_HOST";
 const PORT_ENV_VAR: &str = "ORA_PORT";
 const LOG_LEVEL_ENV_VAR: &str = "ORA_LOG_LEVEL";
@@ -26,7 +24,7 @@ const DEFAULT_LOG_MAX_DAYS: &str = "3";
 pub struct RuntimeConfig {
     database: DatabaseConfig,
     file_system: FileSystemConfig,
-    project: ProjectConfig,
+    worktree: WorktreeConfig,
     server: ServerConfig,
     logging: LoggingConfig,
 }
@@ -42,9 +40,9 @@ impl RuntimeConfig {
         &self.database
     }
 
-    /// Returns the configured bootstrap project identity used during startup reconciliation.
-    pub fn project(&self) -> &ProjectConfig {
-        &self.project
+    /// Returns the filesystem root used for task-owned linked worktrees.
+    pub fn worktree(&self) -> &WorktreeConfig {
+        &self.worktree
     }
 
     /// Returns the filesystem configuration used by server-side path browsing.
@@ -67,9 +65,10 @@ impl RuntimeConfig {
         mut read_variable: impl FnMut(&str) -> Option<String>,
     ) -> Result<Self, WebBootstrapError> {
         let database = DatabaseConfig::from_reader(&mut read_variable)?;
+        let worktree = WorktreeConfig::from_database(&database);
 
         Ok(Self {
-            project: ProjectConfig::from_reader(&mut read_variable, &database)?,
+            worktree,
             file_system: FileSystemConfig::from_reader(&mut read_variable)?,
             database,
             server: ServerConfig::from_reader(&mut read_variable)?,
@@ -132,49 +131,22 @@ impl DatabaseConfig {
     }
 }
 
-/// Describes the bootstrap project identity that startup reconciles into persistent storage.
-pub struct ProjectConfig {
-    name: String,
-    path: PathBuf,
-    work_dir: PathBuf,
+/// Describes the global filesystem root used for task-owned linked worktrees.
+pub struct WorktreeConfig {
+    root: PathBuf,
 }
 
-impl ProjectConfig {
-    /// Returns the configured project name used for bootstrap reconciliation.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Returns the configured project root path used for bootstrap reconciliation.
-    pub fn path(&self) -> &Path {
-        self.path.as_path()
-    }
-
+impl WorktreeConfig {
     /// Returns the configured linked-worktree root used for task-owned worktree provisioning.
-    pub fn work_dir(&self) -> &Path {
-        self.work_dir.as_path()
+    pub fn root(&self) -> &Path {
+        self.root.as_path()
     }
 
-    /// Loads the bootstrap project identity from a caller-provided variable reader for testability.
-    fn from_reader(
-        mut read_variable: impl FnMut(&str) -> Option<String>,
-        database_config: &DatabaseConfig,
-    ) -> Result<Self, WebBootstrapError> {
-        let work_dir = default_work_dir(database_config.path());
-
-        Ok(Self {
-            name: read_required_non_empty_variable(
-                &mut read_variable,
-                PROJECT_NAME_ENV_VAR,
-                WebBootstrapError::InvalidProjectNameEmpty,
-            )?,
-            path: PathBuf::from(read_required_non_empty_variable(
-                &mut read_variable,
-                PROJECT_PATH_ENV_VAR,
-                WebBootstrapError::InvalidProjectPathEmpty,
-            )?),
-            work_dir,
-        })
+    /// Derives the linked-worktree root from the shared runtime data directory.
+    fn from_database(database_config: &DatabaseConfig) -> Self {
+        Self {
+            root: default_worktree_root(database_config.path()),
+        }
     }
 }
 
@@ -202,7 +174,7 @@ fn read_data_dir_root(
 }
 
 /// Derives the default linked-worktree root from the configured SQLite database location.
-fn default_work_dir(database_path: &Path) -> PathBuf {
+fn default_worktree_root(database_path: &Path) -> PathBuf {
     database_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
@@ -314,27 +286,12 @@ fn read_log_max_days(
     NonZeroUsize::new(parsed_value).ok_or(WebBootstrapError::InvalidLogMaxDaysZero)
 }
 
-/// Reads one required environment variable and rejects blank values before bootstrap proceeds.
-fn read_required_non_empty_variable(
-    mut read_variable: impl FnMut(&str) -> Option<String>,
-    variable_name: &str,
-    empty_error: WebBootstrapError,
-) -> Result<String, WebBootstrapError> {
-    let value = read_variable(variable_name).unwrap_or_default();
-
-    if value.trim().is_empty() {
-        return Err(empty_error);
-    }
-
-    Ok(value)
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
         DATA_DIR_ENV_VAR, DEFAULT_HOST, DEFAULT_PORT, DatabaseConfig, FileSystemConfig,
-        HOME_ENV_VAR, HOST_ENV_VAR, LOG_MODE_ENV_VAR, PORT_ENV_VAR, PROJECT_NAME_ENV_VAR,
-        PROJECT_PATH_ENV_VAR, ProjectConfig, RuntimeConfig, ServerConfig,
+        HOME_ENV_VAR, HOST_ENV_VAR, LOG_MODE_ENV_VAR, PORT_ENV_VAR, RuntimeConfig, ServerConfig,
+        WorktreeConfig,
     };
     use crate::error::WebBootstrapError;
     use pretty_assertions::assert_eq;
@@ -394,109 +351,33 @@ mod tests {
         assert!(matches!(error, WebBootstrapError::InvalidDatabasePathEmpty));
     }
 
-    /// Verifies bootstrap project configuration requires both a non-empty name and path.
-    #[test]
-    fn rejects_missing_project_configuration() {
-        let database_config = DatabaseConfig::from_reader(|_| None).unwrap();
-        let error = match ProjectConfig::from_reader(|_| None, &database_config) {
-            Ok(_) => panic!("expected missing project configuration to fail"),
-            Err(error) => error,
-        };
-
-        assert!(matches!(error, WebBootstrapError::InvalidProjectNameEmpty));
-    }
-
-    /// Verifies blank bootstrap project paths fail with a typed bootstrap error.
-    #[test]
-    fn rejects_empty_project_path_configuration() {
-        let error = match ProjectConfig::from_reader(
-            |key| match key {
-                PROJECT_NAME_ENV_VAR => Some("Ora".to_string()),
-                PROJECT_PATH_ENV_VAR => Some("   ".to_string()),
-                _ => None,
-            },
-            &DatabaseConfig::from_reader(|_| None).unwrap(),
-        ) {
-            Ok(_) => panic!("expected empty project path configuration to fail"),
-            Err(error) => error,
-        };
-
-        assert!(matches!(error, WebBootstrapError::InvalidProjectPathEmpty));
-    }
-
-    /// Verifies bootstrap project configuration exposes the configured identity unchanged.
-    #[test]
-    fn loads_project_configuration() {
-        let temp_dir = TempDir::new().unwrap();
-        let project_path = temp_dir.path().join("ora");
-        let data_dir = temp_dir.path().join("ora-worktrees");
-        let config = ProjectConfig::from_reader(
-            |key| match key {
-                PROJECT_NAME_ENV_VAR => Some("Ora".to_string()),
-                PROJECT_PATH_ENV_VAR => Some(project_path.to_string_lossy().to_string()),
-                _ => None,
-            },
-            &DatabaseConfig::from_reader(|key| match key {
-                DATA_DIR_ENV_VAR => Some(data_dir.to_string_lossy().to_string()),
-                _ => None,
-            })
-            .unwrap(),
-        )
-        .unwrap_or_else(|error| panic!("expected project configuration to load: {error}"));
-
-        let expected_work_dir = data_dir.join("worktrees");
-
-        assert_eq!(config.name(), "Ora");
-        assert_eq!(config.path(), project_path.as_path());
-        assert_eq!(config.work_dir(), expected_work_dir.as_path());
-    }
-
     /// Verifies the linked-worktree root falls back to an absolute path in the current directory when unset.
     #[test]
-    fn loads_default_work_dir_from_current_directory() {
+    fn loads_default_worktree_root_from_current_directory() {
         let database_config = DatabaseConfig::from_reader(|_| None)
             .unwrap_or_else(|error| panic!("expected database configuration to load: {error}"));
-        let temp_dir = TempDir::new().unwrap();
-        let project_path = temp_dir.path().join("ora");
-        let config = ProjectConfig::from_reader(
-            |key| match key {
-                PROJECT_NAME_ENV_VAR => Some("Ora".to_string()),
-                PROJECT_PATH_ENV_VAR => Some(project_path.to_string_lossy().to_string()),
-                _ => None,
-            },
-            &database_config,
-        )
-        .unwrap_or_else(|error| panic!("expected project configuration to load: {error}"));
+        let config = WorktreeConfig::from_database(&database_config);
 
-        let expected_work_dir = std::env::current_dir().unwrap().join("worktrees");
+        let expected_root = std::env::current_dir().unwrap().join("worktrees");
 
-        assert_eq!(config.work_dir(), expected_work_dir.as_path());
+        assert_eq!(config.root(), expected_root.as_path());
     }
 
     /// Verifies the linked-worktree root defaults to a `worktrees` sibling of the SQLite database path.
     #[test]
-    fn defaults_work_dir_next_to_database_path() {
+    fn defaults_worktree_root_next_to_database_path() {
         let temp_dir = TempDir::new().unwrap();
         let data_dir = temp_dir.path().join("state");
-        let project_path = temp_dir.path().join("ora");
         let database_config = DatabaseConfig::from_reader(|key| match key {
             DATA_DIR_ENV_VAR => Some(data_dir.to_string_lossy().to_string()),
             _ => None,
         })
         .unwrap_or_else(|error| panic!("expected database configuration to load: {error}"));
-        let config = ProjectConfig::from_reader(
-            |key| match key {
-                PROJECT_NAME_ENV_VAR => Some("Ora".to_string()),
-                PROJECT_PATH_ENV_VAR => Some(project_path.to_string_lossy().to_string()),
-                _ => None,
-            },
-            &database_config,
-        )
-        .unwrap_or_else(|error| panic!("expected project configuration to load: {error}"));
+        let config = WorktreeConfig::from_database(&database_config);
 
-        let expected_work_dir = data_dir.join("worktrees");
+        let expected_root = data_dir.join("worktrees");
 
-        assert_eq!(config.work_dir(), expected_work_dir.as_path());
+        assert_eq!(config.root(), expected_root.as_path());
     }
 
     /// Verifies the logging configuration derives the file path from `ORA_DATA_DIR`.
@@ -556,11 +437,8 @@ mod tests {
     #[test]
     fn loads_runtime_configuration() {
         let temp_dir = TempDir::new().unwrap();
-        let project_path = temp_dir.path().join("ora");
         let data_dir = temp_dir.path().join("state");
         let config = RuntimeConfig::from_reader(|key| match key {
-            PROJECT_NAME_ENV_VAR => Some("Ora".to_string()),
-            PROJECT_PATH_ENV_VAR => Some(project_path.to_string_lossy().to_string()),
             DATA_DIR_ENV_VAR => Some(data_dir.to_string_lossy().to_string()),
             LOG_MODE_ENV_VAR => Some("file".to_string()),
             HOME_ENV_VAR => Some(temp_dir.path().to_string_lossy().to_string()),
@@ -569,13 +447,11 @@ mod tests {
         .unwrap_or_else(|error| panic!("expected runtime configuration to load: {error}"));
 
         let expected_database_path = data_dir.join("ora.sqlite3");
-        let expected_work_dir = data_dir.join("worktrees");
+        let expected_worktree_root = data_dir.join("worktrees");
         let expected_log_path = data_dir.join("logs").join("ora.log");
 
         assert_eq!(config.database().path(), expected_database_path.as_path());
-        assert_eq!(config.project().name(), "Ora");
-        assert_eq!(config.project().path(), project_path.as_path());
-        assert_eq!(config.project().work_dir(), expected_work_dir.as_path());
+        assert_eq!(config.worktree().root(), expected_worktree_root.as_path());
         assert_eq!(config.file_system().home_directory(), temp_dir.path());
 
         match &config.logging().output {

--- a/apps/web/server/src/error.rs
+++ b/apps/web/server/src/error.rs
@@ -34,10 +34,6 @@ pub enum WebBootstrapError {
     },
     #[error("ORA_DATA_DIR must not be empty")]
     InvalidDatabasePathEmpty,
-    #[error("ORA_PROJECT_NAME must not be empty")]
-    InvalidProjectNameEmpty,
-    #[error("ORA_PROJECT_PATH must not be empty")]
-    InvalidProjectPathEmpty,
     #[error("ORA_LOG_MAX_DAYS must be greater than zero")]
     InvalidLogMaxDaysZero,
     #[error("server user home directory is unavailable")]
@@ -48,8 +44,8 @@ pub enum WebBootstrapError {
     DataDirectoryCreate(#[source] std::io::Error),
     #[error("failed to bootstrap SQLite database")]
     DatabaseBootstrap(#[source] ora_db::DatabaseError),
-    #[error("failed to reconcile bootstrap project: {message}")]
-    ProjectBootstrap { message: String },
+    #[error("failed to initialize backend runtime")]
+    BackendRuntimeBootstrap(#[source] ora_backend::BackendError),
     #[error(transparent)]
     LoggingInit(#[from] ora_logging::LoggingInitError),
     #[error("failed to bind HTTP listener")]

--- a/crates/application/src/project/ports.rs
+++ b/crates/application/src/project/ports.rs
@@ -14,12 +14,6 @@ pub trait ProjectRepository {
         project_id: &ProjectId,
     ) -> Result<Option<Project>, ProjectRepositoryError>;
 
-    /// Loads one visible project by its exact persisted name.
-    fn find_project_by_name(
-        &self,
-        project_name: &str,
-    ) -> Result<Option<Project>, ProjectRepositoryError>;
-
     /// Lists every visible project in storage order.
     fn list_projects(&self) -> Result<Vec<Project>, ProjectRepositoryError>;
 

--- a/crates/application/src/project/tests.rs
+++ b/crates/application/src/project/tests.rs
@@ -344,20 +344,6 @@ impl ProjectRepository for Rc<FakeProjectRepository> {
             .cloned())
     }
 
-    fn find_project_by_name(
-        &self,
-        project_name: &str,
-    ) -> Result<Option<Project>, ProjectRepositoryError> {
-        self.take_error()?;
-
-        Ok(self
-            .projects
-            .borrow()
-            .iter()
-            .find(|project| project.name == project_name && !project.audit_fields.is_deleted)
-            .cloned())
-    }
-
     fn list_projects(&self) -> Result<Vec<Project>, ProjectRepositoryError> {
         self.take_error()?;
 

--- a/crates/application/src/project_work_context/tests.rs
+++ b/crates/application/src/project_work_context/tests.rs
@@ -318,21 +318,6 @@ impl ProjectRepository for Rc<FakeProjectRepository> {
             .cloned())
     }
 
-    /// Loads one visible project by exact name from the fake in-memory store.
-    fn find_project_by_name(
-        &self,
-        project_name: &str,
-    ) -> Result<Option<Project>, ProjectRepositoryError> {
-        self.take_error()?;
-
-        Ok(self
-            .projects
-            .borrow()
-            .iter()
-            .find(|project| project.name == project_name && !project.audit_fields.is_deleted)
-            .cloned())
-    }
-
     /// Lists every visible project from the fake in-memory store.
     fn list_projects(&self) -> Result<Vec<Project>, ProjectRepositoryError> {
         self.take_error()?;

--- a/crates/db/src/repository/project.rs
+++ b/crates/db/src/repository/project.rs
@@ -62,30 +62,6 @@ impl ProjectRepository for SqliteProjectRepository {
             .map_err(project_repository_error_from_database)
     }
 
-    /// Loads one visible project row by its exact persisted name.
-    fn find_project_by_name(
-        &self,
-        project_name: &str,
-    ) -> Result<Option<Project>, ProjectRepositoryError> {
-        self.pool
-            .with_connection(|connection| {
-                let mut statement = connection.prepare(
-                    "SELECT id, name, root_path, created_at, updated_at, is_deleted
-                     FROM projects
-                     WHERE name = ?1 AND is_deleted = 0
-                     ORDER BY created_at, id
-                     LIMIT 1",
-                )?;
-                let mut rows = statement.query(params![project_name])?;
-
-                match rows.next()? {
-                    Some(row) => Ok(Some(map_project_row(row)?)),
-                    None => Ok(None),
-                }
-            })
-            .map_err(project_repository_error_from_database)
-    }
-
     /// Lists every visible project row in stable storage order.
     fn list_projects(&self) -> Result<Vec<Project>, ProjectRepositoryError> {
         self.pool

--- a/crates/db/src/repository_tests.rs
+++ b/crates/db/src/repository_tests.rs
@@ -202,12 +202,6 @@ fn project_repository_supports_crud_and_soft_delete() {
         Some(created_project.clone())
     );
     assert_eq!(
-        repository
-            .find_project_by_name(&created_project.name)
-            .unwrap(),
-        Some(created_project.clone())
-    );
-    assert_eq!(
         repository.list_projects().unwrap(),
         vec![created_project.clone()]
     );
@@ -229,65 +223,12 @@ fn project_repository_supports_crud_and_soft_delete() {
     );
     assert_eq!(
         repository
-            .find_project_by_name(&updated_project.name)
-            .unwrap(),
-        Some(updated_project.clone())
-    );
-    assert_eq!(
-        repository
             .soft_delete_project(&updated_project.id, /*deleted_at*/ 30)
             .unwrap(),
         true
     );
     assert_eq!(repository.find_project(&updated_project.id).unwrap(), None);
-    assert_eq!(
-        repository
-            .find_project_by_name(&updated_project.name)
-            .unwrap(),
-        None
-    );
     assert_eq!(repository.list_projects().unwrap(), Vec::<Project>::new());
-}
-
-/// Verifies the SQLite-backed project repository can load one visible project by exact name.
-#[test]
-fn project_repository_finds_visible_project_by_name() {
-    let (_temp_dir, pool) = bootstrapped_repository_pool();
-    let repository = SqliteProjectRepository::new(pool);
-    let project = Project::new(
-        ProjectId::new("project-1"),
-        "Ora",
-        "/tmp/ora",
-        AuditFields::new(14, 14, false),
-    );
-
-    repository.create_project(project.clone()).unwrap();
-
-    assert_eq!(
-        repository.find_project_by_name("Ora").unwrap(),
-        Some(project)
-    );
-    assert_eq!(repository.find_project_by_name("Missing").unwrap(), None);
-}
-
-/// Verifies the SQLite-backed project repository hides soft-deleted rows during name-based lookup.
-#[test]
-fn project_repository_ignores_soft_deleted_projects_during_name_lookup() {
-    let (_temp_dir, pool) = bootstrapped_repository_pool();
-    let repository = SqliteProjectRepository::new(pool);
-    let project = Project::new(
-        ProjectId::new("project-1"),
-        "Ora",
-        "/tmp/ora",
-        AuditFields::new(15, 15, false),
-    );
-
-    repository.create_project(project.clone()).unwrap();
-    repository
-        .soft_delete_project(&project.id, /*deleted_at*/ 16)
-        .unwrap();
-
-    assert_eq!(repository.find_project_by_name("Ora").unwrap(), None);
 }
 
 /// Verifies the SQLite-backed project work context repository preserves lease-aware rows and cleanup.

--- a/docs/web-server-runtime.md
+++ b/docs/web-server-runtime.md
@@ -23,22 +23,14 @@ Startup asks `ora-backend` to bootstrap the database, apply the active migration
 - Worktree root: `<ORA_DATA_DIR>/worktrees`
 - Log file: `<ORA_DATA_DIR>/logs/ora.log`
 
-## Project Configuration
+## Project and Worktree Configuration
 
-The web server also requires a bootstrap project identity:
+The web server does not require a bootstrap project. A new database starts with an empty project
+catalog, and users add repositories through the project CRUD API or Web UI.
 
-- `ORA_PROJECT_NAME`: persisted workspace project name. Required.
-- `ORA_PROJECT_PATH`: persisted workspace root path. Required.
-
-Startup reconciles this configured project into the `projects` table before the runtime is marked ready.
-
-- If no visible project exists with the configured name, startup creates one row.
-- If a visible project exists with the configured name but a different stored path, startup fails because project roots are immutable.
-- If both the configured name and path already match, startup leaves the row unchanged.
-- If `ORA_WORK_DIR` is unset, startup uses a `worktrees/` directory next to the configured SQLite database file.
-- Task creation resolves the project named by the request and provisions linked worktrees under `ORA_WORK_DIR/<full-task-id>`.
+- The global worktree root is `<ORA_DATA_DIR>/worktrees`.
+- Task creation resolves the project identified by the request and provisions linked worktrees under `<ORA_DATA_DIR>/worktrees/<full-task-id>`.
 - Agent Session startup resolves Task → Worktree → branch and then asks Git for the authoritative linked-worktree path to use as the child process cwd.
-- After project reconciliation, startup also opens the synthetic web work context `surface = web`, `window_id = main` for that project and refreshes its lease immediately.
 
 ## Bind Configuration
 
@@ -131,5 +123,5 @@ The Web production build always selects the fetch transport. Development startup
 The current runtime uses a file-backed SQLite database bootstrapped through `ora-db`.
 
 - Data persists across process restarts as long as the same `ORA_DATA_DIR` is reused.
-- Readiness depends on successful database bootstrap, repository-pool construction, bootstrap-project reconciliation, and synthetic web work context reconciliation.
+- Readiness depends on successful database bootstrap, repository-pool construction, and shared backend initialization; an empty project catalog is ready for use.
 - Shared backend failures map into the structured HTTP error envelope using the same public code and message returned by Desktop commands. HTTP alone adds the status code.

--- a/openspec/specs/database-repositories/spec.md
+++ b/openspec/specs/database-repositories/spec.md
@@ -33,21 +33,6 @@ The system SHALL treat `is_deleted = 1` rows as deleted implementation detail in
 - **WHEN** a caller invokes a repository soft-delete operation for an existing visible entity
 - **THEN** `ora-db` updates the row `is_deleted` flag and `updated_at` timestamp and reports that one visible entity was deleted
 
-### Requirement: Project repositories SHALL support visible lookup by project name
-The system SHALL allow `ora-db` project repositories to load one visible `Project` by its exact persisted `name` so bootstrap flows can reconcile a configured workspace identity without listing the full project table. Name-based lookup SHALL ignore soft-deleted rows the same way identifier-based reads do.
-
-#### Scenario: Visible project is queried by exact name
-- **WHEN** a caller asks an `ora-db` project repository to find a project by a name stored on one visible row
-- **THEN** the repository returns that full `Project` snapshot, including its existing identifier, root path, and audit fields
-
-#### Scenario: Soft-deleted project shares the queried name
-- **WHEN** a caller asks an `ora-db` project repository to find a project by name and only soft-deleted rows match that name
-- **THEN** the repository returns `None` instead of exposing deleted project rows to bootstrap or application code
-
-#### Scenario: No visible project matches the queried name
-- **WHEN** a caller asks an `ora-db` project repository to find a project by name that does not exist among visible rows
-- **THEN** the repository returns `None`
-
 ### Requirement: Repository adapters SHALL map persisted rows to existing domain models
 The system SHALL persist and load `ora-domain` `Project`, `Task`, `Session`, and `Worktree` values by mapping SQLite columns to the current domain shapes, including audit fields and enum-backed integer columns already defined by the domain layer.
 

--- a/openspec/specs/project-work-contexts/spec.md
+++ b/openspec/specs/project-work-contexts/spec.md
@@ -7,10 +7,6 @@ Define the persisted project work context contract that tracks which client wind
 ### Requirement: System SHALL persist window-scoped project work contexts
 The system SHALL persist a typed `project_work_context` record for each active client window, including a unique identifier, `surface`, `window_id`, `project_id`, `lease_expires_at`, `created_at`, and `updated_at`. The `projects` table SHALL remain limited to project identity and SHALL NOT become the source of truth for active working context. The backend SHALL compute `lease_expires_at` from its own current time using a two-minute lease duration and SHALL NOT trust clients to provide an absolute expiry timestamp.
 
-#### Scenario: Web runtime records its active project
-- **WHEN** the web runtime finishes bootstrap for its configured project
-- **THEN** the backend persists or updates one work-context row for the synthetic web window identity that points at the configured project and includes a non-expired lease
-
 #### Scenario: Client sends a lease-related context request
 - **WHEN** a client asks the backend to create, switch, or renew a project work context
 - **THEN** the backend computes the resulting `lease_expires_at` from backend time plus two minutes instead of accepting a client-supplied absolute expiration
@@ -35,7 +31,7 @@ The system SHALL allow at most one non-expired active work context per `(surface
 - **THEN** the client-facing response reports only that the project is occupied and the backend logs identify the owning `surface` and `window_id`
 
 ### Requirement: System SHALL ignore expired work contexts during conflict detection
-The system SHALL treat `lease_expires_at` as the boundary for active ownership. Project-open and project-switch checks SHALL consider only non-expired contexts, and expired rows SHALL NOT block a new context from claiming the project. Clients SHALL renew active leases every 30 seconds, and bootstrap, open, and switch operations SHALL immediately refresh the lease as part of establishing the context.
+The system SHALL treat `lease_expires_at` as the boundary for active ownership. Project-open and project-switch checks SHALL consider only non-expired contexts, and expired rows SHALL NOT block a new context from claiming the project. Clients SHALL renew active leases every 30 seconds, and open and switch operations SHALL immediately refresh the lease as part of establishing the context.
 
 #### Scenario: Expired context exists for requested project
 - **WHEN** a caller requests a project whose only matching work-context rows have `lease_expires_at` earlier than the current backend time
@@ -46,7 +42,7 @@ The system SHALL treat `lease_expires_at` as the boundary for active ownership. 
 - **THEN** the backend extends the same row's lease rather than creating a duplicate active context
 
 #### Scenario: Context-establishing action refreshes the lease immediately
-- **WHEN** the backend handles bootstrap, open, or switch for a client window
+- **WHEN** the backend handles open or switch for a client window
 - **THEN** it writes a fresh non-expired lease for that context during the same operation instead of waiting for the next 30-second renewal tick
 
 ### Requirement: System SHALL retain expired contexts temporarily without keeping them active

--- a/openspec/specs/task-worktree-provisioning/spec.md
+++ b/openspec/specs/task-worktree-provisioning/spec.md
@@ -5,10 +5,10 @@ Define the backend-owned linked-worktree lifecycle that task creation and deleti
 ## Requirements
 
 ### Requirement: Task creation SHALL provision exactly one internal linked worktree
-The system SHALL treat linked worktree provisioning as part of task creation. When a new task is created, the backend SHALL derive a task-owned branch name and worktree root from the generated task identifier, SHALL create one linked Git worktree from the configured project repository, SHALL persist one worktree record for that checkout, and SHALL persist the task with the new internal `worktree_id`.
+The system SHALL treat linked worktree provisioning as part of task creation. When a new task is created, the backend SHALL derive a task-owned branch name and worktree root from the generated task identifier, SHALL create one linked Git worktree from the repository belonging to the requested project, SHALL persist one worktree record for that checkout, and SHALL persist the task with the new internal `worktree_id`.
 
 #### Scenario: Creating a task provisions and links a worktree
-- **WHEN** the backend handles a valid task creation request for the configured project
+- **WHEN** the backend handles a valid task creation request for an existing project
 - **THEN** it creates one linked Git worktree, persists one worktree record, and stores the task-to-worktree linkage internally without exposing the internal `worktree_id` in the public task payload
 
 #### Scenario: Branch and path are derived from the generated task identity

--- a/openspec/specs/web-server-runtime/spec.md
+++ b/openspec/specs/web-server-runtime/spec.md
@@ -3,30 +3,18 @@
 Define the persisted web server runtime contract for Ora's HTTP backend, including SQLite-backed bootstrap, CRUD route exposure, and stable readiness and error behavior.
 ## Requirements
 ### Requirement: Web server runtime SHALL bootstrap a file-backed SQLite application state
-The system SHALL make `apps/web/server` construct its shared runtime state from a file-backed SQLite database through `ora-db` during startup. The runtime SHALL load a runtime data root and a configured bootstrap project identity from typed bootstrap configuration, SHALL derive the SQLite database path, worktree root, and log file path from that data root, SHALL run database bootstrap and repository-pool construction before marking the server ready, SHALL reconcile the configured project into persistent storage before application state is returned, and SHALL fail startup with a typed bootstrap error when the data root or bootstrap project configuration is invalid or the SQLite bootstrap sequence cannot complete.
+The system SHALL make `apps/web/server` construct its shared runtime state from a file-backed SQLite database through `ora-db` during startup. The runtime SHALL load a runtime data root from typed bootstrap configuration, SHALL derive the SQLite database path, worktree root, and log file path from that data root, SHALL run database bootstrap and repository-pool construction before marking the server ready, and SHALL fail startup with a typed bootstrap error when the data root is invalid or the SQLite bootstrap sequence cannot complete. Runtime readiness SHALL NOT require a persisted project.
 
-#### Scenario: Server starts with a usable database path and a missing configured project
-- **WHEN** `ora-web-server` starts with a valid `ORA_DATA_DIR` plus `ORA_PROJECT_NAME` and `ORA_PROJECT_PATH`, and no visible project row exists with that configured name
-- **THEN** startup bootstraps SQLite at `<ORA_DATA_DIR>/ora.sqlite3`, creates one project row with the configured name and path, constructs the shared runtime state, and only then reports readiness success
-
-#### Scenario: Server starts with an existing configured project whose stored path drifted
-- **WHEN** `ora-web-server` starts with a valid bootstrap configuration and a visible project row already exists for the configured project name but its stored `root_path` differs from `ORA_PROJECT_PATH`
-- **THEN** startup updates that existing project row in place to the configured path before the runtime is considered ready
-
-#### Scenario: Server starts with a usable database path and an already reconciled configured project
-- **WHEN** `ora-web-server` starts with a valid bootstrap configuration and a visible project row already exists whose name and path match the configured project identity
-- **THEN** startup leaves the existing row unchanged, constructs shared repositories and handlers, and reports readiness success
-
-#### Scenario: Bootstrap project configuration is invalid
-- **WHEN** `ora-web-server` starts with a blank or missing configured bootstrap project name or path
-- **THEN** startup fails with a typed bootstrap error instead of serving requests with an unknown workspace identity
+#### Scenario: Server starts with an empty project catalog
+- **WHEN** `ora-web-server` starts with a valid `ORA_DATA_DIR` and no visible project rows exist
+- **THEN** startup bootstraps SQLite at `<ORA_DATA_DIR>/ora.sqlite3`, constructs the shared runtime state without creating a project, and reports readiness success
 
 #### Scenario: Database bootstrap fails during startup
 - **WHEN** the configured SQLite database cannot be opened, migrated, or pooled during web-server bootstrap
 - **THEN** startup fails with a typed bootstrap error instead of serving requests with a partially initialized runtime
 
 ### Requirement: Web server runtime SHALL expose HTTP CRUD routes for supported persisted models
-The system SHALL expose create, get, list, update, and delete HTTP routes for `project`, `task`, and `session`, and it SHALL expose the backend-managed project-work-context routes required for web runtime ownership. The runtime SHALL NOT expose standalone public worktree CRUD routes. Each supported route SHALL translate transport input into the matching `ora-contracts` request DTO, SHALL delegate to the corresponding `ora-application` handler, and SHALL serialize the returned `ora-contracts` response DTO without adding adapter-local response shapes. Task-create runtime wiring SHALL provide the configured project repository and worktree root needed for backend-owned linked-worktree provisioning.
+The system SHALL expose create, get, list, update, and delete HTTP routes for `project`, `task`, and `session`, and it SHALL expose the backend-managed project-work-context routes required for web runtime ownership. The runtime SHALL NOT expose standalone public worktree CRUD routes. Each supported route SHALL translate transport input into the matching `ora-contracts` request DTO, SHALL delegate to the corresponding `ora-application` handler, and SHALL serialize the returned `ora-contracts` response DTO without adding adapter-local response shapes. Task-create runtime wiring SHALL provide the requested project repository and runtime worktree root needed for backend-owned linked-worktree provisioning.
 
 #### Scenario: Client performs task CRUD over HTTP
 - **WHEN** a caller creates, fetches, lists, updates, or deletes a task through the web server
@@ -34,7 +22,7 @@ The system SHALL expose create, get, list, update, and delete HTTP routes for `p
 
 #### Scenario: Task creation provisions an internal worktree through runtime wiring
 - **WHEN** a caller creates a task through the web server
-- **THEN** the runtime-owned task-create dependencies use the configured project repository and the effective worktree root to provision the task's linked worktree before the created task response is returned
+- **THEN** the runtime-owned task-create dependencies use the requested project's repository and the effective worktree root to provision the task's linked worktree before the created task response is returned
 
 #### Scenario: Client attempts standalone worktree CRUD over HTTP
 - **WHEN** a caller targets `/api/worktrees` or `/api/worktrees/{worktree_id}`


### PR DESCRIPTION
## Summary

- remove the required `ORA_PROJECT_NAME` / `ORA_PROJECT_PATH` startup configuration and bootstrap project reconciliation
- stop creating a synthetic `web/main` project work context during server startup
- introduce `WorktreeConfig` for the useful worktree root and keep the existing project-work-context subsystem intact
- allow the web backend to become ready with an empty project catalog
- remove the obsolete project-name repository lookup and update tests, runtime documentation, and OpenSpec requirements

## Why

The web runtime now supports multiple projects, so forcing one project into the database and into a fixed startup work context is no longer a valid ownership model. Projects should instead be created or added through the normal project APIs, while task operations continue to select their project and context explicitly.

Existing database projects are retained. This change only removes the fixed bootstrap chain and does not remove the project-work-context subsystem.

## Configuration note

`WorktreeConfig::from_database()` currently derives the data directory from the parent of the SQLite database path. This is correct while both paths are governed by `ORA_DATA_DIR`, but it creates a small configuration coupling. If the database path becomes independently configurable, introduce an explicit `DataDirectoryConfig` and derive both `DatabaseConfig` and `WorktreeConfig` from it.

## Checks

- `cargo fmt --all`
- `task test`
- `cargo clippy -p ora-web-server --all-targets -- -D warnings`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p ora-web-server --no-deps`
