### PR TITLE
feat(logging): configure process timezone at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,6 +1422,7 @@ name = "ora-web-server"
 version = "0.0.0"
 dependencies = [
  "axum",
+ "chrono-tz",
  "futures-util",
  "ora-application",
  "ora-backend",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -387,9 +387,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -712,6 +724,12 @@ dependencies = [
  "syn 2.0.117",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2525,9 +2543,12 @@ dependencies = [
 name = "ora-desktop"
 version = "0.1.0"
 dependencies = [
+ "chrono-tz",
+ "iana-time-zone",
  "ora-backend",
  "ora-contracts",
  "ora-logging",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "tauri",
@@ -2537,6 +2558,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2551,6 +2573,8 @@ dependencies = [
 name = "ora-logging"
 version = "0.0.0"
 dependencies = [
+ "chrono",
+ "chrono-tz",
  "gitlancer",
  "serde_json",
  "thiserror 2.0.18",
@@ -2651,6 +2675,15 @@ checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -2803,6 +2836,15 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
@@ -2877,6 +2919,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "prettyplease"
@@ -5859,6 +5911,12 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,8 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.5.6", features = [] }
 
 [dependencies]
+chrono-tz = "0.10"
+iana-time-zone = "0.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2.10.3", features = [] }
@@ -29,3 +31,7 @@ tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+tracing = "0.1"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,8 +8,8 @@ use crate::error::DesktopBootstrapError;
 use crate::state::{DesktopRuntimeGuard, DesktopState};
 use ora_backend::{Backend, BackendPaths};
 use ora_logging::{
-    FileLoggingConfig, LogLevel, LogOutput, LoggingConfig, RotationPolicy, init_logging,
-    register_gitlancer_logger,
+    FileLoggingConfig, LogLevel, LogOutput, LoggingConfig, RotationPolicy, init_logging, ora_info,
+    ora_warn, register_gitlancer_logger,
 };
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
@@ -73,7 +73,35 @@ fn bootstrap_desktop(
         .map_err(DesktopBootstrapError::AppDataDirectory)?;
     let config = DesktopConfigStore::load_or_create(&app_data_directory)?;
     let config_snapshot = config.snapshot()?;
-    let logging = init_logging(desktop_logging_config(&app_data_directory))?;
+    let resolved_timezone = read_system_timezone();
+    let logging = init_logging(desktop_logging_config(
+        &app_data_directory,
+        resolved_timezone.timezone,
+    ))?;
+    match &resolved_timezone.warning {
+        Some(DesktopTimezoneWarning::SystemRead { error }) => {
+            ora_warn!(
+                message = "failed to read the system timezone, falling back to UTC",
+                source = "system_timezone",
+                error = %error,
+                fallback_timezone = %resolved_timezone.timezone,
+            );
+        }
+        Some(DesktopTimezoneWarning::InvalidTimezone { timezone }) => {
+            ora_warn!(
+                message = "invalid IANA system timezone, falling back to UTC",
+                source = "system_timezone",
+                timezone,
+                fallback_timezone = %resolved_timezone.timezone,
+            );
+        }
+        None => {}
+    }
+    ora_info!(
+        message = "logging initialized",
+        timezone = %resolved_timezone.timezone,
+        timezone_source = "system_timezone",
+    );
     register_gitlancer_logger();
     let backend = Backend::open(BackendPaths {
         database_path: app_data_directory.join("ora.sqlite3"),
@@ -94,8 +122,55 @@ fn bootstrap_desktop(
     ))
 }
 
+/// Carries the startup timezone selected from the operating system and any deferred warning.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResolvedDesktopTimezone {
+    timezone: chrono_tz::Tz,
+    warning: Option<DesktopTimezoneWarning>,
+}
+
+/// Describes a recoverable Desktop system-timezone failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum DesktopTimezoneWarning {
+    SystemRead { error: String },
+    InvalidTimezone { timezone: String },
+}
+
+/// Reads the operating system's IANA timezone once for the Desktop process lifetime.
+fn read_system_timezone() -> ResolvedDesktopTimezone {
+    resolve_system_timezone(iana_time_zone::get_timezone().map_err(|error| error.to_string()))
+}
+
+/// Validates an injected system-timezone result so failure branches remain unit-testable.
+fn resolve_system_timezone(system_timezone: Result<String, String>) -> ResolvedDesktopTimezone {
+    match system_timezone {
+        Ok(timezone_name) => {
+            let timezone_name = timezone_name.trim().to_string();
+            match timezone_name.parse::<chrono_tz::Tz>() {
+                Ok(timezone) => ResolvedDesktopTimezone {
+                    timezone,
+                    warning: None,
+                },
+                Err(_) => ResolvedDesktopTimezone {
+                    timezone: chrono_tz::UTC,
+                    warning: Some(DesktopTimezoneWarning::InvalidTimezone {
+                        timezone: timezone_name,
+                    }),
+                },
+            }
+        }
+        Err(error) => ResolvedDesktopTimezone {
+            timezone: chrono_tz::UTC,
+            warning: Some(DesktopTimezoneWarning::SystemRead { error }),
+        },
+    }
+}
+
 /// Builds the Desktop logging topology rooted in the stable system application directory.
-fn desktop_logging_config(app_data_directory: &std::path::Path) -> LoggingConfig {
+fn desktop_logging_config(
+    app_data_directory: &std::path::Path,
+    timezone: chrono_tz::Tz,
+) -> LoggingConfig {
     let file = FileLoggingConfig::new(
         app_data_directory.join("logs").join("ora.log"),
         RotationPolicy::Daily,
@@ -107,5 +182,52 @@ fn desktop_logging_config(app_data_directory: &std::path::Path) -> LoggingConfig
         LogOutput::File(file)
     };
 
-    LoggingConfig::new(LogLevel::Info, output)
+    LoggingConfig::new(LogLevel::Info, output, timezone)
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::{DesktopTimezoneWarning, ResolvedDesktopTimezone, resolve_system_timezone};
+
+    /// Verifies Desktop accepts and trims a system-provided IANA timezone.
+    #[test]
+    fn resolves_valid_system_timezone() {
+        assert_eq!(
+            resolve_system_timezone(Ok("  Europe/London  ".to_string())),
+            ResolvedDesktopTimezone {
+                timezone: chrono_tz::Europe::London,
+                warning: None,
+            }
+        );
+    }
+
+    /// Verifies an invalid system timezone remains visible while Desktop safely selects UTC.
+    #[test]
+    fn falls_back_when_system_timezone_is_invalid() {
+        assert_eq!(
+            resolve_system_timezone(Ok("London".to_string())),
+            ResolvedDesktopTimezone {
+                timezone: chrono_tz::UTC,
+                warning: Some(DesktopTimezoneWarning::InvalidTimezone {
+                    timezone: "London".to_string(),
+                }),
+            }
+        );
+    }
+
+    /// Verifies an operating-system lookup failure remains visible while Desktop safely selects UTC.
+    #[test]
+    fn falls_back_when_system_timezone_lookup_fails() {
+        assert_eq!(
+            resolve_system_timezone(Err("timezone unavailable".to_string())),
+            ResolvedDesktopTimezone {
+                timezone: chrono_tz::UTC,
+                warning: Some(DesktopTimezoneWarning::SystemRead {
+                    error: "timezone unavailable".to_string(),
+                }),
+            }
+        );
+    }
 }

--- a/apps/web/server/Cargo.toml
+++ b/apps/web/server/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
+chrono-tz = { workspace = true }
 futures-util = { workspace = true }
 ora-application = { workspace = true }
 ora-backend = { workspace = true }

--- a/apps/web/server/src/config.rs
+++ b/apps/web/server/src/config.rs
@@ -1,4 +1,5 @@
 use crate::error::WebBootstrapError;
+use crate::timezone::{TimezoneSource, TimezoneWarning};
 use ora_logging::{FileLoggingConfig, LogLevel, LogOutput, LoggingConfig, RotationPolicy};
 use std::env;
 use std::net::{IpAddr, SocketAddr};
@@ -29,6 +30,8 @@ pub struct RuntimeConfig {
     project: ProjectConfig,
     server: ServerConfig,
     logging: LoggingConfig,
+    timezone_source: TimezoneSource,
+    timezone_warning: Option<TimezoneWarning>,
 }
 
 impl RuntimeConfig {
@@ -62,18 +65,31 @@ impl RuntimeConfig {
         &self.logging
     }
 
+    /// Returns where the Web process obtained its selected logging timezone.
+    pub(crate) fn timezone_source(&self) -> TimezoneSource {
+        self.timezone_source
+    }
+
+    /// Returns the deferred timezone warning to emit after logging becomes available.
+    pub(crate) fn timezone_warning(&self) -> Option<&TimezoneWarning> {
+        self.timezone_warning.as_ref()
+    }
+
     /// Loads the runtime configuration from a caller-provided variable reader for testability.
     pub(crate) fn from_reader(
         mut read_variable: impl FnMut(&str) -> Option<String>,
     ) -> Result<Self, WebBootstrapError> {
         let database = DatabaseConfig::from_reader(&mut read_variable)?;
+        let resolved_timezone = crate::timezone::resolve(&mut read_variable);
 
         Ok(Self {
             project: ProjectConfig::from_reader(&mut read_variable, &database)?,
             file_system: FileSystemConfig::from_reader(&mut read_variable)?,
             database,
             server: ServerConfig::from_reader(&mut read_variable)?,
-            logging: read_logging_config(&mut read_variable)?,
+            logging: read_logging_config(&mut read_variable, resolved_timezone.timezone)?,
+            timezone_source: resolved_timezone.source,
+            timezone_warning: resolved_timezone.warning,
         })
     }
 }
@@ -257,6 +273,7 @@ impl ServerConfig {
 /// Loads the logging configuration from the environment contract defined for the web server bootstrap.
 fn read_logging_config(
     mut read_variable: impl FnMut(&str) -> Option<String>,
+    timezone: chrono_tz::Tz,
 ) -> Result<LoggingConfig, WebBootstrapError> {
     let level = match read_variable(LOG_LEVEL_ENV_VAR)
         .unwrap_or_else(|| DEFAULT_LOG_LEVEL.to_string())
@@ -294,7 +311,7 @@ fn read_logging_config(
         }
     };
 
-    Ok(LoggingConfig::new(level, output))
+    Ok(LoggingConfig::new(level, output, timezone))
 }
 
 /// Parses the configured retention window and rejects zero-day values explicitly.
@@ -337,6 +354,7 @@ mod tests {
         PROJECT_PATH_ENV_VAR, ProjectConfig, RuntimeConfig, ServerConfig,
     };
     use crate::error::WebBootstrapError;
+    use crate::timezone::{TimezoneSource, TimezoneWarning};
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
@@ -504,11 +522,14 @@ mod tests {
     fn loads_logging_configuration_from_data_dir() {
         let temp_dir = TempDir::new().unwrap();
         let data_dir = temp_dir.path().join("state");
-        let config = super::read_logging_config(|key| match key {
-            DATA_DIR_ENV_VAR => Some(data_dir.to_string_lossy().to_string()),
-            LOG_MODE_ENV_VAR => Some("file".to_string()),
-            _ => None,
-        })
+        let config = super::read_logging_config(
+            |key| match key {
+                DATA_DIR_ENV_VAR => Some(data_dir.to_string_lossy().to_string()),
+                LOG_MODE_ENV_VAR => Some("file".to_string()),
+                _ => None,
+            },
+            chrono_tz::Asia::Shanghai,
+        )
         .unwrap_or_else(|error| panic!("expected logging configuration to load: {error}"));
 
         match config.output {
@@ -577,6 +598,12 @@ mod tests {
         assert_eq!(config.project().path(), project_path.as_path());
         assert_eq!(config.project().work_dir(), expected_work_dir.as_path());
         assert_eq!(config.file_system().home_directory(), temp_dir.path());
+        assert_eq!(config.logging().timezone, chrono_tz::Asia::Shanghai);
+        assert_eq!(config.timezone_source(), TimezoneSource::Default);
+        assert_eq!(
+            config.timezone_warning(),
+            Some(&TimezoneWarning::MissingConfiguration)
+        );
 
         match &config.logging().output {
             ora_logging::LogOutput::Stdout => panic!("expected file-backed logging output"),

--- a/apps/web/server/src/main.rs
+++ b/apps/web/server/src/main.rs
@@ -5,12 +5,14 @@ mod error;
 mod handlers;
 mod routes;
 mod service;
+mod timezone;
 
 use crate::bootstrap::build_app_state;
 use crate::config::RuntimeConfig;
 use crate::error::WebBootstrapError;
+use crate::timezone::TimezoneWarning;
 use axum::Router;
-use ora_logging::{LoggingGuard, init_logging, ora_info, register_gitlancer_logger};
+use ora_logging::{LoggingGuard, init_logging, ora_info, ora_warn, register_gitlancer_logger};
 use tokio::net::TcpListener;
 
 /// Boots the web server runtime, initializes shared services, and starts serving HTTP traffic.
@@ -18,6 +20,29 @@ use tokio::net::TcpListener;
 async fn main() -> Result<(), WebBootstrapError> {
     let runtime_config = RuntimeConfig::from_env()?;
     let _logging_guard = initialize_logging(runtime_config.logging())?;
+    match runtime_config.timezone_warning() {
+        Some(TimezoneWarning::MissingConfiguration) => {
+            ora_warn!(
+                message = "timezone is not explicitly configured, using default timezone",
+                source = runtime_config.timezone_source().as_str(),
+                fallback_timezone = %runtime_config.logging().timezone,
+            );
+        }
+        Some(TimezoneWarning::InvalidConfiguration { source, timezone }) => {
+            ora_warn!(
+                message = "invalid IANA timezone configuration, falling back to UTC",
+                source = source.as_str(),
+                timezone,
+                fallback_timezone = %runtime_config.logging().timezone,
+            );
+        }
+        None => {}
+    }
+    ora_info!(
+        message = "logging initialized",
+        timezone = %runtime_config.logging().timezone,
+        timezone_source = runtime_config.timezone_source().as_str(),
+    );
     register_gitlancer_logger();
     let app_state = build_app_state(&runtime_config)?;
     let router = build_router(app_state.clone());

--- a/apps/web/server/src/timezone.rs
+++ b/apps/web/server/src/timezone.rs
@@ -1,0 +1,188 @@
+//! Resolves the Web server's process timezone without leaking environment policy into libraries.
+
+const TIMEZONE_ENV_VAR: &str = "ORA_TIMEZONE";
+const SYSTEM_TIMEZONE_ENV_VAR: &str = "TZ";
+const DEFAULT_TIMEZONE: &str = "Asia/Shanghai";
+
+/// Identifies the Web configuration source that determined the process timezone.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TimezoneSource {
+    OraEnvironment,
+    SystemEnvironment,
+    Default,
+}
+
+impl TimezoneSource {
+    /// Returns the stable configuration-source label used by structured startup logs.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::OraEnvironment => TIMEZONE_ENV_VAR,
+            Self::SystemEnvironment => SYSTEM_TIMEZONE_ENV_VAR,
+            Self::Default => "default",
+        }
+    }
+}
+
+/// Describes a recoverable timezone configuration problem that startup logs after initialization.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum TimezoneWarning {
+    MissingConfiguration,
+    InvalidConfiguration {
+        source: TimezoneSource,
+        timezone: String,
+    },
+}
+
+/// Carries a valid timezone plus the startup diagnostics used to explain how it was selected.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResolvedTimezone {
+    pub(crate) timezone: chrono_tz::Tz,
+    pub(crate) source: TimezoneSource,
+    pub(crate) warning: Option<TimezoneWarning>,
+}
+
+/// Resolves the Web process timezone according to Ora's explicit environment precedence.
+pub(crate) fn resolve(mut read_variable: impl FnMut(&str) -> Option<String>) -> ResolvedTimezone {
+    let configured = read_non_empty_trimmed_variable(&mut read_variable, TIMEZONE_ENV_VAR)
+        .map(|timezone| (TimezoneSource::OraEnvironment, timezone))
+        .or_else(|| {
+            read_non_empty_trimmed_variable(&mut read_variable, SYSTEM_TIMEZONE_ENV_VAR)
+                .map(|timezone| (TimezoneSource::SystemEnvironment, timezone))
+        });
+
+    match configured {
+        Some((source, timezone_name)) => match timezone_name.parse::<chrono_tz::Tz>() {
+            Ok(timezone) => ResolvedTimezone {
+                timezone,
+                source,
+                warning: None,
+            },
+            Err(_) => ResolvedTimezone {
+                timezone: chrono_tz::UTC,
+                source,
+                warning: Some(TimezoneWarning::InvalidConfiguration {
+                    source,
+                    timezone: timezone_name,
+                }),
+            },
+        },
+        None => {
+            let timezone = match DEFAULT_TIMEZONE.parse::<chrono_tz::Tz>() {
+                Ok(timezone) => timezone,
+                Err(_) => panic!("the built-in Web timezone must be a valid IANA timezone"),
+            };
+
+            ResolvedTimezone {
+                timezone,
+                source: TimezoneSource::Default,
+                warning: Some(TimezoneWarning::MissingConfiguration),
+            }
+        }
+    }
+}
+
+/// Reads and trims one optional variable while treating blank values as absent.
+fn read_non_empty_trimmed_variable(
+    mut read_variable: impl FnMut(&str) -> Option<String>,
+    variable_name: &str,
+) -> Option<String> {
+    read_variable(variable_name)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::{
+        ResolvedTimezone, SYSTEM_TIMEZONE_ENV_VAR, TIMEZONE_ENV_VAR, TimezoneSource,
+        TimezoneWarning, resolve,
+    };
+
+    /// Verifies Ora's explicit timezone overrides the generic system environment variable.
+    #[test]
+    fn prefers_explicit_ora_timezone() {
+        assert_eq!(
+            resolve(|key| match key {
+                TIMEZONE_ENV_VAR => Some("  Asia/Shanghai  ".to_string()),
+                SYSTEM_TIMEZONE_ENV_VAR => Some("Europe/London".to_string()),
+                _ => None,
+            }),
+            ResolvedTimezone {
+                timezone: chrono_tz::Asia::Shanghai,
+                source: TimezoneSource::OraEnvironment,
+                warning: None,
+            }
+        );
+    }
+
+    /// Verifies blank Ora configuration delegates to the generic system timezone.
+    #[test]
+    fn uses_system_timezone_when_ora_timezone_is_blank() {
+        assert_eq!(
+            resolve(|key| match key {
+                TIMEZONE_ENV_VAR => Some("   ".to_string()),
+                SYSTEM_TIMEZONE_ENV_VAR => Some(" Europe/London ".to_string()),
+                _ => None,
+            }),
+            ResolvedTimezone {
+                timezone: chrono_tz::Europe::London,
+                source: TimezoneSource::SystemEnvironment,
+                warning: None,
+            }
+        );
+    }
+
+    /// Verifies an invalid explicit Ora timezone is visible and cannot be masked by `TZ`.
+    #[test]
+    fn falls_back_to_utc_for_invalid_ora_timezone() {
+        assert_eq!(
+            resolve(|key| match key {
+                TIMEZONE_ENV_VAR => Some("Shanghai".to_string()),
+                SYSTEM_TIMEZONE_ENV_VAR => Some("Europe/London".to_string()),
+                _ => None,
+            }),
+            ResolvedTimezone {
+                timezone: chrono_tz::UTC,
+                source: TimezoneSource::OraEnvironment,
+                warning: Some(TimezoneWarning::InvalidConfiguration {
+                    source: TimezoneSource::OraEnvironment,
+                    timezone: "Shanghai".to_string(),
+                }),
+            }
+        );
+    }
+
+    /// Verifies an invalid generic timezone is visible and falls back to UTC.
+    #[test]
+    fn falls_back_to_utc_for_invalid_system_timezone() {
+        assert_eq!(
+            resolve(|key| match key {
+                SYSTEM_TIMEZONE_ENV_VAR => Some("UTC+8".to_string()),
+                _ => None,
+            }),
+            ResolvedTimezone {
+                timezone: chrono_tz::UTC,
+                source: TimezoneSource::SystemEnvironment,
+                warning: Some(TimezoneWarning::InvalidConfiguration {
+                    source: TimezoneSource::SystemEnvironment,
+                    timezone: "UTC+8".to_string(),
+                }),
+            }
+        );
+    }
+
+    /// Verifies missing timezone configuration uses the documented default with a deferred warning.
+    #[test]
+    fn warns_when_using_default_timezone() {
+        assert_eq!(
+            resolve(|_| None),
+            ResolvedTimezone {
+                timezone: chrono_tz::Asia::Shanghai,
+                source: TimezoneSource::Default,
+                warning: Some(TimezoneWarning::MissingConfiguration),
+            }
+        );
+    }
+}

--- a/crates/logging/src/clock.rs
+++ b/crates/logging/src/clock.rs
@@ -1,43 +1,73 @@
+//! Provides Ora's process-wide local clock.
+//!
+//! This module does not use `OffsetDateTime::now_local()` because platform local-offset discovery
+//! can return `IndeterminateOffset` in otherwise valid runtime environments. Ora instead resolves
+//! an IANA timezone during application startup and uses its cached rules for every local timestamp.
+
 use std::sync::OnceLock;
 
 use chrono::{Offset as _, TimeZone as _};
 use time::{OffsetDateTime, UtcOffset};
 
-const APP_TIMEZONE_VAR: &str = "DASHBOARD_TIMEZONE";
-const SYSTEM_TIMEZONE_VAR: &str = "TZ";
-const DEFAULT_TIMEZONE: &str = "Asia/Shanghai";
-
-/// Caches the process-wide timezone so the environment is read and parsed at most once.
-///
-/// The first caller resolves the timezone from the environment; every later caller reuses the
-/// cached `chrono_tz::Tz`. This keeps hot paths like `now_local()` allocation-free after warmup
-/// and pins the timezone for the process lifetime, so a mid-run environment change cannot shift
-/// wall-clock offsets underneath already-recorded data.
-static CONFIGURED_TIMEZONE: OnceLock<chrono_tz::Tz> = OnceLock::new();
-
-/// Returns the current local time using chrono-tz instead of the platform localtime APIs.
-pub fn now_local() -> OffsetDateTime {
-    let utc_now = chrono::Utc::now();
-    let offset = offset_for_unix_timestamp(utc_now.timestamp());
-    let nanos = i128::from(utc_now.timestamp()) * 1_000_000_000
-        + i128::from(utc_now.timestamp_subsec_nanos());
-
-    OffsetDateTime::from_unix_timestamp_nanos(nanos)
-        .unwrap_or_else(|_| OffsetDateTime::now_utc())
-        .to_offset(offset)
+/// Owns one immutable timezone so tests can exercise clock behavior without sharing global state.
+struct Clock {
+    timezone: OnceLock<chrono_tz::Tz>,
 }
 
-/// Returns the current Unix timestamp in milliseconds using the configured local timezone.
+impl Clock {
+    /// Creates an uninitialized clock whose timezone must be supplied before local-time access.
+    const fn new() -> Self {
+        Self {
+            timezone: OnceLock::new(),
+        }
+    }
+
+    /// Fixes this clock's timezone for its lifetime.
+    fn initialize(&self, timezone: chrono_tz::Tz) -> Result<(), chrono_tz::Tz> {
+        self.timezone.set(timezone)
+    }
+
+    /// Returns the configured timezone or fails fast when startup skipped clock initialization.
+    fn timezone(&self) -> chrono_tz::Tz {
+        match self.timezone.get() {
+            Some(timezone) => *timezone,
+            None => panic!("ora-logging clock must be initialized before use"),
+        }
+    }
+
+    /// Returns the current time expressed in this clock's configured timezone.
+    fn now_local(&self) -> OffsetDateTime {
+        now_local_in(self.timezone())
+    }
+}
+
+/// Stores the timezone selected by the process composition root during logging initialization.
+static PROCESS_CLOCK: Clock = Clock::new();
+
+/// Initializes the process-wide timezone exactly once during logging startup.
+pub(crate) fn initialize(timezone: chrono_tz::Tz) -> Result<(), chrono_tz::Tz> {
+    PROCESS_CLOCK.initialize(timezone)
+}
+
+/// Returns the current time expressed in the process-wide configured timezone.
+pub fn now_local() -> OffsetDateTime {
+    PROCESS_CLOCK.now_local()
+}
+
+/// Returns the current Unix timestamp in milliseconds.
 ///
-/// The nanosecond value is narrowed to i64 only *after* dividing, so the division runs on the full
-/// i128 range and the cast can never truncate meaningful magnitude.
+/// The nanosecond value is divided before narrowing so a representable millisecond timestamp cannot
+/// be truncated merely because its nanosecond representation exceeds `i64`.
 pub fn now_millis() -> i64 {
-    (now_local().unix_timestamp_nanos() / 1_000_000) as i64
+    timestamp_millis(now_local().unix_timestamp_nanos())
 }
 
 /// Returns the current configured local UTC offset.
 pub fn local_offset() -> UtcOffset {
-    offset_for_unix_timestamp(chrono::Utc::now().timestamp())
+    offset_for_unix_timestamp(
+        PROCESS_CLOCK.timezone(),
+        OffsetDateTime::now_utc().unix_timestamp(),
+    )
 }
 
 /// Returns the configured local UTC offset in milliseconds for SQL wall-clock reconstruction.
@@ -45,50 +75,111 @@ pub fn local_offset_millis() -> i64 {
     i64::from(local_offset().whole_seconds()) * 1000
 }
 
-/// Chooses the configured IANA timezone name without requiring global unsafe time crate setup.
-fn configured_timezone_name() -> String {
-    [APP_TIMEZONE_VAR, SYSTEM_TIMEZONE_VAR]
-        .into_iter()
-        .find_map(|key| {
-            std::env::var(key)
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-        })
-        .unwrap_or_else(|| DEFAULT_TIMEZONE.to_string())
+/// Expresses the current instant in an explicitly supplied timezone for injected consumers.
+pub(crate) fn now_local_in(timezone: chrono_tz::Tz) -> OffsetDateTime {
+    // UTC is only the unambiguous source instant; `localize` applies the configured presentation
+    // offset before this value reaches callers or structured logs.
+    localize(OffsetDateTime::now_utc(), timezone)
 }
 
-/// Returns the cached process timezone, resolving and validating it from the environment on first use.
-///
-/// An unparseable deployment configuration is reported once via `ora_warn!` and falls back to UTC,
-/// so misconfiguration stays visible instead of being swallowed silently.
-fn configured_timezone() -> chrono_tz::Tz {
-    *CONFIGURED_TIMEZONE.get_or_init(|| {
-        let name = configured_timezone_name();
-        match name.parse::<chrono_tz::Tz>() {
-            Ok(timezone) => timezone,
-            Err(_) => {
-                crate::ora_warn!(
-                    message = "invalid timezone configuration, falling back to UTC",
-                    timezone = %name,
-                );
-                chrono_tz::UTC
-            }
+/// Expresses a fixed UTC instant in an IANA timezone while preserving the represented instant.
+fn localize(utc_now: OffsetDateTime, timezone: chrono_tz::Tz) -> OffsetDateTime {
+    let offset = offset_for_unix_timestamp(timezone, utc_now.unix_timestamp());
+    utc_now.to_offset(offset)
+}
+
+/// Resolves the UTC offset for a specific instant so daylight-saving transitions remain accurate.
+fn offset_for_unix_timestamp(timezone: chrono_tz::Tz, timestamp: i64) -> UtcOffset {
+    let local = match timezone.timestamp_opt(timestamp, 0).single() {
+        Some(local) => local,
+        None => panic!("an in-range Unix timestamp must map to one IANA timezone instant"),
+    };
+    let offset_seconds = local.offset().fix().local_minus_utc();
+
+    match UtcOffset::from_whole_seconds(offset_seconds) {
+        Ok(offset) => offset,
+        Err(error) => {
+            panic!("an IANA timezone offset must fit within time::UtcOffset: {error}")
         }
-    })
+    }
 }
 
-/// Resolves the offset for a specific instant, so DST transitions are handled by chrono-tz data.
-fn offset_for_unix_timestamp(timestamp: i64) -> UtcOffset {
-    let local = configured_timezone().timestamp_opt(timestamp, 0);
-    let offset_seconds = local
-        .single()
-        .map(|dt| dt.offset().fix().local_minus_utc())
-        .unwrap_or(0);
+/// Converts nanoseconds to milliseconds before performing the checked integer narrowing.
+fn timestamp_millis(timestamp_nanos: i128) -> i64 {
+    let milliseconds = timestamp_nanos / 1_000_000;
 
-    offset_from_seconds(offset_seconds)
+    match i64::try_from(milliseconds) {
+        Ok(milliseconds) => milliseconds,
+        Err(error) => panic!("current Unix milliseconds must fit within i64: {error}"),
+    }
 }
 
-/// Converts chrono's offset seconds into time's offset type while keeping invalid data contained.
-fn offset_from_seconds(offset_seconds: i32) -> UtcOffset {
-    UtcOffset::from_whole_seconds(offset_seconds).unwrap_or(UtcOffset::UTC)
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use time::{
+        Month, UtcOffset,
+        macros::{datetime, offset},
+    };
+
+    use super::{Clock, localize, timestamp_millis};
+
+    /// Verifies independent clock instances retain distinct immutable timezone configuration.
+    #[test]
+    fn keeps_timezone_configuration_isolated_per_clock() {
+        let shanghai = Clock::new();
+        let london = Clock::new();
+
+        assert_eq!(shanghai.initialize(chrono_tz::Asia::Shanghai), Ok(()));
+        assert_eq!(london.initialize(chrono_tz::Europe::London), Ok(()));
+        assert_eq!(shanghai.initialize(chrono_tz::UTC), Err(chrono_tz::UTC));
+        assert_eq!(shanghai.timezone(), chrono_tz::Asia::Shanghai);
+        assert_eq!(london.timezone(), chrono_tz::Europe::London);
+    }
+
+    /// Verifies Shanghai uses its stable eight-hour offset for a fixed instant.
+    #[test]
+    fn localizes_fixed_instants_for_shanghai() {
+        let utc = datetime!(2026-07-23 12:00 UTC);
+
+        assert_eq!(
+            localize(utc, chrono_tz::Asia::Shanghai),
+            datetime!(2026-07-23 20:00 +08:00)
+        );
+    }
+
+    /// Verifies IANA rules select London's winter and summer offsets for their respective instants.
+    #[test]
+    fn localizes_london_across_daylight_saving_time() {
+        let winter = datetime!(2026-01-15 12:00 UTC);
+        let summer = datetime!(2026-07-15 12:00 UTC);
+
+        assert_eq!(
+            localize(winter, chrono_tz::Europe::London).offset(),
+            UtcOffset::UTC
+        );
+        assert_eq!(
+            localize(summer, chrono_tz::Europe::London).offset(),
+            offset!(+1)
+        );
+        assert_eq!(
+            localize(summer, chrono_tz::Europe::London).month(),
+            Month::July
+        );
+    }
+
+    /// Verifies millisecond conversion narrows only after reducing nanosecond magnitude.
+    #[test]
+    fn converts_nanoseconds_before_narrowing() {
+        let largest_i64_milliseconds = i128::from(i64::MAX) * 1_000_000;
+
+        assert_eq!(timestamp_millis(largest_i64_milliseconds), i64::MAX);
+    }
+
+    /// Verifies local-time access cannot silently select a timezone before initialization.
+    #[test]
+    #[should_panic(expected = "ora-logging clock must be initialized before use")]
+    fn rejects_local_time_access_before_initialization() {
+        Clock::new().now_local();
+    }
 }

--- a/crates/logging/src/config.rs
+++ b/crates/logging/src/config.rs
@@ -6,12 +6,17 @@ use std::path::PathBuf;
 pub struct LoggingConfig {
     pub level: LogLevel,
     pub output: LogOutput,
+    pub timezone: chrono_tz::Tz,
 }
 
 impl LoggingConfig {
-    /// Builds a logging configuration from an explicit level and output mode.
-    pub fn new(level: LogLevel, output: LogOutput) -> Self {
-        Self { level, output }
+    /// Builds a logging configuration from an explicit level, output mode, and process timezone.
+    pub fn new(level: LogLevel, output: LogOutput, timezone: chrono_tz::Tz) -> Self {
+        Self {
+            level,
+            output,
+            timezone,
+        }
     }
 }
 

--- a/crates/logging/src/error.rs
+++ b/crates/logging/src/error.rs
@@ -24,4 +24,6 @@ pub enum LoggingInitError {
     },
     #[error("failed to install the global tracing subscriber")]
     SetGlobalSubscriber(#[source] tracing::dispatcher::SetGlobalDefaultError),
+    #[error("the process-wide logging clock was already initialized")]
+    ClockAlreadyInitialized,
 }

--- a/crates/logging/src/formatter.rs
+++ b/crates/logging/src/formatter.rs
@@ -1,15 +1,25 @@
 use serde_json::{Map, Value, json};
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use time::format_description::well_known::Rfc3339;
 use tracing::Event;
 use tracing_subscriber::fmt::FmtContext;
 use tracing_subscriber::fmt::format::{FormatEvent, FormatFields, Writer};
 use tracing_subscriber::registry::LookupSpan;
 
+use crate::clock::now_local_in;
 use crate::correlation::scope_correlation;
 
 /// Formats every tracing event as one JSON line that follows the shared runtime envelope.
-#[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct JsonEventFormatter;
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct JsonEventFormatter {
+    timezone: chrono_tz::Tz,
+}
+
+impl JsonEventFormatter {
+    /// Creates a formatter whose timestamps use the injected process timezone.
+    pub(crate) fn new(timezone: chrono_tz::Tz) -> Self {
+        Self { timezone }
+    }
+}
 
 impl<S, N> FormatEvent<S, N> for JsonEventFormatter
 where
@@ -28,14 +38,10 @@ where
 
         let scope = scope_correlation(context.event_scope());
         let mut payload = Map::new();
-        payload.insert(
-            "timestamp".to_string(),
-            json!(
-                OffsetDateTime::now_utc()
-                    .format(&Rfc3339)
-                    .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
-            ),
-        );
+        let timestamp = now_local_in(self.timezone)
+            .format(&Rfc3339)
+            .map_err(|_| std::fmt::Error)?;
+        payload.insert("timestamp".to_string(), json!(timestamp));
         payload.insert(
             "level".to_string(),
             Value::String(event.metadata().level().to_string()),

--- a/crates/logging/src/gitlancer_bridge.rs
+++ b/crates/logging/src/gitlancer_bridge.rs
@@ -57,7 +57,7 @@ mod tests {
     fn log_command_emits_info_event_with_cwd_and_command() {
         let buffer = SharedBuffer::default();
         let (dispatch, _guard) = build_dispatch(
-            &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout),
+            &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
             buffer.make_writer(),
         )
         .unwrap();
@@ -90,7 +90,7 @@ mod tests {
     fn log_result_emits_info_on_success() {
         let buffer = SharedBuffer::default();
         let (dispatch, _guard) = build_dispatch(
-            &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout),
+            &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
             buffer.make_writer(),
         )
         .unwrap();
@@ -112,7 +112,7 @@ mod tests {
     fn log_result_emits_error_on_failure() {
         let buffer = SharedBuffer::default();
         let (dispatch, _guard) = build_dispatch(
-            &LoggingConfig::new(LogLevel::Error, LogOutput::Stdout),
+            &LoggingConfig::new(LogLevel::Error, LogOutput::Stdout, chrono_tz::UTC),
             buffer.make_writer(),
         )
         .unwrap();

--- a/crates/logging/src/init.rs
+++ b/crates/logging/src/init.rs
@@ -8,9 +8,12 @@ use crate::file_output::prepare_file_output;
 use crate::formatter::JsonEventFormatter;
 use crate::{LogLevel, LogOutput, LoggingConfig, LoggingGuard, LoggingInitError};
 
-/// Installs the process-wide subscriber described by `config` and returns its writer-lifetime guard.
+/// Installs the configured process clock and subscriber, then returns its writer-lifetime guard.
 pub fn init_logging(config: LoggingConfig) -> Result<LoggingGuard, LoggingInitError> {
+    // Prepare fallible sinks before changing either irreversible process-wide singleton.
     let (dispatch, guard) = build_dispatch(&config, std::io::stdout)?;
+    crate::clock::initialize(config.timezone)
+        .map_err(|_| LoggingInitError::ClockAlreadyInitialized)?;
     tracing::dispatcher::set_global_default(dispatch)
         .map_err(LoggingInitError::SetGlobalSubscriber)?;
 
@@ -34,7 +37,7 @@ where
                 .with(level_filter)
                 .with(
                     layer()
-                        .event_format(JsonEventFormatter)
+                        .event_format(JsonEventFormatter::new(config.timezone))
                         .with_writer(stdout_writer)
                         .with_ansi(false),
                 );
@@ -48,7 +51,7 @@ where
                 .with(level_filter)
                 .with(
                     layer()
-                        .event_format(JsonEventFormatter)
+                        .event_format(JsonEventFormatter::new(config.timezone))
                         .with_writer(prepared_output.writer.clone())
                         .with_ansi(false),
                 );
@@ -65,13 +68,13 @@ where
                 .with(level_filter)
                 .with(
                     layer()
-                        .event_format(JsonEventFormatter)
+                        .event_format(JsonEventFormatter::new(config.timezone))
                         .with_writer(stdout_writer)
                         .with_ansi(false),
                 )
                 .with(
                     layer()
-                        .event_format(JsonEventFormatter)
+                        .event_format(JsonEventFormatter::new(config.timezone))
                         .with_writer(prepared_output.writer.clone())
                         .with_ansi(false),
                 );

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -24,6 +24,7 @@ fn preserves_the_public_configuration_model() {
             RotationPolicy::Daily,
             NonZeroUsize::new(3).unwrap(),
         )),
+        chrono_tz::Asia::Shanghai,
     );
 
     assert_eq!(
@@ -35,6 +36,7 @@ fn preserves_the_public_configuration_model() {
                 rotation: RotationPolicy::Daily,
                 max_days: NonZeroUsize::new(3).unwrap(),
             }),
+            timezone: chrono_tz::Asia::Shanghai,
         }
     );
 }
@@ -42,8 +44,8 @@ fn preserves_the_public_configuration_model() {
 /// Verifies the crate exports the intended API surface through public constructors and helpers.
 #[test]
 fn preserves_the_public_logging_api_surface() {
-    let stdout_only = LoggingConfig::new(LogLevel::Debug, LogOutput::Stdout);
-    let warn_only = LoggingConfig::new(LogLevel::Warn, LogOutput::Stdout);
+    let stdout_only = LoggingConfig::new(LogLevel::Debug, LogOutput::Stdout, chrono_tz::UTC);
+    let warn_only = LoggingConfig::new(LogLevel::Warn, LogOutput::Stdout, chrono_tz::UTC);
     let file_only = FileLoggingConfig::new(
         "./ora.log",
         RotationPolicy::Daily,
@@ -66,7 +68,7 @@ fn preserves_the_public_logging_api_surface() {
 fn filters_events_at_warn_level() {
     let stdout = SharedBuffer::default();
     let (dispatch, _guard) = build_dispatch(
-        &LoggingConfig::new(LogLevel::Warn, LogOutput::Stdout),
+        &LoggingConfig::new(LogLevel::Warn, LogOutput::Stdout, chrono_tz::UTC),
         stdout.make_writer(),
     )
     .unwrap();
@@ -100,7 +102,11 @@ fn formats_json_events_with_context_and_error_objects() {
         NonZeroUsize::new(3).unwrap(),
     );
     let (dispatch, _guard) = build_dispatch(
-        &LoggingConfig::new(LogLevel::Info, LogOutput::StdoutAndFile(file_config)),
+        &LoggingConfig::new(
+            LogLevel::Info,
+            LogOutput::StdoutAndFile(file_config),
+            chrono_tz::Asia::Shanghai,
+        ),
         stdout.make_writer(),
     )
     .unwrap();
@@ -155,7 +161,12 @@ fn formats_json_events_with_context_and_error_objects() {
             "kind": "none"
         })
     );
-    assert_eq!(stdout_event["timestamp"].as_str().is_some(), true);
+    assert_eq!(
+        stdout_event["timestamp"]
+            .as_str()
+            .map(|timestamp| timestamp.ends_with("+08:00")),
+        Some(true)
+    );
 }
 
 /// Verifies the wrapper macros add the current function name under the top-level `method` field.
@@ -163,7 +174,7 @@ fn formats_json_events_with_context_and_error_objects() {
 fn emits_method_field_from_wrapper_macros() {
     let stdout = SharedBuffer::default();
     let (dispatch, _guard) = build_dispatch(
-        &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout),
+        &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
         stdout.make_writer(),
     )
     .unwrap();
@@ -186,7 +197,7 @@ fn emits_method_field_from_wrapper_macros() {
 fn emits_helper_api_correlation_fields_consistently() {
     let stdout = SharedBuffer::default();
     let (dispatch, _guard) = build_dispatch(
-        &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout),
+        &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
         stdout.make_writer(),
     )
     .unwrap();
@@ -209,7 +220,7 @@ fn emits_helper_api_correlation_fields_consistently() {
 fn selects_stdout_only_sink_behavior() {
     let stdout = SharedBuffer::default();
     let (dispatch, guard) = build_dispatch(
-        &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout),
+        &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
         stdout.make_writer(),
     )
     .unwrap();
@@ -233,7 +244,7 @@ fn selects_file_only_sink_behavior() {
     );
     let stdout = SharedBuffer::default();
     let (dispatch, guard) = build_dispatch(
-        &LoggingConfig::new(LogLevel::Info, LogOutput::File(file_config)),
+        &LoggingConfig::new(LogLevel::Info, LogOutput::File(file_config), chrono_tz::UTC),
         stdout.make_writer(),
     )
     .unwrap();
@@ -259,7 +270,11 @@ fn selects_stdout_and_file_sink_behavior() {
     );
     let stdout = SharedBuffer::default();
     let (dispatch, guard) = build_dispatch(
-        &LoggingConfig::new(LogLevel::Info, LogOutput::StdoutAndFile(file_config)),
+        &LoggingConfig::new(
+            LogLevel::Info,
+            LogOutput::StdoutAndFile(file_config),
+            chrono_tz::UTC,
+        ),
         stdout.make_writer(),
     )
     .unwrap();
@@ -286,6 +301,7 @@ fn reports_typed_initialization_failures() {
                 RotationPolicy::Daily,
                 NonZeroUsize::new(3).unwrap(),
             )),
+            chrono_tz::UTC,
         ),
         stdout.make_writer(),
     )
@@ -327,7 +343,7 @@ fn cleans_up_rotated_files_by_retention_window() {
     );
 }
 
-/// Verifies the public initializer reports the global-subscriber boundary as a typed failure.
+/// Verifies the public initializer rejects attempts to replace the configured process clock.
 #[test]
 fn rejects_a_second_global_initialization_attempt() {
     let lock = global_logging_test_lock();
@@ -341,12 +357,14 @@ fn rejects_a_second_global_initialization_attempt() {
             RotationPolicy::Daily,
             NonZeroUsize::new(3).unwrap(),
         )),
+        chrono_tz::UTC,
     );
     let _first_guard = init_logging(config.clone()).unwrap();
+    assert_eq!(crate::clock::local_offset(), time::UtcOffset::UTC);
     let error = init_logging(config).unwrap_err();
 
     assert_eq!(
-        matches!(error, LoggingInitError::SetGlobalSubscriber(_)),
+        matches!(error, LoggingInitError::ClockAlreadyInitialized),
         true
     );
 }

--- a/docs/desktop-runtime.md
+++ b/docs/desktop-runtime.md
@@ -35,6 +35,11 @@ The configured root is only a creation target. Existing worktree locations are r
 
 Desktop initializes `ora-logging` before opening the backend and registers the Gitlancer logger bridge. Logs rotate daily and retain three files. Debug builds write to stdout and the file; release builds write to the file only. The logging guard remains managed for the application lifetime.
 
+At startup, Desktop reads the operating system's IANA timezone and fixes it for the process
+lifetime. Structured event timestamps use that timezone. If the system timezone cannot be read or
+parsed, Desktop records a warning, uses UTC, and continues startup. A system timezone change takes
+effect after Ora restarts. Daily log files continue to rotate at UTC boundaries.
+
 ## Verification
 
 The Tauri Rust crate keeps its own `Cargo.lock` and is intentionally excluded from the root Cargo workspace. `task test:desktop` checks the Desktop transport, formatting, Clippy, and the independent Rust tests. `task test` includes this task explicitly.

--- a/docs/runtime-logging.md
+++ b/docs/runtime-logging.md
@@ -16,8 +16,15 @@ Ora Rust services initialize shared structured logging through `ora-logging`.
 - `ORA_LOG_MODE`: `stdout`, `file`, or `stdout_and_file`. Default: `stdout`.
 - `ORA_LOG_PATH`: base path for file-backed logging. Default: `./ora.log`.
 - `ORA_LOG_MAX_DAYS`: retention window in days for file-backed logging, including the current active file. Default: `3`.
+- `ORA_TIMEZONE`: IANA timezone used by structured event timestamps, such as `Asia/Shanghai`
+  or `Europe/London`.
 
 `ORA_LOG_MODE=stdout` ignores file path and retention settings. File-backed modes rotate daily and clean up older matching files once the retained daily window would exceed `ORA_LOG_MAX_DAYS`.
+
+The Web server resolves its process timezone once during startup. A non-empty `ORA_TIMEZONE` takes
+precedence over the generic `TZ` environment variable. If neither is configured, startup warns and
+uses `Asia/Shanghai`. If the selected value is not a valid IANA timezone, startup warns and uses UTC
+without trying a lower-priority source. Values are trimmed before parsing.
 
 ## JSON Event Contract
 
@@ -39,7 +46,7 @@ Business metadata belongs under `context`, and failure details belong under `err
 
 ```json
 {
-  "timestamp": "2026-05-09T12:00:00Z",
+  "timestamp": "2026-05-09T20:00:00+08:00",
   "level": "INFO",
   "target": "ora_application::project::handlers",
   "message": "project operation completed",
@@ -49,6 +56,10 @@ Business metadata belongs under `context`, and failure details belong under `err
   }
 }
 ```
+
+The RFC 3339 timestamp uses the configured process timezone and includes its UTC offset. The current
+`tracing-appender` file writer still names and rotates daily files at UTC boundaries; event
+timestamps remain authoritative when a local calendar date differs from the file suffix.
 
 `ora-logging` also provides helper APIs for correlation-aware spans so runtime crates can attach `span`, `trace_id`, and `request_id` consistently.
 For runtime event calls, prefer `ora_logging::ora_debug!`, `ora_logging::ora_info!`, `ora_logging::ora_warn!`, and `ora_logging::ora_error!`; these wrappers automatically attach the current function name as the top-level `method` field.


### PR DESCRIPTION
## Summary

- move Web timezone resolution into the Web composition root with `ORA_TIMEZONE > TZ > Asia/Shanghai` precedence
- read the operating system IANA timezone once during Tauri startup
- require a validated `chrono_tz::Tz` in `LoggingConfig` and initialize the process clock during `init_logging`
- format structured log timestamps in the configured local timezone
- add DST, fallback, initialization, timestamp-conversion, and configuration-precedence coverage
- document Web and Desktop timezone behavior, including UTC-based file rotation

## Why

Direct platform local-offset discovery can return `IndeterminateOffset`, and handling it independently at call sites makes silent UTC fallback and inconsistent time sources possible. The previous clock also owned application environment policy and initialized lazily on first use.

This change makes Web and Tauri responsible for selecting a timezone at startup, passes a validated timezone through `LoggingConfig`, and keeps the logging clock immutable for the process lifetime. Invalid external configuration remains visible through structured warnings, while internal invariant failures are no longer silently converted to UTC.

## Impact

- `LoggingConfig::new` now requires an explicit timezone.
- Web deployments can set `ORA_TIMEZONE` with an IANA timezone name.
- Tauri follows the system timezone captured at startup.
- Structured JSON timestamps include the configured RFC 3339 offset.
- Daily log files continue to rotate at UTC boundaries.

## Validation

- `task test`
- `cargo doc -p ora-logging --no-deps`
- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`
- `git diff --check`
