### PR TITLE
fix(web): accept decisions-only body on skill import commit

### DIFF
--- a/apps/web/server/src/handlers/skill_imports.rs
+++ b/apps/web/server/src/handlers/skill_imports.rs
@@ -9,7 +9,7 @@ use ora_backend::Backend;
 use ora_contracts::{
     CancelSkillImportRequest, CancelSkillImportResponse, CommitSkillImportRequest,
     GetSkillImportSessionRequest, GetSkillImportSessionResponse, PrepareSkillImportRequest,
-    PrepareSkillImportResponse, SkillImportSource,
+    PrepareSkillImportResponse, SkillImportConflictDecision, SkillImportSource,
 };
 use ora_skill_package::path::RelativePath;
 use serde::Deserialize;
@@ -30,6 +30,13 @@ pub struct PrepareSkillImportQuery {
 #[serde(rename_all = "camelCase")]
 pub struct SkillImportSessionPath {
     session_id: String,
+}
+
+/// Carries conflict decisions before the route session id is attached.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitSkillImportBody {
+    decisions: Vec<SkillImportConflictDecision>,
 }
 
 /// Cap for one raw archive upload streamed by the web adapter.
@@ -93,7 +100,7 @@ pub async fn get_skill_import(
 pub async fn commit_skill_import(
     State(app_state): State<AppState>,
     AxumPath(path): AxumPath<SkillImportSessionPath>,
-    Json(body): Json<CommitSkillImportRequest>,
+    Json(body): Json<CommitSkillImportBody>,
 ) -> Result<Response, WebApiError> {
     let response = app_state
         .backend()

--- a/packages/contracts/tests/client.test.ts
+++ b/packages/contracts/tests/client.test.ts
@@ -191,6 +191,38 @@ test("puts the session id in the config path while the choice stays in the body"
   ]);
 });
 
+test("puts the session id in the commit path while decisions stay in JSON", async () => {
+  const requests: ContractTransportRequest[] = [];
+  const client = createContractsClient(
+    recordingTransport(requests, {
+      sessionId: "import-1",
+      status: "committing",
+      progress: { processed: 0, total: 1, results: [] },
+    }),
+  );
+  const request = {
+    sessionId: "import-1",
+    decisions: [{ candidateId: "candidate-1", decision: "skip" as const }],
+  };
+
+  await client.skillImport.commit(request);
+
+  assert.deepEqual(requests, [
+    {
+      operationName: "commitSkillImport",
+      request,
+      method: "POST",
+      path: "/api/skill-imports/import-1/commit",
+      body: {
+        decisions: [{ candidateId: "candidate-1", decision: "skip" }],
+      },
+      headers: {
+        "content-type": "application/json",
+      },
+    },
+  ]);
+});
+
 test("uses a skill id in PUT paths while leaving editable fields in JSON", async () => {
   const requests: ContractTransportRequest[] = [];
   const client = createContractsClient(


### PR DESCRIPTION
The contracts client puts sessionId in the URL and sends only decisions in the JSON body. Deserialize CommitSkillImportBody in the handler and merge the route session id before calling the backend.