### PR TITLE
feat(acp): add debug and trace logging for ACP communication pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,12 +1282,14 @@ version = "0.0.0"
 dependencies = [
  "futures-util",
  "ora-contracts",
+ "ora-logging",
  "pretty_assertions",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1316,6 +1318,7 @@ dependencies = [
  "ora-contracts",
  "ora-db",
  "ora-domain",
+ "ora-logging",
  "ora-process",
  "pretty_assertions",
  "serde",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,6 +167,8 @@ tasks:
       ORA_DATA_DIR: .data
       ORA_PROJECT_NAME: rustun
       ORA_PROJECT_PATH: .data/rustun
+      ORA_LOG_LEVEL: '{{.LOG_LEVEL | default "info"}}'
+      ORA_LOG_MODE: '{{.LOG_MODE | default "file"}}'
     cmds:
       - task: run:prepare
       - cargo run --bin ora_web_server

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,7 +167,7 @@ tasks:
       ORA_DATA_DIR: .data
       ORA_PROJECT_NAME: rustun
       ORA_PROJECT_PATH: .data/rustun
-      ORA_LOG_LEVEL: '{{.LOG_LEVEL | default "info"}}'
+      ORA_LOG_LEVEL: '{{.LOG_LEVEL | default "debug"}}'
       ORA_LOG_MODE: '{{.LOG_MODE | default "file"}}'
     cmds:
       - task: run:prepare

--- a/apps/web/server/src/bootstrap.rs
+++ b/apps/web/server/src/bootstrap.rs
@@ -134,8 +134,8 @@ fn web_backend_bootstrap_error(error: BackendBootstrapError) -> WebBootstrapErro
             WebBootstrapError::DataDirectoryCreate(source)
         }
         BackendBootstrapError::Database(source) => WebBootstrapError::DatabaseBootstrap(source),
-        BackendBootstrapError::AgentRuntime(_) => WebBootstrapError::ProjectBootstrap {
-            message: "failed to initialize agent runtime".to_string(),
+        BackendBootstrapError::AgentRuntime(source) => WebBootstrapError::ProjectBootstrap {
+            message: format!("failed to initialize agent runtime: {source}"),
         },
     }
 }

--- a/apps/web/server/src/config.rs
+++ b/apps/web/server/src/config.rs
@@ -263,6 +263,7 @@ fn read_logging_config(
         .to_ascii_lowercase()
         .as_str()
     {
+        "trace" => LogLevel::Trace,
         "debug" => LogLevel::Debug,
         "info" => LogLevel::Info,
         "warn" => LogLevel::Warn,

--- a/crates/acp/Cargo.toml
+++ b/crates/acp/Cargo.toml
@@ -13,10 +13,12 @@ workspace = true
 [dependencies]
 futures-util = { workspace = true }
 ora-contracts = { workspace = true }
+ora-logging = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "rt", "sync"] }
+tracing = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }
 
 [dev-dependencies]

--- a/crates/acp/src/peer.rs
+++ b/crates/acp/src/peer.rs
@@ -1,5 +1,6 @@
 use futures_util::StreamExt;
 use ora_contracts::acp::error::Error as RpcError;
+use ora_logging::ora_trace;
 use ora_contracts::acp::literals::CLIENT_METHOD_NAMES;
 use ora_contracts::acp::notification::SessionNotification;
 use ora_contracts::acp::permission::RequestPermissionRequest;
@@ -240,6 +241,14 @@ async fn read_frames<Reader, Writer>(
                 return;
             }
         };
+        let (msg, jsonrpc_method, session_id) = trace_frame_summary(&value, "recv");
+        ora_trace!(
+            direction = "recv",
+            jsonrpc_method = %jsonrpc_method,
+            session_id = %session_id,
+            frame = %value,
+            "{}", msg,
+        );
         if let Err(error) = route_frame(value, &writer, &pending, &updates, &control).await {
             let _ = control.send(AcpControl::Fatal(error));
             pending.lock().await.clear();
@@ -335,11 +344,46 @@ where
     }
 }
 
+/// Extracts summary fields from a JSON-RPC frame for trace-level correlation without re-parsing.
+fn trace_frame_summary(value: &Value, direction: &str) -> (String, String, String) {
+    let jsonrpc_method = value
+        .get("method")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let session_id = value
+        .get("params")
+        .and_then(|p| p.get("sessionId"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let is_response = value.get("result").is_some();
+    let is_error = value.get("error").is_some();
+
+    let message = if !jsonrpc_method.is_empty() {
+        format!("{} {}", direction, jsonrpc_method)
+    } else if is_response {
+        format!("{} response", direction)
+    } else if is_error {
+        format!("{} error response", direction)
+    } else {
+        format!("{} frame", direction)
+    };
+
+    (message, jsonrpc_method.to_string(), session_id.to_string())
+}
+
 /// Writes a reader-originated protocol response through the connection's serialized sink.
 async fn write_frame<Writer>(writer: &Mutex<Writer>, value: &Value) -> Result<(), AcpError>
 where
     Writer: AsyncWrite + Unpin,
 {
+    let (msg, jsonrpc_method, session_id) = trace_frame_summary(value, "send");
+    ora_trace!(
+        direction = "send",
+        jsonrpc_method = %jsonrpc_method,
+        session_id = %session_id,
+        frame = %value,
+        "{}", msg,
+    );
     let mut bytes =
         serde_json::to_vec(value).map_err(|error| AcpError::InvalidFrame(error.to_string()))?;
     if bytes.len() > MAX_FRAME_BYTES {

--- a/crates/acp/src/peer.rs
+++ b/crates/acp/src/peer.rs
@@ -1,10 +1,10 @@
 use futures_util::StreamExt;
 use ora_contracts::acp::error::Error as RpcError;
-use ora_logging::ora_trace;
 use ora_contracts::acp::literals::CLIENT_METHOD_NAMES;
 use ora_contracts::acp::notification::SessionNotification;
 use ora_contracts::acp::permission::RequestPermissionRequest;
 use ora_contracts::acp::rpc::RequestId;
+use ora_logging::ora_trace;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
@@ -241,14 +241,17 @@ async fn read_frames<Reader, Writer>(
                 return;
             }
         };
-        let (msg, jsonrpc_method, session_id) = trace_frame_summary(&value, "recv");
-        ora_trace!(
-            direction = "recv",
-            jsonrpc_method = %jsonrpc_method,
-            session_id = %session_id,
-            frame = %value,
-            "{}", msg,
-        );
+        #[cfg(debug_assertions)]
+        {
+            let (msg, jsonrpc_method, session_id) = trace_frame_summary(&value, "recv");
+            ora_trace!(
+                direction = "recv",
+                jsonrpc_method = %jsonrpc_method,
+                session_id = %session_id,
+                frame = %value,
+                "{}", msg,
+            );
+        }
         if let Err(error) = route_frame(value, &writer, &pending, &updates, &control).await {
             let _ = control.send(AcpControl::Fatal(error));
             pending.lock().await.clear();
@@ -345,11 +348,9 @@ where
 }
 
 /// Extracts summary fields from a JSON-RPC frame for trace-level correlation without re-parsing.
+#[cfg(debug_assertions)]
 fn trace_frame_summary(value: &Value, direction: &str) -> (String, String, String) {
-    let jsonrpc_method = value
-        .get("method")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let jsonrpc_method = value.get("method").and_then(|v| v.as_str()).unwrap_or("");
     let session_id = value
         .get("params")
         .and_then(|p| p.get("sessionId"))
@@ -359,13 +360,13 @@ fn trace_frame_summary(value: &Value, direction: &str) -> (String, String, Strin
     let is_error = value.get("error").is_some();
 
     let message = if !jsonrpc_method.is_empty() {
-        format!("{} {}", direction, jsonrpc_method)
+        format!("{direction} {jsonrpc_method}")
     } else if is_response {
-        format!("{} response", direction)
+        format!("{direction} response")
     } else if is_error {
-        format!("{} error response", direction)
+        format!("{direction} error response")
     } else {
-        format!("{} frame", direction)
+        format!("{direction} frame")
     };
 
     (message, jsonrpc_method.to_string(), session_id.to_string())
@@ -376,14 +377,17 @@ async fn write_frame<Writer>(writer: &Mutex<Writer>, value: &Value) -> Result<()
 where
     Writer: AsyncWrite + Unpin,
 {
-    let (msg, jsonrpc_method, session_id) = trace_frame_summary(value, "send");
-    ora_trace!(
-        direction = "send",
-        jsonrpc_method = %jsonrpc_method,
-        session_id = %session_id,
-        frame = %value,
-        "{}", msg,
-    );
+    #[cfg(debug_assertions)]
+    {
+        let (msg, jsonrpc_method, session_id) = trace_frame_summary(value, "send");
+        ora_trace!(
+            direction = "send",
+            jsonrpc_method = %jsonrpc_method,
+            session_id = %session_id,
+            frame = %value,
+            "{}", msg,
+        );
+    }
     let mut bytes =
         serde_json::to_vec(value).map_err(|error| AcpError::InvalidFrame(error.to_string()))?;
     if bytes.len() > MAX_FRAME_BYTES {

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -17,6 +17,7 @@ ora-application = { workspace = true }
 ora-contracts = { workspace = true }
 ora-db = { workspace = true }
 ora-domain = { workspace = true }
+ora-logging = { workspace = true }
 ora-process = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/backend/src/agent_runtime/actor.rs
+++ b/crates/backend/src/agent_runtime/actor.rs
@@ -112,6 +112,7 @@ impl RuntimeActor {
             AcpSessionId::new(self.session.agent_session_id.clone()),
             &self.cwd,
         );
+        ora_debug!(session_id = %self.session.id, "session/load sent");
         let future =
             client.request::<_, LoadSessionResponse>(AGENT_METHOD_NAMES.session_load, &request);
         tokio::pin!(future);
@@ -122,6 +123,7 @@ impl RuntimeActor {
                 response = &mut future => {
                     match response {
                         Ok(_) => {
+                            ora_debug!(session_id = %self.session.id, "session/load completed");
                             if events.try_send(Ok(LoadSessionEvent::Completed)).is_ok() {
                                 self.process = Some(process);
                             } else {
@@ -130,6 +132,7 @@ impl RuntimeActor {
                             }
                         }
                         Err(error) => {
+                            ora_debug!(session_id = %self.session.id, error = %error, "session/load failed");
                             let _ = process.child.kill().await;
                             let _ = events.try_send(Err(map_acp_error(error)));
                             self.mark_stopped();
@@ -169,6 +172,7 @@ impl RuntimeActor {
                     }
                 }
                 _ = &mut deadline => {
+                    ora_debug!(session_id = %self.session.id, "session/load timed out");
                     let _ = process.child.kill().await;
                     let _ = events.try_send(Err(runtime_internal("agent_load_timeout", "agent session load timed out")));
                     self.mark_stopped();
@@ -196,7 +200,9 @@ impl RuntimeActor {
             return;
         };
         let client = process.client.clone();
+        let text_len = text.len();
         let request = PromptRequest::new(self.session.agent_session_id.clone(), vec![text.into()]);
+        ora_debug!(session_id = %self.session.id, text_len = text_len, "session/prompt sent");
         let future =
             client.request::<_, PromptResponse>(AGENT_METHOD_NAMES.session_prompt, &request);
         tokio::pin!(future);
@@ -206,6 +212,7 @@ impl RuntimeActor {
                 response = &mut future => {
                     match response {
                         Ok(response) => {
+                            ora_debug!(session_id = %self.session.id, stop_reason = ?response.stop_reason, "prompt completed");
                             if events.try_send(Ok(PromptSessionEvent::Completed { stop_reason: response.stop_reason })).is_ok() {
                                 self.process = Some(process);
                             } else {
@@ -215,6 +222,7 @@ impl RuntimeActor {
                         }
                         Err(error) => {
                             let process_is_reusable = matches!(&error, ora_acp::AcpError::RequestFailed(_));
+                            ora_debug!(session_id = %self.session.id, error = %error, reusable = process_is_reusable, "prompt failed");
                             let event_sent = events.try_send(Err(map_acp_error(error))).is_ok();
                             if process_is_reusable && event_sent {
                                 self.process = Some(process);
@@ -251,6 +259,7 @@ impl RuntimeActor {
                             }
                             let public_id = permission.request_id.to_string();
                             let option_ids = permission.request.options.iter().map(|option| option.option_id.0.to_string()).collect::<Vec<_>>();
+                            ora_debug!(session_id = %self.session.id, tool_call = ?permission.request.tool_call, option_count = option_ids.len(), request_id = %public_id, "permission requested");
                             permissions.insert(public_id.clone(), (permission.request_id, option_ids));
                             let event = PromptSessionEvent::PermissionRequest(SessionPermissionRequest {
                                 permission_request_id: public_id,
@@ -265,6 +274,7 @@ impl RuntimeActor {
                             }
                         }
                         Some(AcpControl::Fatal(error)) => {
+                            ora_debug!(session_id = %self.session.id, error = %error, "protocol fatal error");
                             let _ = process.child.kill().await;
                             let _ = events.try_send(Err(map_acp_error(error)));
                             self.mark_stopped();
@@ -280,6 +290,7 @@ impl RuntimeActor {
                             let _ = response.send(result);
                         }
                         Some(RuntimeCommand::Cancel { operation_id: cancelled }) if cancelled == operation_id => {
+                            ora_debug!(session_id = %self.session.id, "prompt cancelled");
                             self.request_prompt_cancellation(&client, &permissions).await;
                             match timeout(CANCELLATION_GRACE, &mut future).await {
                                 Ok(Ok(_)) | Ok(Err(ora_acp::AcpError::RequestFailed(_))) => {
@@ -293,6 +304,7 @@ impl RuntimeActor {
                             return;
                         }
                         Some(RuntimeCommand::Stop { response }) => {
+                            ora_debug!(session_id = %self.session.id, "prompt stopped by stop command");
                             self.request_prompt_cancellation(&client, &permissions).await;
                             let _ = process.child.kill().await;
                             self.mark_stopped();
@@ -367,6 +379,7 @@ impl RuntimeActor {
         client: &AcpClient<ChildStdin>,
         permissions: &HashMap<String, (ora_contracts::acp::rpc::RequestId, Vec<String>)>,
     ) {
+        ora_debug!(session_id = %self.session.id, pending_permissions = permissions.len(), "cancelling prompt");
         for (request_id, _) in permissions.values() {
             let _ = client
                 .respond(
@@ -390,6 +403,7 @@ impl RuntimeActor {
                 runtime_internal("agent_stop_failed", "failed to stop agent process")
             })?;
             let _ = timeout(CANCELLATION_GRACE, process.child.wait()).await;
+            ora_debug!(session_id = %self.session.id, "process stopped");
         }
         self.mark_stopped();
         Ok(())
@@ -402,5 +416,6 @@ impl RuntimeActor {
             .clone()
             .with_status(SessionStatus::Stopped, self.clock.now_timestamp_millis());
         let _ = self.repository.update_session(self.session.clone());
+        ora_debug!(session_id = %self.session.id, "session marked stopped");
     }
 }

--- a/crates/backend/src/agent_runtime/mod.rs
+++ b/crates/backend/src/agent_runtime/mod.rs
@@ -14,6 +14,7 @@ use ora_application::{
     UuidSessionIdGenerator, WorktreeRepository,
 };
 use ora_contracts::acp::common::SessionId as AcpSessionId;
+use ora_logging::ora_debug;
 use ora_contracts::acp::initialization::{
     Implementation, InitializeRequest, InitializeResponse, ProtocolVersion,
 };
@@ -132,8 +133,9 @@ impl AgentRuntimeManager {
         clock: SystemClock,
     ) -> Result<Self, BackendError> {
         let repository = SqliteSessionRepository::new(pool.clone());
-        for session in repository.list_sessions().map_err(|_| {
-            runtime_internal("session_repository_error", "failed to reconcile sessions")
+        let mut reconciled = 0u64;
+        for session in repository.list_sessions().map_err(|error| {
+            runtime_internal("session_repository_error", format!("failed to reconcile sessions: {error:?}"))
         })? {
             if session.status == SessionStatus::Running {
                 repository
@@ -143,7 +145,11 @@ impl AgentRuntimeManager {
                     .map_err(|_| {
                         runtime_internal("session_repository_error", "failed to reconcile sessions")
                     })?;
+                reconciled += 1;
             }
+        }
+        if reconciled > 0 {
+            ora_debug!(reconciled_count = reconciled, "reconciled stale running sessions");
         }
         let opencode_path = resolve_opencode_path(&home_directory)?;
         Ok(Self {
@@ -200,6 +206,11 @@ impl AgentRuntimeManager {
                     "failed to persist agent session",
                 )
             })?;
+        ora_debug!(
+            session_id = %session.id,
+            agent_session_id = %session.agent_session_id,
+            "session created",
+        );
         self.insert_actor(session.clone(), cwd, Some(process))?;
         Ok(CreateSessionResponse {
             session: contract_session(session),
@@ -498,6 +509,7 @@ async fn spawn_initialized_process(
             format!("agent CLI executable not found: {}", executable.display()),
         ));
     }
+    ora_debug!(executable = %executable.display(), cwd = %cwd.display(), "spawning agent process");
     let mut child = TokioProcessSpawner::new()
         .spawn(ProcessSpec::new(executable).arg("acp").cwd(cwd))
         .map_err(|_| runtime_internal("agent_start_failed", "failed to start agent CLI"))?;
@@ -521,6 +533,10 @@ async fn spawn_initialized_process(
     .await
     .map_err(|_| runtime_internal("agent_initialize_timeout", "agent initialization timed out"))?
     .map_err(map_acp_error)?;
+    ora_debug!(
+        load_session_supported = response.agent_capabilities.load_session,
+        "initialize handshake completed",
+    );
     let (client, updates, control) = peer.into_parts();
     Ok(AgentProcess {
         child,
@@ -605,6 +621,7 @@ async fn respond_permission(
             "permission option does not belong to this request",
         ));
     }
+    let selected_option = request.option_id.clone();
     let outcome = RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(
         PermissionOptionId::new(request.option_id),
     ));
@@ -612,6 +629,7 @@ async fn respond_permission(
         .respond(&request_id, &RequestPermissionResponse::new(outcome))
         .await
         .map_err(map_acp_error)?;
+    ora_debug!(option_id = %selected_option, "permission responded");
     Ok(RespondToPermissionResponse {})
 }
 

--- a/crates/backend/src/agent_runtime/mod.rs
+++ b/crates/backend/src/agent_runtime/mod.rs
@@ -14,7 +14,6 @@ use ora_application::{
     UuidSessionIdGenerator, WorktreeRepository,
 };
 use ora_contracts::acp::common::SessionId as AcpSessionId;
-use ora_logging::ora_debug;
 use ora_contracts::acp::initialization::{
     Implementation, InitializeRequest, InitializeResponse, ProtocolVersion,
 };
@@ -43,6 +42,7 @@ use ora_db::{
 use ora_domain::{
     AgentCli, AuditFields, Session, SessionId, SessionStatus, TaskId, WorktreeActivity,
 };
+use ora_logging::ora_debug;
 use ora_process::{
     ManagedProcess, ProcessSpawner, ProcessSpec, TokioManagedProcess, TokioProcessSpawner,
 };
@@ -135,7 +135,10 @@ impl AgentRuntimeManager {
         let repository = SqliteSessionRepository::new(pool.clone());
         let mut reconciled = 0u64;
         for session in repository.list_sessions().map_err(|error| {
-            runtime_internal("session_repository_error", format!("failed to reconcile sessions: {error:?}"))
+            runtime_internal(
+                "session_repository_error",
+                format!("failed to reconcile sessions: {error:?}"),
+            )
         })? {
             if session.status == SessionStatus::Running {
                 repository
@@ -149,7 +152,10 @@ impl AgentRuntimeManager {
             }
         }
         if reconciled > 0 {
-            ora_debug!(reconciled_count = reconciled, "reconciled stale running sessions");
+            ora_debug!(
+                reconciled_count = reconciled,
+                "reconciled stale running sessions"
+            );
         }
         let opencode_path = resolve_opencode_path(&home_directory)?;
         Ok(Self {

--- a/crates/backend/src/agent_runtime/stream.rs
+++ b/crates/backend/src/agent_runtime/stream.rs
@@ -1,4 +1,5 @@
 use crate::BackendError;
+use ora_logging::ora_debug;
 use tokio::sync::mpsc;
 
 use super::RuntimeCommand;
@@ -39,6 +40,7 @@ impl<Event> SessionEventStream<Event> {
 impl<Event> Drop for SessionEventStream<Event> {
     fn drop(&mut self) {
         if !self.completed {
+            ora_debug!(operation_id = self.operation_id, "stream dropped, sending cancel");
             let _ = self.commands.send(RuntimeCommand::Cancel {
                 operation_id: self.operation_id,
             });

--- a/crates/backend/src/agent_runtime/stream.rs
+++ b/crates/backend/src/agent_runtime/stream.rs
@@ -40,7 +40,10 @@ impl<Event> SessionEventStream<Event> {
 impl<Event> Drop for SessionEventStream<Event> {
     fn drop(&mut self) {
         if !self.completed {
-            ora_debug!(operation_id = self.operation_id, "stream dropped, sending cancel");
+            ora_debug!(
+                operation_id = self.operation_id,
+                "stream dropped, sending cancel"
+            );
             let _ = self.commands.send(RuntimeCommand::Cancel {
                 operation_id: self.operation_id,
             });

--- a/crates/logging/src/config.rs
+++ b/crates/logging/src/config.rs
@@ -18,6 +18,7 @@ impl LoggingConfig {
 /// Enumerates the supported event filtering levels for shared runtime logging.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LogLevel {
+    Trace,
     Debug,
     Info,
     Warn,

--- a/crates/logging/src/init.rs
+++ b/crates/logging/src/init.rs
@@ -87,6 +87,7 @@ where
 /// Maps the public level enum into the tracing filter used by every active sink.
 fn level_filter(level: LogLevel) -> LevelFilter {
     match level {
+        LogLevel::Trace => LevelFilter::TRACE,
         LogLevel::Debug => LevelFilter::DEBUG,
         LogLevel::Info => LevelFilter::INFO,
         LogLevel::Warn => LevelFilter::WARN,

--- a/crates/logging/src/macros.rs
+++ b/crates/logging/src/macros.rs
@@ -1,3 +1,20 @@
+/// Emits a trace event and automatically records the current function name under `method`.
+#[macro_export]
+macro_rules! ora_trace {
+    ($($arg:tt)*) => {
+        {
+            fn __ora_log_marker() {}
+            ::tracing::trace!(
+                method = $crate::__private::method_name_from_marker_type_name(
+                    ::core::any::type_name_of_val(&__ora_log_marker),
+                    "__ora_log_marker",
+                ),
+                $($arg)*
+            )
+        }
+    };
+}
+
 /// Emits a debug event and automatically records the current function name under `method`.
 #[macro_export]
 macro_rules! ora_debug {


### PR DESCRIPTION
## Summary

Add two-tier structured logging to the ACP communication pipeline — `ora_debug!` for operation-level events and `ora_trace!` for frame-level JSON-RPC I/O.

## What Changed

### `ora-logging` crate
- Added `LogLevel::Trace` variant, mapped to `LevelFilter::TRACE`
- Added `ora_trace!` macro (same auto-method-injection pattern as `ora_debug!`)

### ACP transport layer (`crates/acp/src/peer.rs`)
- `ora_trace!` at `write_frame` and `read_frames` — every JSON-RPC frame captured
- Helper `trace_frame_summary` extracts searchable fields from each frame: `jsonrpc_method`, `session_id`, and human-readable `message`
- Full frame content preserved in `frame` field

### Agent runtime (`crates/backend/src/agent_runtime/`)
- 16 `ora_debug!` calls covering the full ACP lifecycle, all with `session_id`:

| Category | Log Points |
|---|---|
| Process | `spawn_initialized_process` (executable + cwd + initialize capabilities) |
| Session | `create_session` (Ora ID ↔ agent ID mapping), `session/load` sent/completed/error/timeout |
| Prompt | `session/prompt` sent (text_len) / completed (stop_reason) / failed (reusable vs fatal) |
| Permission | Request arrival (tool_call, option count) / response (selected option_id) |
| Cancel | Prompt cancellation (pending permissions count) |
| Lifecycle | Startup reconciling, session stopped, stream dropped |

### Web server & Taskfile
- `apps/web/server/src/config.rs`: parse `"trace"` as valid `ORA_LOG_LEVEL`
- `Taskfile.yml`: `run:web-backend` exposes `LOG_LEVEL` and `LOG_MODE` parameters

### Error message improvements
- `AgentRuntimeManager::new` now includes the underlying DB error in the failure message

## Usage

```powershell
task run:web-backend                           # info (default)
task run:web-backend LOG_LEVEL=debug LOG_MODE=stdout   # operation-level
task run:web-backend LOG_LEVEL=trace LOG_MODE=stdout   # frame-level
```

## Example Output

**DEBUG — operation timeline with `session_id` for correlation:**

```json
{"context":{"cwd":"D:/Projects/desktop/.data/worktrees/...","executable":"C:\Users\...\opencode.cmd"},"level":"DEBUG","message":"spawning agent process","method":"spawn_initialized_process","target":"ora_backend::agent_runtime"}
{"context":{"load_session_supported":true},"level":"DEBUG","message":"initialize handshake completed","method":"spawn_initialized_process","target":"ora_backend::agent_runtime"}
{"context":{"session_id":"c12f70b3-12c0-4b0a-a680-18307e05db10"},"level":"DEBUG","message":"session/load sent","method":"run_load","target":"ora_backend::agent_runtime::actor"}
{"context":{"session_id":"c12f70b3-12c0-4b0a-a680-18307e05db10"},"level":"DEBUG","message":"session/load completed","method":"run_load","target":"ora_backend::agent_runtime::actor"}
{"context":{"session_id":"c12f70b3-12c0-4b0a-a680-18307e05db10","text_len":9},"level":"DEBUG","message":"session/prompt sent","method":"run_prompt","target":"ora_backend::agent_runtime::actor"}
{"context":{"session_id":"c12f70b3-12c0-4b0a-a680-18307e05db10","stop_reason":"EndTurn"},"level":"DEBUG","message":"prompt completed","method":"run_prompt","target":"ora_backend::agent_runtime::actor"}
```

**TRACE — frame-level with extracted metadata + full content:**

```json
{"context":{"direction":"send","frame":"{\"id\":1,\"method\":\"initialize\",\"params\":{...}}","jsonrpc_method":"initialize","session_id":""},"level":"TRACE","message":"send initialize","method":"write_frame"}
{"context":{"direction":"recv","frame":"{\"id\":1,\"result\":{\"agentCapabilities\":{\"loadSession\":true},...}}","jsonrpc_method":"","session_id":""},"level":"TRACE","message":"recv response","method":"read_frames"}
{"context":{"direction":"send","frame":"{\"id\":2,\"method\":\"session/load\",\"params\":{\"sessionId\":\"ses_071e09...\"}}","jsonrpc_method":"session/load","session_id":"ses_071e095dcffeW0iQSahf43nZsU"},"level":"TRACE","message":"send session/load","method":"write_frame"}
{"context":{"direction":"recv","frame":"{\"method\":\"session/update\",\"params\":{\"sessionId\":\"ses_071e09...\",\"update\":{\"sessionUpdate\":\"agent_message_chunk\"}}}","jsonrpc_method":"session/update","session_id":"ses_071e095dcffeW0iQSahf43nZsU"},"level":"TRACE","message":"recv session/update","method":"read_frames"}
```