### PR TITLE
fix(git): preserve commit and worktree diagnostics

### DIFF
--- a/crates/gitlancer/src/error.rs
+++ b/crates/gitlancer/src/error.rs
@@ -21,6 +21,13 @@ pub enum GitlancerError {
     #[error("filesystem operation failed: {0}")]
     Io(#[from] std::io::Error),
 
+    /// Preserves the fact that a commit succeeded when its follow-up metadata read failed.
+    #[error("commit succeeded but reading commit metadata failed: {source}")]
+    CommitMetadataUnavailable {
+        #[source]
+        source: Box<GitlancerError>,
+    },
+
     /// Returned when a generated patch exceeds the API's bounded response budget.
     #[error("task diff is too large: {byte_count} bytes exceeds {max_byte_count} bytes")]
     DiffTooLarge {

--- a/crates/gitlancer/src/git/commit.rs
+++ b/crates/gitlancer/src/git/commit.rs
@@ -73,26 +73,45 @@ impl<R: GitRunner> Git<R> {
     pub fn commit(&self, request: CommitRequest<'_>) -> Result<CommitResponse, GitlancerError> {
         let command = build_commit_command(&request);
         let _output = self.runner().run(&command)?;
-        let hash_output = self.runner().run(&GitCommand::new(
-            request.worktree.worktree_root().as_path().to_path_buf(),
-            vec!["rev-parse".to_string(), "HEAD".to_string()],
-            GitEnv::default(),
-            GitIntent::ReadOnly,
-        ))?;
-        let summary_output = self.runner().run(&GitCommand::new(
-            request.worktree.worktree_root().as_path().to_path_buf(),
-            vec![
-                "log".to_string(),
-                "-1".to_string(),
-                "--pretty=%s".to_string(),
-                "HEAD".to_string(),
-            ],
-            GitEnv::default(),
-            GitIntent::ReadOnly,
-        ))?;
-        let metadata = format!("{}\n{}", hash_output.stdout, summary_output.stdout);
+        let hash_output = self
+            .runner()
+            .run(&GitCommand::new(
+                request.worktree.worktree_root().as_path().to_path_buf(),
+                vec!["rev-parse".to_string(), "HEAD".to_string()],
+                GitEnv::default(),
+                GitIntent::ReadOnly,
+            ))
+            .map_err(|source| GitlancerError::CommitMetadataUnavailable {
+                source: Box::new(GitlancerError::Exec(source)),
+            })?;
+        let summary_output = self
+            .runner()
+            .run(&GitCommand::new(
+                request.worktree.worktree_root().as_path().to_path_buf(),
+                vec![
+                    "log".to_string(),
+                    "-1".to_string(),
+                    "--pretty=%s".to_string(),
+                    "HEAD".to_string(),
+                ],
+                GitEnv::default(),
+                GitIntent::ReadOnly,
+            ))
+            .map_err(|source| GitlancerError::CommitMetadataUnavailable {
+                source: Box::new(GitlancerError::Exec(source)),
+            })?;
+        // Keep an explicit empty second line so an intentionally empty summary is still a valid response.
+        let metadata = format!(
+            "{}\n{}\n",
+            hash_output.stdout.trim_end(),
+            summary_output.stdout.trim_end()
+        );
 
-        parse_commit_response(&metadata).map_err(Into::into)
+        parse_commit_response(&metadata)
+            .map_err(GitlancerError::from)
+            .map_err(|source| GitlancerError::CommitMetadataUnavailable {
+                source: Box::new(source),
+            })
     }
 }
 

--- a/crates/gitlancer/src/git/push.rs
+++ b/crates/gitlancer/src/git/push.rs
@@ -1,5 +1,5 @@
 use crate::domain::worktree::WorktreeHandle;
-use crate::error::{DomainError, GitlancerError};
+use crate::error::{DomainError, GitExecError, GitlancerError};
 use crate::exec::command::{GitCommand, GitIntent};
 use crate::exec::env::GitEnv;
 use crate::exec::runner::GitRunner;
@@ -28,7 +28,7 @@ impl<R: GitRunner> Git<R> {
                 ))
             })?
             .as_str();
-        self.runner().run(&GitCommand::new(
+        let command = GitCommand::new(
             worktree.worktree_root().as_path().to_path_buf(),
             vec![
                 "push".to_string(),
@@ -38,7 +38,26 @@ impl<R: GitRunner> Git<R> {
             ],
             GitEnv::default().with_variable("GIT_TERMINAL_PROMPT", "0"),
             GitIntent::Network,
-        ))?;
+        );
+        match self.runner().run(&command) {
+            Ok(_) => {}
+            Err(GitExecError::NonZeroExit {
+                code,
+                args,
+                stdout,
+                stderr,
+            }) => {
+                return Err(GitlancerError::Exec(GitExecError::NonZeroExit {
+                    code,
+                    args,
+                    stdout,
+                    stderr: format!(
+                        "{stderr}\npush authentication may be unavailable; configure a Git credential helper or HTTPS token"
+                    ),
+                }));
+            }
+            Err(error) => return Err(GitlancerError::Exec(error)),
+        }
 
         Ok(PushBranchResponse {
             branch_name: branch_name.to_string(),

--- a/crates/gitlancer/src/git/worktree.rs
+++ b/crates/gitlancer/src/git/worktree.rs
@@ -148,16 +148,15 @@ impl<R: GitRunner> Git<R> {
 
         worktrees
             .into_iter()
-            .filter(|worktree| {
-                candidate.starts_with(normalize_path_for_worktree_match(
-                    worktree.worktree_root().as_path(),
-                ))
+            .filter_map(|worktree| {
+                let normalized_root =
+                    normalize_path_for_worktree_match(worktree.worktree_root().as_path());
+                candidate
+                    .starts_with(&normalized_root)
+                    .then_some((worktree, normalized_root))
             })
-            .max_by_key(|worktree| {
-                normalize_path_for_worktree_match(worktree.worktree_root().as_path())
-                    .components()
-                    .count()
-            })
+            .max_by_key(|(_, normalized_root)| normalized_root.components().count())
+            .map(|(worktree, _)| worktree)
             .ok_or(GitlancerError::Domain(DomainError::NotAWorktree(candidate)))
     }
 

--- a/crates/gitlancer/src/parse/README.md
+++ b/crates/gitlancer/src/parse/README.md
@@ -4,7 +4,7 @@ This module converts stable Git porcelain and plumbing output into gitlancer dom
 
 ## Supported boundaries
 
-- Commit parsing reads non-empty object-id and summary lines into `CommitId` and `CommitResponse`.
+- Commit parsing reads the object-id and the following summary line into `CommitId` and `CommitResponse`; the summary may be empty.
 - Status parsing consumes porcelain-v2 NUL-delimited records, ignores headers, and preserves each machine record as a `StatusEntry`.
 - Worktree parsing consumes `git worktree list --porcelain`, associates optional branch refs, and distinguishes the main checkout from linked worktrees.
 

--- a/crates/gitlancer/src/parse/commit.rs
+++ b/crates/gitlancer/src/parse/commit.rs
@@ -4,10 +4,7 @@ use crate::git::commit::CommitResponse;
 
 /// Parses commit metadata from a two-line payload that contains a commit ID followed by a summary.
 pub fn parse_commit_response(stdout: &str) -> Result<CommitResponse, ParseError> {
-    let mut lines = stdout
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty());
+    let mut lines = stdout.lines().map(str::trim);
     let commit_id = lines.next().ok_or(ParseError::MissingLine)?;
     let summary = lines.next().ok_or(ParseError::MissingLine)?;
 

--- a/crates/gitlancer/tests/parse_behaviors.rs
+++ b/crates/gitlancer/tests/parse_behaviors.rs
@@ -22,6 +22,15 @@ fn parse_commit_response_reads_commit_id_and_summary() {
     );
 }
 
+/// Preserves an intentionally empty commit summary instead of borrowing a later output line.
+#[test]
+fn parse_commit_response_preserves_empty_summary() {
+    let response = parse_commit_response("0123456789abcdef0123456789abcdef01234567\n\n")
+        .expect("parse commit response");
+
+    assert_eq!(response.summary, "");
+}
+
 /// Verifies commit ID parsing trims whitespace and returns the first non-empty line.
 #[test]
 fn parse_commit_id_reads_first_non_empty_line() {

--- a/docs/task-worktree-gitlancer-frontend-flow.md
+++ b/docs/task-worktree-gitlancer-frontend-flow.md
@@ -202,3 +202,7 @@ PUT  /api/tasks/{taskId}/diff/comments/{commentId}/status
 - 用户身份、多人权限和远端 Review 同步。
 
 这些能力如果后续需要，应作为独立 Application 用例扩展，而不是放入 Web service 中实现 Git 业务逻辑。
+
+Task branch push is intentionally fixed to the `origin` remote. In a fork workflow, configure
+`origin` as the writable fork and keep `upstream` as the review source; HTTPS pushes also require
+a Git credential helper or token because interactive prompts are disabled.


### PR DESCRIPTION
Preserve metadata failures after a successful commit, accept empty commit summaries, normalize worktree lookup roots once, and provide actionable push authentication hints.

## Root cause
Git operations could either lose the original operation context or turn valid empty metadata into a parse failure.

## Validation
- `cargo test -p gitlancer --lib --test parse_behaviors`
- `cargo test -p gitlancer --test git_runtime`
- `cargo fmt --all -- --check`

Fixes #216
Related to #174