### PR TITLE
fix(task): preserve worktree operation context

### DIFF
--- a/crates/application/src/task/handlers.rs
+++ b/crates/application/src/task/handlers.rs
@@ -146,7 +146,10 @@ where
             Some(branch_name.clone()),
             ora_domain::WorktreeBaseline::recorded(provisioned_worktree.base_commit_id).map_err(
                 |error| ApplicationError::TaskWorktreeProvisioner {
-                    source: crate::TaskWorktreeProvisionerError::operation_failed(error),
+                    source: crate::TaskWorktreeProvisionerError::operation_failed(
+                        "failed to record task worktree baseline",
+                        error,
+                    ),
                 },
             )?,
             DomainWorktreeActivity::Active,

--- a/crates/application/src/task/ports.rs
+++ b/crates/application/src/task/ports.rs
@@ -88,17 +88,22 @@ pub enum TaskWorktreeProvisionerError {
     NotARepository,
     #[error("base branch not found: {branch_name}")]
     BaseBranchNotFound { branch_name: String },
-    #[error("task worktree operation failed")]
+    #[error("{context}")]
     OperationFailed {
+        context: &'static str,
         #[source]
         source: BoxRepositorySource,
     },
 }
 
 impl TaskWorktreeProvisionerError {
-    /// Wraps a provisioning failure without flattening its diagnostic source chain.
-    pub fn operation_failed(error: impl std::error::Error + Send + Sync + 'static) -> Self {
+    /// Preserves both the failed worktree operation and its infrastructure source chain.
+    pub fn operation_failed(
+        context: &'static str,
+        error: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
         Self::OperationFailed {
+            context,
             source: Box::new(error),
         }
     }

--- a/crates/application/src/task/tests.rs
+++ b/crates/application/src/task/tests.rs
@@ -646,6 +646,7 @@ fn reports_application_errors() {
         let worktree_repository = Rc::new(FakeWorktreeRepository::default());
         let provisioner = Rc::new(FakeTaskWorktreeProvisioner::default());
         provisioner.fail_next_create(TaskWorktreeProvisionerError::operation_failed(
+            "failed to create task worktree",
             std::io::Error::other("failed to create linked worktree"),
         ));
         let create_handler = CreateTaskHandler::new(

--- a/crates/application/src/task/worktree_provisioner.rs
+++ b/crates/application/src/task/worktree_provisioner.rs
@@ -42,7 +42,10 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
                 GitlancerError::Domain(DomainError::NotARepository(_)) => {
                     TaskWorktreeProvisionerError::NotARepository
                 }
-                source => TaskWorktreeProvisionerError::operation_failed(source),
+                source => TaskWorktreeProvisionerError::operation_failed(
+                    "failed to validate project repository",
+                    source,
+                ),
             })
     }
 
@@ -58,7 +61,12 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
                     .iter()
                     .any(|branch| branch.as_str() == branch_name)
             })
-            .map_err(TaskWorktreeProvisionerError::operation_failed)
+            .map_err(|source| {
+                TaskWorktreeProvisionerError::operation_failed(
+                    "failed to inspect task branches",
+                    source,
+                )
+            })
     }
 
     /// Creates one linked worktree while keeping Git-specific diagnostics inside the application.
@@ -79,7 +87,10 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
                         branch_name: branch,
                     }
                 }
-                source => TaskWorktreeProvisionerError::operation_failed(source),
+                source => TaskWorktreeProvisionerError::operation_failed(
+                    "failed to resolve task worktree base branch",
+                    source,
+                ),
             })?
             .commit_id;
         create_parent_directory(&request.worktree_path)?;
@@ -93,7 +104,12 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
             .map(|response| CreateTaskWorktreeResponse {
                 base_commit_id: response.head_commit_id.as_str().to_string(),
             })
-            .map_err(TaskWorktreeProvisionerError::operation_failed)
+            .map_err(|source| {
+                TaskWorktreeProvisionerError::operation_failed(
+                    "failed to create task worktree",
+                    source,
+                )
+            })
     }
 
     /// Resolves and deletes one linked worktree through Git's authoritative branch metadata.
@@ -107,7 +123,12 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
                 repository: &self.repository,
                 branch_name: &request.branch_name,
             })
-            .map_err(TaskWorktreeProvisionerError::operation_failed)?;
+            .map_err(|source| {
+                TaskWorktreeProvisionerError::operation_failed(
+                    "failed to resolve task worktree",
+                    source,
+                )
+            })?;
         let mode = match request.mode {
             TaskWorktreeDeletionMode::Force => GitWorktreeDeletionMode::Force,
         };
@@ -119,15 +140,24 @@ impl TaskWorktreeProvisioner for GitTaskWorktreeProvisioner {
                 mode,
             })
             .map(|_| ())
-            .map_err(TaskWorktreeProvisionerError::operation_failed)
+            .map_err(|source| {
+                TaskWorktreeProvisionerError::operation_failed(
+                    "failed to delete task worktree",
+                    source,
+                )
+            })
     }
 }
 
 /// Creates the parent eagerly because Git expects the worktree path's ancestor to exist.
 fn create_parent_directory(worktree_path: &Path) -> Result<(), TaskWorktreeProvisionerError> {
     match worktree_path.parent() {
-        Some(parent_directory) => fs::create_dir_all(parent_directory)
-            .map_err(TaskWorktreeProvisionerError::operation_failed),
+        Some(parent_directory) => fs::create_dir_all(parent_directory).map_err(|source| {
+            TaskWorktreeProvisionerError::operation_failed(
+                "failed to create task worktree parent directory",
+                source,
+            )
+        }),
         None => Ok(()),
     }
 }


### PR DESCRIPTION
Preserve operation-specific context when task worktree provisioning fails, so the API error identifies the failed repository or worktree step instead of exposing only the source error.

## Root cause
Several provisioning paths flattened distinct operations into the same error variant.

## Validation
- `cargo test -p ora-application --lib`
- `cargo fmt --all -- --check`

Fixes #209
Related to #174