### PR TITLE
fix(chat): improve streaming response rendering and tail following

### DIFF
--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -24,6 +24,7 @@
     "react-i18next": "^16.5.8",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "remend": "1.3.0",
     "shiki": "^3.23.0",
     "zustand": "^5.0.14"
   },

--- a/packages/app-shell/src/features/chat/activity-group.tsx
+++ b/packages/app-shell/src/features/chat/activity-group.tsx
@@ -14,6 +14,10 @@ import {
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@ora/ui";
 import { useTranslation } from "react-i18next";
 import type { ChatThought, ChatToolCall, ChatTurnStatus } from "@ora/chat";
+import {
+  StreamingThoughtReveal,
+  useStreamingThoughtRevealStart,
+} from "./streaming-thought-reveal";
 import { ToolCallBlock } from "./tool-call-block";
 
 export type ActivityItem = ChatThought | ChatToolCall;
@@ -88,6 +92,7 @@ export function ActivityGroup({ items, turnStatus, isLatestActivity }: ActivityG
                 <ThoughtTimelineItem
                   thought={entry.thought}
                   open={selectedId === entry.id}
+                  streaming={status === "active" && entry.id === latestItemId}
                   onOpenChange={(nextOpen) => toggleItem(entry.id, nextOpen)}
                 />
               ) : entry.tools.length === 1 ? (
@@ -204,27 +209,65 @@ function ActivityMetrics({ items }: { items: ActivityItem[] }) {
 function ThoughtTimelineItem({
   thought,
   open,
+  streaming,
   onOpenChange,
 }: {
   thought: ChatThought;
   open: boolean;
+  streaming: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
   const { t } = useTranslation();
+  const revealStart = useStreamingThoughtRevealStart(thought.content, streaming);
   return (
     <Collapsible open={open} onOpenChange={onOpenChange}>
       <CollapsibleTrigger className={`flex min-h-11 w-full items-center gap-2 rounded-r-sm px-2 py-1.5 text-left text-xs outline-none transition-colors duration-200 hover:bg-muted/25 hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50 ${open ? "bg-muted/25 text-foreground" : "text-muted-foreground"}`}>
         <IconRoute className="size-4 shrink-0 text-violet-600 dark:text-violet-400" />
         <span className="shrink-0 font-medium">{t("chat.thought")}</span>
-        <span className="min-w-0 flex-1 truncate opacity-80">{thought.content}</span>
+        <span className="min-w-0 flex-1 truncate opacity-80">
+          <StreamingThoughtText
+            content={thought.content}
+            reveal={streaming && !open}
+            revealStart={revealStart}
+          />
+        </span>
         <IconChevronDown className={`size-3.5 shrink-0 transition-transform duration-200 motion-reduce:transition-none ${open ? "rotate-180" : ""}`} />
       </CollapsibleTrigger>
       <CollapsibleContent>
         <p data-selectable className="ml-6 rounded-r-sm border-l-2 border-violet-500/50 bg-muted/20 px-3 py-2 text-xs leading-5 whitespace-pre-wrap text-muted-foreground">
-          {thought.content}
+          <StreamingThoughtText
+            content={thought.content}
+            reveal={streaming && open}
+            revealStart={revealStart}
+          />
         </p>
       </CollapsibleContent>
     </Collapsible>
+  );
+}
+
+/** Reveals only the live thought suffix while leaving completed reasoning visually stable. */
+function StreamingThoughtText({
+  content,
+  reveal,
+  revealStart,
+}: {
+  content: string;
+  reveal: boolean;
+  revealStart: number;
+}) {
+  if (!reveal) return content;
+  const stableText = content.slice(0, revealStart);
+  const revealedText = content.slice(revealStart);
+  return (
+    <>
+      {stableText}
+      {revealedText !== "" && (
+        <StreamingThoughtReveal key={`${revealStart}-${content.length}`}>
+          {revealedText}
+        </StreamingThoughtReveal>
+      )}
+    </>
   );
 }
 

--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -542,9 +542,19 @@ describe("MessageList", () => {
     expect(list.style.scrollBehavior).toBe("auto");
     expect(list.scrollTop).toBe(560);
 
+    // A programmatic scroll event can arrive after another fast content growth.
+    // It must not look like a reader abandoning the live tail.
     Object.defineProperty(list, "clientHeight", { configurable: true, value: 100 });
-    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 600 });
+    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 720 });
+    list.scrollTop = 460;
+    fireEvent.scroll(list);
+    act(() => resizeCallback?.([], {} as ResizeObserver));
+
+    expect(list.scrollTop).toBe(720);
+
+    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 800 });
     list.scrollTop = 0;
+    fireEvent.wheel(list, { deltaY: -120 });
     fireEvent.scroll(list);
     act(() => resizeCallback?.([], {} as ResizeObserver));
 
@@ -563,8 +573,9 @@ describe("MessageList", () => {
     Object.defineProperty(list, "scrollHeight", { configurable: true, value: 240 });
     Object.defineProperty(list, "clientHeight", { configurable: true, value: 100 });
 
-    // Scrolling far from the bottom is the signal that the reader is reading
-    // history rather than following the stream.
+    // An upward wheel gesture is the user intent; scroll events alone can also
+    // come from the component's own tail correction.
+    fireEvent.wheel(list, { deltaY: -120 });
     list.scrollTop = 0;
     fireEvent.scroll(list);
 
@@ -587,6 +598,7 @@ describe("MessageList", () => {
     const list = screen.getByTestId("message-list");
     Object.defineProperty(list, "scrollHeight", { configurable: true, value: 240 });
     Object.defineProperty(list, "clientHeight", { configurable: true, value: 100 });
+    fireEvent.wheel(list, { deltaY: -120 });
     list.scrollTop = 0;
     fireEvent.scroll(list);
 

--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -491,6 +491,23 @@ describe("MessageList", () => {
       expect(screen.getByText("Still streaming.")).toBeInTheDocument();
   });
 
+  it("flushes a previous text item's literal marker while the turn continues with a tool", () => {
+    renderWithI18n(
+      <MessageList
+        turns={[
+          turn("turn-1", "hello", 100, [
+            assistantItem("assistant-1", "Use literal *", 200),
+            toolCallItem("tool-1", 300),
+          ], "streaming"),
+        ]}
+        userName="Eric"
+        isResponding
+      />,
+    );
+
+    expect(screen.getByText("Use literal *")).toBeInTheDocument();
+  });
+
   it("keeps following when deferred content changes the rendered height", () => {
     let resizeCallback: ResizeObserverCallback | undefined;
     class TestResizeObserver implements ResizeObserver {

--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -403,6 +403,51 @@ describe("MessageList", () => {
     expect(activity).toHaveTextContent(/1 个文件 · 1 次分析|1 file · 1 analysis step/);
   });
 
+  it("reveals only the live thought suffix and settles it before the next activity", () => {
+    const view = renderWithI18n(
+      <MessageList
+        turns={[turn("turn-1", "Inspect", 100, [
+          thoughtItem("thought-1", "Checking", 200),
+        ], "streaming")]}
+        userName="Eric"
+        isResponding
+      />,
+    );
+
+    expect(
+      Array.from(view.container.querySelectorAll("[data-stream-thought-reveal]"))
+        .map((node) => node.textContent),
+    ).toEqual(["Checking"]);
+
+    view.rerender(
+      <MessageList
+        turns={[turn("turn-1", "Inspect", 100, [
+          thoughtItem("thought-1", "Checking files", 200),
+        ], "streaming")]}
+        userName="Eric"
+        isResponding
+      />,
+    );
+
+    expect(
+      Array.from(view.container.querySelectorAll("[data-stream-thought-reveal]"))
+        .map((node) => node.textContent),
+    ).toEqual([" files"]);
+
+    view.rerender(
+      <MessageList
+        turns={[turn("turn-1", "Inspect", 100, [
+          thoughtItem("thought-1", "Checking files", 200),
+          toolCallItem("tool-1", 300),
+        ], "streaming")]}
+        userName="Eric"
+        isResponding
+      />,
+    );
+
+    expect(view.container.querySelector("[data-stream-thought-reveal]")).toBeNull();
+  });
+
   it("condenses interleaved analysis and file reads into one expandable activity timeline", async () => {
     const user = userEvent.setup();
     renderWithI18n(

--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -1,8 +1,8 @@
 import { createElement, type ReactNode } from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChatMessage, ChatThought, ChatToolCall, ChatTurn, ChatTurnItem } from "@ora/chat";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@ora/ui";
@@ -13,6 +13,10 @@ import { ChatView } from "./chat-view";
 import { Composer } from "./composer";
 import { ConversationNavigator } from "./conversation-navigator";
 import { MessageList } from "./message-list";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 /** Stale-time-zero QueryClient so tests don't need to wait for refetch intervals. */
 function createTestQueryClient() {
@@ -487,7 +491,29 @@ describe("MessageList", () => {
       expect(screen.getByText("Still streaming.")).toBeInTheDocument();
   });
 
-  it("keeps scrolling as streamed content grows within the same message", () => {
+  it("keeps following when deferred content changes the rendered height", () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    class TestResizeObserver implements ResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+
+      /** The observed target is irrelevant to this layout-focused regression test. */
+      observe() {}
+
+      /** The component only observes one content root for its full lifetime. */
+      unobserve() {}
+
+      /** Testing Library owns unmount cleanup after the assertion. */
+      disconnect() {}
+
+      /** This test drives the callback directly, so no queued records exist. */
+      takeRecords() {
+        return [];
+      }
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+
     const view = renderWithI18n(
       <MessageList
         turns={[turn("turn-1", "hello", 100, [assistantItem("assistant-1", "Mock", 200)], "streaming")]}
@@ -496,18 +522,33 @@ describe("MessageList", () => {
       />,
     );
     const list = screen.getByTestId("message-list");
-    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 240 });
+    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 480 });
     list.scrollTop = 0;
 
-    view.rerender(
-        <MessageList
-          turns={[turn("turn-1", "hello", 100, [assistantItem("assistant-1", "Mock response", 200)], "streaming")]}
-          userName="Eric"
-          isResponding
-        />
-    );
+    act(() => resizeCallback?.([], {} as ResizeObserver));
 
-    expect(list.scrollTop).toBe(240);
+    expect(list.scrollTop).toBe(480);
+
+    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 560 });
+    view.rerender(
+      <MessageList
+        turns={[turn("turn-1", "hello", 100, [assistantItem("assistant-1", "Mock final code", 200)], "completed")]}
+        userName="Eric"
+        isResponding={false}
+      />,
+    );
+    act(() => resizeCallback?.([], {} as ResizeObserver));
+
+    expect(list.style.scrollBehavior).toBe("auto");
+    expect(list.scrollTop).toBe(560);
+
+    Object.defineProperty(list, "clientHeight", { configurable: true, value: 100 });
+    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 600 });
+    list.scrollTop = 0;
+    fireEvent.scroll(list);
+    act(() => resizeCallback?.([], {} as ResizeObserver));
+
+    expect(list.scrollTop).toBe(0);
   });
 
   it("stops chasing the tail once the reader scrolls up mid-stream", () => {

--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -472,6 +472,21 @@ describe("MessageList", () => {
     expect(screen.queryByLabelText(/正在运行|is working/)).not.toBeInTheDocument();
   });
 
+  it("renders streamed assistant text as markdown while keeping the thread responsive", () => {
+    renderWithI18n(
+      <MessageList
+        turns={[
+          turn("turn-1", "hello", 100, [assistantItem("assistant-1", "# Live heading\n\nStill streaming.", 200)], "streaming"),
+        ]}
+        userName="Eric"
+        isResponding
+      />,
+    );
+
+      expect(screen.getByRole("heading", { level: 1, name: "Live heading" })).toBeInTheDocument();
+      expect(screen.getByText("Still streaming.")).toBeInTheDocument();
+  });
+
   it("keeps scrolling as streamed content grows within the same message", () => {
     const view = renderWithI18n(
       <MessageList

--- a/packages/app-shell/src/features/chat/markdown-message.test.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.test.tsx
@@ -42,6 +42,64 @@ describe("MarkdownMessage", () => {
     expect(screen.getByText("Still streaming.")).toBeInTheDocument();
   });
 
+  it.each(["*", "**", "***", "_", "__", "___", "~", "~~", "`", "``"])(
+    "withholds an ambiguous %s boundary until prose arrives",
+    (delimiter) => {
+      const view = render(<MarkdownMessage content={delimiter} streaming />);
+
+      expect(view.container).not.toHaveTextContent(delimiter);
+    },
+  );
+
+  it("reveals a buffered emphasis boundary and its first prose in one render", async () => {
+    const view = render(<MarkdownMessage content="Prefix **" streaming />);
+
+    expect(view.container).toHaveTextContent("Prefix");
+    expect(view.container).not.toHaveTextContent("**");
+
+    view.rerender(<MarkdownMessage content="Prefix **natural" streaming />);
+
+    await waitFor(() => expect(screen.getByText("natural").closest("strong")).not.toBeNull());
+    expect(view.container).toHaveTextContent("Prefix natural");
+  });
+
+  it("flushes an ambiguous literal marker when streaming completes", () => {
+    const view = render(<MarkdownMessage content="Literal *" streaming />);
+    expect(view.container).toHaveTextContent("Literal");
+    expect(view.container).not.toHaveTextContent("Literal *");
+
+    view.rerender(<MarkdownMessage content="Literal *" streaming={false} />);
+
+    expect(view.container).toHaveTextContent("Literal *");
+  });
+
+  it("withholds empty block markers without delaying completed block content", async () => {
+    const view = render(<MarkdownMessage content="##" streaming />);
+
+    expect(view.container).not.toHaveTextContent("##");
+
+    view.rerender(<MarkdownMessage content="## Live heading" streaming />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { level: 2, name: "Live heading" })).toBeInTheDocument();
+    });
+  });
+
+  it("preserves trailing markers that belong to code or escaped prose", () => {
+    const code = render(<MarkdownMessage content={"`literal *`"} streaming />);
+    expect(screen.getByText("literal *").closest("code")).not.toBeNull();
+    code.unmount();
+
+    render(<MarkdownMessage content={"Escaped \\* and \\#"} streaming />);
+    expect(screen.getByText("Escaped * and #")).toBeInTheDocument();
+  });
+
+  it("releases literal marker characters as soon as following prose resolves them", () => {
+    render(<MarkdownMessage content="Use * as a wildcard and # as a heading marker." streaming />);
+
+    expect(screen.getByText("Use * as a wildcard and # as a heading marker.")).toBeInTheDocument();
+  });
+
   it("renders growing GFM block structures without waiting for completion", () => {
     render(
       <MarkdownMessage

--- a/packages/app-shell/src/features/chat/markdown-message.test.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { AppI18nProvider } from "../../i18n/i18n";
@@ -35,11 +35,126 @@ describe("MarkdownMessage", () => {
     expect(screen.queryByText(/# Wrapped result/)).toBeNull();
   });
 
-  it("keeps streamed markdown visible while deferring expensive parsing", () => {
+  it("keeps streamed markdown visible while batching expensive parsing", () => {
     render(<MarkdownMessage content={"# Live heading\n\nStill streaming."} streaming />);
 
     expect(screen.getByRole("heading", { level: 1, name: "Live heading" })).toBeInTheDocument();
     expect(screen.getByText("Still streaming.")).toBeInTheDocument();
+  });
+
+  it("renders growing GFM block structures without waiting for completion", () => {
+    render(
+      <MarkdownMessage
+        content={"- first item\n- growing item\n\n> Live quote\n\n| Name | Value |\n| --- | --- |\n| Ora | stream"}
+        streaming
+      />,
+    );
+
+    expect(screen.getByRole("list")).toHaveTextContent("growing item");
+    expect(screen.getByText("Live quote").closest("blockquote")).not.toBeNull();
+    expect(screen.getByRole("table")).toHaveTextContent("Ora");
+    expect(screen.getByRole("table")).toHaveTextContent("stream");
+  });
+
+  it.each([
+    ["strong", "**Live strong", "strong"],
+    ["asterisk emphasis", "*Live emphasis", "em"],
+    ["underscore emphasis", "_Live emphasis", "em"],
+    ["strikethrough", "~~Live removed", "del"],
+    ["inline code", "`Live code", "code"],
+  ])("renders unfinished %s immediately with its final styling", (_label, content, selector) => {
+    const visibleText = content.replace(/^[*_~`]+/, "");
+    const view = render(<MarkdownMessage content={content} streaming />);
+
+    expect(screen.getByText(visibleText).closest(selector)).not.toBeNull();
+    expect(view.container).not.toHaveTextContent(content.slice(0, content.length - visibleText.length));
+  });
+
+  it("keeps nested unfinished emphasis stable when real delimiters arrive", async () => {
+    const view = render(<MarkdownMessage content="***Live bold italic" streaming />);
+
+    expect(screen.getByText("Live bold italic").closest("strong")).not.toBeNull();
+    expect(screen.getByText("Live bold italic").closest("em")).not.toBeNull();
+
+    view.rerender(<MarkdownMessage content="***Live bold italic***" streaming />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Live bold italic").closest("strong")).not.toBeNull();
+      expect(screen.getByText("Live bold italic").closest("em")).not.toBeNull();
+    });
+    expect(view.container).not.toHaveTextContent("******");
+  });
+
+  it("completes partial links without exposing their destination syntax", () => {
+    const view = render(<MarkdownMessage content="[Documentation](https://exam" streaming />);
+
+    expect(screen.getByText("Documentation").closest("a")).not.toBeNull();
+    expect(view.container).not.toHaveTextContent("https://exam");
+  });
+
+  it("does not interpret formatting markers inside streamed inline code", () => {
+    render(<MarkdownMessage content="`**literal _markers_`" streaming />);
+
+    const code = screen.getByText("**literal _markers_");
+    expect(code.closest("code")).not.toBeNull();
+    expect(code.closest("strong")).toBeNull();
+    expect(code.closest("em")).toBeNull();
+  });
+
+  it("keeps escaped markers literal while streaming", () => {
+    render(<MarkdownMessage content={"\\*literal emphasis marker"} streaming />);
+
+    const text = screen.getByText("*literal emphasis marker");
+    expect(text.closest("em")).toBeNull();
+  });
+
+  it("keeps an unfinished fenced code block visible without parsing its contents as prose", () => {
+    render(<MarkdownMessage content={"```typescript\nconst marker = '**literal**';"} streaming />);
+
+    const code = screen.getByText("const marker = '**literal**';");
+    expect(code.closest(".markdown-code-block")).not.toBeNull();
+    expect(code.closest("strong")).toBeNull();
+  });
+
+  it("reveals entity-backed text without dropping newly appended characters", async () => {
+    const view = render(<MarkdownMessage content="Stable &amp;" streaming />);
+
+    view.rerender(<MarkdownMessage content="Stable &amp; addition" streaming />);
+
+    await waitFor(() => {
+      expect(view.container.querySelector("[data-stream-text-reveal]")?.textContent).toBe(" addition");
+    });
+    expect(view.container).toHaveTextContent("Stable & addition");
+  });
+
+  it("coalesces rapid chunks into one rendered update per animation frame", () => {
+    const originalRequestAnimationFrame = Object.getOwnPropertyDescriptor(window, "requestAnimationFrame");
+    const originalCancelAnimationFrame = Object.getOwnPropertyDescriptor(window, "cancelAnimationFrame");
+    let frameCallback: FrameRequestCallback | undefined;
+    const requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallback = callback;
+      return 1;
+    });
+    Object.defineProperty(window, "requestAnimationFrame", { configurable: true, value: requestAnimationFrame });
+    Object.defineProperty(window, "cancelAnimationFrame", { configurable: true, value: vi.fn() });
+
+    try {
+      const view = render(<MarkdownMessage content="A" streaming />);
+      view.rerender(<MarkdownMessage content="AB" streaming />);
+      view.rerender(<MarkdownMessage content="ABC" streaming />);
+
+      expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+      expect(view.container).toHaveTextContent("A");
+
+      act(() => frameCallback?.(16));
+
+      expect(view.container).toHaveTextContent("ABC");
+    } finally {
+      if (originalRequestAnimationFrame === undefined) Reflect.deleteProperty(window, "requestAnimationFrame");
+      else Object.defineProperty(window, "requestAnimationFrame", originalRequestAnimationFrame);
+      if (originalCancelAnimationFrame === undefined) Reflect.deleteProperty(window, "cancelAnimationFrame");
+      else Object.defineProperty(window, "cancelAnimationFrame", originalCancelAnimationFrame);
+    }
   });
 
   it("reveals only newly streamed prose without reanimating stable text", async () => {

--- a/packages/app-shell/src/features/chat/markdown-message.test.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.test.tsx
@@ -42,6 +42,51 @@ describe("MarkdownMessage", () => {
     expect(screen.getByText("Still streaming.")).toBeInTheDocument();
   });
 
+  it("reveals only newly streamed prose without reanimating stable text", async () => {
+    const view = render(<MarkdownMessage content="Stable" streaming />);
+
+    expect(view.container.querySelector("[data-stream-text-reveal]")).toHaveTextContent("Stable");
+
+    view.rerender(<MarkdownMessage content="Stable addition" streaming />);
+
+    await waitFor(() => {
+      expect(view.container.querySelector("[data-stream-text-reveal]")?.textContent).toBe(" addition");
+    });
+    expect(view.container).toHaveTextContent("Stable addition");
+  });
+
+  it("does not animate completed Markdown or code contents", () => {
+    const completed = render(<MarkdownMessage content="Complete" />);
+    expect(completed.container.querySelector("[data-stream-text-reveal]")).toBeNull();
+    completed.unmount();
+
+    const streamingCode = render(<MarkdownMessage content={"```typescript\nconst answer = 42;\n```"} streaming />);
+    expect(streamingCode.container.querySelector("[data-stream-text-reveal]")).toBeNull();
+  });
+
+  it("uses a crisp opacity-only reveal without blur or movement", () => {
+    const originalAnimate = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "animate");
+    const originalGetAnimations = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "getAnimations");
+    const animation = { addEventListener: vi.fn() } as unknown as Animation;
+    const animate = vi.fn(() => animation);
+    Object.defineProperty(HTMLElement.prototype, "animate", { configurable: true, value: animate });
+    Object.defineProperty(HTMLElement.prototype, "getAnimations", { configurable: true, value: () => [] });
+
+    try {
+      render(<MarkdownMessage content="Crisp stream" streaming />);
+
+      expect(animate).toHaveBeenCalledWith(
+        [{ opacity: 0.2 }, { opacity: 1 }],
+        { duration: 180, easing: "cubic-bezier(0.2, 0, 0, 1)" },
+      );
+    } finally {
+      if (originalAnimate === undefined) Reflect.deleteProperty(HTMLElement.prototype, "animate");
+      else Object.defineProperty(HTMLElement.prototype, "animate", originalAnimate);
+      if (originalGetAnimations === undefined) Reflect.deleteProperty(HTMLElement.prototype, "getAnimations");
+      else Object.defineProperty(HTMLElement.prototype, "getAnimations", originalGetAnimations);
+    }
+  });
+
   it("preserves ordinary fenced code blocks", () => {
     render(<MarkdownMessage content={"Example:\n\n```markdown\n# Literal Markdown\n```"} />);
 

--- a/packages/app-shell/src/features/chat/markdown-message.test.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.test.tsx
@@ -35,6 +35,13 @@ describe("MarkdownMessage", () => {
     expect(screen.queryByText(/# Wrapped result/)).toBeNull();
   });
 
+  it("keeps streamed markdown visible while deferring expensive parsing", () => {
+    render(<MarkdownMessage content={"# Live heading\n\nStill streaming."} streaming />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Live heading" })).toBeInTheDocument();
+    expect(screen.getByText("Still streaming.")).toBeInTheDocument();
+  });
+
   it("preserves ordinary fenced code blocks", () => {
     render(<MarkdownMessage content={"Example:\n\n```markdown\n# Literal Markdown\n```"} />);
 

--- a/packages/app-shell/src/features/chat/markdown-message.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.tsx
@@ -1,4 +1,16 @@
-import { isValidElement, useDeferredValue, useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import {
+  isValidElement,
+  useDeferredValue,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { IconCheck, IconChevronsDown, IconChevronsUp, IconCopy } from "@tabler/icons-react";
 import { Button } from "@ora/ui";
 import type { Components } from "react-markdown";
@@ -18,6 +30,32 @@ const highlightedCodeCache = new Map<string, Promise<ThemedTokenWithVariants[][]
 
 interface ShikiTokenStyle extends CSSProperties {
   "--shiki-dark"?: string;
+}
+
+interface MarkdownAstPosition {
+  start: { offset?: number };
+  end: { offset?: number };
+}
+
+interface MarkdownAstNode {
+  type: string;
+  value?: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: MarkdownAstNode[];
+  position?: MarkdownAstPosition;
+}
+
+interface StreamingRevealState {
+  renderedLength: number;
+  revealStart: number;
+  streaming: boolean;
+}
+
+interface StreamingRevealSpanProps extends ComponentPropsWithoutRef<"span"> {
+  node?: MarkdownAstNode;
+  registryRef: RefObject<Set<HTMLElement>>;
+  "data-stream-text-reveal"?: boolean;
 }
 
 const markdownComponents: Components = {
@@ -71,11 +109,133 @@ export function MarkdownMessage({ content, streaming = false }: MarkdownMessageP
   const markdown = unwrapMarkdownDocument(content);
   const deferredMarkdown = useDeferredValue(markdown);
   const renderedMarkdown = streaming ? deferredMarkdown : markdown;
+  const [storedRevealState, setStoredRevealState] = useState<StreamingRevealState>(() => ({
+    renderedLength: renderedMarkdown.length,
+    revealStart: streaming ? 0 : renderedMarkdown.length,
+    streaming,
+  }));
+  let revealState = storedRevealState;
+  if (storedRevealState.renderedLength !== renderedMarkdown.length || storedRevealState.streaming !== streaming) {
+    // Chat content is append-only while streaming. Length is therefore enough
+    // to retain the prior boundary without rescanning an ever-growing string.
+    revealState = {
+      renderedLength: renderedMarkdown.length,
+      revealStart: streaming && renderedMarkdown.length >= storedRevealState.renderedLength
+        ? storedRevealState.renderedLength
+        : renderedMarkdown.length,
+      streaming,
+    };
+    setStoredRevealState(revealState);
+  }
+  const revealPlugin = useMemo(
+    () => createStreamingRevealPlugin(revealState.revealStart),
+    [revealState.revealStart],
+  );
+  const revealNodesRef = useRef(new Set<HTMLElement>());
+  const streamingMarkdownComponents = useMemo<Components>(() => ({
+    ...markdownComponents,
+    span: (props) => <StreamingRevealSpan {...props} registryRef={revealNodesRef} />,
+  }), []);
+
+  useLayoutEffect(() => {
+    if (streaming) animateStreamingReveal(revealNodesRef.current);
+  }, [renderedMarkdown, streaming]);
+
   return (
     <div data-selectable className="min-w-0 break-words text-[15px] leading-[26px] text-foreground">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{renderedMarkdown}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={streaming ? [revealPlugin] : []}
+        components={streaming ? streamingMarkdownComponents : markdownComponents}
+      >
+        {renderedMarkdown}
+      </ReactMarkdown>
     </div>
   );
+}
+
+/** Creates one Markdown transform that marks only newly streamed prose for reveal animation. */
+function createStreamingRevealPlugin(revealStart: number) {
+  return () => (tree: MarkdownAstNode) => {
+    wrapStreamingText(tree, revealStart);
+  };
+}
+
+/** Wraps text after the previous stream boundary while leaving code structures untouched. */
+function wrapStreamingText(node: MarkdownAstNode, revealStart: number) {
+  if (node.tagName === "code" || node.tagName === "pre" || node.children === undefined) return;
+  for (let index = node.children.length - 1; index >= 0; index -= 1) {
+    const child = node.children[index]!;
+    const childEndOffset = child.position?.end.offset;
+    // Source-ordered HAST lets us stop as soon as we reach stable content,
+    // keeping reveal work proportional to the newest streamed suffix.
+    if (childEndOffset !== undefined && childEndOffset <= revealStart) break;
+    if (child.type !== "text" || child.value === undefined) {
+      wrapStreamingText(child, revealStart);
+      continue;
+    }
+
+    const startOffset = child.position?.start.offset;
+    if (startOffset === undefined || childEndOffset === undefined) continue;
+
+    const splitIndex = revealStart <= startOffset
+      ? 0
+      : Math.round(((revealStart - startOffset) / Math.max(1, childEndOffset - startOffset)) * child.value.length);
+    const stableText = child.value.slice(0, splitIndex);
+    const revealedText = child.value.slice(splitIndex);
+    if (revealedText === "") continue;
+    const revealNode: MarkdownAstNode = {
+      type: "element",
+      tagName: "span",
+      properties: { dataStreamTextReveal: true },
+      children: [{ ...child, value: revealedText }],
+    };
+    node.children.splice(
+      index,
+      1,
+      ...(stableText === "" ? [revealNode] : [{ ...child, value: stableText }, revealNode]),
+    );
+  }
+}
+
+/** Animates the latest prose batch and releases compositor resources when it settles. */
+function animateStreamingReveal(nodes: ReadonlySet<HTMLElement>) {
+  if (typeof HTMLElement.prototype.animate !== "function") return;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  nodes.forEach((node) => {
+    node.getAnimations().forEach((animation) => animation.cancel());
+    const animation = node.animate(
+      [
+        { opacity: 0.2 },
+        { opacity: 1 },
+      ],
+      { duration: 180, easing: "cubic-bezier(0.2, 0, 0, 1)" },
+    );
+    animation.addEventListener("finish", () => animation.cancel(), { once: true });
+  });
+}
+
+/** Registers one animated Markdown span without rescanning the complete message DOM. */
+function StreamingRevealSpan({
+  node,
+  registryRef,
+  "data-stream-text-reveal": reveal,
+  ...props
+}: StreamingRevealSpanProps) {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  const shouldReveal = reveal === true || node?.properties?.dataStreamTextReveal === true;
+
+  useLayoutEffect(() => {
+    const span = spanRef.current;
+    if (!shouldReveal || span === null) return;
+    const registry = registryRef.current;
+    registry.add(span);
+    return () => {
+      registry.delete(span);
+    };
+  }, [registryRef, shouldReveal]);
+
+  return <span ref={spanRef} data-stream-text-reveal={shouldReveal || undefined} {...props} />;
 }
 
 /** Wraps fenced code with persistent copy and disclosure controls. */

--- a/packages/app-shell/src/features/chat/markdown-message.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import { isValidElement, useDeferredValue, useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { IconCheck, IconChevronsDown, IconChevronsUp, IconCopy } from "@tabler/icons-react";
 import { Button } from "@ora/ui";
 import type { Components } from "react-markdown";
@@ -10,6 +10,7 @@ import { unwrapMarkdownDocument } from "./markdown-document";
 
 interface MarkdownMessageProps {
   content: string;
+  streaming?: boolean;
 }
 
 const LANGUAGE_CLASS_PATTERN = /(?:^|\s)language-([^\s]+)/;
@@ -66,11 +67,13 @@ const markdownComponents: Components = {
 };
 
 /** Renders untrusted assistant Markdown without enabling raw HTML execution. */
-export function MarkdownMessage({ content }: MarkdownMessageProps) {
+export function MarkdownMessage({ content, streaming = false }: MarkdownMessageProps) {
   const markdown = unwrapMarkdownDocument(content);
+  const deferredMarkdown = useDeferredValue(markdown);
+  const renderedMarkdown = streaming ? deferredMarkdown : markdown;
   return (
     <div data-selectable className="min-w-0 break-words text-[15px] leading-[26px] text-foreground">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{markdown}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{renderedMarkdown}</ReactMarkdown>
     </div>
   );
 }

--- a/packages/app-shell/src/features/chat/markdown-message.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.tsx
@@ -12,13 +12,13 @@ import {
 } from "react";
 import { IconCheck, IconChevronsDown, IconChevronsUp, IconCopy } from "@tabler/icons-react";
 import { Button } from "@ora/ui";
-import remend from "remend";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import { useTranslation } from "react-i18next";
 import remarkGfm from "remark-gfm";
 import type { BundledLanguage, ThemedTokenWithVariants } from "shiki";
 import { unwrapMarkdownDocument } from "./markdown-document";
+import { prepareStreamingMarkdown } from "./streaming-markdown";
 
 interface MarkdownMessageProps {
   content: string;
@@ -110,7 +110,7 @@ export function MarkdownMessage({ content, streaming = false }: MarkdownMessageP
   const markdown = unwrapMarkdownDocument(content);
   const renderedMarkdown = useFrameBatchedMarkdown(markdown, streaming);
   const parseableMarkdown = useMemo(
-    () => streaming ? remend(renderedMarkdown) : renderedMarkdown,
+    () => streaming ? prepareStreamingMarkdown(renderedMarkdown) : renderedMarkdown,
     [renderedMarkdown, streaming],
   );
   const [storedRevealState, setStoredRevealState] = useState<StreamingRevealState>(() => ({

--- a/packages/app-shell/src/features/chat/markdown-message.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.tsx
@@ -1,6 +1,5 @@
 import {
   isValidElement,
-  useDeferredValue,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -13,6 +12,7 @@ import {
 } from "react";
 import { IconCheck, IconChevronsDown, IconChevronsUp, IconCopy } from "@tabler/icons-react";
 import { Button } from "@ora/ui";
+import remend from "remend";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import { useTranslation } from "react-i18next";
@@ -26,6 +26,7 @@ interface MarkdownMessageProps {
 }
 
 const LANGUAGE_CLASS_PATTERN = /(?:^|\s)language-([^\s]+)/;
+const markdownRemarkPlugins = [remarkGfm];
 const highlightedCodeCache = new Map<string, Promise<ThemedTokenWithVariants[][] | null>>();
 
 interface ShikiTokenStyle extends CSSProperties {
@@ -107,8 +108,11 @@ const markdownComponents: Components = {
 /** Renders untrusted assistant Markdown without enabling raw HTML execution. */
 export function MarkdownMessage({ content, streaming = false }: MarkdownMessageProps) {
   const markdown = unwrapMarkdownDocument(content);
-  const deferredMarkdown = useDeferredValue(markdown);
-  const renderedMarkdown = streaming ? deferredMarkdown : markdown;
+  const renderedMarkdown = useFrameBatchedMarkdown(markdown, streaming);
+  const parseableMarkdown = useMemo(
+    () => streaming ? remend(renderedMarkdown) : renderedMarkdown,
+    [renderedMarkdown, streaming],
+  );
   const [storedRevealState, setStoredRevealState] = useState<StreamingRevealState>(() => ({
     renderedLength: renderedMarkdown.length,
     revealStart: streaming ? 0 : renderedMarkdown.length,
@@ -136,6 +140,22 @@ export function MarkdownMessage({ content, streaming = false }: MarkdownMessageP
     ...markdownComponents,
     span: (props) => <StreamingRevealSpan {...props} registryRef={revealNodesRef} />,
   }), []);
+  const rehypePlugins = useMemo(
+    () => streaming ? [revealPlugin] : [],
+    [revealPlugin, streaming],
+  );
+  const markdownBody = useMemo(
+    () => (
+      <ReactMarkdown
+        remarkPlugins={markdownRemarkPlugins}
+        rehypePlugins={rehypePlugins}
+        components={streaming ? streamingMarkdownComponents : markdownComponents}
+      >
+        {parseableMarkdown}
+      </ReactMarkdown>
+    ),
+    [parseableMarkdown, rehypePlugins, streaming, streamingMarkdownComponents],
+  );
 
   useLayoutEffect(() => {
     if (streaming) animateStreamingReveal(revealNodesRef.current);
@@ -143,15 +163,39 @@ export function MarkdownMessage({ content, streaming = false }: MarkdownMessageP
 
   return (
     <div data-selectable className="min-w-0 break-words text-[15px] leading-[26px] text-foreground">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={streaming ? [revealPlugin] : []}
-        components={streaming ? streamingMarkdownComponents : markdownComponents}
-      >
-        {renderedMarkdown}
-      </ReactMarkdown>
+      {markdownBody}
     </div>
   );
+}
+
+/** Coalesces stream chunks per frame while guaranteeing progress during continuous output. */
+function useFrameBatchedMarkdown(markdown: string, streaming: boolean) {
+  const [renderedMarkdown, setRenderedMarkdown] = useState(markdown);
+  const latestMarkdownRef = useRef(markdown);
+  const committedMarkdownRef = useRef(markdown);
+  const frameRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    latestMarkdownRef.current = markdown;
+    if (committedMarkdownRef.current === markdown || frameRef.current !== null) return;
+
+    const scheduleFrame = window.requestAnimationFrame
+      ?? ((callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 16));
+    frameRef.current = scheduleFrame(() => {
+      frameRef.current = null;
+      const latestMarkdown = latestMarkdownRef.current;
+      committedMarkdownRef.current = latestMarkdown;
+      setRenderedMarkdown(latestMarkdown);
+    });
+  }, [markdown]);
+
+  useEffect(() => () => {
+    if (frameRef.current === null) return;
+    if (window.cancelAnimationFrame) window.cancelAnimationFrame(frameRef.current);
+    else window.clearTimeout(frameRef.current);
+  }, []);
+
+  return streaming ? renderedMarkdown : markdown;
 }
 
 /** Creates one Markdown transform that marks only newly streamed prose for reveal animation. */
@@ -178,9 +222,13 @@ function wrapStreamingText(node: MarkdownAstNode, revealStart: number) {
     const startOffset = child.position?.start.offset;
     if (startOffset === undefined || childEndOffset === undefined) continue;
 
-    const splitIndex = revealStart <= startOffset
+    const sourceLength = childEndOffset - startOffset;
+    // Entities and escapes can make source offsets diverge from visible text.
+    // Revealing the whole node is preferable to hiding freshly streamed text
+    // behind an unsafe proportional offset.
+    const splitIndex = revealStart <= startOffset || sourceLength !== child.value.length
       ? 0
-      : Math.round(((revealStart - startOffset) / Math.max(1, childEndOffset - startOffset)) * child.value.length);
+      : Math.min(child.value.length, revealStart - startOffset);
     const stableText = child.value.slice(0, splitIndex);
     const revealedText = child.value.slice(splitIndex);
     if (revealedText === "") continue;

--- a/packages/app-shell/src/features/chat/message-bubble.tsx
+++ b/packages/app-shell/src/features/chat/message-bubble.tsx
@@ -12,6 +12,7 @@ interface MessageBubbleProps {
   message: ChatMessage;
   userName: string;
   embeddedAssistant?: boolean;
+  streaming?: boolean;
 }
 
 /** Copies message content to the clipboard and briefly confirms with a check. */
@@ -29,7 +30,7 @@ function useCopyMessage(content: string) {
 }
 
 /** A single chat message: avatar + content, with hover actions on replies. */
-export function MessageBubble({ message, userName, embeddedAssistant = false }: MessageBubbleProps) {
+export function MessageBubble({ message, userName, embeddedAssistant = false, streaming = false }: MessageBubbleProps) {
   const { t } = useTranslation();
   const { copied, copy } = useCopyMessage(message.content);
   const isUser = message.role === "user";
@@ -45,7 +46,7 @@ export function MessageBubble({ message, userName, embeddedAssistant = false }: 
             <p data-selectable className="relative whitespace-pre-wrap break-words text-[14px] leading-6 text-foreground">{message.content}</p>
           </div>
         ) : (
-          <MarkdownMessage content={message.content} />
+          <MarkdownMessage content={message.content} streaming={streaming} />
         )}
 
         <div className={`flex min-h-6 items-center gap-2 ${isUser ? "pr-1" : ""}`}>

--- a/packages/app-shell/src/features/chat/message-list.tsx
+++ b/packages/app-shell/src/features/chat/message-list.tsx
@@ -26,6 +26,7 @@ export function MessageList({ turns, userName, isResponding }: MessageListProps)
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const followTailRef = useRef(true);
+  const pointerScrollRef = useRef(false);
   const pendingNavigationRef = useRef<PendingNavigation | null>(null);
   const lastTurn = turns.at(-1);
   const lastAnchorId = lastTurn === undefined
@@ -47,7 +48,6 @@ export function MessageList({ turns, userName, isResponding }: MessageListProps)
   const handleScroll = () => {
     const element = scrollRef.current;
     if (!element) return;
-    followTailRef.current = element.scrollHeight - element.scrollTop - element.clientHeight < TAIL_PROXIMITY_PX;
     const pendingNavigation = pendingNavigationRef.current;
     if (pendingNavigation) {
       const maximumScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
@@ -57,6 +57,9 @@ export function MessageList({ turns, userName, isResponding }: MessageListProps)
       }
       return;
     }
+    const atTail = element.scrollHeight - element.scrollTop - element.clientHeight < TAIL_PROXIMITY_PX;
+    if (atTail) followTailRef.current = true;
+    else if (pointerScrollRef.current) followTailRef.current = false;
     const nextAnchorId = findActiveAnchorId(element);
     setNavigation((current) => (
       current.activeAnchorId === nextAnchorId && current.lastAnchorId === lastAnchorId
@@ -68,6 +71,23 @@ export function MessageList({ turns, userName, isResponding }: MessageListProps)
   /** Returns control to position-based tracking when the reader manually moves the thread. */
   const cancelPendingNavigation = () => {
     pendingNavigationRef.current = null;
+  };
+
+  /** Stops tail-following only for an explicit upward wheel gesture. */
+  const handleWheel = (deltaY: number) => {
+    cancelPendingNavigation();
+    if (deltaY < 0) followTailRef.current = false;
+  };
+
+  /** Distinguishes scrollbar or touch dragging from scroll events emitted by programmatic tail updates. */
+  const beginPointerScroll = () => {
+    cancelPendingNavigation();
+    pointerScrollRef.current = true;
+  };
+
+  /** Ends pointer intent without changing the follow state established by any resulting scroll. */
+  const endPointerScroll = () => {
+    pointerScrollRef.current = false;
   };
 
   useLayoutEffect(() => {
@@ -122,9 +142,13 @@ export function MessageList({ turns, userName, isResponding }: MessageListProps)
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        onWheel={cancelPendingNavigation}
-        onPointerDown={cancelPendingNavigation}
-        onTouchStart={cancelPendingNavigation}
+        onWheel={(event) => handleWheel(event.deltaY)}
+        onPointerDown={beginPointerScroll}
+        onPointerUp={endPointerScroll}
+        onPointerCancel={endPointerScroll}
+        onTouchStart={beginPointerScroll}
+        onTouchEnd={endPointerScroll}
+        onTouchCancel={endPointerScroll}
         data-testid="message-list"
         aria-live="polite"
         className="scrollbar-hide h-full min-h-0 animate-in overflow-y-auto fade-in duration-500"

--- a/packages/app-shell/src/features/chat/message-list.tsx
+++ b/packages/app-shell/src/features/chat/message-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { AgentActivityDots } from "../../components/agent-activity-dots";
 import { useTranslation } from "react-i18next";
 import { AnchorHighlight } from "./anchor-highlight";
@@ -24,6 +24,7 @@ interface PendingNavigation {
 /** The scrollable turn thread, kept pinned to live ACP activity unless the reader scrolls away. */
 export function MessageList({ turns, userName, isResponding }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const followTailRef = useRef(true);
   const pendingNavigationRef = useRef<PendingNavigation | null>(null);
   const lastTurn = turns.at(-1);
@@ -37,7 +38,6 @@ export function MessageList({ turns, userName, isResponding }: MessageListProps)
   const activeAnchorId = navigation.lastAnchorId === lastAnchorId ? navigation.activeAnchorId : lastAnchorId;
   const lastItem = lastTurn?.items.at(-1);
   const lastUserMessageId = lastTurn?.userMessage.id;
-  const tailVersion = itemVersion(lastItem);
   // Hide the running indicator while the answer itself is streaming: the growing
   // text already shows the agent is live, so a second "working" line under it
   // just reads as noise. It returns for thoughts, tool calls, and the waits between.
@@ -70,17 +70,32 @@ export function MessageList({ turns, userName, isResponding }: MessageListProps)
     pendingNavigationRef.current = null;
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (lastUserMessageId === undefined) return;
     followTailRef.current = true;
+    const element = scrollRef.current;
+    if (!element) return;
+    // Tail following must settle in one step. Smooth scrolling emits
+    // intermediate positions that look like a reader moving away, especially
+    // when final Markdown or a large highlighted code block grows at the same time.
+    element.style.scrollBehavior = "auto";
+    element.scrollTop = element.scrollHeight;
   }, [turns.length, lastUserMessageId]);
 
-  useEffect(() => {
-    const element = scrollRef.current;
-    if (!element || !followTailRef.current) return;
-    element.style.scrollBehavior = isResponding ? "auto" : "smooth";
-    element.scrollTop = element.scrollHeight;
-  }, [turns.length, lastTurn?.items.length, tailVersion, isResponding]);
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (!content || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      const element = scrollRef.current;
+      if (!element || !followTailRef.current) return;
+      // Deferred Markdown and async code highlighting can finish after the
+      // message update effect. Following measured height keeps the live tail
+      // stable without treating those later layout passes as user intent.
+      element.scrollTop = element.scrollHeight;
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, []);
 
   /** Moves the thread to a selected prompt or response without resuming live tail-following. */
   const navigateToAnchor = (anchorId: string) => {
@@ -114,7 +129,7 @@ export function MessageList({ turns, userName, isResponding }: MessageListProps)
         aria-live="polite"
         className="scrollbar-hide h-full min-h-0 animate-in overflow-y-auto fade-in duration-500"
       >
-        <div className="mx-auto w-full max-w-[760px] px-3 pb-4 pt-5 sm:px-5 sm:pt-8">
+        <div ref={contentRef} className="mx-auto w-full max-w-[760px] px-3 pb-4 pt-5 sm:px-5 sm:pt-8">
           {turns.map((turn) => (
             <div key={turn.id} data-turn-anchor={turn.id}>
               <div data-turn-user data-conversation-anchor={`${turn.id}:user`}>
@@ -178,21 +193,6 @@ function findActiveAnchorId(element: HTMLDivElement): string | null {
   return activeAnchorId;
 }
 
-/** Returns a primitive version marker for streaming content and lifecycle updates. */
-function itemVersion(item: ChatTurn["items"][number] | undefined): string | number | undefined {
-  if (item === undefined) return undefined;
-  switch (item.kind) {
-    case "message":
-    case "thought":
-      return item.content;
-    case "plan":
-    case "toolCall":
-      return item.updatedAt;
-    case "unsupportedContent":
-      return item.id;
-  }
-}
-
 /** Word rotation cadence — slow enough to read each phrase, quick enough to feel alive. */
 const RUNNING_WORD_INTERVAL_MS = 2600;
 
@@ -213,7 +213,6 @@ function RunningIndicator() {
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
-    setIndex(0);
     if (words.length <= 1 || window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     const timer = setInterval(() => setIndex((current) => (current + 1) % words.length), RUNNING_WORD_INTERVAL_MS);
     return () => clearInterval(timer);

--- a/packages/app-shell/src/features/chat/response-turn.tsx
+++ b/packages/app-shell/src/features/chat/response-turn.tsx
@@ -56,7 +56,15 @@ export function ResponseTurn({ turn, userName }: ResponseTurnProps) {
             case "toolGroup":
               return <ToolCallGroup key={item.id} kind={item.groupKind} tools={item.tools} />;
             case "message":
-              return <MessageBubble key={item.id} message={item} userName={userName} embeddedAssistant streaming={turn.status === "streaming"} />;
+              return (
+                <MessageBubble
+                  key={item.id}
+                  message={item}
+                  userName={userName}
+                  embeddedAssistant
+                  streaming={turn.status === "streaming" && index === displayItems.length - 1}
+                />
+              );
             case "unsupportedContent":
               return (
                 <p key={item.id} className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">

--- a/packages/app-shell/src/features/chat/response-turn.tsx
+++ b/packages/app-shell/src/features/chat/response-turn.tsx
@@ -56,7 +56,7 @@ export function ResponseTurn({ turn, userName }: ResponseTurnProps) {
             case "toolGroup":
               return <ToolCallGroup key={item.id} kind={item.groupKind} tools={item.tools} />;
             case "message":
-              return <MessageBubble key={item.id} message={item} userName={userName} embeddedAssistant />;
+              return <MessageBubble key={item.id} message={item} userName={userName} embeddedAssistant streaming={turn.status === "streaming"} />;
             case "unsupportedContent":
               return (
                 <p key={item.id} className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">

--- a/packages/app-shell/src/features/chat/streaming-markdown.ts
+++ b/packages/app-shell/src/features/chat/streaming-markdown.ts
@@ -1,0 +1,56 @@
+import remend, {
+  isWithinCodeBlock,
+  isWithinLinkOrImageUrl,
+  isWithinMathBlock,
+  type RemendHandler,
+} from "remend";
+
+const AMBIGUOUS_INLINE_DELIMITER_PATTERN = /(?:\*+|_+|~+|`+)$/;
+const AMBIGUOUS_BLOCK_MARKER_PATTERN = /^[ \t]{0,3}(?:#{1,6}|>|[-+*]|\d{1,9}[.)])[ \t]*$/;
+
+const pendingBoundaryHandler: RemendHandler = {
+  name: "pending-markdown-boundary",
+  priority: -1,
+  handle: withholdPendingBoundary,
+};
+
+/**
+ * Repairs an incomplete Markdown snapshot while withholding only its still-ambiguous final boundary.
+ *
+ * The source snapshot remains untouched outside this derived render path. Once another character
+ * resolves the syntax—or the caller stops using this streaming path—the boundary is rendered
+ * normally, so literal marker characters can never be lost.
+ */
+export function prepareStreamingMarkdown(markdown: string) {
+  return remend(markdown, { handlers: [pendingBoundaryHandler] });
+}
+
+/** Removes a syntactically undecidable tail before Remend completes the remaining Markdown. */
+function withholdPendingBoundary(markdown: string) {
+  const lineStart = markdown.lastIndexOf("\n") + 1;
+  const lastLine = markdown.slice(lineStart);
+  if (
+    AMBIGUOUS_BLOCK_MARKER_PATTERN.test(lastLine)
+    && !isWithinCodeBlock(markdown, lineStart)
+    && !isWithinMathBlock(markdown, lineStart)
+  ) {
+    return markdown.slice(0, lineStart);
+  }
+
+  const delimiterMatch = markdown.match(AMBIGUOUS_INLINE_DELIMITER_PATTERN);
+  if (!delimiterMatch) return markdown;
+  const delimiterStart = markdown.length - delimiterMatch[0].length;
+  let escapeCount = 0;
+  for (let index = delimiterStart - 1; index >= 0 && markdown[index] === "\\"; index -= 1) {
+    escapeCount += 1;
+  }
+  if (
+    escapeCount % 2 === 1
+    || isWithinCodeBlock(markdown, delimiterStart)
+    || isWithinMathBlock(markdown, delimiterStart)
+    || isWithinLinkOrImageUrl(markdown, delimiterStart)
+  ) {
+    return markdown;
+  }
+  return markdown.slice(0, delimiterStart);
+}

--- a/packages/app-shell/src/features/chat/streaming-thought-reveal.test.tsx
+++ b/packages/app-shell/src/features/chat/streaming-thought-reveal.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StreamingThoughtReveal } from "./streaming-thought-reveal";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("StreamingThoughtReveal", () => {
+  it("disables thought motion when reduced motion is requested", () => {
+    const originalAnimate = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "animate");
+    const animate = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      value: animate,
+    });
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: true })));
+
+    try {
+      render(<StreamingThoughtReveal>Checking files</StreamingThoughtReveal>);
+
+      expect(animate).not.toHaveBeenCalled();
+    } finally {
+      if (originalAnimate === undefined) Reflect.deleteProperty(HTMLElement.prototype, "animate");
+      else Object.defineProperty(HTMLElement.prototype, "animate", originalAnimate);
+    }
+  });
+});

--- a/packages/app-shell/src/features/chat/streaming-thought-reveal.tsx
+++ b/packages/app-shell/src/features/chat/streaming-thought-reveal.tsx
@@ -1,0 +1,49 @@
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+
+/** Tracks the appended suffix without replaying reveal motion for stable streamed content. */
+export function useStreamingThoughtRevealStart(content: string, streaming: boolean) {
+  const previousRef = useRef<{
+    contentLength: number;
+    revealStart: number;
+    streaming: boolean;
+  } | null>(null);
+  const previous = previousRef.current;
+  if (previous?.contentLength === content.length && previous.streaming === streaming) {
+    return previous.revealStart;
+  }
+  // ChatThought chunks are append-only in the conversation store. Tracking lengths keeps each
+  // streamed update O(1) instead of repeatedly scanning the complete accumulated thought.
+  const revealStart = streaming
+    ? previous !== null && previous.streaming && content.length >= previous.contentLength
+      ? previous.contentLength
+      : 0
+    : content.length;
+  previousRef.current = { contentLength: content.length, revealStart, streaming };
+  return revealStart;
+}
+
+/** Applies a restrained opacity-only reveal to the latest streamed thought suffix. */
+export function StreamingThoughtReveal({ children }: { children: ReactNode }) {
+  const spanRef = useRef<HTMLSpanElement>(null);
+
+  useLayoutEffect(() => {
+    const span = spanRef.current;
+    if (
+      span === null
+      || typeof span.animate !== "function"
+      || window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) return;
+    const animation = span.animate(
+      [{ opacity: 0.55 }, { opacity: 1 }],
+      { duration: 140, easing: "cubic-bezier(0.2, 0, 0, 1)" },
+    );
+    animation.addEventListener("finish", () => animation.cancel(), { once: true });
+    return () => animation.cancel();
+  }, []);
+
+  return (
+    <span ref={spanRef} data-stream-thought-reveal>
+      {children}
+    </span>
+  );
+}

--- a/packages/chat/src/store.ts
+++ b/packages/chat/src/store.ts
@@ -89,6 +89,16 @@ const EMPTY_CONVERSATION: SessionConversation = {
   error: null,
 };
 
+/** Caps one live text batch so streamed output stays responsive under very large responses. */
+const STREAMING_TEXT_BATCH_LIMIT = 4 * 1024;
+
+interface BufferedTextChunk {
+  itemKind: "message" | "thought";
+  messageId: string | undefined;
+  text: string;
+  timestamp: number;
+}
+
 /** Creates a per-session chat state owner backed directly by generated Ora contracts. */
 export function createChatStore(
   client: ChatSessionClient,
@@ -177,6 +187,60 @@ export function createChatStore(
       }
       const controller = new AbortController();
       operations.set(key, controller);
+      let pendingTextChunk: BufferedTextChunk | null = null;
+      let pendingFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+      /** Flushes one buffered text batch into the live turn before a boundary update. */
+      const flushPendingTextChunk = () => {
+        if (pendingFlushTimer !== null) {
+          clearTimeout(pendingFlushTimer);
+          pendingFlushTimer = null;
+        }
+        const batch = pendingTextChunk;
+        if (batch === null) return;
+        updateTurn(set, key, turnId, (current) =>
+          appendTextContentChunk(
+            current,
+            batch.itemKind,
+            batch.messageId,
+            batch.text,
+            batch.timestamp,
+          ),
+        );
+        pendingTextChunk = null;
+      };
+
+      /** Schedules a near-term flush so streaming remains visible without repainting every token. */
+      const schedulePendingTextFlush = () => {
+        if (pendingFlushTimer !== null) return;
+        pendingFlushTimer = setTimeout(() => {
+          pendingFlushTimer = null;
+          flushPendingTextChunk();
+        }, 16);
+      };
+
+      /** Collects one text chunk so repeated provider frames collapse into larger UI updates. */
+      const queueTextChunk = (itemKind: "message" | "thought", chunk: acp.ContentChunk) => {
+        if (chunk.content.type !== "text") return;
+        if (pendingTextChunk !== null && (pendingTextChunk.itemKind !== itemKind || pendingTextChunk.messageId !== (chunk.messageId ?? undefined))) {
+          flushPendingTextChunk();
+        }
+        if (pendingTextChunk === null) {
+          pendingTextChunk = {
+            itemKind,
+            messageId: chunk.messageId ?? undefined,
+            text: chunk.content.text,
+            timestamp: now(),
+          };
+        } else {
+          pendingTextChunk.text += chunk.content.text;
+        }
+        if (pendingTextChunk.text.length >= STREAMING_TEXT_BATCH_LIMIT) {
+          flushPendingTextChunk();
+        } else {
+          schedulePendingTextFlush();
+        }
+      };
 
       const createdAt = now();
       const turnId = createId();
@@ -254,12 +318,23 @@ export function createChatStore(
             // The user turn is already materialized, so the echoed prompt chunk
             // would only duplicate it; every other update belongs to this turn.
             if (event.update.sessionUpdate === "user_message_chunk") continue;
+            if (event.update.sessionUpdate === "agent_message_chunk") {
+              queueTextChunk("message", event.update);
+              continue;
+            }
+            if (event.update.sessionUpdate === "agent_thought_chunk") {
+              queueTextChunk("thought", event.update);
+              continue;
+            }
+            flushPendingTextChunk();
             updateTurn(set, key, turnId, (current) =>
               applyAgentUpdate(current, event.update, createId, now()),
             );
           } else if (event.type === "permission_request") {
+            flushPendingTextChunk();
             appendPermission(set, key, event);
           } else {
+            flushPendingTextChunk();
             updateTurn(set, key, turnId, (current) => ({
               ...current,
               status: event.stopReason === "cancelled" ? "cancelled" : "completed",
@@ -268,6 +343,7 @@ export function createChatStore(
           }
         }
       } catch (error) {
+        flushPendingTextChunk();
         if (isAbortError(error)) {
           updateTurn(set, key, turnId, (current) =>
             current.status === "streaming" ? { ...current, status: "cancelled" } : current,
@@ -287,6 +363,7 @@ export function createChatStore(
           throw error;
         }
       } finally {
+        flushPendingTextChunk();
         operations.delete(key);
         updateTurn(set, key, turnId, (current) =>
           current.status === "streaming" ? { ...current, status: "completed" } : current,
@@ -469,34 +546,44 @@ function appendContentChunk(
     };
   }
 
-  const protocolMessageId = chunk.messageId ?? undefined;
+  return appendTextContentChunk(turn, itemKind, chunk.messageId ?? undefined, content.text, timestamp);
+}
+
+/** Appends one live text batch while preserving the per-message identity rules. */
+function appendTextContentChunk(
+  turn: ChatTurn,
+  itemKind: "message" | "thought",
+  messageId: string | undefined,
+  text: string,
+  timestamp: number,
+): ChatTurn {
   const implicitId = `${itemKind}-implicit-${turn.id}`;
-  const itemId = protocolMessageId === undefined ? implicitId : `${itemKind}-${protocolMessageId}`;
+  const itemId = messageId === undefined ? implicitId : `${itemKind}-${messageId}`;
   const itemIndex = turn.items.findIndex((item) => item.id === itemId && item.kind === itemKind);
   if (itemIndex === -1) {
     const item = itemKind === "message"
       ? {
-        kind: "message" as const,
-        id: itemId,
-        role: "assistant" as const,
-        content: content.text,
-        createdAt: timestamp,
-        ...(protocolMessageId === undefined ? {} : { protocolMessageId }),
-      }
+          kind: "message" as const,
+          id: itemId,
+          role: "assistant" as const,
+          content: text,
+          createdAt: timestamp,
+          ...(messageId === undefined ? {} : { protocolMessageId: messageId }),
+        }
       : {
-        kind: "thought" as const,
-        id: itemId,
-        content: content.text,
-        createdAt: timestamp,
-        ...(protocolMessageId === undefined ? {} : { protocolMessageId }),
-      };
+          kind: "thought" as const,
+          id: itemId,
+          content: text,
+          createdAt: timestamp,
+          ...(messageId === undefined ? {} : { protocolMessageId: messageId }),
+        };
     return { ...turn, items: [...turn.items, item] };
   }
 
   const items = [...turn.items];
   const item = items[itemIndex]!;
   if (item.kind === "message" || item.kind === "thought") {
-    items[itemIndex] = { ...item, content: item.content + content.text };
+    items[itemIndex] = { ...item, content: item.content + text };
   }
   return { ...turn, items };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remend:
+        specifier: 1.3.0
+        version: 1.3.0
       shiki:
         specifier: ^3.23.0
         version: 3.23.0
@@ -3531,6 +3534,9 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remend@1.3.0:
+    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -7428,6 +7434,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.0.0
       unified: 11.0.0
+
+  remend@1.3.0: {}
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
## Summary

- keep long streamed responses responsive with bounded text batches and frame-coalesced Markdown rendering
- repair incomplete Markdown with Remend while preventing ambiguous delimiter flashes
- keep fast and asynchronously resized responses pinned to the tail without overriding explicit user scrolling
- add restrained opacity-only reveals for newly streamed prose and the active thought suffix

## Performance

- cap individual streamed text batches to avoid long main-thread stalls
- coalesce Markdown updates by animation frame and memoize rendered output
- process only newly appended reveal content instead of rescanning stable text
- track thought reveal boundaries in constant time
- avoid applying reveal animations to code blocks, completed responses, or historical thoughts

## Markdown behavior

- render incomplete emphasis, links, code fences, tables, and other Markdown structures while streaming
- withhold only syntactically ambiguous trailing delimiters
- preserve the original source so literal markers are restored when resolved or when streaming completes
- restrict streaming repair to the active final text item

## Scrolling behavior

- follow rapid stream growth and deferred layout changes
- ignore programmatic scroll events when determining reader intent
- stop following only after explicit wheel, pointer, or touch interaction
- resume following when the reader returns to the tail

## Testing

- `pnpm --filter @ora/app-shell test` — 171 tests passed
- `task lint:frontend`
- `npm run build` in `apps/web/client`

Closes #176