### PR TITLE
refactor(diff): use exact worktree paths and strict anchors

### DIFF
--- a/crates/application/src/task_diff/anchor.rs
+++ b/crates/application/src/task_diff/anchor.rs
@@ -17,7 +17,7 @@ fn section_contains_anchor(section: &str, anchor: &TaskDiffCommentAnchor) -> boo
     if !section
         .lines()
         .find_map(|line| line.strip_prefix(marker))
-        .is_some_and(|path| patch_path_matches(path, &anchor.path))
+        .is_some_and(|path| patch_path_matches(path, &anchor.path, anchor.side))
     {
         return false;
     }
@@ -65,6 +65,8 @@ fn hunk_contains_anchor(lines: &[&str], anchor: &TaskDiffCommentAnchor) -> bool 
         }
     }
 
+    // A side-exclusive +/- line does not advance the other side's line number, so every
+    // requested line must contribute to this count before the anchor can be accepted.
     matched_lines == anchor.end_line - anchor.start_line + 1
 }
 
@@ -83,15 +85,19 @@ fn parse_range_start(range: &str, prefix: char) -> Option<u32> {
 }
 
 /// Matches ordinary Git paths and the quoted representation used for unusual filenames.
-fn patch_path_matches(patch_path: &str, expected: &str) -> bool {
+fn patch_path_matches(patch_path: &str, expected: &str, side: TaskDiffSide) -> bool {
     let decoded = if patch_path.starts_with('"') {
         decode_quoted_path(patch_path)
     } else {
         Some(patch_path.to_string())
     };
+    let prefix = match side {
+        TaskDiffSide::Old => "a/",
+        TaskDiffSide::New => "b/",
+    };
     decoded
         .as_deref()
-        .and_then(|path| path.strip_prefix("a/").or_else(|| path.strip_prefix("b/")))
+        .and_then(|path| path.strip_prefix(prefix))
         == Some(expected)
 }
 

--- a/crates/application/src/task_diff/handlers.rs
+++ b/crates/application/src/task_diff/handlers.rs
@@ -23,7 +23,7 @@ pub struct GetTaskDiffHandler<TaskRepositoryPort, WorktreeRepositoryPort, DiffRe
     task_repository: TaskRepositoryPort,
     worktree_repository: WorktreeRepositoryPort,
     diff_reader: DiffReader,
-    work_dir: PathBuf,
+    worktree_path: PathBuf,
 }
 
 impl<TaskRepositoryPort, WorktreeRepositoryPort, DiffReader>
@@ -34,13 +34,13 @@ impl<TaskRepositoryPort, WorktreeRepositoryPort, DiffReader>
         task_repository: TaskRepositoryPort,
         worktree_repository: WorktreeRepositoryPort,
         diff_reader: DiffReader,
-        work_dir: PathBuf,
+        worktree_path: PathBuf,
     ) -> Self {
         Self {
             task_repository,
             worktree_repository,
             diff_reader,
-            work_dir,
+            worktree_path,
         }
     }
 }
@@ -58,14 +58,14 @@ where
         request: GetTaskDiffRequest,
     ) -> Result<GetTaskDiffResponse, ApplicationError> {
         let task_id = TaskId::new(request.task_id);
-        let (task, worktree) =
+        let (_task, worktree) =
             load_task_worktree(&self.task_repository, &self.worktree_repository, &task_id)?;
         let base_commit_id = recorded_baseline(&worktree)?;
 
         let snapshot = self
             .diff_reader
             .read_task_diff(ReadTaskDiffRequest {
-                worktree_path: self.work_dir.join(task.id.as_ref()),
+                worktree_path: self.worktree_path.clone(),
                 base_commit_id: base_commit_id.to_string(),
                 scope: map_diff_scope(request.scope),
             })
@@ -138,7 +138,7 @@ pub struct CreateTaskDiffCommentHandler<
     comment_repository: CommentRepository,
     comment_id_generator: CommentIdGenerator,
     clock: ClockSource,
-    work_dir: PathBuf,
+    worktree_path: PathBuf,
 }
 
 impl<
@@ -166,7 +166,7 @@ impl<
         comment_repository: CommentRepository,
         comment_id_generator: CommentIdGenerator,
         clock: ClockSource,
-        work_dir: PathBuf,
+        worktree_path: PathBuf,
     ) -> Self {
         Self {
             task_repository,
@@ -175,7 +175,7 @@ impl<
             comment_repository,
             comment_id_generator,
             clock,
-            work_dir,
+            worktree_path,
         }
     }
 }
@@ -210,7 +210,7 @@ where
         request: CreateTaskDiffCommentRequest,
     ) -> Result<CreateTaskDiffCommentResponse, ApplicationError> {
         let task_id = TaskId::new(request.task_id);
-        let (task, worktree) =
+        let (_task, worktree) =
             load_task_worktree(&self.task_repository, &self.worktree_repository, &task_id)?;
         let base_commit_id = recorded_baseline(&worktree)?;
         validate_comment_body(&request.body)?;
@@ -223,7 +223,7 @@ where
         let snapshot = self
             .diff_reader
             .read_task_diff(ReadTaskDiffRequest {
-                worktree_path: self.work_dir.join(task.id.as_ref()),
+                worktree_path: self.worktree_path.clone(),
                 base_commit_id: base_commit_id.to_string(),
                 scope: ReadTaskDiffScope::Branch,
             })
@@ -283,7 +283,7 @@ pub struct CommitTaskChangesHandler<TaskRepositoryPort, WorktreeRepositoryPort, 
     task_repository: TaskRepositoryPort,
     worktree_repository: WorktreeRepositoryPort,
     git_writer: GitWriter,
-    work_dir: PathBuf,
+    worktree_path: PathBuf,
 }
 
 impl<TaskRepositoryPort, WorktreeRepositoryPort, GitWriter>
@@ -294,13 +294,13 @@ impl<TaskRepositoryPort, WorktreeRepositoryPort, GitWriter>
         task_repository: TaskRepositoryPort,
         worktree_repository: WorktreeRepositoryPort,
         git_writer: GitWriter,
-        work_dir: PathBuf,
+        worktree_path: PathBuf,
     ) -> Self {
         Self {
             task_repository,
             worktree_repository,
             git_writer,
-            work_dir,
+            worktree_path,
         }
     }
 }
@@ -322,13 +322,13 @@ where
             return Err(ApplicationError::TaskDiffCommitMessageBlank);
         }
         let task_id = TaskId::new(request.task_id);
-        let (task, worktree) =
+        let (_task, worktree) =
             load_task_worktree(&self.task_repository, &self.worktree_repository, &task_id)?;
         let branch_name = recorded_branch(&worktree)?;
         let commit = self
             .git_writer
             .commit_changes(CommitTaskGitRequest {
-                worktree_path: self.work_dir.join(task.id.as_ref()),
+                worktree_path: self.worktree_path.clone(),
                 expected_branch_name: branch_name.to_string(),
                 message: message.to_string(),
             })
@@ -346,7 +346,7 @@ pub struct PushTaskBranchHandler<TaskRepositoryPort, WorktreeRepositoryPort, Git
     task_repository: TaskRepositoryPort,
     worktree_repository: WorktreeRepositoryPort,
     git_writer: GitWriter,
-    work_dir: PathBuf,
+    worktree_path: PathBuf,
 }
 
 impl<TaskRepositoryPort, WorktreeRepositoryPort, GitWriter>
@@ -357,13 +357,13 @@ impl<TaskRepositoryPort, WorktreeRepositoryPort, GitWriter>
         task_repository: TaskRepositoryPort,
         worktree_repository: WorktreeRepositoryPort,
         git_writer: GitWriter,
-        work_dir: PathBuf,
+        worktree_path: PathBuf,
     ) -> Self {
         Self {
             task_repository,
             worktree_repository,
             git_writer,
-            work_dir,
+            worktree_path,
         }
     }
 }
@@ -381,13 +381,13 @@ where
         request: PushTaskBranchRequest,
     ) -> Result<PushTaskBranchResponse, ApplicationError> {
         let task_id = TaskId::new(request.task_id);
-        let (task, worktree) =
+        let (_task, worktree) =
             load_task_worktree(&self.task_repository, &self.worktree_repository, &task_id)?;
         let branch_name = recorded_branch(&worktree)?;
         let push = self
             .git_writer
             .push_branch(PushTaskGitRequest {
-                worktree_path: self.work_dir.join(task.id.as_ref()),
+                worktree_path: self.worktree_path.clone(),
                 expected_branch_name: branch_name.to_string(),
             })
             .map_err(task_git_writer_error)?;
@@ -568,7 +568,9 @@ where
                 });
             }
         }
-        comment.audit_fields.updated_at = self.clock.now_timestamp_millis();
+        comment
+            .audit_fields
+            .touch(self.clock.now_timestamp_millis());
         let comment = self
             .comment_repository
             .update_comment(comment)

--- a/crates/backend/src/task_diff.rs
+++ b/crates/backend/src/task_diff.rs
@@ -89,12 +89,12 @@ impl TaskDiffApi {
         &self,
         request: CommitTaskChangesRequest,
     ) -> Result<CommitTaskChangesResponse, BackendError> {
-        let (task, project, work_dir) = self.worktree_context(&request.task_id)?;
+        let (task, project, worktree_path) = self.worktree_context(&request.task_id)?;
         CommitTaskChangesHandler::new(
             SqliteTaskRepository::new(self.pool.clone()),
             SqliteWorktreeRepository::new(self.pool.clone()),
             GitTaskGitWriter::new(PathBuf::from(project.root_path)),
-            work_dir,
+            worktree_path,
         )
         .handle(CommitTaskChangesRequest {
             task_id: task.id.to_string(),
@@ -108,12 +108,12 @@ impl TaskDiffApi {
         &self,
         request: PushTaskBranchRequest,
     ) -> Result<PushTaskBranchResponse, BackendError> {
-        let (task, project, work_dir) = self.worktree_context(&request.task_id)?;
+        let (task, project, worktree_path) = self.worktree_context(&request.task_id)?;
         PushTaskBranchHandler::new(
             SqliteTaskRepository::new(self.pool.clone()),
             SqliteWorktreeRepository::new(self.pool.clone()),
             GitTaskGitWriter::new(PathBuf::from(project.root_path)),
-            work_dir,
+            worktree_path,
         )
         .handle(PushTaskBranchRequest {
             task_id: task.id.to_string(),
@@ -139,7 +139,7 @@ impl TaskDiffApi {
         &self,
         request: CreateTaskDiffCommentRequest,
     ) -> Result<CreateTaskDiffCommentResponse, BackendError> {
-        let (task, project, work_dir) = self.worktree_context(&request.task_id)?;
+        let (task, project, worktree_path) = self.worktree_context(&request.task_id)?;
         CreateTaskDiffCommentHandler::new(
             SqliteTaskRepository::new(self.pool.clone()),
             SqliteWorktreeRepository::new(self.pool.clone()),
@@ -147,7 +147,7 @@ impl TaskDiffApi {
             SqliteTaskDiffCommentRepository::new(self.pool.clone()),
             UuidTaskDiffCommentIdGenerator::new(),
             self.clock,
-            work_dir,
+            worktree_path,
         )
         .handle(CreateTaskDiffCommentRequest {
             task_id: task.id.to_string(),
@@ -227,14 +227,7 @@ impl TaskDiffApi {
         }
         let project = self.load_project(&task)?;
         let cwd = resolve_task_cwd(&self.pool, &task_id)?;
-        let work_dir = cwd.parent().map(Path::to_path_buf).ok_or_else(|| {
-            BackendError::new(
-                ErrorClassification::Internal,
-                PublicError::InternalError(EmptyErrorParams {}),
-                "task worktree parent directory is unavailable",
-            )
-        })?;
-        Ok((task, project, work_dir))
+        Ok((task, project, cwd))
     }
 }
 

--- a/crates/domain/src/audit_fields.rs
+++ b/crates/domain/src/audit_fields.rs
@@ -17,4 +17,9 @@ impl AuditFields {
             is_deleted,
         }
     }
+
+    /// Advances the modification timestamp without exposing audit-field mutation to callers.
+    pub fn touch(&mut self, updated_at: i64) {
+        self.updated_at = updated_at;
+    }
 }


### PR DESCRIPTION
Use exact resolved worktree paths for diff, comment, and Git operations; touch audit timestamps through the domain API; and validate patch anchors against their correct old/new side.

## Root cause
Reconstructed worktree paths and loose patch-side matching could target the wrong checkout or accept malformed anchors.

## Validation
- `cargo test -p ora-application --lib`
- `cargo check -p ora-backend`
- `cargo fmt --all -- --check`

Fixes #218
Related to #174