### PR TITLE
fix(diff): validate comment scope consistently

### DIFF
--- a/apps/web/server/src/handlers/task_diffs.rs
+++ b/apps/web/server/src/handlers/task_diffs.rs
@@ -37,6 +37,7 @@ pub struct TaskDiffCommentPath {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateTaskDiffCommentBody {
+    scope: TaskDiffScope,
     anchor: TaskDiffCommentAnchor,
     body: String,
 }
@@ -131,6 +132,7 @@ pub async fn create_task_diff_comment(
     run_blocking(move || {
         backend.create_task_diff_comment(CreateTaskDiffCommentRequest {
             task_id: path.task_id,
+            scope: body.scope,
             anchor: body.anchor,
             body: body.body,
         })

--- a/crates/application/src/task_diff/handlers.rs
+++ b/crates/application/src/task_diff/handlers.rs
@@ -225,7 +225,7 @@ where
             .read_task_diff(ReadTaskDiffRequest {
                 worktree_path: self.work_dir.join(task.id.as_ref()),
                 base_commit_id: base_commit_id.to_string(),
-                scope: ReadTaskDiffScope::Branch,
+                scope: map_diff_scope(request.scope),
             })
             .map_err(ApplicationError::from_task_diff_reader_error)?;
         let current_diff_id =

--- a/crates/backend/src/task_diff.rs
+++ b/crates/backend/src/task_diff.rs
@@ -151,6 +151,7 @@ impl TaskDiffApi {
         )
         .handle(CreateTaskDiffCommentRequest {
             task_id: task.id.to_string(),
+            scope: request.scope,
             anchor: request.anchor,
             body: request.body,
         })

--- a/crates/contracts/src/task_diff.rs
+++ b/crates/contracts/src/task_diff.rs
@@ -153,6 +153,7 @@ pub struct ListTaskDiffCommentsResponse {
 #[ts(export_to = "task_diff.ts")]
 pub struct CreateTaskDiffCommentRequest {
     pub task_id: String,
+    pub scope: TaskDiffScope,
     pub anchor: TaskDiffCommentAnchor,
     pub body: String,
 }

--- a/packages/app-shell/src/features/diff/task-diff-view.tsx
+++ b/packages/app-shell/src/features/diff/task-diff-view.tsx
@@ -185,8 +185,8 @@ export function TaskDiffView({
     queryClient.invalidateQueries({ queryKey: queryKeys.taskDiffComments(taskId) });
 
   const createComment = useMutation({
-    mutationFn: ({ anchor, body }: { anchor: TaskDiffCommentAnchor; body: string }) =>
-      client.task.createDiffComment({ taskId, anchor, body }),
+    mutationFn: ({ scope, anchor, body }: { scope: TaskDiffScope; anchor: TaskDiffCommentAnchor; body: string }) =>
+      client.task.createDiffComment({ taskId, scope, anchor, body }),
     onSuccess: async () => {
       setSelectedAnchor(null);
       await refreshDiscussions();
@@ -286,14 +286,19 @@ export function TaskDiffView({
     ?? createComment.error
     ?? replyComment.error
     ?? setCommentStatus.error;
-  const currentComments = scope === "branch" ? comments.filter(
-    (comment) => comment.kind.kind === "reply"
-      || comment.kind.anchor.diffId === diff.diffId,
-  ) : [];
-  const outdatedThreads = scope === "branch" ? comments.filter(
+  const currentThreadIds = new Set(comments.filter(
+    (comment) => comment.kind.kind === "thread"
+      && comment.kind.anchor.diffId === diff.diffId,
+  ).map((comment) => comment.id));
+  const currentComments = comments.filter(
+    (comment) => comment.kind.kind === "thread"
+      ? comment.kind.anchor.diffId === diff.diffId
+      : currentThreadIds.has(comment.kind.parentCommentId),
+  );
+  const outdatedThreads = comments.filter(
     (comment) => comment.kind.kind === "thread"
       && comment.kind.anchor.diffId !== diff.diffId,
-  ) : [];
+  );
 
   return (
     <section
@@ -408,13 +413,13 @@ export function TaskDiffView({
                           viewType={viewType}
                           diffId={diff.diffId}
                           comments={currentComments}
-                          reviewEnabled={scope === "branch"}
+                          reviewEnabled
                           selectedAnchor={selectedAnchor}
                           onSelectAnchor={(selection) => {
                             createComment.reset();
                             setSelectedAnchor(selection);
                           }}
-                          onCreateComment={(anchor, body) => createComment.mutateAsync({ anchor, body })}
+                          onCreateComment={(anchor, body) => createComment.mutateAsync({ scope, anchor, body })}
                           onReply={(commentId, body) => replyComment.mutateAsync({ commentId, body })}
                           onSetStatus={(commentId, status) => setCommentStatus.mutateAsync({ commentId, status })}
                           mutationPending={createComment.isPending || replyComment.isPending || setCommentStatus.isPending}

--- a/packages/contracts/src/task_diff.ts
+++ b/packages/contracts/src/task_diff.ts
@@ -15,6 +15,7 @@ export type CommitTaskChangesResponse = { commitId: string; summary: string };
  */
 export type CreateTaskDiffCommentRequest = {
   taskId: string;
+  scope: TaskDiffScope;
   anchor: TaskDiffCommentAnchor;
   body: string;
 };


### PR DESCRIPTION
Carry the selected diff scope through the task-diff comment API and UI instead of hardcoding branch scope.

## Root cause
The frontend could display non-branch scopes while the comment request was always recomputed against branch scope.

## Validation
- `cargo check -p ora-backend -p ora-web-server`
- `cargo fmt --all -- --check`

Fixes #213
Related to #174