### PR TITLE
feat(diff): refine review controls and comments

### DIFF
--- a/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
+++ b/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { PlatformProvider, type PlatformAdapter } from "@ora/platform";
+import { PlatformProvider } from "@ora/platform";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { AppI18nProvider } from "../../i18n/i18n";
@@ -9,30 +9,19 @@ import { TaskChangesLayout } from "./task-changes-layout";
 
 vi.mock("./task-diff-view", () => ({
   TaskDiffView: ({ toolbar }: { toolbar?: ReactNode }) => (
-    <section aria-label="Task diff">{toolbar}</section>
+    <section aria-label="Task diff">
+      <header data-diff-toolbar>
+        <button type="button">Commit</button>
+        {toolbar}
+      </header>
+    </section>
   ),
 }));
 
-/** Creates a desktop platform adapter without invoking real window commands. */
-function desktopPlatform(): PlatformAdapter {
-  return {
-    ...createStubPlatform(),
-    windowControls: {
-      kind: "overlay",
-      os: "windows",
-      minimize: vi.fn(),
-      toggleMaximize: vi.fn(),
-      close: vi.fn(),
-      isMaximized: vi.fn().mockResolvedValue(false),
-      subscribeMaximized: vi.fn().mockReturnValue(() => undefined),
-    },
-  };
-}
-
 describe("TaskChangesLayout", () => {
-  it("reserves the desktop caption-button area for the Changes trigger", () => {
+  it("positions the closed Changes trigger at the diff-toolbar coordinates", () => {
     render(
-      <PlatformProvider adapter={desktopPlatform()}>
+      <PlatformProvider adapter={createStubPlatform()}>
         <AppI18nProvider>
           <TaskChangesLayout taskId="task-1">
             <main>Workspace</main>
@@ -41,14 +30,15 @@ describe("TaskChangesLayout", () => {
       </PlatformProvider>,
     );
 
-    expect(screen.getByRole("group", { name: /变更|Changes/ }).parentElement)
-      .toHaveClass("right-56");
+    expect(
+      screen.getByRole("group", { name: /变更|Changes/ }).parentElement,
+    ).toHaveClass("right-4", "top-2");
   });
 
-  it("moves the Changes controls into the diff header after opening", async () => {
+  it("moves the Changes controls beside Commit after opening", async () => {
     const user = userEvent.setup();
     render(
-      <PlatformProvider adapter={desktopPlatform()}>
+      <PlatformProvider adapter={createStubPlatform()}>
         <AppI18nProvider>
           <TaskChangesLayout taskId="task-1">
             <main>Workspace</main>
@@ -59,9 +49,17 @@ describe("TaskChangesLayout", () => {
 
     await user.click(screen.getByRole("button", { name: /变更|Changes/ }));
 
-    const diff = screen.getByRole("region", { name: "Task diff" });
-    expect(diff).toContainElement(screen.getByRole("group", { name: /变更|Changes/ }));
-    expect(screen.getByRole("group", { name: /变更|Changes/ }).parentElement)
-      .toBe(diff);
+    const toolbar = document.querySelector("[data-diff-toolbar]");
+    expect(toolbar).toContainElement(
+      screen.getByRole("button", { name: "Commit" }),
+    );
+    expect(toolbar).toContainElement(
+      screen.getByRole("group", { name: /变更|Changes/ }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: /显示或隐藏变更文件目录|toggle file tree/i,
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/features/diff/task-changes-layout.tsx
+++ b/packages/app-shell/src/features/diff/task-changes-layout.tsx
@@ -9,11 +9,11 @@ import {
   IconArrowsMaximize,
   IconArrowsMinimize,
   IconColumns2,
-  IconFiles,
   IconGitBranch,
+  IconLayoutSidebarRightCollapse,
+  IconLayoutSidebarRightExpand,
 } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
-import { usePlatform } from "@ora/platform";
 import { TaskDiffView, type TaskDiffViewType } from "./task-diff-view";
 
 const EXPANDED_PANEL_EXIT_MS = 180;
@@ -26,7 +26,6 @@ interface TaskChangesLayoutProps {
 /** Adds the independently resizable right-side review surface around existing workspace content. */
 export function TaskChangesLayout({ taskId, children }: TaskChangesLayoutProps) {
   const { t } = useTranslation();
-  const { windowControls } = usePlatform();
   const [open, setOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [closing, setClosing] = useState(false);
@@ -84,7 +83,11 @@ export function TaskChangesLayout({ taskId, children }: TaskChangesLayoutProps) 
             aria-label={t("diff.toggleFileTree")}
             onClick={() => setFileTreeOpen((value) => !value)}
           >
-            <IconFiles />
+            {fileTreeOpen ? (
+              <IconLayoutSidebarRightCollapse />
+            ) : (
+              <IconLayoutSidebarRightExpand />
+            )}
           </Button>
           <Button
             size="icon-sm"
@@ -148,44 +151,40 @@ export function TaskChangesLayout({ taskId, children }: TaskChangesLayoutProps) 
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1">
-      <div
-        className="flex min-h-0 min-w-0 flex-1"
-        aria-hidden={expanded || undefined}
-        inert={expanded || undefined}
-      >
-        {workspaceContent}
-      </div>
-      {taskId !== undefined && open && expanded && (
-        <>
-          <button
-            type="button"
-            aria-label={t("diff.closeExpandedPanel")}
-            className={`ora-changes-backdrop fixed inset-0 z-40 bg-background/45 backdrop-blur-[1.5px] ${closing ? "is-closing" : ""}`}
-            onClick={toggleExpanded}
-          />
-          <section
-            aria-label={t("diff.expandedPanel")}
-            className={`ora-changes-overlay fixed bottom-2 left-[clamp(180px,12vw,260px)] right-2 top-2 z-50 overflow-hidden rounded-xl border border-border/80 bg-background shadow-[0_24px_90px_rgba(0,0,0,0.32),0_2px_12px_rgba(0,0,0,0.16)] ring-1 ring-foreground/5 dark:shadow-[0_28px_100px_rgba(0,0,0,0.62),0_2px_16px_rgba(0,0,0,0.32)] ${closing ? "is-closing" : ""}`}
-          >
-            <TaskDiffView
-              taskId={taskId}
-              viewType={viewType}
-              fileTreeOpen={fileTreeOpen}
-              toolbar={changesControls}
-              onFileTreeOpenChange={setFileTreeOpen}
-            />
-          </section>
-        </>
-      )}
       {taskId !== undefined && !open && (
-        <div
-          className={`absolute top-3 z-30 ${
-            windowControls.kind === "overlay" ? "right-56" : "right-3"
-          }`}
-        >
-          {changesControls}
-        </div>
+        <div className="absolute right-4 top-2 z-30">{changesControls}</div>
       )}
+      <div className="relative flex min-h-0 min-w-0 flex-1">
+        <div
+          className="flex min-h-0 min-w-0 flex-1"
+          aria-hidden={expanded || undefined}
+          inert={expanded || undefined}
+        >
+          {workspaceContent}
+        </div>
+        {taskId !== undefined && open && expanded && (
+          <>
+            <button
+              type="button"
+              aria-label={t("diff.closeExpandedPanel")}
+              className={`ora-changes-backdrop absolute inset-0 z-40 bg-background/45 backdrop-blur-[1.5px] ${closing ? "is-closing" : ""}`}
+              onClick={toggleExpanded}
+            />
+            <section
+              aria-label={t("diff.expandedPanel")}
+              className={`ora-changes-overlay absolute inset-2 z-50 overflow-hidden rounded-xl border border-border/80 bg-background shadow-[0_24px_90px_rgba(0,0,0,0.32),0_2px_12px_rgba(0,0,0,0.16)] ring-1 ring-foreground/5 dark:shadow-[0_28px_100px_rgba(0,0,0,0.62),0_2px_16px_rgba(0,0,0,0.32)] ${closing ? "is-closing" : ""}`}
+            >
+              <TaskDiffView
+                taskId={taskId}
+                viewType={viewType}
+                fileTreeOpen={fileTreeOpen}
+                toolbar={changesControls}
+                onFileTreeOpenChange={setFileTreeOpen}
+              />
+            </section>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/app-shell/src/features/diff/task-diff-data.ts
+++ b/packages/app-shell/src/features/diff/task-diff-data.ts
@@ -1,0 +1,32 @@
+import { parseDiff, type FileData } from "react-diff-view";
+
+export interface DiffStats {
+  additions: number;
+  deletions: number;
+}
+
+/** Treats an empty backend snapshot as no files instead of a synthetic blank diff entry. */
+export function parseTaskDiffPatch(patch: string): FileData[] {
+  return patch.trim().length === 0 ? [] : parseDiff(patch);
+}
+
+/** Counts inserted and deleted lines across parsed patch files. */
+export function countChanges(files: FileData[]): DiffStats {
+  return files.reduce(
+    (total, file) =>
+      file.hunks.reduce(
+        (fileTotal, hunk) =>
+          hunk.changes.reduce(
+            (hunkTotal, change) => ({
+              additions:
+                hunkTotal.additions + (change.type === "insert" ? 1 : 0),
+              deletions:
+                hunkTotal.deletions + (change.type === "delete" ? 1 : 0),
+            }),
+            fileTotal,
+          ),
+        total,
+      ),
+    { additions: 0, deletions: 0 },
+  );
+}

--- a/packages/app-shell/src/features/diff/task-diff-view.css
+++ b/packages/app-shell/src/features/diff/task-diff-view.css
@@ -12,6 +12,7 @@
   --diff-code-selected-background-color: color-mix(in oklab, var(--primary) 14%, transparent);
   font-size: 12.5px;
   line-height: 1.6;
+  container-type: inline-size;
 }
 
 .ora-task-diff--split {
@@ -32,14 +33,43 @@
 }
 
 .ora-task-diff .diff-gutter {
-  cursor: pointer;
+  position: relative;
+  cursor: default;
   border-right: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
   color: var(--muted-foreground);
 }
 
-.ora-task-diff .diff-gutter:hover {
-  color: var(--foreground);
+.ora-task-diff--reviewable .diff-gutter {
+  cursor: pointer;
+}
+
+.ora-task-diff--reviewable .diff-gutter:hover {
+  color: transparent;
   background: color-mix(in oklab, var(--primary) 14%, transparent);
+}
+
+.ora-task-diff--reviewable .diff-gutter::after {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  display: grid;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  border-radius: 4px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  content: "+";
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+}
+
+.ora-task-diff--reviewable .diff-gutter:hover::after {
+  opacity: 1;
 }
 
 .ora-task-diff .diff-code {
@@ -157,6 +187,14 @@
 .ora-task-diff .diff-widget-content {
   padding: 10px 12px;
   background: var(--background);
+}
+
+.ora-task-diff .ora-comment-composer {
+  position: sticky;
+  left: 12px;
+  width: min(42rem, calc(100cqi - 24px));
+  max-width: calc(100cqi - 24px);
+  box-sizing: border-box;
 }
 
 .ora-task-diff .ora-diff-collapsed {

--- a/packages/app-shell/src/features/diff/task-diff-view.test.ts
+++ b/packages/app-shell/src/features/diff/task-diff-view.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { parseDiff } from "react-diff-view";
 import {
-  countChanges,
   createCommentAnchor,
-  parseTaskDiffPatch,
 } from "./task-diff-view";
+import { countChanges, parseTaskDiffPatch } from "./task-diff-data";
 
 const PATCH = [
   "diff --git a/src/main.ts b/src/main.ts",

--- a/packages/app-shell/src/features/diff/task-diff-view.tsx
+++ b/packages/app-shell/src/features/diff/task-diff-view.tsx
@@ -5,7 +5,6 @@ import {
   Diff,
   Hunk,
   getChangeKey,
-  parseDiff,
   type ChangeData,
   type FileData,
   type GutterOptions,
@@ -63,6 +62,7 @@ import { useContractsClient } from "../../contracts-client-context";
 import { queryKeys } from "../../state/hooks/query-keys";
 import { useTaskDiff, useTaskDiffComments } from "../../state/hooks/use-task-diff";
 import { buildCollapsedDiffSegments } from "./task-diff-collapse";
+import { countChanges, parseTaskDiffPatch } from "./task-diff-data";
 import { diffFilePath, TaskDiffFileTree } from "./task-diff-file-tree";
 
 interface TaskDiffViewProps {
@@ -78,11 +78,6 @@ export type TaskDiffViewType = "unified" | "split";
 interface SelectedAnchor {
   anchor: TaskDiffCommentAnchor;
   changeKey: string;
-}
-
-interface DiffStats {
-  additions: number;
-  deletions: number;
 }
 
 /** Renders a task worktree patch and its line-anchored review discussions. */
@@ -194,6 +189,40 @@ export function TaskDiffView({
     },
   });
 
+  const gitActions = (
+    <div className="flex h-8 items-center gap-0.5 rounded-lg border border-border/70 bg-background p-0.5 shadow-xs">
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-7 px-2.5"
+        disabled={commitChanges.isPending || pushBranch.isPending}
+        onClick={() => {
+          commitChanges.reset();
+          setGitNotice(null);
+          setCommitOpen(true);
+        }}
+      >
+        <IconGitCommit />
+        {t("diff.commit")}
+      </Button>
+      <span className="h-4 w-px bg-border/70" aria-hidden="true" />
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-7 px-2.5"
+        disabled={commitChanges.isPending || pushBranch.isPending}
+        onClick={() => {
+          pushBranch.reset();
+          setGitNotice(null);
+          setPushOpen(true);
+        }}
+      >
+        <IconUpload />
+        {t("diff.push")}
+      </Button>
+    </div>
+  );
+
   const refresh = async () => {
     setSelectedAnchor(null);
     await Promise.all([diffQuery.refetch(), commentsQuery.refetch()]);
@@ -239,7 +268,7 @@ export function TaskDiffView({
       aria-busy={diffQuery.isFetching}
     >
       <header
-        className="flex min-h-12 shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4"
+        className="flex min-h-12 shrink-0 flex-nowrap items-center gap-2 overflow-x-auto border-b border-border px-3 py-2 sm:px-4"
       >
         <div className="flex min-w-0 items-center gap-2">
           <IconCode className="size-4 text-muted-foreground" />
@@ -284,35 +313,7 @@ export function TaskDiffView({
           </Button>
         </div>
         <div className="flex-1" />
-        <div className="flex h-8 items-center gap-0.5 rounded-lg border border-border/70 bg-background p-0.5 shadow-xs">
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-7 px-2.5"
-            disabled={commitChanges.isPending || pushBranch.isPending}
-            onClick={() => {
-              commitChanges.reset();
-              setGitNotice(null);
-              setCommitOpen(true);
-            }}
-          >
-            <IconGitCommit />{t("diff.commit")}
-          </Button>
-          <span className="h-4 w-px bg-border/70" aria-hidden="true" />
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-7 px-2.5"
-            disabled={commitChanges.isPending || pushBranch.isPending}
-            onClick={() => {
-              pushBranch.reset();
-              setGitNotice(null);
-              setPushOpen(true);
-            }}
-          >
-            <IconUpload />{t("diff.push")}
-          </Button>
-        </div>
+        {gitActions}
         {toolbar}
       </header>
       {diffQuery.isFetching && (
@@ -469,11 +470,6 @@ export function TaskDiffView({
       />
     </section>
   );
-}
-
-/** Treats an empty backend snapshot as no files instead of a synthetic blank diff entry. */
-export function parseTaskDiffPatch(patch: string): FileData[] {
-  return patch.trim().length === 0 ? [] : parseDiff(patch);
 }
 
 interface CommitChangesDialogProps {
@@ -690,7 +686,9 @@ function TaskDiffFile({
         </div>
       ) : (
         <div
-          className={`ora-task-diff ora-task-diff--${viewType} ora-task-diff--${file.type} overflow-x-auto`}
+          className={`ora-task-diff ora-task-diff--${viewType} ora-task-diff--${file.type} ${
+            reviewEnabled ? "ora-task-diff--reviewable" : ""
+          } overflow-x-auto`}
         >
           {viewType === "split" && (
             <div className="ora-diff-version-headings" aria-hidden="true">
@@ -820,6 +818,12 @@ interface CommentComposerProps {
 function CommentComposer({ anchor, onCancel, onSubmit, disabled }: CommentComposerProps) {
   const { t } = useTranslation();
   const [body, setBody] = useState("");
+  const composerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    // Wide patches can place the widget off-screen horizontally, so reveal its full action area.
+    composerRef.current?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+  }, []);
 
   const submit = async () => {
     const comment = body.trim();
@@ -828,7 +832,10 @@ function CommentComposer({ anchor, onCancel, onSubmit, disabled }: CommentCompos
   };
 
   return (
-    <section className="rounded-md border border-primary/30 bg-background p-3 text-xs shadow-sm">
+    <section
+      ref={composerRef}
+      className="ora-comment-composer flex max-h-[min(20rem,calc(100vh-9rem))] flex-col rounded-md border border-primary/30 bg-background p-3 text-xs shadow-sm"
+    >
       <p className="mb-2 font-medium">
         {t("diff.commentOn", { path: anchor.path, line: anchor.startLine })}
       </p>
@@ -839,9 +846,9 @@ function CommentComposer({ anchor, onCancel, onSubmit, disabled }: CommentCompos
         rows={3}
         placeholder={t("diff.commentPlaceholder")}
         aria-label={t("diff.commentLabel")}
-        className="resize-y text-xs"
+        className="min-h-16 max-h-40 resize-none overflow-y-auto text-xs"
       />
-      <div className="mt-2 flex justify-end gap-2">
+      <div className="mt-2 flex shrink-0 justify-end gap-2">
         <Button size="sm" variant="ghost" disabled={disabled} onClick={onCancel}>{t("common.cancel")}</Button>
         <Button size="sm" disabled={disabled || body.trim() === ""} onClick={() => void submit()}>
           {t("diff.addComment")}
@@ -909,23 +916,6 @@ function DiffMessage({ title, detail, action }: DiffMessageProps) {
         {action && <div className="mt-4">{action}</div>}
       </div>
     </div>
-  );
-}
-
-/** Counts inserted and deleted lines across parsed patch files. */
-export function countChanges(files: FileData[]): DiffStats {
-  return files.reduce(
-    (total, file) => file.hunks.reduce(
-      (fileTotal, hunk) => hunk.changes.reduce(
-        (hunkTotal, change) => ({
-          additions: hunkTotal.additions + (change.type === "insert" ? 1 : 0),
-          deletions: hunkTotal.deletions + (change.type === "delete" ? 1 : 0),
-        }),
-        fileTotal,
-      ),
-      total,
-    ),
-    { additions: 0, deletions: 0 },
   );
 }
 

--- a/packages/app-shell/src/features/workspace/workspace-view.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-view.tsx
@@ -298,7 +298,6 @@ export function WorkspaceView({ userName }: WorkspaceViewProps) {
       conversation?.isLoaded !== true &&
       conversation?.error == null;
     return (
-      <TaskChangesLayout taskId={task?.id}>
       <main
         id="main-content"
         className="relative flex min-h-0 min-w-0 flex-1 flex-col bg-background"
@@ -334,7 +333,7 @@ export function WorkspaceView({ userName }: WorkspaceViewProps) {
           </Button>
           <WindowControls />
         </div>
-        <div className="flex min-h-0 flex-1 flex-col">
+        <TaskChangesLayout taskId={task?.id}>
           <ChatView
             turns={conversation?.turns ?? []}
             userName={userName}
@@ -380,14 +379,12 @@ export function WorkspaceView({ userName }: WorkspaceViewProps) {
               }
             }}
           />
-        </div>
+        </TaskChangesLayout>
       </main>
-      </TaskChangesLayout>
     );
   }
 
   return (
-    <TaskChangesLayout taskId={task?.id}>
     <main
       id="main-content"
       className="flex min-h-0 min-w-0 flex-1 flex-col bg-background"
@@ -414,60 +411,61 @@ export function WorkspaceView({ userName }: WorkspaceViewProps) {
         />
         <WindowControls />
       </header>
-      <div className="flex flex-1 items-center justify-center p-6">
-        <section className="w-full max-w-xl">
-          <div className="mb-6 flex size-11 items-center justify-center rounded-lg border border-border bg-muted">
-            {task ? (
-              <IconGitBranch className="size-5 text-sky-600" />
-            ) : (
-              <IconFolder className="size-5 text-amber-600" />
-            )}
-          </div>
-          <h1 className="text-xl font-semibold">
-            {task?.title ?? project?.name ?? t("workspace.defaultTitle")}
-          </h1>
-          <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
-            {task
-              ? t("workspace.taskHint")
-              : project
-                ? t("workspace.projectHint")
-                : t("workspace.emptyHint")}
-          </p>
-          {(project || task) && (
-            <div className="mt-6 grid gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-2">
-              <div className="bg-background p-4">
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <IconBrandGit className="size-4" />
-                  {t("workspace.repository")}
-                </div>
-                <p className="mt-2 truncate text-sm font-medium">
-                  {project?.rootPath}
-                </p>
-              </div>
-              <div className="bg-background p-4">
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <IconPlayerPlay className="size-4" />
-                  {t("workspace.agentSessions")}
-                </div>
-                <p className="mt-2 text-sm font-medium">
-                  {task
-                    ? t("workspace.sessionCount", {
-                        count: sessions.filter(
-                          (item) => item.taskId === task.id,
-                        ).length,
-                      })
-                    : t("workspace.worktreeCount", {
-                        count: tasks.filter(
-                          (item) => item.projectId === project?.id,
-                        ).length,
-                      })}
-                </p>
-              </div>
+      <TaskChangesLayout taskId={task?.id}>
+        <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+          <section className="w-full max-w-xl">
+            <div className="mb-6 flex size-11 items-center justify-center rounded-lg border border-border bg-muted">
+              {task ? (
+                <IconGitBranch className="size-5 text-sky-600" />
+              ) : (
+                <IconFolder className="size-5 text-amber-600" />
+              )}
             </div>
-          )}
-        </section>
-      </div>
+            <h1 className="text-xl font-semibold">
+              {task?.title ?? project?.name ?? t("workspace.defaultTitle")}
+            </h1>
+            <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+              {task
+                ? t("workspace.taskHint")
+                : project
+                  ? t("workspace.projectHint")
+                  : t("workspace.emptyHint")}
+            </p>
+            {(project || task) && (
+              <div className="mt-6 grid gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-2">
+                <div className="bg-background p-4">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <IconBrandGit className="size-4" />
+                    {t("workspace.repository")}
+                  </div>
+                  <p className="mt-2 truncate text-sm font-medium">
+                    {project?.rootPath}
+                  </p>
+                </div>
+                <div className="bg-background p-4">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <IconPlayerPlay className="size-4" />
+                    {t("workspace.agentSessions")}
+                  </div>
+                  <p className="mt-2 text-sm font-medium">
+                    {task
+                      ? t("workspace.sessionCount", {
+                          count: sessions.filter(
+                            (item) => item.taskId === task.id,
+                          ).length,
+                        })
+                      : t("workspace.worktreeCount", {
+                          count: tasks.filter(
+                            (item) => item.projectId === project?.id,
+                          ).length,
+                        })}
+                  </p>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+      </TaskChangesLayout>
     </main>
-    </TaskChangesLayout>
   );
 }


### PR DESCRIPTION
## Summary

- keep the Changes trigger at the same visual position before and after opening the diff panel
- place the open-state Changes controls beside Commit and Push without adding an empty toolbar row
- use explicit file-tree expand/collapse icons and add a commentable-line plus affordance
- keep the comment composer and its actions visible inside narrow or horizontally scrolled diffs

## Why

The previous review controls competed with desktop window actions, moved between states, and left an otherwise empty row. Comment entry could also extend outside the visible diff area.

## Validation

- `pnpm --filter @ora/app-shell test -- task-changes-layout.test.tsx task-diff-view.test.ts`
- `.\node_modules\.bin\tsc.cmd -b apps/desktop/tsconfig.json --pretty false`
- `pnpm --filter @ora/desktop build`
