### PR TITLE
fix(logging): make stdout sink non-blocking

### DIFF
--- a/crates/logging/src/gitlancer_bridge.rs
+++ b/crates/logging/src/gitlancer_bridge.rs
@@ -56,7 +56,7 @@ mod tests {
     #[test]
     fn log_command_emits_info_event_with_cwd_and_command() {
         let buffer = SharedBuffer::default();
-        let (dispatch, _guard) = build_dispatch(
+        let (dispatch, guard) = build_dispatch(
             &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
             buffer.make_writer(),
         )
@@ -68,6 +68,8 @@ mod tests {
                 "git status --porcelain=v2",
             );
         });
+        drop(dispatch);
+        drop(guard);
 
         let events = buffer.json_lines();
         assert_eq!(events.len(), 1);
@@ -89,7 +91,7 @@ mod tests {
     #[test]
     fn log_result_emits_info_on_success() {
         let buffer = SharedBuffer::default();
-        let (dispatch, _guard) = build_dispatch(
+        let (dispatch, guard) = build_dispatch(
             &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
             buffer.make_writer(),
         )
@@ -98,6 +100,8 @@ mod tests {
         with_default(&dispatch, || {
             OraGitlancerLogger.log_result(42, true, Some(0));
         });
+        drop(dispatch);
+        drop(guard);
 
         let events = buffer.json_lines();
         assert_eq!(events.len(), 1);
@@ -111,7 +115,7 @@ mod tests {
     #[test]
     fn log_result_emits_error_on_failure() {
         let buffer = SharedBuffer::default();
-        let (dispatch, _guard) = build_dispatch(
+        let (dispatch, guard) = build_dispatch(
             &LoggingConfig::new(LogLevel::Error, LogOutput::Stdout, chrono_tz::UTC),
             buffer.make_writer(),
         )
@@ -120,6 +124,8 @@ mod tests {
         with_default(&dispatch, || {
             OraGitlancerLogger.log_result(0, false, Some(1));
         });
+        drop(dispatch);
+        drop(guard);
 
         let events = buffer.json_lines();
         assert_eq!(events.len(), 1);
@@ -178,6 +184,20 @@ mod tests {
             Ok(buf.len())
         }
 
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Appends formatted log bytes directly into the shared buffer for non-blocking sink tests.
+    impl Write for SharedBufferWriter {
+        /// Appends one formatted chunk to the shared in-memory capture buffer.
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.bytes.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        /// Completes the in-memory write contract without additional synchronization.
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
         }

--- a/crates/logging/src/guard.rs
+++ b/crates/logging/src/guard.rs
@@ -7,13 +7,13 @@ pub struct LoggingGuard {
 }
 
 impl LoggingGuard {
-    /// Creates a guard that owns the writer lifetimes for every active file-backed sink.
+    /// Creates a guard that owns the worker lifetimes for every active non-blocking sink.
     pub fn new(guards: Vec<WorkerGuard>) -> Self {
         Self { guards }
     }
 
-    /// Reports whether the active logging setup owns any file-backed writers.
-    pub fn has_file_writer(&self) -> bool {
+    /// Reports whether the active logging setup owns any non-blocking writer workers.
+    pub fn has_worker_guard(&self) -> bool {
         !self.guards.is_empty()
     }
 }

--- a/crates/logging/src/init.rs
+++ b/crates/logging/src/init.rs
@@ -1,4 +1,7 @@
+use std::io::Write;
+
 use tracing::Dispatch;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::layer;
 use tracing_subscriber::prelude::*;
@@ -11,7 +14,7 @@ use crate::{LogLevel, LogOutput, LoggingConfig, LoggingGuard, LoggingInitError};
 /// Installs the configured process clock and subscriber, then returns its writer-lifetime guard.
 pub fn init_logging(config: LoggingConfig) -> Result<LoggingGuard, LoggingInitError> {
     // Prepare fallible sinks before changing either irreversible process-wide singleton.
-    let (dispatch, guard) = build_dispatch(&config, std::io::stdout)?;
+    let (dispatch, guard) = build_dispatch(&config, std::io::stdout())?;
     crate::clock::initialize(config.timezone)
         .map_err(|_| LoggingInitError::ClockAlreadyInitialized)?;
     tracing::dispatcher::set_global_default(dispatch)
@@ -26,12 +29,13 @@ pub(crate) fn build_dispatch<W>(
     stdout_writer: W,
 ) -> Result<(Dispatch, LoggingGuard), LoggingInitError>
 where
-    W: for<'writer> tracing_subscriber::fmt::MakeWriter<'writer> + Send + Sync + Clone + 'static,
+    W: Write + Send + 'static,
 {
     let level_filter = level_filter(config.level);
 
     match &config.output {
         LogOutput::Stdout => {
+            let (stdout_writer, stdout_guard) = prepare_stdout_output(stdout_writer);
             let subscriber = tracing_subscriber::registry()
                 .with(CorrelationLayer)
                 .with(level_filter)
@@ -42,7 +46,10 @@ where
                         .with_ansi(false),
                 );
 
-            Ok((Dispatch::new(subscriber), LoggingGuard::default()))
+            Ok((
+                Dispatch::new(subscriber),
+                LoggingGuard::new(vec![stdout_guard]),
+            ))
         }
         LogOutput::File(file_config) => {
             let prepared_output = prepare_file_output(file_config)?;
@@ -63,6 +70,7 @@ where
         }
         LogOutput::StdoutAndFile(file_config) => {
             let prepared_output = prepare_file_output(file_config)?;
+            let (stdout_writer, stdout_guard) = prepare_stdout_output(stdout_writer);
             let subscriber = tracing_subscriber::registry()
                 .with(CorrelationLayer)
                 .with(level_filter)
@@ -81,10 +89,20 @@ where
 
             Ok((
                 Dispatch::new(subscriber),
-                LoggingGuard::new(vec![prepared_output.guard]),
+                LoggingGuard::new(vec![stdout_guard, prepared_output.guard]),
             ))
         }
     }
+}
+
+/// Creates an explicitly lossy non-blocking writer so stdout backpressure cannot stall async workers.
+fn prepare_stdout_output<W>(stdout_writer: W) -> (NonBlocking, WorkerGuard)
+where
+    W: Write + Send + 'static,
+{
+    tracing_appender::non_blocking::NonBlockingBuilder::default()
+        .lossy(true)
+        .finish(stdout_writer)
 }
 
 /// Maps the public level enum into the tracing filter used by every active sink.

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -67,7 +67,7 @@ fn preserves_the_public_logging_api_surface() {
 #[test]
 fn filters_events_at_warn_level() {
     let stdout = SharedBuffer::default();
-    let (dispatch, _guard) = build_dispatch(
+    let (dispatch, guard) = build_dispatch(
         &LoggingConfig::new(LogLevel::Warn, LogOutput::Stdout, chrono_tz::UTC),
         stdout.make_writer(),
     )
@@ -78,6 +78,8 @@ fn filters_events_at_warn_level() {
         tracing::warn!(message = "kept warn");
         tracing::error!(message = "kept error");
     });
+    drop(dispatch);
+    drop(guard);
 
     let events = stdout.json_lines();
 
@@ -101,7 +103,7 @@ fn formats_json_events_with_context_and_error_objects() {
         RotationPolicy::Daily,
         NonZeroUsize::new(3).unwrap(),
     );
-    let (dispatch, _guard) = build_dispatch(
+    let (dispatch, guard) = build_dispatch(
         &LoggingConfig::new(
             LogLevel::Info,
             LogOutput::StdoutAndFile(file_config),
@@ -122,6 +124,8 @@ fn formats_json_events_with_context_and_error_objects() {
         );
         drop(entered);
     });
+    drop(dispatch);
+    drop(guard);
 
     let stdout_events = stdout.json_lines();
     let stdout_event = &stdout_events[0];
@@ -173,7 +177,7 @@ fn formats_json_events_with_context_and_error_objects() {
 #[test]
 fn emits_method_field_from_wrapper_macros() {
     let stdout = SharedBuffer::default();
-    let (dispatch, _guard) = build_dispatch(
+    let (dispatch, guard) = build_dispatch(
         &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
         stdout.make_writer(),
     )
@@ -182,6 +186,8 @@ fn emits_method_field_from_wrapper_macros() {
     with_default(&dispatch, || {
         crate::ora_info!(message = "macro event");
     });
+    drop(dispatch);
+    drop(guard);
 
     let event = &stdout.json_lines()[0];
 
@@ -196,7 +202,7 @@ fn emits_method_field_from_wrapper_macros() {
 #[test]
 fn emits_helper_api_correlation_fields_consistently() {
     let stdout = SharedBuffer::default();
-    let (dispatch, _guard) = build_dispatch(
+    let (dispatch, guard) = build_dispatch(
         &LoggingConfig::new(LogLevel::Info, LogOutput::Stdout, chrono_tz::UTC),
         stdout.make_writer(),
     )
@@ -208,6 +214,8 @@ fn emits_helper_api_correlation_fields_consistently() {
         tracing::info!(message = "bootstrapped");
         drop(entered);
     });
+    drop(dispatch);
+    drop(guard);
 
     let event = &stdout.json_lines()[0];
     assert_eq!(event["span"], Value::String("bootstrap".to_string()));
@@ -229,7 +237,9 @@ fn selects_stdout_only_sink_behavior() {
         tracing::info!(message = "stdout only");
     });
 
-    assert_eq!(guard.has_file_writer(), false);
+    drop(dispatch);
+    assert_eq!(guard.has_worker_guard(), true);
+    drop(guard);
     assert_eq!(stdout.json_lines().len(), 1);
 }
 
@@ -469,6 +479,20 @@ impl std::io::Write for SharedBufferHandle {
     }
 
     /// Satisfies the writer contract without extra work because the buffer is purely in memory.
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Appends formatted log bytes directly into the shared buffer for non-blocking sink tests.
+impl std::io::Write for SharedBufferWriter {
+    /// Appends one formatted chunk to the shared in-memory capture buffer.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.bytes.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    /// Completes the in-memory write contract without additional synchronization.
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Make stdout logging non-blocking for `stdout` and `stdout_and_file` modes.
- Keep the stdout and file `WorkerGuard` values alive through `LoggingGuard`.
- Update sink tests to wait for the background workers before asserting output.

## Root cause

The stdout sink wrote directly through `std::io::stdout`, so a slow pipe, terminal, log collector, or redirected output could block a Tokio worker thread. File logging already used `tracing_appender::non_blocking`, but stdout did not.

## Behavior

The stdout sink now uses an explicitly lossy non-blocking queue. Under sustained backpressure, events may be dropped instead of blocking the caller, preserving async runtime responsiveness.

## Validation

- `cargo fmt --package ora-logging`
- `cargo test -p ora-logging` (23 passed)
- `cargo clippy -p ora-logging -- -D warnings`
- `git diff --check -- crates/logging`

Fixes #205