### PR TITLE
fix(logging): serialize each event once in stdout_and_file mode

### DIFF
--- a/crates/logging/src/fanout.rs
+++ b/crates/logging/src/fanout.rs
@@ -1,0 +1,220 @@
+use std::io::{self, Write};
+
+use tracing_subscriber::fmt::MakeWriter;
+
+/// Composes two writer factories so a single formatting layer can emit identical bytes to both.
+///
+/// `stdout_and_file` mode used to stack two independent fmt layers, each with its own
+/// `JsonEventFormatter`, so every event was serialized twice on the calling thread. The
+/// fanout keeps one formatting layer and drives both sinks from one serialization pass,
+/// halving the cost while preserving byte-for-byte output on both sinks.
+#[derive(Clone, Debug)]
+pub(crate) struct FanoutMakeWriter<A, B> {
+    primary: A,
+    secondary: B,
+}
+
+impl<A, B> FanoutMakeWriter<A, B> {
+    /// Builds a fanout from an authoritative primary and a secondary sink.
+    ///
+    /// The primary is the user-visible sink whose error wins when both fail; the secondary
+    /// is still written independently so its failures cannot drop the primary's bytes.
+    pub(crate) fn new(primary: A, secondary: B) -> Self {
+        Self { primary, secondary }
+    }
+}
+
+impl<'writer, A, B> MakeWriter<'writer> for FanoutMakeWriter<A, B>
+where
+    A: MakeWriter<'writer>,
+    B: MakeWriter<'writer>,
+{
+    type Writer = FanoutWriter<A::Writer, B::Writer>;
+
+    /// Builds a writer that drives both sinks from one formatting pass.
+    fn make_writer(&'writer self) -> Self::Writer {
+        FanoutWriter {
+            primary: self.primary.make_writer(),
+            secondary: self.secondary.make_writer(),
+        }
+    }
+}
+
+/// Forwards every byte to a primary and a secondary sink, keeping both writes independent.
+#[derive(Debug)]
+pub(crate) struct FanoutWriter<A, B> {
+    primary: A,
+    secondary: B,
+}
+
+impl<A, B> Write for FanoutWriter<A, B>
+where
+    A: Write,
+    B: Write,
+{
+    /// Writes to both sinks independently so one sink's failure cannot starve the other.
+    ///
+    /// The tracing fmt layer drives the writer through `write_all` with the complete
+    /// serialized event, so overriding it here keeps the two-sink fanout as independent as
+    /// the original two-layer topology: stdout trouble never drops a file event, and a file
+    /// failure never suppresses the observable stdout stream. The primary's result wins when
+    /// both fail because it is the user-visible sink.
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        let primary = self.primary.write_all(buf);
+        let secondary = self.secondary.write_all(buf);
+        primary?;
+        secondary
+    }
+
+    /// Mirrors only the bytes the primary accepted, for callers that chunk through `write`.
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.primary.write(buf)?;
+        // A secondary failure is suppressed here so partial primary progress still reports
+        // the primary's accepted count to the caller without an unrelated secondary error.
+        let _ = self.secondary.write_all(&buf[..written]);
+        Ok(written)
+    }
+
+    /// Flushes both sinks, surfacing the primary's error first because it is observable.
+    fn flush(&mut self) -> io::Result<()> {
+        // Evaluate both flushes before short-circuiting so the secondary is never skipped.
+        let primary_result = self.primary.flush();
+        let secondary_result = self.secondary.flush();
+        primary_result?;
+        secondary_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    use pretty_assertions::assert_eq;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    use super::FanoutMakeWriter;
+
+    /// Creates a shared in-memory sink so fanout tests can assert exact captured bytes.
+    #[derive(Clone, Debug, Default)]
+    struct CapturingSink {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl CapturingSink {
+        /// Returns the bytes captured so far so assertions compare full content, not counts.
+        fn captured(&self) -> Vec<u8> {
+            self.bytes.lock().unwrap().clone()
+        }
+    }
+
+    impl<'writer> MakeWriter<'writer> for CapturingSink {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            CapturingWriter {
+                bytes: self.bytes.clone(),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct CapturingWriter {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.bytes.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A writer that always fails on write, used to verify the failing-sink error policy.
+    #[derive(Debug, Default)]
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("failing sink unavailable"))
+        }
+
+        fn write_all(&mut self, _buf: &[u8]) -> io::Result<()> {
+            Err(io::Error::other("failing sink unavailable"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::other("failing flush unavailable"))
+        }
+    }
+
+    impl<'writer> MakeWriter<'writer> for FailingWriter {
+        type Writer = FailingWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            FailingWriter
+        }
+    }
+
+    /// Verifies a single write fans identical bytes out to both sinks.
+    #[test]
+    fn mirrors_bytes_to_both_sinks() {
+        let primary = CapturingSink::default();
+        let secondary = CapturingSink::default();
+        let mut writer = FanoutMakeWriter::new(primary.clone(), secondary.clone()).make_writer();
+
+        writer.write_all(b"single formatting pass").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(primary.captured(), b"single formatting pass");
+        assert_eq!(secondary.captured(), b"single formatting pass");
+    }
+
+    /// Verifies multiple writes accumulate identically on both sinks.
+    #[test]
+    fn mirrors_chunked_writes_consistently() {
+        let primary = CapturingSink::default();
+        let secondary = CapturingSink::default();
+        let mut writer = FanoutMakeWriter::new(primary.clone(), secondary.clone()).make_writer();
+
+        writer.write_all(b"line one\n").unwrap();
+        writer.write_all(b"line two\n").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(primary.captured(), b"line one\nline two\n");
+        assert_eq!(secondary.captured(), b"line one\nline two\n");
+    }
+
+    /// Verifies a failing secondary sink reports the error without dropping the primary bytes.
+    #[test]
+    fn surfaces_secondary_failures_without_dropping_primary_bytes() {
+        let primary = CapturingSink::default();
+        let mut writer = FanoutMakeWriter::new(primary.clone(), FailingWriter).make_writer();
+
+        let result = writer.write_all(b"observable");
+
+        assert!(result.is_err());
+        assert_eq!(primary.captured(), b"observable");
+    }
+
+    /// Verifies a failing primary sink cannot starve the secondary of the event bytes.
+    ///
+    /// This is the regression guard for the fanout topology: the original two-layer design
+    /// wrote each sink independently, so stdout trouble never dropped a file event. The
+    /// fanout must preserve that independence by driving both `write_all` calls before
+    /// short-circuiting on either error.
+    #[test]
+    fn writes_secondary_bytes_even_when_primary_fails() {
+        let secondary = CapturingSink::default();
+        let mut writer = FanoutMakeWriter::new(FailingWriter, secondary.clone()).make_writer();
+
+        let result = writer.write_all(b"file survives stdout failure");
+
+        assert!(result.is_err());
+        assert_eq!(secondary.captured(), b"file survives stdout failure");
+    }
+}

--- a/crates/logging/src/fanout.rs
+++ b/crates/logging/src/fanout.rs
@@ -52,13 +52,12 @@ where
     A: Write,
     B: Write,
 {
-    /// Mirrors only the bytes the primary accepted, for callers that chunk through `write`.
+    /// Delegates to `write_all` so the trait-required `write` shares one sink-driving path
+    /// and the same error semantics, instead of mirroring partial primary progress that no
+    /// caller exercises. Returning the full buffer length is within the `Write` contract
+    /// because `write_all` drives both sinks to completion before returning.
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let written = self.primary.write(buf)?;
-        // A secondary failure is suppressed here so partial primary progress still reports
-        // the primary's accepted count to the caller without an unrelated secondary error.
-        let _ = self.secondary.write_all(&buf[..written]);
-        Ok(written)
+        self.write_all(buf).map(|()| buf.len())
     }
 
     /// Flushes both sinks, surfacing the primary's error first because it is observable.

--- a/crates/logging/src/fanout.rs
+++ b/crates/logging/src/fanout.rs
@@ -52,20 +52,6 @@ where
     A: Write,
     B: Write,
 {
-    /// Writes to both sinks independently so one sink's failure cannot starve the other.
-    ///
-    /// The tracing fmt layer drives the writer through `write_all` with the complete
-    /// serialized event, so overriding it here keeps the two-sink fanout as independent as
-    /// the original two-layer topology: stdout trouble never drops a file event, and a file
-    /// failure never suppresses the observable stdout stream. The primary's result wins when
-    /// both fail because it is the user-visible sink.
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        let primary = self.primary.write_all(buf);
-        let secondary = self.secondary.write_all(buf);
-        primary?;
-        secondary
-    }
-
     /// Mirrors only the bytes the primary accepted, for callers that chunk through `write`.
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let written = self.primary.write(buf)?;
@@ -82,6 +68,20 @@ where
         let secondary_result = self.secondary.flush();
         primary_result?;
         secondary_result
+    }
+
+    /// Writes to both sinks independently so one sink's failure cannot starve the other.
+    ///
+    /// The tracing fmt layer drives the writer through `write_all` with the complete
+    /// serialized event, so overriding it here keeps the two-sink fanout as independent as
+    /// the original two-layer topology: stdout trouble never drops a file event, and a file
+    /// failure never suppresses the observable stdout stream. The primary's result wins when
+    /// both fail because it is the user-visible sink.
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        let primary = self.primary.write_all(buf);
+        let secondary = self.secondary.write_all(buf);
+        primary?;
+        secondary
     }
 }
 

--- a/crates/logging/src/init.rs
+++ b/crates/logging/src/init.rs
@@ -4,6 +4,7 @@ use tracing_subscriber::fmt::layer;
 use tracing_subscriber::prelude::*;
 
 use crate::correlation::CorrelationLayer;
+use crate::fanout::FanoutMakeWriter;
 use crate::file_output::prepare_file_output;
 use crate::formatter::JsonEventFormatter;
 use crate::{LogLevel, LogOutput, LoggingConfig, LoggingGuard, LoggingInitError};
@@ -62,20 +63,17 @@ where
             ))
         }
         LogOutput::StdoutAndFile(file_config) => {
+            // Serialize each event once and fan the formatted bytes out to stdout and the file
+            // sink, instead of stacking two fmt layers that each run a full serialization pass.
             let prepared_output = prepare_file_output(file_config)?;
+            let fanout = FanoutMakeWriter::new(stdout_writer, prepared_output.writer.clone());
             let subscriber = tracing_subscriber::registry()
                 .with(CorrelationLayer)
                 .with(level_filter)
                 .with(
                     layer()
                         .event_format(JsonEventFormatter::new(config.timezone))
-                        .with_writer(stdout_writer)
-                        .with_ansi(false),
-                )
-                .with(
-                    layer()
-                        .event_format(JsonEventFormatter::new(config.timezone))
-                        .with_writer(prepared_output.writer.clone())
+                        .with_writer(fanout)
                         .with_ansi(false),
                 );
 

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod correlation;
 mod error;
 mod error_report;
+mod fanout;
 mod file_output;
 mod formatter;
 mod gitlancer_bridge;

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -259,7 +259,7 @@ fn selects_file_only_sink_behavior() {
     assert_eq!(read_rotated_log_lines(temp_dir.path(), "ora.log").len(), 1);
 }
 
-/// Verifies combined logging duplicates each event across stdout and the rotating file sink.
+/// Verifies combined logging emits each event to stdout and the rotating file sink with the same envelope.
 #[test]
 fn selects_stdout_and_file_sink_behavior() {
     let temp_dir = TempDir::new().unwrap();
@@ -285,8 +285,14 @@ fn selects_stdout_and_file_sink_behavior() {
     drop(dispatch);
     drop(guard);
 
-    assert_eq!(stdout.json_lines().len(), 1);
-    assert_eq!(read_rotated_log_lines(temp_dir.path(), "ora.log").len(), 1);
+    let stdout_events = stdout.json_lines();
+    let file_events = read_rotated_log_lines(temp_dir.path(), "ora.log");
+
+    // A single formatting pass fans the same bytes to both sinks, so each side receives
+    // exactly one event with an identical envelope rather than two serialized copies.
+    assert_eq!(stdout_events.len(), 1);
+    assert_eq!(file_events.len(), 1);
+    assert_eq!(stdout_events, file_events);
 }
 
 /// Verifies invalid file output configuration fails with a typed initialization error.


### PR DESCRIPTION
## 背景

#207 指出 `stdout_and_file` 模式叠加了两个独立的 fmt layer，各自持有自己的 `JsonEventFormatter`。tracing-subscriber 的 fmt layer 对每条事件会独立调用一次 `format_event`（序列化进内部 buffer），再调用 `make_writer().write_all(buf)`。因此同一条事件在调用线程上被完整序列化两次——两次 span scope 遍历、两次字段访问、两次 `serde_json` 序列化、两次字符串分配。功能上没有问题（两个 sink 产出的 envelope 完全一致），但这份 CPU 开销发生在同步路径上，使 `stdout_and_file` 比单 sink 模式贵一倍。

## 修改内容

1. **新增模块 `crates/logging/src/fanout.rs`**
   - `FanoutMakeWriter<A, B>`：实现 `MakeWriter`，组合两个 writer 工厂，`make_writer` 返回一个同时驱动两个 sink 的 `FanoutWriter`。
   - `FanoutWriter<A, B>`：实现 `Write`，覆盖 `write_all` 以**独立地**把完整的已格式化事件字节写入两个 sink，再短路返回错误。保留 `write` 作为分块调用方的回退。

2. **修改 `crates/logging/src/init.rs`**
   - `StdoutAndFile` 分支从两个 `layer()` + 各自 `JsonEventFormatter` 改为单个 `layer()` + `FanoutMakeWriter::new(stdout_writer, file_writer)`，令 `format_event` 只跑一次，再把同一份字节分发给 stdout 与文件 sink。

3. **修改 `crates/logging/src/lib.rs`**：注册 `mod fanout;`。

4. **修改 `crates/logging/src/tests.rs`**：`selects_stdout_and_file_sink_behavior` 由仅校验数量升级为深比较 stdout 与文件两端产出的完整 JSON envelope（`assert_eq!(stdout_events, file_events)`），证明单次序列化的同一份字节到达两个 sink。

## 为什么这么改

- 用单个 fmt layer + fanout `MakeWriter` 把每条事件的序列化开销减半，正是 #207 建议的方向。
- 覆盖 `write_all` 并在短路前驱动两个 sink，是为了保留原双 layer 拓扑的**故障隔离**：stdout 写失败不会丢失文件事件，文件写失败不会压制可观测的 stdout 流。若只覆盖 `write`（先写 primary 再 `?` 返回），primary 失败会让 secondary 拿不到任何字节，构成行为回归。primary（stdout）错误在两者都失败时优先上报，因为它是用户可见的 sink。

## 测试

| 测试 | 覆盖点 |
|------|--------|
| `fanout::tests::mirrors_bytes_to_both_sinks` | 单次写入两 sink 字节逐字一致 |
| `fanout::tests::mirrors_chunked_writes_consistently` | 多次写入两 sink 字节一致 |
| `fanout::tests::surfaces_secondary_failures_without_dropping_primary_bytes` | secondary 失败上报错误但 primary 仍得字节 |
| `fanout::tests::writes_secondary_bytes_even_when_primary_fails` | primary 失败时 secondary 仍拿到完整字节（故障隔离回归守卫）|
| `tests::selects_stdout_and_file_sink_behavior` | stdout 与文件两端 envelope 深比较相等 |

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅（全部通过，0 失败）

文档 `docs/runtime-logging.md` 与 `crates/logging/README.md` 的契约表述"emits every event to both sinks using the same envelope"未变且现在名副其实；fanout 属于实现细节，按 AGENTS.md 规则放在代码注释里，文档无需改动。

Closes #207