### PR TITLE
feat(ui): make app text non-selectable by default

### DIFF
--- a/packages/app-shell/src/features/chat/chat-view.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.tsx
@@ -124,7 +124,7 @@ export function ChatView({ turns, userName, isResponding, isStreaming = false, i
         }
       >
         <div className="mx-auto w-full max-w-[760px]">
-          {error && <p role="alert" className="mb-2 px-1 text-xs text-destructive">{error}</p>}
+          {error && <p role="alert" data-selectable className="mb-2 px-1 text-xs text-destructive">{error}</p>}
           {pendingPermissions.map((request) => (
             <section key={request.permissionRequestId} className="mb-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
               <p className="text-xs font-medium">{t("chat.permissionRequired")}</p>

--- a/packages/app-shell/src/features/chat/diff-view.tsx
+++ b/packages/app-shell/src/features/chat/diff-view.tsx
@@ -31,7 +31,7 @@ export function DiffView({ path, oldText, newText }: DiffViewProps) {
   return (
     <div className="overflow-hidden rounded-md border border-border bg-background">
       <div className="flex items-center gap-2 border-b border-border bg-muted/50 px-3 py-2 text-[11px]">
-        <span className="min-w-0 flex-1 truncate font-mono" title={path}>{path}</span>
+        <span data-selectable className="min-w-0 flex-1 truncate font-mono" title={path}>{path}</span>
         <span className="text-emerald-600">+{additions}</span>
         <span className="text-red-600">-{deletions}</span>
       </div>
@@ -52,7 +52,7 @@ export function DiffView({ path, oldText, newText }: DiffViewProps) {
             <span className="w-10 shrink-0 select-none border-r border-border/50 px-2 text-right text-muted-foreground/70">{line.oldLine ?? ""}</span>
             <span className="w-10 shrink-0 select-none border-r border-border/50 px-2 text-right text-muted-foreground/70">{line.newLine ?? ""}</span>
             <span className="w-5 shrink-0 select-none text-center">{line.kind === "added" ? "+" : line.kind === "removed" ? "-" : " "}</span>
-            <span className="pr-4 whitespace-pre">{line.text}</span>
+            <span data-selectable className="pr-4 whitespace-pre">{line.text}</span>
           </div>
         ))}
       </div>

--- a/packages/app-shell/src/features/chat/markdown-message.test.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.test.tsx
@@ -13,7 +13,7 @@ describe("MarkdownMessage", () => {
   it("renders GitHub-flavored Markdown with semantic elements", () => {
     render(<MarkdownMessage content={"## Result\n\n- one\n- two\n\n| Name | Value |\n| --- | --- |\n| Ora | IDE |\n\n`const ready = true;`"} />);
 
-    expect(screen.getByRole("heading", { level: 2, name: "Result" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Result" }).closest("[data-selectable]")).not.toBeNull();
     expect(screen.getByRole("list")).toHaveTextContent("one");
     expect(screen.getByRole("table")).toHaveTextContent("Ora");
     expect(screen.getByText("const ready = true;")).toHaveClass("font-mono");
@@ -74,5 +74,6 @@ describe("MarkdownMessage", () => {
     expect(screen.getByText(/2 行|2 lines/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /复制代码|Copy code/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /收起代码|Collapse code/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /复制代码|Copy code/ }).closest("[data-selection-control]")).not.toBeNull();
   });
 });

--- a/packages/app-shell/src/features/chat/markdown-message.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.tsx
@@ -69,7 +69,7 @@ const markdownComponents: Components = {
 export function MarkdownMessage({ content }: MarkdownMessageProps) {
   const markdown = unwrapMarkdownDocument(content);
   return (
-    <div className="min-w-0 break-words text-[15px] leading-[26px] text-foreground">
+    <div data-selectable className="min-w-0 break-words text-[15px] leading-[26px] text-foreground">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{markdown}</ReactMarkdown>
     </div>
   );
@@ -103,7 +103,7 @@ function CodeBlock({ code, language }: { code: string; language: string }) {
           : "border-border bg-[var(--code-background)]"
       }`}
     >
-      <div className="flex min-h-9 items-center px-3">
+      <div data-selection-control className="flex min-h-9 items-center px-3">
         <span className="font-mono text-[11px] font-medium text-muted-foreground">{language}</span>
         <span className="mx-2 h-3 w-px bg-border" aria-hidden="true" />
         <span className="text-[11px] text-muted-foreground" aria-live="polite">

--- a/packages/app-shell/src/features/chat/message-bubble.tsx
+++ b/packages/app-shell/src/features/chat/message-bubble.tsx
@@ -42,7 +42,7 @@ export function MessageBubble({ message, userName, embeddedAssistant = false }: 
         {isUser ? (
           <div className="relative w-fit max-w-full rounded-2xl rounded-br-md bg-secondary px-4 py-2.5">
             <AnchorHighlight />
-            <p className="relative whitespace-pre-wrap break-words text-[14px] leading-6 text-foreground">{message.content}</p>
+            <p data-selectable className="relative whitespace-pre-wrap break-words text-[14px] leading-6 text-foreground">{message.content}</p>
           </div>
         ) : (
           <MarkdownMessage content={message.content} />

--- a/packages/app-shell/src/features/chat/plan-block.tsx
+++ b/packages/app-shell/src/features/chat/plan-block.tsx
@@ -33,7 +33,7 @@ export function PlanBlock({ plan }: PlanBlockProps) {
           {plan.entries.map((entry, index) => (
             <li key={`${index}-${entry.content}`} className="flex items-start gap-2 text-xs leading-5">
               <PlanStatusIcon status={entry.status} />
-              <span className={entry.status === "completed" ? "text-muted-foreground line-through" : "text-foreground"}>
+              <span data-selectable className={entry.status === "completed" ? "text-muted-foreground line-through" : "text-foreground"}>
                 {entry.content}
               </span>
             </li>

--- a/packages/app-shell/src/features/chat/response-turn.tsx
+++ b/packages/app-shell/src/features/chat/response-turn.tsx
@@ -94,7 +94,7 @@ function TurnEnding({ turn }: { turn: ChatTurn }) {
     return <p className="flex items-center gap-1.5 text-xs text-muted-foreground"><IconBan className="size-3.5" />{t("chat.turnCancelled")}</p>;
   }
   if (turn.status === "failed") {
-    return <p className="flex items-center gap-1.5 text-xs text-destructive"><IconAlertTriangle className="size-3.5" />{turn.error ?? t("chat.turnFailed")}</p>;
+    return <p data-selectable className="flex items-center gap-1.5 text-xs text-destructive"><IconAlertTriangle className="size-3.5" />{turn.error ?? t("chat.turnFailed")}</p>;
   }
   if (turn.stopReason === "max_tokens" || turn.stopReason === "max_turn_requests") {
     return <p className="flex items-center gap-1.5 text-xs text-amber-700 dark:text-amber-400"><IconAlertTriangle className="size-3.5" />{t("chat.turnIncomplete")}</p>;

--- a/packages/app-shell/src/features/chat/thought-block.tsx
+++ b/packages/app-shell/src/features/chat/thought-block.tsx
@@ -26,7 +26,7 @@ export function ThoughtBlock({ thought, hasFollowingActivity }: ThoughtBlockProp
         <IconChevronDown className={`ml-auto size-3.5 transition-transform motion-reduce:transition-none ${open ? "rotate-180" : ""}`} />
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <p className="border-t border-border/60 px-3 py-2.5 text-xs leading-5 text-muted-foreground whitespace-pre-wrap">
+        <p data-selectable className="border-t border-border/60 px-3 py-2.5 text-xs leading-5 text-muted-foreground whitespace-pre-wrap">
           {thought.content}
         </p>
       </CollapsibleContent>

--- a/packages/app-shell/src/features/chat/tool-call-block.tsx
+++ b/packages/app-shell/src/features/chat/tool-call-block.tsx
@@ -68,7 +68,7 @@ export function ToolCallBlock({ tool, appearance = "standalone" }: ToolCallBlock
           {tool.locations.length > 0 && (
             <div className="space-y-1">
               {tool.locations.map((location) => (
-                <code key={`${location.path}:${location.line ?? ""}`} className="block max-w-full truncate text-[11px] text-sky-700 dark:text-sky-400" title={location.path}>
+                <code data-selectable key={`${location.path}:${location.line ?? ""}`} className="block max-w-full truncate text-[11px] text-sky-700 dark:text-sky-400" title={location.path}>
                   {location.path}{location.line === undefined || location.line === null ? "" : `:${location.line}`}
                 </code>
               ))}
@@ -93,10 +93,10 @@ function ToolContent({ content }: { content: acp.ToolCallContent }) {
     case "diff":
       return <DiffView path={content.path} oldText={content.oldText} newText={content.newText} />;
     case "terminal":
-      return <p className="flex items-center gap-2 rounded-md border border-border/70 bg-muted/40 px-3 py-2 font-mono text-[11px] text-muted-foreground"><IconTerminal2 className="size-3.5" />{t("chat.terminalSession", { id: content.terminalId })}</p>;
+      return <p data-selectable className="flex items-center gap-2 rounded-md border border-border/70 bg-muted/40 px-3 py-2 font-mono text-[11px] text-muted-foreground"><IconTerminal2 className="size-3.5" />{t("chat.terminalSession", { id: content.terminalId })}</p>;
     case "content":
       if (content.content.type === "text") {
-        return <pre className="max-h-72 overflow-auto rounded-md border border-border/60 bg-muted/45 p-3 text-[11px] leading-5 whitespace-pre-wrap">{content.content.text}</pre>;
+        return <pre data-selectable className="max-h-72 overflow-auto rounded-md border border-border/60 bg-muted/45 p-3 text-[11px] leading-5 whitespace-pre-wrap">{content.content.text}</pre>;
       }
       return <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">{t("chat.unsupportedContent", { type: content.content.type })}</p>;
   }
@@ -108,7 +108,7 @@ function RawData({ input, output }: { input: unknown; output: unknown }) {
   return (
     <details className="rounded-md border border-border/70 bg-muted/20">
       <summary className="cursor-pointer px-3 py-2 text-[11px] font-medium text-muted-foreground">{t("chat.rawData")}</summary>
-      <pre className="max-h-72 overflow-auto border-t border-border/60 p-3 text-[11px] leading-5">{safeStringify({ input, output })}</pre>
+      <pre data-selectable className="max-h-72 overflow-auto border-t border-border/60 p-3 text-[11px] leading-5">{safeStringify({ input, output })}</pre>
     </details>
   );
 }

--- a/packages/app-shell/src/features/settings/settings-dialog.tsx
+++ b/packages/app-shell/src/features/settings/settings-dialog.tsx
@@ -314,14 +314,14 @@ function PrivacySettings({ settings, onUpdate, onClearHistory }: { settings: Set
       {worktreeStorage.kind === "configurable" && (
         <SettingsRow icon={IconFolder} title={t("settings.privacy.worktreeRoot")} description={t("settings.privacy.worktreeRootDescription")}>
           <div className="flex max-w-sm flex-col items-end gap-2">
-            <code className="max-w-full break-all text-right text-xs text-muted-foreground">
+            <code data-selectable className="max-w-full break-all text-right text-xs text-muted-foreground">
               {worktreeRoot ?? t("settings.privacy.worktreeRootLoading")}
             </code>
             <Button variant="outline" disabled={worktreeRoot === null || worktreeSaving} onClick={changeWorktreeRoot}>
               <IconFolder />
               {worktreeSaving ? t("common.saving") : t("settings.privacy.changeWorktreeRoot")}
             </Button>
-            {worktreeError !== null && <p className="text-right text-xs text-destructive">{worktreeError}</p>}
+            {worktreeError !== null && <p data-selectable className="text-right text-xs text-destructive">{worktreeError}</p>}
           </div>
         </SettingsRow>
       )}

--- a/packages/app-shell/src/features/workspace/entity-dialog.tsx
+++ b/packages/app-shell/src/features/workspace/entity-dialog.tsx
@@ -178,7 +178,7 @@ export function EntityDialog({
                   />
                 )}
                 {pathSelectionError === field.name && (
-                  <p role="alert" className="text-xs text-destructive">
+                  <p role="alert" data-selectable className="text-xs text-destructive">
                     {t("dialog.pathSelectionError")}
                   </p>
                 )}
@@ -186,7 +186,7 @@ export function EntityDialog({
             ))}
           </div>
           {validationError && <p role="alert" className="text-xs text-destructive">{t("dialog.required")}</p>}
-          {submissionError && <p role="alert" className="text-xs text-destructive">{submissionError}</p>}
+          {submissionError && <p role="alert" data-selectable className="text-xs text-destructive">{submissionError}</p>}
           <DialogFooter>
             <Button type="button" variant="outline" disabled={submitting} onClick={() => onOpenChange(false)}>{t("common.cancel")}</Button>
             <Button type="submit" disabled={submitting}>{submitting ? t("common.saving") : submitLabel}</Button>

--- a/packages/app-shell/src/features/workspace/workspace-dialogs.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-dialogs.tsx
@@ -79,7 +79,7 @@ function DeleteEntityDialog({ target, onOpenChange }: { target: DeleteTarget | n
         <AlertDialogHeader>
           <AlertDialogTitle>{t("delete.title", { name: target?.name ?? "" })}</AlertDialogTitle>
           <AlertDialogDescription>{target ? t(`delete.${target.kind}Description`) : ""}</AlertDialogDescription>
-          {deleteError && <p role="alert" className="text-sm text-destructive">{deleteError}</p>}
+          {deleteError && <p role="alert" data-selectable className="text-sm text-destructive">{deleteError}</p>}
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={deleting}>{t("common.cancel")}</AlertDialogCancel>

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
@@ -278,7 +278,7 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
           })}
         </nav>
 
-        {error && <p className="border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{error.message}</p>}
+        {error && <p data-selectable className="border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{error.message}</p>}
         <div className="p-2">
           <UserProfile user={user} onOpenSettings={() => setSettingsOpen(true)} onSignOut={onSignOut} />
         </div>

--- a/packages/platform/src/web/web-path-picker-host.tsx
+++ b/packages/platform/src/web/web-path-picker-host.tsx
@@ -320,7 +320,7 @@ function WebPathPickerDialog({
         >
           {!loading && readError && (
             <div role="alert" className="grid h-full place-items-center gap-3 p-6 text-center">
-              <p className="text-sm text-destructive">{messages.readError}</p>
+              <p data-selectable className="text-sm text-destructive">{messages.readError}</p>
               <Button type="button" variant="outline" onClick={() => void loadDirectory(pathDraft.trim() || undefined)}>
                 <IconRefresh />
                 {messages.retry}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -204,6 +204,25 @@
   body {
     @apply bg-background text-foreground;
     font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei UI", "Microsoft YaHei", ui-sans-serif, sans-serif;
+    /* Desktop chrome should not drag-select; user and agent content opts in explicitly. */
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  input,
+  textarea,
+  [contenteditable]:not([contenteditable="false"]),
+  [data-selectable] {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  button,
+  [role="button"],
+  summary,
+  [data-selection-control] {
+    -webkit-user-select: none;
+    user-select: none;
   }
 
   button:not(:disabled),


### PR DESCRIPTION
  Explicitly allow text selection for editable controls, chat content,
  tool output, diffs, paths, and error messages while keeping interface
  chrome and interactive controls non-selectable.