### PR TITLE
feat(marketplace): add SkillHub webview window

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -38,3 +38,4 @@ urlencoding = "2"
 
 [dev-dependencies]
 pretty_assertions = "1"
+tauri = { version = "2.10.3", features = ["test"] }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 mod config;
 mod dashboard;
 mod error;
+mod skill_marketplace;
 mod state;
 
 use crate::config::DesktopConfigStore;
@@ -71,6 +72,7 @@ pub fn run() {
             commands::resolve_task_cwd,
             commands::open_location,
             dashboard::get_dashboard_url,
+            skill_marketplace::open_skill_marketplace,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/skill_marketplace.rs
+++ b/apps/desktop/src-tauri/src/skill_marketplace.rs
@@ -1,0 +1,116 @@
+use crate::error::CommandError;
+use tauri::{AppHandle, Manager, Runtime, Url, WebviewUrl, WebviewWindowBuilder};
+
+const SKILLHUB_URL: &str = "https://www.skillhub.cn";
+const SKILLHUB_WINDOW_LABEL: &str = "skillhub-marketplace";
+
+/// Opens the SkillHub marketplace or focuses the existing single marketplace window.
+#[tauri::command]
+pub async fn open_skill_marketplace(app: AppHandle) -> Result<(), CommandError> {
+    open_or_focus_skill_marketplace(&app)
+}
+
+/// Reuses one marketplace window so repeated settings actions preserve navigation and cookies.
+fn open_or_focus_skill_marketplace<R: Runtime>(app: &AppHandle<R>) -> Result<(), CommandError> {
+    if let Some(window) = app.get_webview_window(SKILLHUB_WINDOW_LABEL) {
+        window
+            .show()
+            .and_then(|_| window.unminimize())
+            .and_then(|_| window.set_focus())
+            .map_err(|_| marketplace_window_error())?;
+        return Ok(());
+    }
+
+    let url = Url::parse(SKILLHUB_URL).map_err(|_| marketplace_window_error())?;
+    WebviewWindowBuilder::new(app, SKILLHUB_WINDOW_LABEL, WebviewUrl::External(url))
+        .title("SkillHub")
+        .inner_size(1100.0, 760.0)
+        .min_inner_size(720.0, 520.0)
+        .center()
+        .on_navigation(is_skillhub_navigation_allowed)
+        .build()
+        .map_err(|_| marketplace_window_error())?;
+
+    Ok(())
+}
+
+/// Restricts top-level navigation to the two canonical SkillHub HTTPS hosts.
+fn is_skillhub_navigation_allowed(url: &Url) -> bool {
+    url.scheme() == "https"
+        && url.port().is_none()
+        && url.username().is_empty()
+        && url.password().is_none()
+        && matches!(url.host_str(), Some("skillhub.cn" | "www.skillhub.cn"))
+}
+
+/// Hides platform-specific window failures behind one stable frontend error.
+fn marketplace_window_error() -> CommandError {
+    CommandError::new(
+        "skill_marketplace_window_error",
+        "failed to open the SkillHub marketplace",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SKILLHUB_WINDOW_LABEL, is_skillhub_navigation_allowed, open_or_focus_skill_marketplace,
+    };
+    use pretty_assertions::assert_eq;
+    use tauri::{Manager, Url};
+
+    /// Verifies both canonical SkillHub hosts remain available over HTTPS.
+    #[test]
+    fn allows_canonical_skillhub_navigation() {
+        assert_eq!(
+            [
+                "https://skillhub.cn",
+                "https://www.skillhub.cn/skills/example?tab=install",
+            ]
+            .map(parse_url)
+            .map(|url| is_skillhub_navigation_allowed(&url)),
+            [true, true],
+        );
+    }
+
+    /// Verifies lookalike hosts, credentials, custom ports, and insecure schemes are rejected.
+    #[test]
+    fn rejects_untrusted_marketplace_navigation() {
+        assert_eq!(
+            [
+                "http://www.skillhub.cn",
+                "https://www.skillhub.cn.evil.example",
+                "https://user@www.skillhub.cn",
+                "https://www.skillhub.cn:8443",
+                "https://example.com",
+            ]
+            .map(parse_url)
+            .map(|url| is_skillhub_navigation_allowed(&url)),
+            [false, false, false, false, false],
+        );
+    }
+
+    /// Verifies repeated opens preserve exactly one marketplace webview window.
+    #[test]
+    fn reuses_the_existing_marketplace_window() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle().clone();
+
+        open_or_focus_skill_marketplace(&handle)
+            .unwrap_or_else(|error| panic!("expected first marketplace open: {error:?}"));
+        open_or_focus_skill_marketplace(&handle)
+            .unwrap_or_else(|error| panic!("expected marketplace reuse: {error:?}"));
+
+        assert_eq!(
+            app.webview_windows()
+                .keys()
+                .filter(|label| label.as_str() == SKILLHUB_WINDOW_LABEL)
+                .count(),
+            1,
+        );
+    }
+
+    fn parse_url(value: &str) -> Url {
+        Url::parse(value).unwrap_or_else(|error| panic!("expected test URL to parse: {error}"))
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated Tauri window for the live SkillHub marketplace
- reuse and focus the existing marketplace window on repeated opens
- restrict top-level navigation to canonical SkillHub HTTPS hosts
- register the `open_skill_marketplace` Tauri command
- add tests for navigation restrictions and window reuse

## Scope

This PR only implements the SkillHub WebView window.

It does not yet include:

- settings-page integration
- ZIP download interception
- download persistence
- Skill installation or ZIP parsing

## Testing

- SkillHub Rust tests: 3 passed
- Desktop TypeScript tests: 6 passed
- Desktop Rust tests: 10 passed
- Desktop ESLint, rustfmt, and Clippy passed
- Frontend package and Rust workspace tests passed