### PR TITLE
refactor(workflow): improve canvas connection responsiveness

### DIFF
--- a/packages/app-shell/src/features/settings/workflow-flow/adapters.test.ts
+++ b/packages/app-shell/src/features/settings/workflow-flow/adapters.test.ts
@@ -123,8 +123,9 @@ describe("workflow-flow adapters", () => {
         reconnectable: true,
         markerEnd: {
           type: "arrowclosed",
-          width: 12,
-          height: 12,
+          width: 28,
+          height: 28,
+          markerUnits: "userSpaceOnUse",
           color: "var(--ring)",
         },
         data: {

--- a/packages/app-shell/src/features/settings/workflow-flow/adapters.ts
+++ b/packages/app-shell/src/features/settings/workflow-flow/adapters.ts
@@ -97,11 +97,12 @@ export function toFlowEdges(
     reconnectable: true,
     markerEnd: {
       type: MarkerType.ArrowClosed,
-      width: 12,
-      height: 12,
+      width: 28,
+      height: 28,
+      markerUnits: "userSpaceOnUse",
       color: selectedEdgeId === edge.id
         ? "var(--ring)"
-        : "color-mix(in oklch, var(--foreground) 46%, transparent)",
+        : "color-mix(in oklch, var(--foreground) 64%, transparent)",
     },
     data: {
       sourceTitle: titles.get(edge.source) ?? edge.source,

--- a/packages/app-shell/src/features/settings/workflow-flow/callbacks.test.tsx
+++ b/packages/app-shell/src/features/settings/workflow-flow/callbacks.test.tsx
@@ -1,0 +1,67 @@
+import { memo } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  WorkflowFlowCallbacksProvider,
+  useWorkflowFlowActions,
+  useWorkflowFlowConnectionState,
+  type WorkflowFlowCallbacks,
+} from "./callbacks";
+
+/** Tracks action-context renders while exposing one callback for a semantic assertion. */
+const ActionConsumer = memo(function ActionConsumer({
+  onRender,
+}: {
+  onRender: () => void;
+}) {
+  onRender();
+  const { onDeleteNode } = useWorkflowFlowActions();
+  return <button type="button" onClick={() => onDeleteNode("node-1")}>delete</button>;
+});
+
+/** Tracks connection-context renders independently from stable graph actions. */
+const ConnectionConsumer = memo(function ConnectionConsumer({
+  onRender,
+}: {
+  onRender: () => void;
+}) {
+  onRender();
+  const { connectionCandidateNodeId } = useWorkflowFlowConnectionState();
+  return <span>{connectionCandidateNodeId ?? "none"}</span>;
+});
+
+describe("WorkflowFlowCallbacksProvider", () => {
+  it("does not rerender action-only edge consumers when the candidate changes", () => {
+    const onDeleteNode = vi.fn();
+    const actions = {
+      onDeleteNode,
+      onDeleteEdge: vi.fn(),
+      onSelectEdge: vi.fn(),
+    };
+    const actionRender = vi.fn();
+    const connectionRender = vi.fn();
+
+    /** Renders both consumer classes with a chosen transient candidate. */
+    function view(candidateNodeId: string | null) {
+      const value: WorkflowFlowCallbacks = {
+        ...actions,
+        connectionCandidateEndpoint: candidateNodeId === null ? null : "target",
+        connectionCandidateNodeId: candidateNodeId,
+      };
+      return (
+        <WorkflowFlowCallbacksProvider value={value}>
+          <ActionConsumer onRender={actionRender} />
+          <ConnectionConsumer onRender={connectionRender} />
+        </WorkflowFlowCallbacksProvider>
+      );
+    }
+
+    const { rerender } = render(view(null));
+    rerender(view("node-2"));
+
+    expect(actionRender).toHaveBeenCalledTimes(1);
+    expect(connectionRender).toHaveBeenCalledTimes(2);
+    screen.getByRole("button", { name: "delete" }).click();
+    expect(onDeleteNode).toHaveBeenCalledExactlyOnceWith("node-1");
+  });
+});

--- a/packages/app-shell/src/features/settings/workflow-flow/callbacks.tsx
+++ b/packages/app-shell/src/features/settings/workflow-flow/callbacks.tsx
@@ -1,16 +1,23 @@
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 
-export interface WorkflowFlowCallbacks {
-  connectionCandidateEndpoint?: "source" | "target" | null;
-  connectionCandidateNodeId?: string | null;
+export interface WorkflowFlowActions {
   onDeleteNode: (nodeId: string) => void;
   onDeleteEdge: (edgeId: string) => void;
   onSelectEdge: (edgeId: string) => void;
 }
 
-const WorkflowFlowCallbacksContext = createContext<WorkflowFlowCallbacks | null>(null);
+export interface WorkflowFlowConnectionState {
+  connectionCandidateEndpoint?: "source" | "target" | null;
+  connectionCandidateNodeId?: string | null;
+}
 
-/** Provides canvas mutation callbacks to custom React Flow node/edge renderers. */
+export type WorkflowFlowCallbacks = WorkflowFlowActions & WorkflowFlowConnectionState;
+
+const WorkflowFlowActionsContext = createContext<WorkflowFlowActions | null>(null);
+const WorkflowFlowConnectionStateContext =
+  createContext<WorkflowFlowConnectionState | null>(null);
+
+/** Separates stable graph actions from pointer-frequency connection state. */
 export function WorkflowFlowCallbacksProvider({
   value,
   children,
@@ -18,18 +25,39 @@ export function WorkflowFlowCallbacksProvider({
   value: WorkflowFlowCallbacks;
   children: ReactNode;
 }) {
+  const actions = useMemo<WorkflowFlowActions>(() => ({
+    onDeleteNode: value.onDeleteNode,
+    onDeleteEdge: value.onDeleteEdge,
+    onSelectEdge: value.onSelectEdge,
+  }), [value.onDeleteEdge, value.onDeleteNode, value.onSelectEdge]);
+  const connectionState = useMemo<WorkflowFlowConnectionState>(() => ({
+    connectionCandidateEndpoint: value.connectionCandidateEndpoint,
+    connectionCandidateNodeId: value.connectionCandidateNodeId,
+  }), [value.connectionCandidateEndpoint, value.connectionCandidateNodeId]);
+
   return (
-    <WorkflowFlowCallbacksContext.Provider value={value}>
-      {children}
-    </WorkflowFlowCallbacksContext.Provider>
+    <WorkflowFlowActionsContext.Provider value={actions}>
+      <WorkflowFlowConnectionStateContext.Provider value={connectionState}>
+        {children}
+      </WorkflowFlowConnectionStateContext.Provider>
+    </WorkflowFlowActionsContext.Provider>
   );
 }
 
-/** Reads canvas callbacks; custom nodes must render inside the provider. */
-export function useWorkflowFlowCallbacks(): WorkflowFlowCallbacks {
-  const value = useContext(WorkflowFlowCallbacksContext);
+/** Reads stable graph actions without subscribing an edge to drag-preview state. */
+export function useWorkflowFlowActions(): WorkflowFlowActions {
+  const value = useContext(WorkflowFlowActionsContext);
   if (value === null) {
-    throw new Error("useWorkflowFlowCallbacks requires WorkflowFlowCallbacksProvider");
+    throw new Error("useWorkflowFlowActions requires WorkflowFlowCallbacksProvider");
+  }
+  return value;
+}
+
+/** Reads transient connection state only where candidate feedback is rendered. */
+export function useWorkflowFlowConnectionState(): WorkflowFlowConnectionState {
+  const value = useContext(WorkflowFlowConnectionStateContext);
+  if (value === null) {
+    throw new Error("useWorkflowFlowConnectionState requires WorkflowFlowCallbacksProvider");
   }
   return value;
 }

--- a/packages/app-shell/src/features/settings/workflow-flow/canvas.tsx
+++ b/packages/app-shell/src/features/settings/workflow-flow/canvas.tsx
@@ -1,4 +1,5 @@
 import {
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -159,6 +160,9 @@ function WorkflowCanvasInner({
   const { t } = useTranslation();
   const canvasRef = useRef<HTMLDivElement>(null);
   const connectionDraftRef = useRef<ConnectionDraft | null>(null);
+  const connectionCandidateFrameRef = useRef<number | null>(null);
+  const connectionCandidatePointRef = useRef<ClientPosition | null>(null);
+  const connectionCandidateNodeIdRef = useRef<string | null>(null);
   const [connectionCandidateNodeId, setConnectionCandidateNodeId] =
     useState<string | null>(null);
   const { screenToFlowPosition } = useReactFlow();
@@ -204,29 +208,64 @@ function WorkflowCanvasInner({
     [connectionCandidateNodeId, flowCallbacks],
   );
 
-  /** Clears connection-only state after React Flow has completed or cancelled a gesture. */
-  function finishConnectionGesture(): void {
-    connectionDraftRef.current = null;
-    reconnectingEdgeIdRef.current = null;
-    setConnectionCandidateNodeId(null);
+  useEffect(() => () => {
+    if (connectionCandidateFrameRef.current !== null) {
+      cancelAnimationFrame(connectionCandidateFrameRef.current);
+    }
+  }, []);
+
+  /** Updates candidate state only when the actual card changes. */
+  function commitConnectionCandidate(candidateNodeId: string | null): void {
+    if (connectionCandidateNodeIdRef.current === candidateNodeId) {
+      return;
+    }
+    connectionCandidateNodeIdRef.current = candidateNodeId;
+    setConnectionCandidateNodeId(candidateNodeId);
   }
 
-  /** Updates the whole-card candidate highlight without writing graph state on pointer move. */
+  /** Clears connection-only state after React Flow has completed or cancelled a gesture. */
+  function finishConnectionGesture(): void {
+    if (connectionCandidateFrameRef.current !== null) {
+      cancelAnimationFrame(connectionCandidateFrameRef.current);
+      connectionCandidateFrameRef.current = null;
+    }
+    connectionCandidatePointRef.current = null;
+    connectionDraftRef.current = null;
+    reconnectingEdgeIdRef.current = null;
+    commitConnectionCandidate(null);
+  }
+
+  /**
+   * Coalesces whole-card hit testing to one check per animation frame so React
+   * Flow can update the preview endpoint before candidate detection does DOM work.
+   */
   function updateConnectionCandidate(
     event: ReactPointerEvent<HTMLDivElement>,
   ): void {
-    const draft = connectionDraftRef.current;
-    if (draft === null) {
+    if (connectionDraftRef.current === null) {
       return;
     }
-    const candidate = workflowNodeAtClientPoint(event.clientX, event.clientY);
-    const validCandidate = candidate !== null
-      && isValidConnection(connectionForCandidate(draft, candidate))
-      ? candidate
-      : null;
-    setConnectionCandidateNodeId((current) =>
-      current === validCandidate ? current : validCandidate,
-    );
+    connectionCandidatePointRef.current = {
+      clientX: event.clientX,
+      clientY: event.clientY,
+    };
+    if (connectionCandidateFrameRef.current !== null) {
+      return;
+    }
+    connectionCandidateFrameRef.current = requestAnimationFrame(() => {
+      connectionCandidateFrameRef.current = null;
+      const draft = connectionDraftRef.current;
+      const point = connectionCandidatePointRef.current;
+      if (draft === null || point === null) {
+        return;
+      }
+      const candidate = workflowNodeAtClientPoint(point.clientX, point.clientY);
+      const validCandidate = candidate !== null
+        && isValidConnection(connectionForCandidate(draft, candidate))
+        ? candidate
+        : null;
+      commitConnectionCandidate(validCandidate);
+    });
   }
 
   /** Records a source drag so nearby cards can provide the original forgiving target. */

--- a/packages/app-shell/src/features/settings/workflow-flow/connection-line.tsx
+++ b/packages/app-shell/src/features/settings/workflow-flow/connection-line.tsx
@@ -7,7 +7,7 @@ import {
   workflowEdgePath,
 } from "./path";
 import { NODE_ANCHOR_Y, NODE_WIDTH } from "./adapters";
-import { useWorkflowFlowCallbacks } from "./callbacks";
+import { useWorkflowFlowConnectionState } from "./callbacks";
 
 /** Uses the same soft curve for a connection preview as for a committed edge. */
 export function WorkflowConnectionLine({
@@ -25,7 +25,7 @@ export function WorkflowConnectionLine({
   const {
     connectionCandidateEndpoint,
     connectionCandidateNodeId,
-  } = useWorkflowFlowCallbacks();
+  } = useWorkflowFlowConnectionState();
   const { getInternalNode } = useReactFlow();
   const source = workflowConnectionAnchor({
     x: fromX,

--- a/packages/app-shell/src/features/settings/workflow-flow/edge.tsx
+++ b/packages/app-shell/src/features/settings/workflow-flow/edge.tsx
@@ -6,7 +6,7 @@ import {
 } from "@xyflow/react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@ora/ui";
-import { useWorkflowFlowCallbacks } from "./callbacks";
+import { useWorkflowFlowActions } from "./callbacks";
 import { workflowEdgePath } from "./path";
 
 /** Draws a selectable workflow edge with an accessible hit target and optional branch label. */
@@ -23,7 +23,7 @@ export const WorkflowFlowEdgeView = memo(function WorkflowFlowEdgeView({
   data,
 }: EdgeProps) {
   const { t } = useTranslation();
-  const { onDeleteEdge, onSelectEdge } = useWorkflowFlowCallbacks();
+  const { onDeleteEdge, onSelectEdge } = useWorkflowFlowActions();
   const edgePath = workflowEdgePath({
     sourceX,
     sourceY,

--- a/packages/app-shell/src/features/settings/workflow-flow/node.tsx
+++ b/packages/app-shell/src/features/settings/workflow-flow/node.tsx
@@ -9,7 +9,10 @@ import {
 } from "@ora/workflow-mock";
 import { getNodeMetadata } from "../workflow-node-metadata";
 import { type WorkflowFlowNode } from "./adapters";
-import { useWorkflowFlowCallbacks } from "./callbacks";
+import {
+  useWorkflowFlowActions,
+  useWorkflowFlowConnectionState,
+} from "./callbacks";
 
 /** Renders one workflow card with left/right handles styled for the settings editor. */
 export const WorkflowFlowNodeView = memo(function WorkflowFlowNodeView({
@@ -20,7 +23,11 @@ export const WorkflowFlowNodeView = memo(function WorkflowFlowNodeView({
   positionAbsoluteY,
 }: NodeProps<WorkflowFlowNode>) {
   const { i18n, t } = useTranslation();
-  const { connectionCandidateNodeId, onDeleteNode } = useWorkflowFlowCallbacks();
+  const { onDeleteNode } = useWorkflowFlowActions();
+  const {
+    connectionCandidateEndpoint,
+    connectionCandidateNodeId,
+  } = useWorkflowFlowConnectionState();
   const locale: WorkflowLocale = i18n.resolvedLanguage === "en-US" ? "en-US" : "zh-CN";
   const metadata = getNodeMetadata(data.kind);
   const nodeKindLabel = createMockWorkflowNodeType(data.kind, locale).label;
@@ -28,6 +35,11 @@ export const WorkflowFlowNodeView = memo(function WorkflowFlowNodeView({
   const detail = data.config.model
     ?? data.config.tool
     ?? t("settings.workflow.immediate");
+  const isConnectionCandidate = connectionCandidateNodeId === id;
+  const isInputCandidate = isConnectionCandidate
+    && connectionCandidateEndpoint === "target";
+  const isOutputCandidate = isConnectionCandidate
+    && connectionCandidateEndpoint === "source";
 
   return (
     <article
@@ -40,8 +52,7 @@ export const WorkflowFlowNodeView = memo(function WorkflowFlowNodeView({
         selected
           ? "border-foreground/45 shadow-md ring-2 ring-ring/25"
           : "border-border hover:border-foreground/25 hover:shadow-md",
-        connectionCandidateNodeId === id
-          && "border-ring shadow-md ring-4 ring-ring/20",
+        isConnectionCandidate && "border-ring/60 shadow-md ring-2 ring-ring/10",
       )}
       aria-label={`${t("settings.workflow.nodeSuffix", { type: nodeKindLabel })}: ${data.title}`}
     >
@@ -50,7 +61,10 @@ export const WorkflowFlowNodeView = memo(function WorkflowFlowNodeView({
         position={Position.Left}
         data-workflow-input={id}
         aria-label={t("settings.workflow.connectTo", { name: data.title })}
-        className="!size-6 !border-[6px] !border-transparent !bg-muted-foreground !bg-clip-content !shadow-sm opacity-0 transition-[opacity,transform,box-shadow] group-hover/workflow-node:opacity-100 hover:!scale-110 hover:!shadow-md focus:opacity-100"
+        className={cn(
+          "workflow-port workflow-port-input !size-6 !border-0 !bg-transparent",
+          isInputCandidate && "workflow-port-candidate",
+        )}
         style={{ top: 61 }}
       />
       <div className="flex items-start gap-2.5 border-b border-border px-3 py-3">
@@ -88,7 +102,10 @@ export const WorkflowFlowNodeView = memo(function WorkflowFlowNodeView({
         position={Position.Right}
         data-workflow-output={id}
         aria-label={t("settings.workflow.connectFrom", { name: data.title })}
-        className="!size-6 !border-[6px] !border-transparent !bg-foreground !bg-clip-content !shadow-sm opacity-0 transition-[opacity,transform,box-shadow] group-hover/workflow-node:opacity-100 hover:!scale-110 hover:!shadow-md focus:opacity-100"
+        className={cn(
+          "workflow-port workflow-port-output !size-6 !border-0 !bg-transparent",
+          isOutputCandidate && "workflow-port-candidate",
+        )}
         style={{ top: 61 }}
       />
     </article>

--- a/packages/app-shell/src/features/settings/workflow-flow/overview.tsx
+++ b/packages/app-shell/src/features/settings/workflow-flow/overview.tsx
@@ -1,9 +1,22 @@
+import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { MiniMap, type Node } from "@xyflow/react";
 import type { WorkflowFlowNodeData } from "./adapters";
 
+/** Resolves minimap node color without allocating a new callback on canvas renders. */
+function workflowOverviewNodeColor(node: Node<WorkflowFlowNodeData>): string {
+  if (node.selected) {
+    return "var(--ring)";
+  }
+  return "color-mix(in oklch, var(--foreground) 45%, var(--muted))";
+}
+
 /** Shows an interactive graph overview when multiple nodes benefit from spatial navigation. */
-export function WorkflowFlowOverview({ nodeCount }: { nodeCount: number }) {
+export const WorkflowFlowOverview = memo(function WorkflowFlowOverview({
+  nodeCount,
+}: {
+  nodeCount: number;
+}) {
   const { t } = useTranslation();
 
   if (nodeCount < 2) {
@@ -17,12 +30,7 @@ export function WorkflowFlowOverview({ nodeCount }: { nodeCount: number }) {
       maskColor="color-mix(in oklch, var(--background) 72%, transparent)"
       maskStrokeColor="color-mix(in oklch, var(--foreground) 22%, transparent)"
       nodeBorderRadius={8}
-      nodeColor={(node: Node<WorkflowFlowNodeData>) => {
-        if (node.selected) {
-          return "var(--ring)";
-        }
-        return "color-mix(in oklch, var(--foreground) 45%, var(--muted))";
-      }}
+      nodeColor={workflowOverviewNodeColor}
       nodeStrokeColor="var(--background)"
       nodeStrokeWidth={2}
       pannable
@@ -30,4 +38,4 @@ export function WorkflowFlowOverview({ nodeCount }: { nodeCount: number }) {
       zoomable
     />
   );
-}
+});

--- a/packages/app-shell/src/features/settings/workflow-flow/use-workflow-flow-state.test.tsx
+++ b/packages/app-shell/src/features/settings/workflow-flow/use-workflow-flow-state.test.tsx
@@ -121,6 +121,18 @@ describe("useWorkflowFlowState", () => {
       sourceHandle: null,
       targetHandle: null,
     })).toBe(false);
+    act(() => {
+      result.current.reconnectingEdgeIdRef.current = "edge-start-output";
+    });
+    expect(result.current.isValidConnection({
+      source: "start",
+      target: "output",
+      sourceHandle: null,
+      targetHandle: null,
+    })).toBe(true);
+    act(() => {
+      result.current.reconnectingEdgeIdRef.current = null;
+    });
     expect(result.current.isValidConnection({
       source: "start",
       target: "other",

--- a/packages/app-shell/src/features/settings/workflow-flow/use-workflow-flow-state.ts
+++ b/packages/app-shell/src/features/settings/workflow-flow/use-workflow-flow-state.ts
@@ -106,6 +106,15 @@ export function useWorkflowFlowState({
     useNodesState<WorkflowFlowNode>(toFlowNodes(nodes, selectedNodeId));
   const [flowEdges, setFlowEdges, applyFlowEdgeChanges] =
     useEdgesState(toFlowEdges(edges, nodes, selectedEdgeId));
+  const edgeIdByDirectedPair = useMemo(() => {
+    const bySource = new Map<string, Map<string, string>>();
+    for (const edge of edges) {
+      const byTarget = bySource.get(edge.source) ?? new Map<string, string>();
+      byTarget.set(edge.target, edge.id);
+      bySource.set(edge.source, byTarget);
+    }
+    return bySource;
+  }, [edges]);
 
   useEffect(() => {
     setFlowNodes((current) =>
@@ -177,7 +186,7 @@ export function useWorkflowFlowState({
     [onMoveNode],
   );
 
-  /** Rejects self-loops and duplicate directed pairs, excluding the edge being reconnected. */
+  /** Rejects self-loops and indexed duplicate pairs, excluding the reconnected edge. */
   const isValidConnection = useCallback(
     (connection: Connection | Edge) => {
       const source = connection.source;
@@ -186,14 +195,10 @@ export function useWorkflowFlowState({
         return false;
       }
       const reconnectingEdgeId = reconnectingEdgeIdRef.current;
-      return !edges.some(
-        (edge) =>
-          edge.id !== reconnectingEdgeId
-          && edge.source === source
-          && edge.target === target,
-      );
+      const existingEdgeId = edgeIdByDirectedPair.get(source)?.get(target);
+      return existingEdgeId === undefined || existingEdgeId === reconnectingEdgeId;
     },
-    [edges],
+    [edgeIdByDirectedPair],
   );
 
   /** Creates a domain edge after React Flow has accepted both connection endpoints. */

--- a/packages/app-shell/src/features/settings/workflow-flow/workflow-flow.css
+++ b/packages/app-shell/src/features/settings/workflow-flow/workflow-flow.css
@@ -68,17 +68,102 @@
   border-radius: 9999px;
 }
 
-.workflow-flow .react-flow__handle.connectingfrom,
-.workflow-flow .react-flow__handle.connectingto {
+.workflow-flow .workflow-port {
   opacity: 1;
-  box-shadow: 0 0 0 5px color-mix(in oklch, var(--ring) 18%, transparent);
 }
 
-.workflow-flow .react-flow__handle.valid {
+/*
+ * The 24px Handle remains a forgiving hit target while pseudo-elements draw
+ * the smaller port independently, so visual animation never moves the anchor.
+ */
+.workflow-flow .workflow-port::before,
+.workflow-flow .workflow-port::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 9999px;
+  content: "";
+  pointer-events: none;
+}
+
+.workflow-flow .workflow-port::before {
+  z-index: 1;
+  width: 10px;
+  height: 10px;
+  box-shadow: 0 0 0 1px var(--background);
+  transform: translate(-50%, -50%);
+  transition:
+    width 160ms ease-out,
+    height 160ms ease-out,
+    box-shadow 160ms ease-out,
+    background-color 160ms ease-out;
+}
+
+.workflow-flow .workflow-port-input::before {
+  width: 8px;
+  height: 8px;
+  background: var(--muted-foreground);
+}
+
+.workflow-flow .workflow-port-output::before {
+  background: var(--foreground);
+}
+
+.workflow-flow .workflow-port::after {
+  width: 22px;
+  height: 22px;
+  border: 2px solid color-mix(in oklch, var(--ring) 60%, transparent);
+  background: color-mix(in oklch, var(--ring) 12%, var(--background));
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  transition: opacity 160ms ease-out;
+}
+
+/* The visible dot stays small while the transparent border preserves a forgiving hit area. */
+.workflow-flow .workflow-port:hover::before,
+.workflow-flow .workflow-port:focus-visible::before {
+  width: 12px;
+  height: 12px;
+  box-shadow:
+    0 0 0 1px var(--background),
+    0 0 0 3px color-mix(in oklch, var(--foreground) 10%, transparent);
+}
+
+.workflow-flow .workflow-port-input:hover::before,
+.workflow-flow .workflow-port-input:focus-visible::before {
+  width: 10px;
+  height: 10px;
+}
+
+.workflow-flow .workflow-port:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+/* Keep source feedback restrained; the strong ring belongs to the actual drop target. */
+.workflow-flow .workflow-port.connectingfrom:not(.workflow-port-candidate)::before {
+  box-shadow:
+    0 0 0 1px var(--background),
+    0 0 0 3px color-mix(in oklch, var(--ring) 16%, transparent);
+}
+
+.workflow-flow .workflow-port.valid::after,
+.workflow-flow .workflow-port-candidate::after {
   opacity: 1;
-  background: var(--ring) !important;
-  box-shadow: 0 0 0 5px color-mix(in oklch, var(--ring) 24%, transparent);
-  transform: scale(1.25);
+}
+
+.workflow-flow .workflow-port.valid::before,
+.workflow-flow .workflow-port-candidate::before {
+  width: 10px;
+  height: 10px;
+  background: color-mix(in oklch, var(--foreground) 72%, var(--ring));
+  box-shadow: 0 0 0 1px var(--background);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workflow-flow .workflow-port {
+    transition: none;
+  }
 }
 
 .workflow-flow .workflow-connection-preview {

--- a/packages/app-shell/src/features/settings/workflow-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/workflow-settings.test.tsx
@@ -143,6 +143,19 @@ describe("WorkflowSettings", () => {
     });
   });
 
+  it("keeps each workflow port independently visible without node-wide hover styles", async () => {
+    render(<WorkflowSettings />);
+    const input = await screen.findByLabelText("连接到理解改动");
+    const output = screen.getByLabelText("从理解改动开始连接");
+
+    expect(input).toHaveClass("workflow-port", "workflow-port-input");
+    expect(output).toHaveClass("workflow-port", "workflow-port-output");
+    expect(input).not.toHaveClass("opacity-0");
+    expect(output).not.toHaveClass("opacity-0");
+    expect(input.className).not.toContain("group-hover");
+    expect(output.className).not.toContain("group-hover");
+  });
+
   it("collapses node configuration after a stationary blank-canvas click", async () => {
     const user = userEvent.setup();
     render(<WorkflowSettings />);


### PR DESCRIPTION
Coalesce connection hit testing and index directed edges for faster validation.

Split transient drag state from stable actions to avoid unnecessary renders.

Refine port feedback while preserving generous connection hit targets.