### PR TITLE
feat(skill): add atomic skill folder import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "ast_node"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +93,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -564,6 +571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +763,17 @@ version = "0.0.0"
 dependencies = [
  "pretty_assertions",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gray_matter"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3563a3eb8bacf11a0a6d93de7885f2cca224dddff0114e4eb8053ca0f1918acd"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -1212,6 +1239,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,10 +1351,13 @@ name = "ora-application"
 version = "0.0.0"
 dependencies = [
  "gitlancer",
+ "gray_matter",
  "ora-contracts",
  "ora-domain",
  "ora-logging",
  "pretty_assertions",
+ "serde",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2189,6 +2236,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"
@@ -3319,6 +3372,17 @@ dependencies = [
  "pretty_assertions",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ chrono = "0.4"
 chrono-tz = "0.10"
 derive_more = "2"
 futures-util = { version = "0.3", features = ["sink"] }
+gray_matter = { version = "0.3", default-features = false, features = ["yaml"] }
 libc = "0.2"
 log = "0.4"
 portable-pty = "0.9"

--- a/apps/web/server/Cargo.toml
+++ b/apps/web/server/Cargo.toml
@@ -8,7 +8,7 @@ name = "ora_web_server"
 path = "src/main.rs"
 
 [dependencies]
-axum = { version = "0.8", features = ["ws"] }
+axum = { version = "0.8", features = ["multipart", "ws"] }
 chrono-tz = { workspace = true }
 futures-util = { workspace = true }
 ora-application = { workspace = true }

--- a/apps/web/server/src/bootstrap.rs
+++ b/apps/web/server/src/bootstrap.rs
@@ -134,6 +134,9 @@ fn web_backend_bootstrap_error(error: BackendBootstrapError) -> WebBootstrapErro
             WebBootstrapError::DataDirectoryCreate(source)
         }
         BackendBootstrapError::Database(source) => WebBootstrapError::DatabaseBootstrap(source),
+        BackendBootstrapError::SkillStorage(message) => {
+            WebBootstrapError::SkillStorageReconcile { message }
+        }
         BackendBootstrapError::AgentRuntime(_) => WebBootstrapError::ProjectBootstrap {
             message: "failed to initialize agent runtime".to_string(),
         },

--- a/apps/web/server/src/error.rs
+++ b/apps/web/server/src/error.rs
@@ -50,6 +50,8 @@ pub enum WebBootstrapError {
     DatabaseBootstrap(#[source] ora_db::DatabaseError),
     #[error("failed to reconcile bootstrap project: {message}")]
     ProjectBootstrap { message: String },
+    #[error("failed to reconcile skill storage: {message}")]
+    SkillStorageReconcile { message: String },
     #[error(transparent)]
     LoggingInit(#[from] ora_logging::LoggingInitError),
     #[error("failed to bind HTTP listener")]
@@ -117,6 +119,21 @@ impl From<ApplicationError> for WebApiError {
             ApplicationError::SkillRepository { message } => Self {
                 status: StatusCode::INTERNAL_SERVER_ERROR,
                 code: "skill_repository_error",
+                message,
+            },
+            ApplicationError::SkillImportInvalid { reason } => Self {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                code: "skill_import_invalid",
+                message: reason,
+            },
+            ApplicationError::SkillFolderConflict { name } => Self {
+                status: StatusCode::CONFLICT,
+                code: "skill_folder_conflict",
+                message: format!("skill folder already exists: {name}"),
+            },
+            ApplicationError::SkillPackageStorage { message } => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "skill_package_storage_error",
                 message,
             },
             ApplicationError::AgentDefinitionNameBlank => Self {
@@ -205,6 +222,7 @@ impl From<BackendError> for WebApiError {
             BackendErrorKind::BadRequest => StatusCode::BAD_REQUEST,
             BackendErrorKind::NotFound => StatusCode::NOT_FOUND,
             BackendErrorKind::Conflict => StatusCode::CONFLICT,
+            BackendErrorKind::Unprocessable => StatusCode::UNPROCESSABLE_ENTITY,
             BackendErrorKind::Internal => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/apps/web/server/src/handlers/skills.rs
+++ b/apps/web/server/src/handlers/skills.rs
@@ -1,7 +1,8 @@
 use crate::app_state::AppState;
 use crate::error::WebApiError;
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::{Multipart, Path, State};
+use ora_application::UploadedSkillFile;
 use ora_contracts::{
     CreateSkillRequest, CreateSkillResponse, DeleteSkillRequest, DeleteSkillResponse,
     GetSkillRequest, GetSkillResponse, ListSkillsRequest, ListSkillsResponse, UpdateSkillRequest,
@@ -74,6 +75,41 @@ pub async fn update_skill(
             name: body.name,
             description: body.description,
         })
+        .map(Json)
+        .map_err(Into::into)
+}
+
+/// Imports one uploaded skill folder from a multipart request, committing it atomically.
+///
+/// Each file part carries its skill-root-relative path as the part file name; non-file fields are
+/// ignored so the application layer receives only the uploaded folder contents to stage.
+pub async fn import_skill(
+    State(app_state): State<AppState>,
+    mut multipart: Multipart,
+) -> Result<Json<CreateSkillResponse>, WebApiError> {
+    let mut files = Vec::new();
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|error| WebApiError::bad_request(error.to_string()))?
+    {
+        let relative_path = match field.file_name() {
+            Some(file_name) => file_name.to_string(),
+            None => continue,
+        };
+        let bytes = field
+            .bytes()
+            .await
+            .map_err(|error| WebApiError::bad_request(error.to_string()))?;
+        files.push(UploadedSkillFile {
+            relative_path,
+            bytes: bytes.to_vec(),
+        });
+    }
+
+    app_state
+        .backend()
+        .import_skill(files)
         .map(Json)
         .map_err(Into::into)
 }

--- a/apps/web/server/src/routes.rs
+++ b/apps/web/server/src/routes.rs
@@ -3,13 +3,18 @@ use crate::handlers::{
     agents, file_system, health, project_work_contexts, projects, sessions, skills, tasks,
 };
 use axum::Router;
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use ora_contracts::{
     AGENT_PATH, AGENTS_PATH, FILE_SYSTEM_DIRECTORY_PATH, PROJECT_PATH,
     PROJECT_WORK_CONTEXT_OPEN_PATH, PROJECT_WORK_CONTEXT_RENEW_PATH, PROJECTS_PATH,
     SESSION_LOAD_PATH, SESSION_PATH, SESSION_PERMISSION_RESPONSE_PATH, SESSION_PROMPT_PATH,
-    SESSION_STOP_PATH, SESSIONS_PATH, SKILL_PATH, SKILLS_PATH, TASK_PATH, TASKS_PATH,
+    SESSION_STOP_PATH, SESSIONS_PATH, SKILL_IMPORT_PATH, SKILL_PATH, SKILLS_PATH, TASK_PATH,
+    TASKS_PATH,
 };
+
+/// Caps the total size of one skill folder upload, matching the application-layer file-count limit.
+const MAX_SKILL_UPLOAD_BYTES: usize = 50 * 1024 * 1024;
 
 /// Builds the top-level router for health checks and the persisted CRUD routes.
 pub fn build_router(app_state: AppState) -> Router {
@@ -60,6 +65,10 @@ pub fn build_router(app_state: AppState) -> Router {
         .route(
             SKILLS_PATH,
             post(skills::create_skill).get(skills::list_skills),
+        )
+        .route(
+            SKILL_IMPORT_PATH,
+            post(skills::import_skill).layer(DefaultBodyLimit::max(MAX_SKILL_UPLOAD_BYTES)),
         )
         .route(
             SKILL_PATH,
@@ -981,6 +990,84 @@ mod tests {
             .status(),
             StatusCode::BAD_REQUEST
         );
+    }
+
+    /// Verifies the router imports a skill folder atomically and rejects conflicts and bad uploads.
+    #[tokio::test]
+    async fn serves_skill_folder_import_route() {
+        let (_temp_dir, _database_path, app) = test_router();
+        let manifest: &[u8] = b"---\nname: grilling\ndescription: Grill the user\n---\n";
+
+        let import = app
+            .clone()
+            .oneshot(multipart_request(
+                "/api/skills/import",
+                &[("SKILL.md", manifest), ("refs/util.py", b"noop".as_slice())],
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("request failed: {error}"));
+        assert_eq!(import.status(), StatusCode::OK);
+        let created = response_json(import).await;
+        let skill_id = created["skill"]["id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("response did not include a skill id"))
+            .to_string();
+        assert_eq!(
+            created,
+            json!({
+                "skill": { "id": skill_id, "name": "grilling", "description": "Grill the user" },
+            })
+        );
+
+        // A second import that resolves to the same committed directory name conflicts.
+        let conflict = app
+            .clone()
+            .oneshot(multipart_request(
+                "/api/skills/import",
+                &[("SKILL.md", manifest)],
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("request failed: {error}"));
+        assert_eq!(conflict.status(), StatusCode::CONFLICT);
+
+        // An upload without a manifest is unprocessable.
+        let invalid = app
+            .oneshot(multipart_request(
+                "/api/skills/import",
+                &[("refs/util.py", b"noop".as_slice())],
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("request failed: {error}"));
+        assert_eq!(invalid.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    /// Builds one multipart upload request whose file parts carry their relative path as the filename.
+    fn multipart_request(uri: &str, parts: &[(&str, &[u8])]) -> Request<Body> {
+        let boundary = "ORASKILLBOUNDARY";
+        let mut body = Vec::new();
+        for (filename, bytes) in parts {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(
+                format!(
+                    "Content-Disposition: form-data; name=\"files\"; filename=\"{filename}\"\r\n"
+                )
+                .as_bytes(),
+            );
+            body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+            body.extend_from_slice(bytes);
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+
+        Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(Body::from(body))
+            .unwrap_or_else(|error| panic!("failed to build request: {error}"))
     }
 
     /// Sends one JSON request to the router under test.

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -12,9 +12,11 @@ workspace = true
 
 [dependencies]
 gitlancer = { workspace = true }
+gray_matter = { workspace = true }
 ora-contracts = { workspace = true }
 ora-domain = { workspace = true }
 ora-logging = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
@@ -22,4 +24,5 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/application/src/error.rs
+++ b/crates/application/src/error.rs
@@ -15,6 +15,12 @@ pub enum ApplicationError {
     SkillNotFound { skill_id: String },
     #[error("skill repository operation failed: {message}")]
     SkillRepository { message: String },
+    #[error("skill import is invalid: {reason}")]
+    SkillImportInvalid { reason: String },
+    #[error("skill folder already exists: {name}")]
+    SkillFolderConflict { name: String },
+    #[error("skill package storage operation failed: {message}")]
+    SkillPackageStorage { message: String },
     #[error("agent definition name must not be blank")]
     AgentDefinitionNameBlank,
     #[error("agent definition not found: {agent_id}")]

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -28,8 +28,10 @@ pub use session::{
     SessionRepository, SessionRepositoryError, UuidSessionIdGenerator,
 };
 pub use skill::{
-    CreateSkillHandler, DeleteSkillHandler, GetSkillHandler, ListSkillsHandler, SkillIdGenerator,
-    SkillRepository, SkillRepositoryError, UpdateSkillHandler, UuidSkillIdGenerator,
+    CreateSkillHandler, DeleteSkillHandler, GetSkillHandler, ImportSkillHandler, ListSkillsHandler,
+    LocalSkillPackageStore, ReconcileSkillStorageHandler, SkillIdGenerator, SkillImportCommitError,
+    SkillImportUnitOfWork, SkillPackageStore, SkillPackageStoreError, SkillRepository,
+    SkillRepositoryError, UpdateSkillHandler, UploadedSkillFile, UuidSkillIdGenerator,
 };
 pub use task::{
     CreateTaskHandler, CreateTaskWorktreeRequest, DeleteTaskWorktreeRequest, GetTaskHandler,

--- a/crates/application/src/skill/handlers.rs
+++ b/crates/application/src/skill/handlers.rs
@@ -1,5 +1,5 @@
 use crate::skill::mapper::map_skill;
-use crate::skill::ports::{SkillIdGenerator, SkillRepository};
+use crate::skill::ports::{SkillIdGenerator, SkillPackageStore, SkillRepository};
 use crate::{ApplicationError, Clock};
 use ora_contracts::{
     CreateSkillRequest, CreateSkillResponse, DeleteSkillRequest, DeleteSkillResponse,
@@ -171,29 +171,44 @@ where
     }
 }
 
-/// Handles soft deletion of reusable skill definitions.
-pub struct DeleteSkillHandler<Repository, ClockSource> {
+/// Handles soft deletion of reusable skill definitions and their imported folders.
+pub struct DeleteSkillHandler<Repository, Store, ClockSource> {
     repository: Repository,
+    store: Store,
     clock: ClockSource,
 }
 
-impl<Repository, ClockSource> DeleteSkillHandler<Repository, ClockSource> {
-    pub fn new(repository: Repository, clock: ClockSource) -> Self {
-        Self { repository, clock }
+impl<Repository, Store, ClockSource> DeleteSkillHandler<Repository, Store, ClockSource> {
+    pub fn new(repository: Repository, store: Store, clock: ClockSource) -> Self {
+        Self {
+            repository,
+            store,
+            clock,
+        }
     }
 }
 
-impl<Repository, ClockSource> DeleteSkillHandler<Repository, ClockSource>
+impl<Repository, Store, ClockSource> DeleteSkillHandler<Repository, Store, ClockSource>
 where
     Repository: SkillRepository,
+    Store: SkillPackageStore,
     ClockSource: Clock,
 {
-    /// Soft-deletes one visible skill and returns its identifier.
+    /// Soft-deletes one visible skill, frees its committed folder, and returns its identifier.
     pub fn handle(
         &self,
         request: DeleteSkillRequest,
     ) -> Result<DeleteSkillResponse, ApplicationError> {
         let skill_id = SkillId::new(request.skill_id);
+        // Resolve the name before deleting so the committed directory (named after the skill) can
+        // be located; a missing visible skill is reported the same way as a soft-delete miss.
+        let existing = self
+            .repository
+            .find_skill(&skill_id)
+            .map_err(ApplicationError::from_skill_repository_error)?
+            .ok_or_else(|| ApplicationError::SkillNotFound {
+                skill_id: skill_id.to_string(),
+            })?;
         let deleted = self
             .repository
             .soft_delete_skill(&skill_id, self.clock.now_timestamp_millis())
@@ -203,6 +218,10 @@ where
                 skill_id: skill_id.to_string(),
             });
         }
+
+        // Best-effort folder removal: the catalog row is already the source of truth, and a failure
+        // here self-heals on the next startup reconciliation because the row is no longer visible.
+        let _ = self.store.remove_committed(&existing.name);
 
         Ok(DeleteSkillResponse {
             skill_id: skill_id.to_string(),

--- a/crates/application/src/skill/import.rs
+++ b/crates/application/src/skill/import.rs
@@ -1,0 +1,213 @@
+use crate::skill::mapper::map_skill;
+use crate::skill::ports::{
+    SkillIdGenerator, SkillImportCommitError, SkillImportUnitOfWork, SkillPackageStore,
+    SkillPackageStoreError,
+};
+use crate::skill::validation::{is_safe_skill_name, normalize_relative_path, parse_skill_manifest};
+use crate::{ApplicationError, Clock};
+use ora_contracts::CreateSkillResponse;
+use ora_domain::{AuditFields, Skill, SkillId};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+/// Caps the number of files one skill upload may carry to bound staging cost and abuse.
+const MAX_SKILL_FILES: usize = 1000;
+
+/// Carries one uploaded file already materialized from transport, ready to stage on disk.
+///
+/// The web layer owns multipart decoding and hands the application in-memory files so the import
+/// use case stays transport-agnostic and unit-testable without touching a real filesystem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UploadedSkillFile {
+    pub relative_path: String,
+    pub bytes: Vec<u8>,
+}
+
+/// Imports an uploaded skill folder atomically: stage files, parse its manifest, then commit.
+///
+/// The handler runs two phases. The first stages every file under an `<id>.tmp` directory and
+/// resolves the skill from its `SKILL.md`; any failure discards that staging. The second delegates
+/// to a unit of work that inserts the row, promotes the directory, and commits together, so the
+/// database record and the on-disk folder appear or vanish as one unit.
+pub struct ImportSkillHandler<Store, UnitOfWork, IdGenerator, ClockSource> {
+    store: Store,
+    unit_of_work: UnitOfWork,
+    id_generator: IdGenerator,
+    clock: ClockSource,
+}
+
+impl<Store, UnitOfWork, IdGenerator, ClockSource>
+    ImportSkillHandler<Store, UnitOfWork, IdGenerator, ClockSource>
+{
+    /// Builds the import handler from its filesystem, transaction, identifier, and clock ports.
+    pub fn new(
+        store: Store,
+        unit_of_work: UnitOfWork,
+        id_generator: IdGenerator,
+        clock: ClockSource,
+    ) -> Self {
+        Self {
+            store,
+            unit_of_work,
+            id_generator,
+            clock,
+        }
+    }
+}
+
+impl<Store, UnitOfWork, IdGenerator, ClockSource>
+    ImportSkillHandler<Store, UnitOfWork, IdGenerator, ClockSource>
+where
+    Store: SkillPackageStore,
+    UnitOfWork: SkillImportUnitOfWork,
+    IdGenerator: SkillIdGenerator,
+    ClockSource: Clock,
+{
+    /// Validates the upload, stages it, and commits the resolved skill or rolls everything back.
+    pub fn handle(
+        &self,
+        files: Vec<UploadedSkillFile>,
+    ) -> Result<CreateSkillResponse, ApplicationError> {
+        let staged_paths = validate_upload(&files)?;
+        let skill_id = self.id_generator.generate_skill_id();
+        self.store
+            .create_staging(&skill_id)
+            .map_err(storage_error)?;
+
+        // Any preparation failure must discard the staging directory the import just created so a
+        // rejected upload never leaves an orphaned `<id>.tmp` behind.
+        let skill = match self.stage_and_resolve(&skill_id, &files, &staged_paths) {
+            Ok(skill) => skill,
+            Err(error) => {
+                let _ = self.store.discard_staging(&skill_id);
+                return Err(error);
+            }
+        };
+
+        self.commit(skill_id, skill)
+    }
+
+    /// Writes staged files, then resolves the durable skill from its parsed, validated manifest.
+    fn stage_and_resolve(
+        &self,
+        skill_id: &SkillId,
+        files: &[UploadedSkillFile],
+        staged_paths: &[PathBuf],
+    ) -> Result<Skill, ApplicationError> {
+        for (file, relative_path) in files.iter().zip(staged_paths) {
+            self.store
+                .write_file(skill_id, relative_path, &file.bytes)
+                .map_err(storage_error)?;
+        }
+
+        let manifest_contents = self
+            .store
+            .read_manifest(skill_id)
+            .map_err(storage_error)?
+            .ok_or_else(|| ApplicationError::SkillImportInvalid {
+                reason: "skill upload is missing a SKILL.md manifest at its root".to_string(),
+            })?;
+        let manifest = parse_skill_manifest(&manifest_contents)
+            .map_err(|reason| ApplicationError::SkillImportInvalid { reason })?;
+
+        if !is_safe_skill_name(&manifest.name) {
+            return Err(ApplicationError::SkillImportInvalid {
+                reason: format!(
+                    "SKILL.md name `{}` is not a valid single-segment directory name",
+                    manifest.name
+                ),
+            });
+        }
+        if self
+            .store
+            .committed_exists(&manifest.name)
+            .map_err(storage_error)?
+        {
+            return Err(ApplicationError::SkillFolderConflict {
+                name: manifest.name,
+            });
+        }
+
+        let now = self.clock.now_timestamp_millis();
+        Skill::new(
+            skill_id.clone(),
+            manifest.name,
+            manifest.description,
+            AuditFields::new(now, now, false),
+        )
+        .map_err(ApplicationError::from_skill_domain_error)
+    }
+
+    /// Runs the insert-then-promote-then-commit unit of work, compensating for each failure point.
+    fn commit(
+        &self,
+        skill_id: SkillId,
+        skill: Skill,
+    ) -> Result<CreateSkillResponse, ApplicationError> {
+        let name = skill.name.clone();
+        let promote = || {
+            self.store
+                .promote(&skill_id, &name)
+                .map_err(|SkillPackageStoreError::OperationFailed(message)| message)
+        };
+
+        match self.unit_of_work.insert_then(skill.clone(), promote) {
+            Ok(()) => Ok(CreateSkillResponse {
+                skill: map_skill(skill),
+            }),
+            Err(SkillImportCommitError::Insert { message }) => {
+                let _ = self.store.discard_staging(&skill_id);
+                Err(ApplicationError::SkillRepository { message })
+            }
+            Err(SkillImportCommitError::Promote { message }) => {
+                let _ = self.store.discard_staging(&skill_id);
+                Err(ApplicationError::SkillPackageStorage { message })
+            }
+            Err(SkillImportCommitError::CommitAfterPromote { message }) => {
+                let _ = self.store.remove_committed(&name);
+                Err(ApplicationError::SkillRepository { message })
+            }
+        }
+    }
+}
+
+/// Rejects empty, oversized, unsafe, or duplicate-path uploads before any staging directory exists.
+fn validate_upload(files: &[UploadedSkillFile]) -> Result<Vec<PathBuf>, ApplicationError> {
+    if files.is_empty() {
+        return Err(ApplicationError::SkillImportInvalid {
+            reason: "skill upload contained no files".to_string(),
+        });
+    }
+    if files.len() > MAX_SKILL_FILES {
+        return Err(ApplicationError::SkillImportInvalid {
+            reason: format!("skill upload exceeds the {MAX_SKILL_FILES}-file limit"),
+        });
+    }
+
+    let mut staged_paths = Vec::with_capacity(files.len());
+    let mut seen_paths = HashSet::with_capacity(files.len());
+    for file in files {
+        let relative_path = normalize_relative_path(&file.relative_path).ok_or_else(|| {
+            ApplicationError::SkillImportInvalid {
+                reason: format!("unsafe upload path `{}`", file.relative_path),
+            }
+        })?;
+        if !seen_paths.insert(relative_path.clone()) {
+            return Err(ApplicationError::SkillImportInvalid {
+                reason: format!("duplicate upload path `{}`", relative_path.display()),
+            });
+        }
+        staged_paths.push(relative_path);
+    }
+
+    Ok(staged_paths)
+}
+
+/// Maps skill filesystem failures onto the stable storage application error.
+fn storage_error(error: SkillPackageStoreError) -> ApplicationError {
+    match error {
+        SkillPackageStoreError::OperationFailed(message) => {
+            ApplicationError::SkillPackageStorage { message }
+        }
+    }
+}

--- a/crates/application/src/skill/import_tests.rs
+++ b/crates/application/src/skill/import_tests.rs
@@ -1,0 +1,519 @@
+use super::import::UploadedSkillFile;
+use super::{
+    DeleteSkillHandler, ImportSkillHandler, ReconcileSkillStorageHandler, SkillIdGenerator,
+    SkillImportCommitError, SkillImportUnitOfWork, SkillPackageStore, SkillPackageStoreError,
+    SkillRepository, SkillRepositoryError,
+};
+use crate::{ApplicationError, Clock};
+use ora_contracts::{CreateSkillResponse, DeleteSkillRequest, Skill as ContractSkill};
+use ora_domain::{AuditFields, Skill, SkillId};
+use pretty_assertions::assert_eq;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+const MANIFEST: &str = "---\nname: grilling\ndescription: Grill the user\n---\nbody\n";
+
+#[test]
+fn imports_skill_and_promotes_staging_into_committed_directory() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    let unit_of_work = FakeUnitOfWork::default();
+    let response = handler(store.clone(), unit_of_work.clone())
+        .handle(vec![
+            uploaded("SKILL.md", MANIFEST.as_bytes()),
+            uploaded("refs/util.py", b"print('hi')"),
+        ])
+        .unwrap();
+
+    assert_eq!(
+        response,
+        CreateSkillResponse {
+            skill: ContractSkill {
+                id: "skill-1".to_string(),
+                name: "grilling".to_string(),
+                description: "Grill the user".to_string(),
+            },
+        }
+    );
+    assert_eq!(
+        unit_of_work.committed_rows(),
+        vec![skill("skill-1", "grilling", "Grill the user", 7, 7, false)]
+    );
+    assert_eq!(
+        store.committed_files("grilling"),
+        Some(package(&[
+            ("SKILL.md", MANIFEST.as_bytes()),
+            ("refs/util.py", b"print('hi')")
+        ]))
+    );
+    assert_eq!(store.staging_ids(), Vec::<String>::new());
+}
+
+#[test]
+fn rejects_upload_without_manifest_and_discards_staging() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    let error = handler(store.clone(), FakeUnitOfWork::default())
+        .handle(vec![uploaded("refs/util.py", b"noop")])
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApplicationError::SkillImportInvalid {
+            reason: "skill upload is missing a SKILL.md manifest at its root".to_string(),
+        }
+    );
+    assert_eq!(store.staging_ids(), Vec::<String>::new());
+    assert_eq!(store.committed_names(), Vec::<String>::new());
+}
+
+#[test]
+fn rejects_unsafe_manifest_name() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    let error = handler(store, FakeUnitOfWork::default())
+        .handle(vec![uploaded(
+            "SKILL.md",
+            b"---\nname: review / guide\ndescription: x\n---\n",
+        )])
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApplicationError::SkillImportInvalid {
+            reason: "SKILL.md name `review / guide` is not a valid single-segment directory name"
+                .to_string(),
+        }
+    );
+}
+
+#[test]
+fn rejects_empty_unsafe_and_duplicate_uploads_before_staging() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    let empty = handler(store.clone(), FakeUnitOfWork::default())
+        .handle(Vec::new())
+        .unwrap_err();
+    let unsafe_path = handler(store.clone(), FakeUnitOfWork::default())
+        .handle(vec![uploaded("../escape", b"x")])
+        .unwrap_err();
+    let duplicate = handler(store.clone(), FakeUnitOfWork::default())
+        .handle(vec![
+            uploaded("SKILL.md", MANIFEST.as_bytes()),
+            uploaded("SKILL.md", MANIFEST.as_bytes()),
+        ])
+        .unwrap_err();
+
+    assert_eq!(
+        empty,
+        ApplicationError::SkillImportInvalid {
+            reason: "skill upload contained no files".to_string(),
+        }
+    );
+    assert_eq!(
+        unsafe_path,
+        ApplicationError::SkillImportInvalid {
+            reason: "unsafe upload path `../escape`".to_string(),
+        }
+    );
+    assert_eq!(
+        duplicate,
+        ApplicationError::SkillImportInvalid {
+            reason: "duplicate upload path `SKILL.md`".to_string(),
+        }
+    );
+    // None of the rejected uploads reached the staging phase.
+    assert_eq!(store.staging_ids(), Vec::<String>::new());
+}
+
+#[test]
+fn rejects_upload_exceeding_the_file_limit() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    let files = (0..1001)
+        .map(|index| uploaded(&format!("file-{index}.txt"), b"x"))
+        .collect();
+    let error = handler(store, FakeUnitOfWork::default())
+        .handle(files)
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApplicationError::SkillImportInvalid {
+            reason: "skill upload exceeds the 1000-file limit".to_string(),
+        }
+    );
+}
+
+#[test]
+fn reports_conflict_when_committed_directory_exists() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    store.seed_committed("grilling");
+    let error = handler(store.clone(), FakeUnitOfWork::default())
+        .handle(vec![uploaded("SKILL.md", MANIFEST.as_bytes())])
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApplicationError::SkillFolderConflict {
+            name: "grilling".to_string(),
+        }
+    );
+    assert_eq!(store.staging_ids(), Vec::<String>::new());
+}
+
+#[test]
+fn rolls_back_row_and_discards_staging_when_promote_fails() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    store.fail_promote();
+    let unit_of_work = FakeUnitOfWork::default();
+    let error = handler(store.clone(), unit_of_work.clone())
+        .handle(vec![uploaded("SKILL.md", MANIFEST.as_bytes())])
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApplicationError::SkillPackageStorage {
+            message: "promote failed".to_string(),
+        }
+    );
+    assert_eq!(unit_of_work.committed_rows(), Vec::<Skill>::new());
+    assert_eq!(store.staging_ids(), Vec::<String>::new());
+    assert_eq!(store.committed_names(), Vec::<String>::new());
+}
+
+#[test]
+fn removes_promoted_directory_when_commit_fails() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    let unit_of_work = FakeUnitOfWork::default();
+    unit_of_work.fail_commit();
+    let error = handler(store.clone(), unit_of_work.clone())
+        .handle(vec![uploaded("SKILL.md", MANIFEST.as_bytes())])
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApplicationError::SkillRepository {
+            message: "commit failed".to_string(),
+        }
+    );
+    assert_eq!(unit_of_work.committed_rows(), Vec::<Skill>::new());
+    // The promote succeeded, so compensation must remove the committed directory again.
+    assert_eq!(store.committed_names(), Vec::<String>::new());
+}
+
+#[test]
+fn reconcile_clears_staging_and_orphan_directories_but_keeps_visible_skills() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    store.seed_staging("abandoned");
+    store.seed_committed("keep");
+    store.seed_committed("orphan");
+    let repository = Rc::new(FakeSkillCatalog::with_skills(vec![skill(
+        "skill-keep",
+        "keep",
+        "Kept skill",
+        1,
+        1,
+        false,
+    )]));
+
+    ReconcileSkillStorageHandler::new(store.clone(), repository)
+        .handle()
+        .unwrap();
+
+    assert_eq!(store.staging_ids(), Vec::<String>::new());
+    assert_eq!(store.committed_names(), vec!["keep".to_string()]);
+}
+
+#[test]
+fn delete_soft_deletes_the_row_and_removes_the_committed_folder() {
+    let store = Rc::new(FakeSkillPackageStore::default());
+    store.seed_committed("grilling");
+    let repository = Rc::new(FakeSkillCatalog::with_skills(vec![skill(
+        "skill-1", "grilling", "Grill", 1, 1, false,
+    )]));
+
+    DeleteSkillHandler::new(repository.clone(), store.clone(), FixedClock(9))
+        .handle(DeleteSkillRequest {
+            skill_id: "skill-1".to_string(),
+        })
+        .unwrap();
+
+    assert_eq!(repository.list_skills().unwrap(), Vec::<Skill>::new());
+    assert_eq!(store.committed_names(), Vec::<String>::new());
+}
+
+/// Builds an import handler over the shared fakes with a fixed identifier and clock.
+fn handler(
+    store: Rc<FakeSkillPackageStore>,
+    unit_of_work: FakeUnitOfWork,
+) -> ImportSkillHandler<Rc<FakeSkillPackageStore>, FakeUnitOfWork, FixedSkillIdGenerator, FixedClock>
+{
+    ImportSkillHandler::new(store, unit_of_work, FixedSkillIdGenerator, FixedClock(7))
+}
+
+/// Builds one uploaded file from a relative path and byte payload.
+fn uploaded(relative_path: &str, bytes: &[u8]) -> UploadedSkillFile {
+    UploadedSkillFile {
+        relative_path: relative_path.to_string(),
+        bytes: bytes.to_vec(),
+    }
+}
+
+/// Builds a committed package map from relative paths so tests can deep-compare on-disk contents.
+fn package(entries: &[(&str, &[u8])]) -> BTreeMap<PathBuf, Vec<u8>> {
+    entries
+        .iter()
+        .map(|(path, bytes)| (PathBuf::from(path), bytes.to_vec()))
+        .collect()
+}
+
+/// Builds a domain skill fixture for deep-equality assertions.
+fn skill(
+    id: &str,
+    name: &str,
+    description: &str,
+    created_at: i64,
+    updated_at: i64,
+    is_deleted: bool,
+) -> Skill {
+    Skill::new(
+        SkillId::new(id),
+        name,
+        description,
+        AuditFields::new(created_at, updated_at, is_deleted),
+    )
+    .unwrap()
+}
+
+/// In-memory skill package store modeling staging and committed directories for handler tests.
+#[derive(Default)]
+struct FakeSkillPackageStore {
+    state: RefCell<FakeStoreState>,
+}
+
+#[derive(Default)]
+struct FakeStoreState {
+    staging: BTreeMap<String, BTreeMap<PathBuf, Vec<u8>>>,
+    committed: BTreeMap<String, BTreeMap<PathBuf, Vec<u8>>>,
+    fail_promote: bool,
+}
+
+impl FakeSkillPackageStore {
+    fn fail_promote(&self) {
+        self.state.borrow_mut().fail_promote = true;
+    }
+    fn seed_staging(&self, id: &str) {
+        self.state
+            .borrow_mut()
+            .staging
+            .insert(format!("{id}.tmp"), BTreeMap::new());
+    }
+    fn seed_committed(&self, name: &str) {
+        self.state
+            .borrow_mut()
+            .committed
+            .insert(name.to_string(), BTreeMap::new());
+    }
+    fn staging_ids(&self) -> Vec<String> {
+        self.state.borrow().staging.keys().cloned().collect()
+    }
+    fn committed_names(&self) -> Vec<String> {
+        self.state.borrow().committed.keys().cloned().collect()
+    }
+    fn committed_files(&self, name: &str) -> Option<BTreeMap<PathBuf, Vec<u8>>> {
+        self.state.borrow().committed.get(name).cloned()
+    }
+}
+
+impl SkillPackageStore for Rc<FakeSkillPackageStore> {
+    fn create_staging(&self, skill_id: &SkillId) -> Result<(), SkillPackageStoreError> {
+        self.state
+            .borrow_mut()
+            .staging
+            .insert(staging_key(skill_id), BTreeMap::new());
+        Ok(())
+    }
+    fn write_file(
+        &self,
+        skill_id: &SkillId,
+        relative_path: &Path,
+        bytes: &[u8],
+    ) -> Result<(), SkillPackageStoreError> {
+        self.state
+            .borrow_mut()
+            .staging
+            .entry(staging_key(skill_id))
+            .or_default()
+            .insert(relative_path.to_path_buf(), bytes.to_vec());
+        Ok(())
+    }
+    fn read_manifest(&self, skill_id: &SkillId) -> Result<Option<String>, SkillPackageStoreError> {
+        Ok(self
+            .state
+            .borrow()
+            .staging
+            .get(&staging_key(skill_id))
+            .and_then(|files| files.get(Path::new("SKILL.md")))
+            .map(|bytes| String::from_utf8_lossy(bytes).into_owned()))
+    }
+    fn committed_exists(&self, name: &str) -> Result<bool, SkillPackageStoreError> {
+        Ok(self.state.borrow().committed.contains_key(name))
+    }
+    fn promote(&self, skill_id: &SkillId, name: &str) -> Result<(), SkillPackageStoreError> {
+        let mut state = self.state.borrow_mut();
+        if state.fail_promote {
+            return Err(SkillPackageStoreError::OperationFailed(
+                "promote failed".to_string(),
+            ));
+        }
+        let files = state
+            .staging
+            .remove(&staging_key(skill_id))
+            .unwrap_or_default();
+        state.committed.insert(name.to_string(), files);
+        Ok(())
+    }
+    fn discard_staging(&self, skill_id: &SkillId) -> Result<(), SkillPackageStoreError> {
+        self.state
+            .borrow_mut()
+            .staging
+            .remove(&staging_key(skill_id));
+        Ok(())
+    }
+    fn remove_committed(&self, name: &str) -> Result<(), SkillPackageStoreError> {
+        self.state.borrow_mut().committed.remove(name);
+        Ok(())
+    }
+    fn remove_all_staging(&self) -> Result<(), SkillPackageStoreError> {
+        self.state.borrow_mut().staging.clear();
+        Ok(())
+    }
+    fn list_committed_names(&self) -> Result<Vec<String>, SkillPackageStoreError> {
+        Ok(self.state.borrow().committed.keys().cloned().collect())
+    }
+}
+
+/// Derives the staging map key matching the store's `<id>.tmp` directory naming.
+fn staging_key(skill_id: &SkillId) -> String {
+    format!("{skill_id}.tmp")
+}
+
+/// In-memory import unit of work recording committed rows and simulating failure points.
+#[derive(Clone, Default)]
+struct FakeUnitOfWork {
+    inner: Rc<FakeUnitOfWorkState>,
+}
+
+#[derive(Default)]
+struct FakeUnitOfWorkState {
+    committed: RefCell<Vec<Skill>>,
+    fail_commit: RefCell<bool>,
+}
+
+impl FakeUnitOfWork {
+    fn fail_commit(&self) {
+        *self.inner.fail_commit.borrow_mut() = true;
+    }
+    fn committed_rows(&self) -> Vec<Skill> {
+        self.inner.committed.borrow().clone()
+    }
+}
+
+impl SkillImportUnitOfWork for FakeUnitOfWork {
+    fn insert_then<OnInserted>(
+        &self,
+        skill: Skill,
+        on_inserted: OnInserted,
+    ) -> Result<(), SkillImportCommitError>
+    where
+        OnInserted: FnOnce() -> Result<(), String>,
+    {
+        // Mirror the real ordering: insert, run the promote callback, then commit. A recorded row
+        // stands in for a committed row, so failures leave `committed` untouched.
+        match on_inserted() {
+            Ok(()) => {
+                if *self.inner.fail_commit.borrow() {
+                    return Err(SkillImportCommitError::CommitAfterPromote {
+                        message: "commit failed".to_string(),
+                    });
+                }
+                self.inner.committed.borrow_mut().push(skill);
+                Ok(())
+            }
+            Err(message) => Err(SkillImportCommitError::Promote { message }),
+        }
+    }
+}
+
+/// Minimal skill catalog fake covering the lookup and soft-delete paths the tests exercise.
+struct FakeSkillCatalog {
+    skills: RefCell<Vec<Skill>>,
+}
+
+impl FakeSkillCatalog {
+    fn with_skills(skills: Vec<Skill>) -> Self {
+        Self {
+            skills: RefCell::new(skills),
+        }
+    }
+}
+
+impl SkillRepository for Rc<FakeSkillCatalog> {
+    fn create_skill(&self, skill: Skill) -> Result<Skill, SkillRepositoryError> {
+        self.skills.borrow_mut().push(skill.clone());
+        Ok(skill)
+    }
+    fn find_skill(&self, skill_id: &SkillId) -> Result<Option<Skill>, SkillRepositoryError> {
+        Ok(self
+            .skills
+            .borrow()
+            .iter()
+            .find(|skill| skill.id == *skill_id && !skill.audit_fields.is_deleted)
+            .cloned())
+    }
+    fn list_skills(&self) -> Result<Vec<Skill>, SkillRepositoryError> {
+        Ok(self
+            .skills
+            .borrow()
+            .iter()
+            .filter(|skill| !skill.audit_fields.is_deleted)
+            .cloned()
+            .collect())
+    }
+    fn update_skill(&self, skill: Skill) -> Result<Skill, SkillRepositoryError> {
+        Ok(skill)
+    }
+    fn soft_delete_skill(
+        &self,
+        skill_id: &SkillId,
+        deleted_at: i64,
+    ) -> Result<bool, SkillRepositoryError> {
+        match self
+            .skills
+            .borrow_mut()
+            .iter_mut()
+            .find(|skill| skill.id == *skill_id && !skill.audit_fields.is_deleted)
+        {
+            Some(skill) => {
+                skill.audit_fields.updated_at = deleted_at;
+                skill.audit_fields.is_deleted = true;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+}
+
+/// Emits a fixed identifier so import tests can assert the generated skill id deterministically.
+struct FixedSkillIdGenerator;
+impl SkillIdGenerator for FixedSkillIdGenerator {
+    fn generate_skill_id(&self) -> SkillId {
+        SkillId::new("skill-1")
+    }
+}
+
+/// Emits a fixed timestamp for deterministic audit fields.
+struct FixedClock(i64);
+impl Clock for FixedClock {
+    fn now_timestamp_millis(&self) -> i64 {
+        self.0
+    }
+}

--- a/crates/application/src/skill/local_store.rs
+++ b/crates/application/src/skill/local_store.rs
@@ -1,0 +1,291 @@
+use crate::skill::ports::{SkillPackageStore, SkillPackageStoreError};
+use crate::skill::validation::{SKILL_MANIFEST_FILE, is_safe_skill_name};
+use ora_domain::SkillId;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Component, Path, PathBuf};
+
+/// Marks in-progress staging directories so reconciliation can tell them from committed skills.
+const STAGING_SUFFIX: &str = ".tmp";
+
+/// Stores uploaded skill folders under a single `atoms/skills` root on the local filesystem.
+///
+/// The adapter is `Clone` because the same layout is shared by the import, delete, and startup
+/// reconciliation use cases; cloning only copies the root path, not any open handles.
+#[derive(Clone, Debug)]
+pub struct LocalSkillPackageStore {
+    root: PathBuf,
+}
+
+impl LocalSkillPackageStore {
+    /// Builds the store rooted at the configured `atoms/skills` directory.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    /// Returns the `<id>.tmp` staging directory path for an in-progress import.
+    fn staging_path(&self, skill_id: &SkillId) -> PathBuf {
+        self.root.join(format!("{skill_id}{STAGING_SUFFIX}"))
+    }
+
+    /// Returns the committed `<name>` directory path for a resolved skill.
+    fn committed_path(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+}
+
+impl SkillPackageStore for LocalSkillPackageStore {
+    fn create_staging(&self, skill_id: &SkillId) -> Result<(), SkillPackageStoreError> {
+        fs::create_dir_all(self.staging_path(skill_id)).map_err(operation_failed)
+    }
+
+    fn write_file(
+        &self,
+        skill_id: &SkillId,
+        relative_path: &Path,
+        bytes: &[u8],
+    ) -> Result<(), SkillPackageStoreError> {
+        // Defense in depth at the filesystem boundary: the caller normalizes paths, but re-reject
+        // any non-`Normal` component so a staged write can never escape the staging directory.
+        if relative_path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err(SkillPackageStoreError::OperationFailed(format!(
+                "refusing to stage unsafe path `{}`",
+                relative_path.display()
+            )));
+        }
+
+        let target = self.staging_path(skill_id).join(relative_path);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(operation_failed)?;
+        }
+        fs::write(target, bytes).map_err(operation_failed)
+    }
+
+    fn read_manifest(&self, skill_id: &SkillId) -> Result<Option<String>, SkillPackageStoreError> {
+        let manifest_path = self.staging_path(skill_id).join(SKILL_MANIFEST_FILE);
+        match fs::read_to_string(manifest_path) {
+            Ok(contents) => Ok(Some(contents)),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(operation_failed(error)),
+        }
+    }
+
+    fn committed_exists(&self, name: &str) -> Result<bool, SkillPackageStoreError> {
+        Ok(is_safe_skill_name(name) && self.committed_path(name).is_dir())
+    }
+
+    fn promote(&self, skill_id: &SkillId, name: &str) -> Result<(), SkillPackageStoreError> {
+        let destination = self.committed_path(name);
+        // Never overwrite an existing committed skill: a losing concurrent import must fail rather
+        // than clobber the directory the winning import already promoted.
+        if destination.exists() {
+            return Err(SkillPackageStoreError::OperationFailed(format!(
+                "committed skill directory `{name}` already exists"
+            )));
+        }
+        fs::rename(self.staging_path(skill_id), destination).map_err(operation_failed)
+    }
+
+    fn discard_staging(&self, skill_id: &SkillId) -> Result<(), SkillPackageStoreError> {
+        remove_dir_if_present(&self.staging_path(skill_id))
+    }
+
+    fn remove_committed(&self, name: &str) -> Result<(), SkillPackageStoreError> {
+        // Only ever touch a safe single-segment child; names from the plain JSON create path may be
+        // arbitrary strings and never have a directory, so unsafe names are a no-op by design.
+        if !is_safe_skill_name(name) {
+            return Ok(());
+        }
+        remove_dir_if_present(&self.committed_path(name))
+    }
+
+    fn remove_all_staging(&self) -> Result<(), SkillPackageStoreError> {
+        for entry in read_dir_if_present(&self.root)? {
+            if entry.name.ends_with(STAGING_SUFFIX) && entry.is_dir {
+                remove_dir_if_present(&self.root.join(&entry.name))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn list_committed_names(&self) -> Result<Vec<String>, SkillPackageStoreError> {
+        let mut names = Vec::new();
+        for entry in read_dir_if_present(&self.root)? {
+            if entry.is_dir && !entry.name.ends_with(STAGING_SUFFIX) {
+                names.push(entry.name);
+            }
+        }
+        Ok(names)
+    }
+}
+
+/// Describes one direct child of the skills root captured for reconciliation decisions.
+struct DirectoryEntry {
+    name: String,
+    is_dir: bool,
+}
+
+/// Lists direct children of the skills root, treating an absent root as an empty directory.
+fn read_dir_if_present(root: &Path) -> Result<Vec<DirectoryEntry>, SkillPackageStoreError> {
+    let read_dir = match fs::read_dir(root) {
+        Ok(read_dir) => read_dir,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(operation_failed(error)),
+    };
+
+    let mut entries = Vec::new();
+    for entry in read_dir {
+        let entry = entry.map_err(operation_failed)?;
+        let file_type = entry.file_type().map_err(operation_failed)?;
+        entries.push(DirectoryEntry {
+            name: entry.file_name().to_string_lossy().into_owned(),
+            is_dir: file_type.is_dir(),
+        });
+    }
+
+    Ok(entries)
+}
+
+/// Removes a directory tree, treating an already-absent directory as success.
+fn remove_dir_if_present(path: &Path) -> Result<(), SkillPackageStoreError> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(operation_failed(error)),
+    }
+}
+
+/// Wraps a filesystem failure into the stable skill storage error.
+fn operation_failed(error: std::io::Error) -> SkillPackageStoreError {
+    SkillPackageStoreError::OperationFailed(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LocalSkillPackageStore;
+    use crate::skill::ports::SkillPackageStore;
+    use ora_domain::SkillId;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const MANIFEST: &str = "---\nname: grilling\ndescription: Grill the user\n---\n";
+
+    #[test]
+    fn stages_files_then_promotes_them_into_a_committed_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path().join("atoms").join("skills");
+        fs::create_dir_all(&root).unwrap();
+        let store = LocalSkillPackageStore::new(root.clone());
+        let skill_id = SkillId::new("id-1");
+
+        store.create_staging(&skill_id).unwrap();
+        store
+            .write_file(
+                &skill_id,
+                std::path::Path::new("SKILL.md"),
+                MANIFEST.as_bytes(),
+            )
+            .unwrap();
+        store
+            .write_file(
+                &skill_id,
+                &std::path::Path::new("refs").join("util.py"),
+                b"noop",
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.read_manifest(&skill_id).unwrap(),
+            Some(MANIFEST.to_string())
+        );
+        assert_eq!(store.committed_exists("grilling").unwrap(), false);
+
+        store.promote(&skill_id, "grilling").unwrap();
+
+        assert_eq!(store.committed_exists("grilling").unwrap(), true);
+        assert_eq!(
+            fs::read_to_string(root.join("grilling").join("SKILL.md")).unwrap(),
+            MANIFEST
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("grilling").join("refs").join("util.py")).unwrap(),
+            "noop"
+        );
+        assert_eq!(root.join("id-1.tmp").exists(), false);
+        assert_eq!(
+            store.list_committed_names().unwrap(),
+            vec!["grilling".to_string()]
+        );
+    }
+
+    #[test]
+    fn promote_refuses_to_overwrite_an_existing_committed_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path().join("atoms").join("skills");
+        fs::create_dir_all(&root).unwrap();
+        let store = LocalSkillPackageStore::new(root);
+        let occupant = SkillId::new("id-1");
+        store.create_staging(&occupant).unwrap();
+        store
+            .write_file(
+                &occupant,
+                std::path::Path::new("SKILL.md"),
+                MANIFEST.as_bytes(),
+            )
+            .unwrap();
+        store.promote(&occupant, "grilling").unwrap();
+
+        let contender = SkillId::new("id-2");
+        store.create_staging(&contender).unwrap();
+        store
+            .write_file(
+                &contender,
+                std::path::Path::new("SKILL.md"),
+                MANIFEST.as_bytes(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.promote(&contender, "grilling"),
+            Err(
+                crate::skill::ports::SkillPackageStoreError::OperationFailed(
+                    "committed skill directory `grilling` already exists".to_string(),
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn removes_only_staging_directories_during_sweep() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path().join("atoms").join("skills");
+        fs::create_dir_all(&root).unwrap();
+        let store = LocalSkillPackageStore::new(root.clone());
+        let promoted = SkillId::new("id-1");
+        store.create_staging(&promoted).unwrap();
+        store
+            .write_file(
+                &promoted,
+                std::path::Path::new("SKILL.md"),
+                MANIFEST.as_bytes(),
+            )
+            .unwrap();
+        store.promote(&promoted, "grilling").unwrap();
+        store.create_staging(&SkillId::new("id-abandoned")).unwrap();
+
+        store.remove_all_staging().unwrap();
+
+        assert_eq!(root.join("id-abandoned.tmp").exists(), false);
+        assert_eq!(
+            store.list_committed_names().unwrap(),
+            vec!["grilling".to_string()]
+        );
+
+        store.remove_committed("grilling").unwrap();
+        assert_eq!(store.committed_exists("grilling").unwrap(), false);
+    }
+}

--- a/crates/application/src/skill/mod.rs
+++ b/crates/application/src/skill/mod.rs
@@ -1,8 +1,14 @@
 mod handlers;
 mod id_generator;
+mod import;
+mod local_store;
 mod mapper;
 mod ports;
+mod reconcile;
+mod validation;
 
+#[cfg(test)]
+mod import_tests;
 #[cfg(test)]
 mod tests;
 
@@ -10,4 +16,10 @@ pub use handlers::{
     CreateSkillHandler, DeleteSkillHandler, GetSkillHandler, ListSkillsHandler, UpdateSkillHandler,
 };
 pub use id_generator::UuidSkillIdGenerator;
-pub use ports::{SkillIdGenerator, SkillRepository, SkillRepositoryError};
+pub use import::{ImportSkillHandler, UploadedSkillFile};
+pub use local_store::LocalSkillPackageStore;
+pub use ports::{
+    SkillIdGenerator, SkillImportCommitError, SkillImportUnitOfWork, SkillPackageStore,
+    SkillPackageStoreError, SkillRepository, SkillRepositoryError,
+};
+pub use reconcile::ReconcileSkillStorageHandler;

--- a/crates/application/src/skill/ports.rs
+++ b/crates/application/src/skill/ports.rs
@@ -1,4 +1,5 @@
 use ora_domain::{Skill, SkillId};
+use std::path::Path;
 
 /// Defines persistence operations required by the skill CRUD use cases.
 pub trait SkillRepository {
@@ -32,4 +33,85 @@ pub trait SkillIdGenerator {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SkillRepositoryError {
     OperationFailed(String),
+}
+
+/// Owns the `atoms/skills` on-disk layout so import orchestration stays testable and hexagonal.
+///
+/// A skill is uploaded into an `<id>.tmp` staging directory keyed by its future identifier, then
+/// promoted to a committed `<name>` directory once its manifest is parsed. Implementations must
+/// keep those two directory shapes distinct because startup reconciliation relies on the `.tmp`
+/// suffix to identify never-committed staging left behind by a crash.
+pub trait SkillPackageStore {
+    /// Creates the empty `<id>.tmp` staging directory for a new import.
+    fn create_staging(&self, skill_id: &SkillId) -> Result<(), SkillPackageStoreError>;
+
+    /// Writes one uploaded file at `relative_path` inside the staging directory, creating parents.
+    fn write_file(
+        &self,
+        skill_id: &SkillId,
+        relative_path: &Path,
+        bytes: &[u8],
+    ) -> Result<(), SkillPackageStoreError>;
+
+    /// Reads the staged `SKILL.md` manifest contents, or `None` when the root has no manifest.
+    fn read_manifest(&self, skill_id: &SkillId) -> Result<Option<String>, SkillPackageStoreError>;
+
+    /// Reports whether a committed `<name>` directory already exists for a resolved skill name.
+    fn committed_exists(&self, name: &str) -> Result<bool, SkillPackageStoreError>;
+
+    /// Atomically renames the `<id>.tmp` staging directory to the committed `<name>` directory.
+    ///
+    /// Implementations must fail rather than overwrite when `<name>` already exists so a losing
+    /// concurrent import cannot clobber a committed skill.
+    fn promote(&self, skill_id: &SkillId, name: &str) -> Result<(), SkillPackageStoreError>;
+
+    /// Removes the `<id>.tmp` staging directory when an import is rolled back.
+    fn discard_staging(&self, skill_id: &SkillId) -> Result<(), SkillPackageStoreError>;
+
+    /// Removes the committed `<name>` directory; used by delete, commit compensation, and GC.
+    fn remove_committed(&self, name: &str) -> Result<(), SkillPackageStoreError>;
+
+    /// Removes every `*.tmp` staging directory, discarding crash-orphaned incomplete imports.
+    fn remove_all_staging(&self) -> Result<(), SkillPackageStoreError>;
+
+    /// Lists the names of committed (non-`.tmp`) skill directories for reconciliation.
+    fn list_committed_names(&self) -> Result<Vec<String>, SkillPackageStoreError>;
+}
+
+/// Represents skill filesystem failures exposed as stable application outcomes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillPackageStoreError {
+    OperationFailed(String),
+}
+
+/// Runs the durable commit step of a skill import as one SQLite transaction.
+///
+/// Implementations insert the skill row, invoke `on_inserted` while the transaction is still open,
+/// and commit only when it returns `Ok`. The `on_inserted` callback performs the filesystem
+/// promote (rename), so the database row and the on-disk directory are made durable together: any
+/// callback error rolls the row back, keeping "insert then rename then commit" atomic.
+pub trait SkillImportUnitOfWork {
+    /// Inserts `skill`, runs `on_inserted` inside the open transaction, and commits iff it succeeds.
+    fn insert_then<OnInserted>(
+        &self,
+        skill: Skill,
+        on_inserted: OnInserted,
+    ) -> Result<(), SkillImportCommitError>
+    where
+        OnInserted: FnOnce() -> Result<(), String>;
+}
+
+/// Distinguishes the failure points of the import commit so the caller can compensate correctly.
+///
+/// The variants tell the orchestrator which side effects already happened: whether the on-disk
+/// promote ran, and therefore whether it must discard the staging directory or remove a directory
+/// that was already promoted before the commit failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillImportCommitError {
+    /// The row insert failed before the promote ran; only staging needs discarding.
+    Insert { message: String },
+    /// The promote failed and the row was rolled back; staging still needs discarding.
+    Promote { message: String },
+    /// The promote succeeded but the commit failed; the promoted directory must be removed.
+    CommitAfterPromote { message: String },
 }

--- a/crates/application/src/skill/reconcile.rs
+++ b/crates/application/src/skill/reconcile.rs
@@ -1,0 +1,58 @@
+use crate::ApplicationError;
+use crate::skill::ports::{SkillPackageStore, SkillPackageStoreError, SkillRepository};
+use std::collections::HashSet;
+
+/// Reconciles the `atoms/skills` directory against the skill catalog during startup.
+///
+/// A hard crash can leave two kinds of debris that in-process rollback never got to clean: an
+/// incomplete `<id>.tmp` staging directory, or a `<name>` directory that was promoted just before
+/// its commit landed. This handler discards every staging directory and removes any committed
+/// directory that no visible skill row claims, restoring the "roll back leaves the folder clean"
+/// guarantee after a crash.
+pub struct ReconcileSkillStorageHandler<Store, Repository> {
+    store: Store,
+    repository: Repository,
+}
+
+impl<Store, Repository> ReconcileSkillStorageHandler<Store, Repository> {
+    /// Builds the reconciliation handler from its filesystem and catalog ports.
+    pub fn new(store: Store, repository: Repository) -> Self {
+        Self { store, repository }
+    }
+}
+
+impl<Store, Repository> ReconcileSkillStorageHandler<Store, Repository>
+where
+    Store: SkillPackageStore,
+    Repository: SkillRepository,
+{
+    /// Sweeps staging debris and orphaned committed directories not backed by a visible skill.
+    pub fn handle(&self) -> Result<(), ApplicationError> {
+        self.store.remove_all_staging().map_err(storage_error)?;
+
+        let visible_names: HashSet<String> = self
+            .repository
+            .list_skills()
+            .map_err(ApplicationError::from_skill_repository_error)?
+            .into_iter()
+            .map(|skill| skill.name)
+            .collect();
+
+        for name in self.store.list_committed_names().map_err(storage_error)? {
+            if !visible_names.contains(&name) {
+                self.store.remove_committed(&name).map_err(storage_error)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Maps skill filesystem failures onto the stable storage application error.
+fn storage_error(error: SkillPackageStoreError) -> ApplicationError {
+    match error {
+        SkillPackageStoreError::OperationFailed(message) => {
+            ApplicationError::SkillPackageStorage { message }
+        }
+    }
+}

--- a/crates/application/src/skill/tests.rs
+++ b/crates/application/src/skill/tests.rs
@@ -1,12 +1,13 @@
 use super::{
-    CreateSkillHandler, DeleteSkillHandler, GetSkillHandler, SkillIdGenerator, SkillRepository,
-    SkillRepositoryError, UpdateSkillHandler,
+    CreateSkillHandler, DeleteSkillHandler, GetSkillHandler, SkillIdGenerator, SkillPackageStore,
+    SkillPackageStoreError, SkillRepository, SkillRepositoryError, UpdateSkillHandler,
 };
 use crate::{ApplicationError, Clock};
 use ora_contracts::{CreateSkillRequest, DeleteSkillRequest, GetSkillRequest, UpdateSkillRequest};
 use ora_domain::{AuditFields, Skill, SkillId};
 use pretty_assertions::assert_eq;
 use std::cell::RefCell;
+use std::path::Path;
 use std::rc::Rc;
 
 #[test]
@@ -102,7 +103,7 @@ fn soft_delete_hides_a_skill_by_id() {
     let repository = Rc::new(FakeSkillRepository::with_skills(vec![skill(
         "skill-1", "review", "Reviews", 1, 1, false,
     )]));
-    DeleteSkillHandler::new(repository.clone(), FixedClock(2))
+    DeleteSkillHandler::new(repository.clone(), NoopSkillPackageStore, FixedClock(2))
         .handle(DeleteSkillRequest {
             skill_id: "skill-1".to_string(),
         })
@@ -227,5 +228,42 @@ struct FixedClock(i64);
 impl Clock for FixedClock {
     fn now_timestamp_millis(&self) -> i64 {
         self.0
+    }
+}
+
+/// Skill package store that performs no filesystem work for CRUD tests that ignore on-disk folders.
+struct NoopSkillPackageStore;
+impl SkillPackageStore for NoopSkillPackageStore {
+    fn create_staging(&self, _skill_id: &SkillId) -> Result<(), SkillPackageStoreError> {
+        Ok(())
+    }
+    fn write_file(
+        &self,
+        _skill_id: &SkillId,
+        _relative_path: &Path,
+        _bytes: &[u8],
+    ) -> Result<(), SkillPackageStoreError> {
+        Ok(())
+    }
+    fn read_manifest(&self, _skill_id: &SkillId) -> Result<Option<String>, SkillPackageStoreError> {
+        Ok(None)
+    }
+    fn committed_exists(&self, _name: &str) -> Result<bool, SkillPackageStoreError> {
+        Ok(false)
+    }
+    fn promote(&self, _skill_id: &SkillId, _name: &str) -> Result<(), SkillPackageStoreError> {
+        Ok(())
+    }
+    fn discard_staging(&self, _skill_id: &SkillId) -> Result<(), SkillPackageStoreError> {
+        Ok(())
+    }
+    fn remove_committed(&self, _name: &str) -> Result<(), SkillPackageStoreError> {
+        Ok(())
+    }
+    fn remove_all_staging(&self) -> Result<(), SkillPackageStoreError> {
+        Ok(())
+    }
+    fn list_committed_names(&self) -> Result<Vec<String>, SkillPackageStoreError> {
+        Ok(Vec::new())
     }
 }

--- a/crates/application/src/skill/validation.rs
+++ b/crates/application/src/skill/validation.rs
@@ -1,0 +1,132 @@
+use gray_matter::Matter;
+use gray_matter::engine::YAML;
+use serde::Deserialize;
+use std::path::{Component, Path, PathBuf};
+
+/// Names the manifest file every uploaded skill folder must carry at its root.
+pub(crate) const SKILL_MANIFEST_FILE: &str = "SKILL.md";
+
+/// Carries the manifest fields parsed from the uploaded skill's `SKILL.md` front matter.
+///
+/// Unknown keys are ignored so richer skill manifests still import; only the two fields the skill
+/// catalog persists are required here.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub(crate) struct SkillManifest {
+    pub(crate) name: String,
+    pub(crate) description: String,
+}
+
+/// Normalizes an uploaded file path into a safe in-package relative path, or `None` when unsafe.
+///
+/// Only `Normal` components are accepted so absolute paths, `..` traversal, `.` segments, and
+/// drive prefixes can never escape the staging directory or collide with the `.tmp`/committed
+/// directory layout the store depends on.
+pub(crate) fn normalize_relative_path(raw: &str) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in Path::new(raw).components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::Prefix(_)
+            | Component::RootDir
+            | Component::CurDir
+            | Component::ParentDir => return None,
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+/// Reports whether a resolved skill name is a single safe directory segment.
+///
+/// The committed directory is named after the skill, so the name must be usable as one path
+/// segment: restricting it to an ASCII slug alphabet and rejecting the `.`/`..` special segments
+/// keeps the promote target inside `atoms/skills`.
+pub(crate) fn is_safe_skill_name(name: &str) -> bool {
+    if name.is_empty() || name == "." || name == ".." {
+        return false;
+    }
+
+    name.chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-'))
+}
+
+/// Parses the skill manifest front matter and returns its trimmed name and description.
+///
+/// Returns a human-readable reason string on any failure — absent front matter, malformed YAML, or
+/// blank required fields — so the caller can surface it as one validation error.
+pub(crate) fn parse_skill_manifest(contents: &str) -> Result<SkillManifest, String> {
+    let matter = Matter::<YAML>::new();
+    let parsed = matter
+        .parse::<SkillManifest>(contents)
+        .map_err(|error| format!("SKILL.md front matter is not valid YAML: {error}"))?;
+    let manifest = parsed
+        .data
+        .ok_or_else(|| "SKILL.md must define name and description front matter".to_string())?;
+    let name = manifest.name.trim().to_string();
+    let description = manifest.description.trim().to_string();
+
+    if name.is_empty() {
+        return Err("SKILL.md front matter name must not be blank".to_string());
+    }
+    if description.is_empty() {
+        return Err("SKILL.md front matter description must not be blank".to_string());
+    }
+
+    Ok(SkillManifest { name, description })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_safe_skill_name, normalize_relative_path, parse_skill_manifest};
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    #[test]
+    fn normalizes_safe_nested_paths_and_rejects_traversal() {
+        assert_eq!(
+            normalize_relative_path("refs/util.py"),
+            Some(PathBuf::from("refs").join("util.py"))
+        );
+        assert_eq!(
+            normalize_relative_path("SKILL.md"),
+            Some(PathBuf::from("SKILL.md"))
+        );
+        assert_eq!(normalize_relative_path(""), None);
+        assert_eq!(normalize_relative_path("../escape"), None);
+        assert_eq!(normalize_relative_path("/etc/passwd"), None);
+        assert_eq!(normalize_relative_path("./here"), None);
+    }
+
+    #[test]
+    fn accepts_slug_names_and_rejects_unsafe_ones() {
+        assert_eq!(is_safe_skill_name("code-review"), true);
+        assert_eq!(is_safe_skill_name("skill.v2_final"), true);
+        assert_eq!(is_safe_skill_name("review / guide"), false);
+        assert_eq!(is_safe_skill_name(".."), false);
+        assert_eq!(is_safe_skill_name("."), false);
+        assert_eq!(is_safe_skill_name(""), false);
+    }
+
+    #[test]
+    fn parses_manifest_and_reports_blank_or_missing_fields() {
+        let manifest =
+            parse_skill_manifest("---\nname: grilling\ndescription: Grill the user\n---\nbody")
+                .unwrap();
+        assert_eq!(
+            (manifest.name, manifest.description),
+            ("grilling".to_string(), "Grill the user".to_string())
+        );
+        assert_eq!(
+            parse_skill_manifest("no front matter here"),
+            Err("SKILL.md must define name and description front matter".to_string())
+        );
+        assert_eq!(
+            parse_skill_manifest("---\nname: grilling\ndescription: \"  \"\n---\n"),
+            Err("SKILL.md front matter description must not be blank".to_string())
+        );
+    }
+}

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -6,8 +6,12 @@ use crate::project::ProjectApi;
 use crate::session::SessionApi;
 use crate::skill::SkillApi;
 use crate::task::TaskApi;
+use ora_application::{LocalSkillPackageStore, ReconcileSkillStorageHandler, UploadedSkillFile};
 use ora_contracts::*;
-use ora_db::{DatabaseBootstrapper, DatabaseLocation, RepositoryPool, default_migration_catalog};
+use ora_db::{
+    DatabaseBootstrapper, DatabaseLocation, RepositoryPool, SqliteSkillRepository,
+    default_migration_catalog,
+};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -32,6 +36,8 @@ pub enum BackendBootstrapError {
     },
     #[error("failed to bootstrap backend database")]
     Database(#[source] ora_db::DatabaseError),
+    #[error("failed to reconcile skill storage: {0}")]
+    SkillStorage(String),
     #[error("failed to initialize agent runtime")]
     AgentRuntime(#[source] BackendError),
 }
@@ -67,13 +73,14 @@ impl Backend {
         let worktree_root = Arc::new(RwLock::new(paths.worktree_root));
         let agent_runtime = AgentRuntimeManager::new(pool.clone(), paths.home_directory, clock)
             .map_err(BackendBootstrapError::AgentRuntime)?;
+        let skill_store = prepare_skill_storage(&paths.database_path, &pool)?;
 
         Ok(Self {
             project: Arc::new(ProjectApi::new(pool.clone(), clock)),
             task: Arc::new(TaskApi::new(pool.clone(), worktree_root.clone(), clock)),
             session: Arc::new(SessionApi::new(pool.clone())),
             agent_runtime: Arc::new(agent_runtime),
-            skill: Arc::new(SkillApi::new(pool.clone(), clock)),
+            skill: Arc::new(SkillApi::new(pool.clone(), clock, skill_store)),
             agent: Arc::new(AgentApi::new(pool.clone(), clock)),
             pool,
             worktree_root,
@@ -266,6 +273,13 @@ impl Backend {
     ) -> Result<DeleteSkillResponse, BackendError> {
         self.skill.delete(request).map_err(BackendError::from)
     }
+    /// Imports one uploaded skill folder atomically through the shared application composition.
+    pub fn import_skill(
+        &self,
+        files: Vec<UploadedSkillFile>,
+    ) -> Result<CreateSkillResponse, BackendError> {
+        self.skill.import(files).map_err(BackendError::from)
+    }
 
     /// Creates one configurable agent through the shared application composition.
     pub fn create_agent(
@@ -299,6 +313,37 @@ impl Backend {
     ) -> Result<DeleteAgentResponse, BackendError> {
         self.agent.delete(request).map_err(BackendError::from)
     }
+}
+
+/// Creates the skill storage root, then reconciles it so startup begins from a clean layout.
+///
+/// Reconciliation runs while the backend is still opening so any crash-orphaned staging or
+/// promoted-but-uncommitted directory is gone before the first import can observe the filesystem.
+fn prepare_skill_storage(
+    database_path: &Path,
+    pool: &RepositoryPool,
+) -> Result<LocalSkillPackageStore, BackendBootstrapError> {
+    let skills_directory = skills_storage_dir(database_path);
+    ensure_directory(&skills_directory)?;
+    let store = LocalSkillPackageStore::new(skills_directory);
+
+    ReconcileSkillStorageHandler::new(store.clone(), SqliteSkillRepository::new(pool.clone()))
+        .handle()
+        .map_err(|error| BackendBootstrapError::SkillStorage(error.to_string()))?;
+
+    Ok(store)
+}
+
+/// Derives the `atoms/skills` root from the configured SQLite database location.
+///
+/// The database sits directly under the runtime data directory, so its parent is the data root
+/// that every derived path (worktrees, skills) hangs off of.
+fn skills_storage_dir(database_path: &Path) -> PathBuf {
+    database_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("atoms")
+        .join("skills")
 }
 
 /// Creates one required runtime directory and preserves its exact failing path.

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -8,6 +8,7 @@ pub enum BackendErrorKind {
     BadRequest,
     NotFound,
     Conflict,
+    Unprocessable,
     Internal,
 }
 
@@ -73,6 +74,20 @@ impl From<ApplicationError> for BackendError {
             ApplicationError::SkillRepository { .. } => internal(
                 "skill_repository_error",
                 "skill repository operation failed",
+            ),
+            ApplicationError::SkillImportInvalid { reason } => Self::new(
+                BackendErrorKind::Unprocessable,
+                "skill_import_invalid",
+                reason,
+            ),
+            ApplicationError::SkillFolderConflict { name } => Self::new(
+                BackendErrorKind::Conflict,
+                "skill_folder_conflict",
+                format!("skill folder already exists: {name}"),
+            ),
+            ApplicationError::SkillPackageStorage { .. } => internal(
+                "skill_package_storage_error",
+                "skill package storage operation failed",
             ),
             ApplicationError::AgentDefinitionNameBlank => Self::new(
                 BackendErrorKind::BadRequest,

--- a/crates/backend/src/skill.rs
+++ b/crates/backend/src/skill.rs
@@ -1,14 +1,15 @@
 use crate::clock::SystemClock;
 use ora_application::{
-    ApplicationError, CreateSkillHandler, DeleteSkillHandler, GetSkillHandler, ListSkillsHandler,
-    UpdateSkillHandler, UuidSkillIdGenerator,
+    ApplicationError, CreateSkillHandler, DeleteSkillHandler, GetSkillHandler, ImportSkillHandler,
+    ListSkillsHandler, LocalSkillPackageStore, UpdateSkillHandler, UploadedSkillFile,
+    UuidSkillIdGenerator,
 };
 use ora_contracts::{
     CreateSkillRequest, CreateSkillResponse, DeleteSkillRequest, DeleteSkillResponse,
     GetSkillRequest, GetSkillResponse, ListSkillsRequest, ListSkillsResponse, UpdateSkillRequest,
     UpdateSkillResponse,
 };
-use ora_db::{RepositoryPool, SqliteSkillRepository};
+use ora_db::{RepositoryPool, SqliteSkillImportUnitOfWork, SqliteSkillRepository};
 
 /// Groups the concrete skill handlers shared by runtime adapters.
 pub(crate) struct SkillApi {
@@ -16,20 +17,36 @@ pub(crate) struct SkillApi {
     get: GetSkillHandler<SqliteSkillRepository>,
     list: ListSkillsHandler<SqliteSkillRepository>,
     update: UpdateSkillHandler<SqliteSkillRepository, SystemClock>,
-    delete: DeleteSkillHandler<SqliteSkillRepository, SystemClock>,
+    delete: DeleteSkillHandler<SqliteSkillRepository, LocalSkillPackageStore, SystemClock>,
+    import: ImportSkillHandler<
+        LocalSkillPackageStore,
+        SqliteSkillImportUnitOfWork,
+        UuidSkillIdGenerator,
+        SystemClock,
+    >,
 }
 
 impl SkillApi {
-    /// Builds skill handlers from the shared repository pool.
-    pub(crate) fn new(pool: RepositoryPool, clock: SystemClock) -> Self {
-        let repository = SqliteSkillRepository::new(pool);
+    /// Builds skill handlers from the shared repository pool and the skill package store.
+    pub(crate) fn new(
+        pool: RepositoryPool,
+        clock: SystemClock,
+        store: LocalSkillPackageStore,
+    ) -> Self {
+        let repository = SqliteSkillRepository::new(pool.clone());
 
         Self {
             create: CreateSkillHandler::new(repository.clone(), UuidSkillIdGenerator::new(), clock),
             get: GetSkillHandler::new(repository.clone()),
             list: ListSkillsHandler::new(repository.clone()),
             update: UpdateSkillHandler::new(repository.clone(), clock),
-            delete: DeleteSkillHandler::new(repository, clock),
+            delete: DeleteSkillHandler::new(repository, store.clone(), clock),
+            import: ImportSkillHandler::new(
+                store,
+                SqliteSkillImportUnitOfWork::new(pool),
+                UuidSkillIdGenerator::new(),
+                clock,
+            ),
         }
     }
 
@@ -71,5 +88,13 @@ impl SkillApi {
         request: DeleteSkillRequest,
     ) -> Result<DeleteSkillResponse, ApplicationError> {
         self.delete.handle(request)
+    }
+
+    /// Executes one atomic skill folder import through the application handler.
+    pub(crate) fn import(
+        &self,
+        files: Vec<UploadedSkillFile>,
+    ) -> Result<CreateSkillResponse, ApplicationError> {
+        self.import.handle(files)
     }
 }

--- a/crates/contracts/src/frontend.rs
+++ b/crates/contracts/src/frontend.rs
@@ -84,6 +84,8 @@ pub const SESSION_PERMISSION_RESPONSE_PATH: &str = "/api/sessions/{sessionId}/pe
 pub const SESSION_STOP_PATH: &str = "/api/sessions/{sessionId}/stop";
 pub const SKILLS_PATH: &str = "/api/skills";
 pub const SKILL_PATH: &str = "/api/skills/{skillId}";
+/// Uploads a local skill folder as a multipart request that the backend commits atomically.
+pub const SKILL_IMPORT_PATH: &str = "/api/skills/import";
 pub const AGENTS_PATH: &str = "/api/agents";
 pub const AGENT_PATH: &str = "/api/agents/{agentId}";
 pub const FILE_SYSTEM_DIRECTORY_PATH: &str = "/api/file-system/directory";

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -23,8 +23,8 @@ pub use frontend::{
     FrontendPathParam, FrontendQueryParam, FrontendResponseMode, PROJECT_PATH,
     PROJECT_WORK_CONTEXT_OPEN_PATH, PROJECT_WORK_CONTEXT_RENEW_PATH, PROJECTS_PATH,
     SESSION_LOAD_PATH, SESSION_PATH, SESSION_PERMISSION_RESPONSE_PATH, SESSION_PROMPT_PATH,
-    SESSION_STOP_PATH, SESSIONS_PATH, SKILL_PATH, SKILLS_PATH, TASK_PATH, TASKS_PATH,
-    frontend_endpoints,
+    SESSION_STOP_PATH, SESSIONS_PATH, SKILL_IMPORT_PATH, SKILL_PATH, SKILLS_PATH, TASK_PATH,
+    TASKS_PATH, frontend_endpoints,
 };
 pub use project::{
     CreateProjectRequest, CreateProjectResponse, DeleteProjectRequest, DeleteProjectResponse,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -17,6 +17,7 @@ pub use migration::{AppliedMigration, Migration, MigrationCatalog, default_migra
 pub use repository::{
     CascadeDeleteOutcome, RepositoryPool, SqliteAgentDefinitionRepository, SqliteCascadeRepository,
     SqliteProjectRepository, SqliteProjectWorkContextRepository, SqliteSessionRepository,
-    SqliteSkillRepository, SqliteTaskRepository, SqliteWorktreeRepository,
+    SqliteSkillImportUnitOfWork, SqliteSkillRepository, SqliteTaskRepository,
+    SqliteWorktreeRepository,
 };
 pub use time::{SystemTimestampSource, TimestampSource};

--- a/crates/db/src/repository/connection.rs
+++ b/crates/db/src/repository/connection.rs
@@ -32,6 +32,20 @@ impl RepositoryPool {
 
         operation(&connection)
     }
+
+    /// Runs one operation with a mutable pooled connection so callers can drive an explicit transaction.
+    ///
+    /// Repositories that commit per statement use `with_connection`; this variant exists for use
+    /// cases that must interleave non-database work between an insert and its commit, such as the
+    /// skill import promoting a directory before the transaction is allowed to commit.
+    pub(crate) fn with_connection_mut<T>(
+        &self,
+        operation: impl FnOnce(&mut Connection) -> Result<T, crate::DatabaseError>,
+    ) -> Result<T, DatabaseError> {
+        let mut connection = self.inner.get()?;
+
+        operation(&mut connection)
+    }
 }
 
 /// Opens and validates SQLite connections for the repository pool.

--- a/crates/db/src/repository/mod.rs
+++ b/crates/db/src/repository/mod.rs
@@ -5,6 +5,7 @@ mod project;
 mod project_work_context;
 mod session;
 mod skill;
+mod skill_import;
 mod task;
 mod worktree;
 
@@ -15,5 +16,6 @@ pub use project::SqliteProjectRepository;
 pub use project_work_context::SqliteProjectWorkContextRepository;
 pub use session::SqliteSessionRepository;
 pub use skill::SqliteSkillRepository;
+pub use skill_import::SqliteSkillImportUnitOfWork;
 pub use task::SqliteTaskRepository;
 pub use worktree::SqliteWorktreeRepository;

--- a/crates/db/src/repository/skill.rs
+++ b/crates/db/src/repository/skill.rs
@@ -19,13 +19,12 @@ impl SqliteSkillRepository {
 
 impl SkillRepository for SqliteSkillRepository {
     fn create_skill(&self, skill: Skill) -> Result<Skill, SkillRepositoryError> {
-        self.pool.with_connection(|connection| {
-            connection.execute(
-                "INSERT INTO skills (id, name, description, created_at, updated_at, is_deleted) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                params![skill.id.to_string(), &skill.name, &skill.description, skill.audit_fields.created_at, skill.audit_fields.updated_at, bool_to_sqlite(skill.audit_fields.is_deleted)],
-            )?;
-            Ok(skill)
-        }).map_err(skill_repository_error_from_database)
+        self.pool
+            .with_connection(|connection| {
+                insert_skill_row(connection, &skill)?;
+                Ok(skill)
+            })
+            .map_err(skill_repository_error_from_database)
     }
 
     fn find_skill(&self, skill_id: &SkillId) -> Result<Option<Skill>, SkillRepositoryError> {
@@ -78,6 +77,29 @@ impl SkillRepository for SqliteSkillRepository {
             ).map(|rows| rows > 0).map_err(Into::into)
         }).map_err(skill_repository_error_from_database)
     }
+}
+
+/// Inserts one skill row on the given connection, shared by the repository and the import unit of work.
+///
+/// Centralizing the statement keeps the per-statement create path and the transactional import path
+/// writing identical columns, so the two insertion routes cannot drift apart.
+pub(crate) fn insert_skill_row(
+    connection: &rusqlite::Connection,
+    skill: &Skill,
+) -> Result<(), rusqlite::Error> {
+    connection.execute(
+        "INSERT INTO skills (id, name, description, created_at, updated_at, is_deleted) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            skill.id.to_string(),
+            &skill.name,
+            &skill.description,
+            skill.audit_fields.created_at,
+            skill.audit_fields.updated_at,
+            bool_to_sqlite(skill.audit_fields.is_deleted),
+        ],
+    )?;
+
+    Ok(())
 }
 
 /// Reconstructs a domain skill from a selected SQLite row.

--- a/crates/db/src/repository/skill_import.rs
+++ b/crates/db/src/repository/skill_import.rs
@@ -1,0 +1,64 @@
+use ora_application::{SkillImportCommitError, SkillImportUnitOfWork};
+use ora_domain::Skill;
+
+use super::RepositoryPool;
+use super::skill::insert_skill_row;
+
+/// Commits a skill import as one SQLite transaction spanning the row insert and directory promote.
+///
+/// The transaction stays open across the caller-provided promote so the row only becomes durable
+/// once the directory rename has succeeded; any promote error rolls the insert back untouched.
+#[derive(Clone, Debug)]
+pub struct SqliteSkillImportUnitOfWork {
+    pool: RepositoryPool,
+}
+
+impl SqliteSkillImportUnitOfWork {
+    /// Builds the import unit of work from the shared SQLite connection pool.
+    pub fn new(pool: RepositoryPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl SkillImportUnitOfWork for SqliteSkillImportUnitOfWork {
+    fn insert_then<OnInserted>(
+        &self,
+        skill: Skill,
+        on_inserted: OnInserted,
+    ) -> Result<(), SkillImportCommitError>
+    where
+        OnInserted: FnOnce() -> Result<(), String>,
+    {
+        // The inner `Result` carries the import outcome; the outer `DatabaseError` only covers pool
+        // checkout and `BEGIN`, both of which precede any promote and are therefore insert-phase.
+        let outcome = self.pool.with_connection_mut(|connection| {
+            let transaction = connection.transaction()?;
+            if let Err(error) = insert_skill_row(&transaction, &skill) {
+                return Ok(Err(SkillImportCommitError::Insert {
+                    message: error.to_string(),
+                }));
+            }
+
+            match on_inserted() {
+                Ok(()) => match transaction.commit() {
+                    Ok(()) => Ok(Ok(())),
+                    Err(error) => Ok(Err(SkillImportCommitError::CommitAfterPromote {
+                        message: error.to_string(),
+                    })),
+                },
+                Err(message) => {
+                    // Dropping the transaction rolls the insert back so no row is ever committed.
+                    drop(transaction);
+                    Ok(Err(SkillImportCommitError::Promote { message }))
+                }
+            }
+        });
+
+        match outcome {
+            Ok(inner) => inner,
+            Err(error) => Err(SkillImportCommitError::Insert {
+                message: error.to_string(),
+            }),
+        }
+    }
+}

--- a/crates/db/src/repository_tests.rs
+++ b/crates/db/src/repository_tests.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 
 use ora_application::{
     AgentDefinitionRepository, ProjectRepository, ProjectRepositoryError,
-    ProjectWorkContextRepository, SessionRepository, SessionRepositoryError, SkillRepository,
-    TaskRepository, TaskRepositoryError, WorktreeRepository, WorktreeRepositoryError,
+    ProjectWorkContextRepository, SessionRepository, SessionRepositoryError,
+    SkillImportCommitError, SkillImportUnitOfWork, SkillRepository, TaskRepository,
+    TaskRepositoryError, WorktreeRepository, WorktreeRepositoryError,
 };
 use ora_domain::{
     AgentCli, AgentDefinition, AgentDefinitionId, AuditFields, Project, ProjectId,
@@ -18,8 +19,9 @@ use tempfile::TempDir;
 use crate::{
     CascadeDeleteOutcome, DatabaseBootstrapper, DatabaseLocation, RepositoryPool,
     SqliteAgentDefinitionRepository, SqliteCascadeRepository, SqliteProjectRepository,
-    SqliteProjectWorkContextRepository, SqliteSessionRepository, SqliteSkillRepository,
-    SqliteTaskRepository, SqliteWorktreeRepository, TimestampSource, default_migration_catalog,
+    SqliteProjectWorkContextRepository, SqliteSessionRepository, SqliteSkillImportUnitOfWork,
+    SqliteSkillRepository, SqliteTaskRepository, SqliteWorktreeRepository, TimestampSource,
+    default_migration_catalog,
 };
 
 /// Verifies catalog repositories use stable identifiers and hide soft-deleted rows.
@@ -108,6 +110,42 @@ fn catalog_repositories_support_id_based_crud_and_allow_duplicate_names() {
             .soft_delete_agent_definition(&AgentDefinitionId::new("missing"), 4)
             .unwrap(),
         false
+    );
+}
+
+/// Verifies the import unit of work commits the row only when the promote callback succeeds.
+#[test]
+fn skill_import_unit_of_work_commits_on_success_and_rolls_back_on_promote_failure() {
+    let (_temp_dir, pool) = bootstrapped_repository_pool();
+    let unit_of_work = SqliteSkillImportUnitOfWork::new(pool.clone());
+    let repository = SqliteSkillRepository::new(pool);
+    let committed = skill("skill-commit", "grilling", "Grill", 1, 1, false);
+    let rolled_back = skill("skill-rollback", "probe", "Probe", 2, 2, false);
+
+    unit_of_work
+        .insert_then(committed.clone(), || Ok(()))
+        .unwrap();
+    let rollback = unit_of_work
+        .insert_then(rolled_back, || Err("promote failed".to_string()))
+        .unwrap_err();
+
+    assert_eq!(
+        rollback,
+        SkillImportCommitError::Promote {
+            message: "promote failed".to_string(),
+        }
+    );
+    assert_eq!(
+        repository
+            .find_skill(&SkillId::new("skill-commit"))
+            .unwrap(),
+        Some(committed)
+    );
+    assert_eq!(
+        repository
+            .find_skill(&SkillId::new("skill-rollback"))
+            .unwrap(),
+        None
     );
 }
 

--- a/docs/web-server-runtime.md
+++ b/docs/web-server-runtime.md
@@ -21,6 +21,7 @@ Startup asks `ora-backend` to bootstrap the database, apply the active migration
 
 - SQLite database path: `<ORA_DATA_DIR>/ora.sqlite3`
 - Worktree root: `<ORA_DATA_DIR>/worktrees`
+- Imported skill folders: `<ORA_DATA_DIR>/atoms/skills`
 - Log file: `<ORA_DATA_DIR>/logs/ora.log`
 
 ## Project Configuration
@@ -87,6 +88,7 @@ The persisted runtime exposes CRUD routes for the supported public models:
 - `GET /api/skills/{skill_id}`
 - `PUT /api/skills/{skill_id}`
 - `DELETE /api/skills/{skill_id}`
+- `POST /api/skills/import`
 - `POST /api/agents`
 - `GET /api/agents`
 - `GET /api/agents/{agent_id}`
@@ -100,6 +102,26 @@ Task payloads do not expose backend-owned worktree identifiers, and the runtime 
 Session create starts `<home>/.opencode/bin/opencode acp`, `<home>/.nga/bin/nga acp`, or `<home>/.codeagentcli/bin/codeagentcli acp` according to the immutable `agentCli`. The server performs `initialize` and `session/new` before persisting. Load performs a fresh `initialize` followed by `session/load` using the private provider session id. The public Session payload never exposes that id.
 
 Load and prompt responses use `application/x-ndjson`. Each line is one complete frame. Data and control paths are separate, session-update queues are bounded at 256 items, frames are limited to 8 MiB, and overflow terminates the operation rather than dropping updates silently.
+
+### Skill Folder Import
+
+`POST /api/skills/import` uploads a local skill folder as one `multipart/form-data` request. Each
+file part carries its skill-root-relative path as the part file name, and the request body is capped
+at 50 MB (oversized uploads return `413`, uploads over 1000 files return `422`).
+
+The import is atomic across the filesystem and the database:
+
+- Files stream into a staging directory `<ORA_DATA_DIR>/atoms/skills/<uuid>.tmp`, where `<uuid>` is
+  the skill's future identifier.
+- The staged `SKILL.md` front matter supplies the skill `name` and `description`; the committed
+  directory is named after that resolved `name`.
+- The row insert, the staging→`<name>` directory rename, and the transaction commit run as one unit
+  of work, so a failure at any point leaves neither a committed row nor a promoted directory.
+- Validation failures return `422`, and importing a folder whose resolved name already has a
+  committed directory returns `409`.
+- Deleting a skill also removes its committed directory. Startup reconciliation discards leftover
+  `*.tmp` staging directories and any committed directory not backed by a visible skill row,
+  restoring a clean layout after a crash.
 
 The project work context routes provide the current backend-managed project selection surface.
 


### PR DESCRIPTION
Add POST /api/skills/import to upload a local skill folder as one multipart request and commit it atomically across the filesystem and the database.

Files stream into an `atoms/skills/<uuid>.tmp` staging directory, the staged SKILL.md front matter resolves the skill name and description, then a unit of work inserts the row, renames staging to the committed `<name>` directory, and commits together — so a failure at any point leaves neither a row nor a promoted directory. Startup reconciliation discards `*.tmp` staging and any committed directory not backed by a visible skill row, and skill deletion now removes its committed folder.

Keep the orchestration hexagonal: a SkillPackageStore port with a local filesystem adapter, a SkillImportUnitOfWork closure port whose SQLite adapter holds the transaction open across the directory promote, and folder/manifest validation, all under crates/application/src/skill. Guard uploads with a 50MB body limit, a 1000-file cap, safe-name and safe-path checks, and empty/duplicate-path rejection, mapping failures to 422/409/413 responses.