### PR TITLE
refactor(diff): remove dead get diff handler

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -44,11 +44,11 @@ pub use task::{
 };
 pub use task_diff::{
     CommitTaskChangesHandler, CommitTaskGitRequest, CreateTaskDiffCommentHandler,
-    GetTaskDiffHandler, GitTaskDiffReader, GitTaskGitWriter, ListTaskDiffCommentsHandler,
-    PushTaskBranchHandler, PushTaskGitRequest, ReadTaskDiffRequest, ReadTaskDiffScope,
-    ReplyTaskDiffCommentHandler, SetTaskDiffCommentStatusHandler, TaskDiffCommentIdGenerator,
-    TaskDiffCommentRepository, TaskDiffCommentRepositoryError, TaskDiffReader, TaskDiffReaderError,
-    TaskDiffSnapshot, TaskGitCommit, TaskGitPush, TaskGitWriter, TaskGitWriterError,
-    UuidTaskDiffCommentIdGenerator, task_diff_id,
+    GitTaskDiffReader, GitTaskGitWriter, ListTaskDiffCommentsHandler, PushTaskBranchHandler,
+    PushTaskGitRequest, ReadTaskDiffRequest, ReadTaskDiffScope, ReplyTaskDiffCommentHandler,
+    SetTaskDiffCommentStatusHandler, TaskDiffCommentIdGenerator, TaskDiffCommentRepository,
+    TaskDiffCommentRepositoryError, TaskDiffReader, TaskDiffReaderError, TaskDiffSnapshot,
+    TaskGitCommit, TaskGitPush, TaskGitWriter, TaskGitWriterError, UuidTaskDiffCommentIdGenerator,
+    task_diff_id,
 };
 pub use worktree::{UuidWorktreeIdGenerator, WorktreeIdGenerator, WorktreeRepository};

--- a/crates/application/src/task_diff/handlers.rs
+++ b/crates/application/src/task_diff/handlers.rs
@@ -7,79 +7,16 @@ use super::ports::{
 use crate::{ApplicationError, Clock, TaskRepository, WorktreeRepository};
 use ora_contracts::{
     CommitTaskChangesRequest, CommitTaskChangesResponse, CreateTaskDiffCommentRequest,
-    CreateTaskDiffCommentResponse, GetTaskDiffRequest, GetTaskDiffResponse,
-    ListTaskDiffCommentsRequest, ListTaskDiffCommentsResponse, PushTaskBranchRequest,
-    PushTaskBranchResponse, ReplyTaskDiffCommentRequest, ReplyTaskDiffCommentResponse,
-    SetTaskDiffCommentStatusRequest, SetTaskDiffCommentStatusResponse, TaskDiffScope,
+    CreateTaskDiffCommentResponse, ListTaskDiffCommentsRequest, ListTaskDiffCommentsResponse,
+    PushTaskBranchRequest, PushTaskBranchResponse, ReplyTaskDiffCommentRequest,
+    ReplyTaskDiffCommentResponse, SetTaskDiffCommentStatusRequest,
+    SetTaskDiffCommentStatusResponse,
 };
 use ora_domain::{
     AuditFields, Task, TaskDiffAnchor, TaskDiffComment, TaskDiffCommentId, TaskDiffCommentKind,
     TaskDiffThreadStatus, TaskId, Worktree,
 };
 use std::path::{Component, Path, PathBuf};
-
-/// Computes the complete task worktree diff without exposing filesystem paths to callers.
-pub struct GetTaskDiffHandler<TaskRepositoryPort, WorktreeRepositoryPort, DiffReader> {
-    task_repository: TaskRepositoryPort,
-    worktree_repository: WorktreeRepositoryPort,
-    diff_reader: DiffReader,
-    work_dir: PathBuf,
-}
-
-impl<TaskRepositoryPort, WorktreeRepositoryPort, DiffReader>
-    GetTaskDiffHandler<TaskRepositoryPort, WorktreeRepositoryPort, DiffReader>
-{
-    /// Builds a task diff handler from persistence, Git, and backend path dependencies.
-    pub fn new(
-        task_repository: TaskRepositoryPort,
-        worktree_repository: WorktreeRepositoryPort,
-        diff_reader: DiffReader,
-        work_dir: PathBuf,
-    ) -> Self {
-        Self {
-            task_repository,
-            worktree_repository,
-            diff_reader,
-            work_dir,
-        }
-    }
-}
-
-impl<TaskRepositoryPort, WorktreeRepositoryPort, DiffReader>
-    GetTaskDiffHandler<TaskRepositoryPort, WorktreeRepositoryPort, DiffReader>
-where
-    TaskRepositoryPort: TaskRepository,
-    WorktreeRepositoryPort: WorktreeRepository,
-    DiffReader: TaskDiffReader,
-{
-    /// Returns a standard unified patch against the immutable task baseline.
-    pub fn handle(
-        &self,
-        request: GetTaskDiffRequest,
-    ) -> Result<GetTaskDiffResponse, ApplicationError> {
-        let task_id = TaskId::new(request.task_id);
-        let (task, worktree) =
-            load_task_worktree(&self.task_repository, &self.worktree_repository, &task_id)?;
-        let base_commit_id = recorded_baseline(&worktree)?;
-
-        let snapshot = self
-            .diff_reader
-            .read_task_diff(ReadTaskDiffRequest {
-                worktree_path: self.work_dir.join(task.id.as_ref()),
-                base_commit_id: base_commit_id.to_string(),
-                scope: map_diff_scope(request.scope),
-            })
-            .map_err(ApplicationError::from_task_diff_reader_error)?;
-        let diff_id = task_diff_id(base_commit_id, &snapshot.head_commit_id, &snapshot.patch);
-
-        Ok(GetTaskDiffResponse {
-            base_commit_id: base_commit_id.to_string(),
-            head_commit_id: snapshot.head_commit_id,
-            diff_id,
-            patch: snapshot.patch,
-        })
-    }
-}
 
 /// Lists persisted root discussions and replies for one visible task.
 pub struct ListTaskDiffCommentsHandler<TaskRepositoryPort, CommentRepository> {
@@ -265,16 +202,6 @@ where
         Ok(CreateTaskDiffCommentResponse {
             comment: map_task_diff_comment(comment),
         })
-    }
-}
-
-/// Maps the public selector into the application port vocabulary.
-fn map_diff_scope(scope: TaskDiffScope) -> ReadTaskDiffScope {
-    match scope {
-        TaskDiffScope::Branch => ReadTaskDiffScope::Branch,
-        TaskDiffScope::Unstaged => ReadTaskDiffScope::Unstaged,
-        TaskDiffScope::Staged => ReadTaskDiffScope::Staged,
-        TaskDiffScope::Committed => ReadTaskDiffScope::Committed,
     }
 }
 

--- a/crates/application/src/task_diff/mod.rs
+++ b/crates/application/src/task_diff/mod.rs
@@ -12,9 +12,9 @@ mod tests;
 pub use git_reader::GitTaskDiffReader;
 pub use git_writer::GitTaskGitWriter;
 pub use handlers::{
-    CommitTaskChangesHandler, CreateTaskDiffCommentHandler, GetTaskDiffHandler,
-    ListTaskDiffCommentsHandler, PushTaskBranchHandler, ReplyTaskDiffCommentHandler,
-    SetTaskDiffCommentStatusHandler, task_diff_id,
+    CommitTaskChangesHandler, CreateTaskDiffCommentHandler, ListTaskDiffCommentsHandler,
+    PushTaskBranchHandler, ReplyTaskDiffCommentHandler, SetTaskDiffCommentStatusHandler,
+    task_diff_id,
 };
 pub use id_generator::UuidTaskDiffCommentIdGenerator;
 pub use ports::{

--- a/docs/task-worktree-gitlancer-frontend-flow.md
+++ b/docs/task-worktree-gitlancer-frontend-flow.md
@@ -40,7 +40,8 @@ flowchart LR
 | Desktop IPC 注册 | `apps/desktop/src-tauri/src/commands.rs` |
 | Tauri transport 映射 | `apps/desktop/web/tauri-transport.ts` |
 | Web/Desktop 共用装配 | `crates/backend/src/task_diff.rs` |
-| Application 用例 | `crates/application/src/task_diff/handlers.rs` |
+| Backend TaskDiffApi | `crates/backend/src/task_diff.rs` |
+| Application 用例（评论与 Git 写操作） | `crates/application/src/task_diff/handlers.rs` |
 | Application ports | `crates/application/src/task_diff/ports.rs` |
 | Gitlancer adapter | `crates/application/src/task_diff/git_reader.rs` |
 | Unified Diff 实现 | `crates/gitlancer/src/git/diff.rs` |


### PR DESCRIPTION
Remove the unused application-level GetTaskDiffHandler and align the flow documentation with the backend-owned diff API and application-owned comment/Git operations.

## Root cause
The dead handler duplicated ownership boundaries and could mislead future callers about where task diffs are resolved.

## Validation
- `cargo test -p ora-application --lib`
- `cargo fmt --all -- --check`

Fixes #212
Related to #174