### PR TITLE
fix(logging): serialize each event once in stdout_and_file mode

### DIFF
--- a/crates/logging/src/fanout.rs
+++ b/crates/logging/src/fanout.rs
@@ -1,0 +1,271 @@
+use std::io::{self, Write};
+
+use tracing::Metadata;
+use tracing_subscriber::fmt::MakeWriter;
+
+/// Composes two writer factories so a single formatting layer can emit identical bytes to both.
+///
+/// `stdout_and_file` mode used to stack two independent fmt layers, each with its own
+/// `JsonEventFormatter`, so every event was serialized twice on the calling thread. The
+/// fanout keeps one formatting layer and drives both sinks from one serialization pass,
+/// halving the cost while preserving byte-for-byte output on both sinks.
+#[derive(Clone, Debug)]
+pub(crate) struct FanoutMakeWriter<A, B> {
+    primary: A,
+    secondary: B,
+}
+
+impl<A, B> FanoutMakeWriter<A, B> {
+    /// Builds a fanout from an authoritative primary and a secondary sink.
+    ///
+    /// The primary is the user-visible sink whose error wins when both fail; the secondary
+    /// is still written independently so its failures cannot drop the primary's bytes.
+    pub(crate) fn new(primary: A, secondary: B) -> Self {
+        Self { primary, secondary }
+    }
+}
+
+impl<'writer, A, B> MakeWriter<'writer> for FanoutMakeWriter<A, B>
+where
+    A: MakeWriter<'writer>,
+    B: MakeWriter<'writer>,
+{
+    type Writer = FanoutWriter<A::Writer, B::Writer>;
+
+    /// Builds a writer that drives both sinks from one formatting pass.
+    fn make_writer(&'writer self) -> Self::Writer {
+        FanoutWriter {
+            primary: self.primary.make_writer(),
+            secondary: self.secondary.make_writer(),
+        }
+    }
+
+    /// Forwards the event metadata to both sinks so per-event writer selection survives the fanout.
+    ///
+    /// The fmt layer always builds its writer through `make_writer_for`, and `MakeWriter`
+    /// combinators implement their per-event routing there rather than in `make_writer`.
+    /// The inherited default drops the metadata, which silently changes what a wrapped sink
+    /// receives: `with_max_level`, for one, treats a metadata-less request as disabled and
+    /// would discard every event on that sink.
+    fn make_writer_for(&'writer self, meta: &Metadata<'_>) -> Self::Writer {
+        FanoutWriter {
+            primary: self.primary.make_writer_for(meta),
+            secondary: self.secondary.make_writer_for(meta),
+        }
+    }
+}
+
+/// Forwards every byte to a primary and a secondary sink, keeping both writes independent.
+#[derive(Debug)]
+pub(crate) struct FanoutWriter<A, B> {
+    primary: A,
+    secondary: B,
+}
+
+impl<A, B> Write for FanoutWriter<A, B>
+where
+    A: Write,
+    B: Write,
+{
+    /// Delegates to `write_all` so the trait-required `write` shares one sink-driving path
+    /// and the same error semantics, instead of mirroring partial primary progress that no
+    /// caller exercises. Returning the full buffer length is within the `Write` contract
+    /// because `write_all` drives both sinks to completion before returning.
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.write_all(buf).map(|()| buf.len())
+    }
+
+    /// Flushes both sinks, surfacing the primary's error first because it is observable.
+    fn flush(&mut self) -> io::Result<()> {
+        // Evaluate both flushes before short-circuiting so the secondary is never skipped.
+        let primary_result = self.primary.flush();
+        let secondary_result = self.secondary.flush();
+        primary_result?;
+        secondary_result
+    }
+
+    /// Writes to both sinks independently so one sink's failure cannot starve the other.
+    ///
+    /// The tracing fmt layer drives the writer through `write_all` with the complete
+    /// serialized event, so overriding it here keeps the two-sink fanout as independent as
+    /// the original two-layer topology: stdout trouble never drops a file event, and a file
+    /// failure never suppresses the observable stdout stream. The primary's result wins when
+    /// both fail because it is the user-visible sink.
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        let primary = self.primary.write_all(buf);
+        let secondary = self.secondary.write_all(buf);
+        primary?;
+        secondary
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    use pretty_assertions::assert_eq;
+    use tracing::Level;
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::fmt::layer;
+    use tracing_subscriber::fmt::writer::MakeWriterExt;
+
+    use super::FanoutMakeWriter;
+    use crate::test_support::with_recorded_trace_logging;
+
+    /// Creates a shared in-memory sink so fanout tests can assert exact captured bytes.
+    #[derive(Clone, Debug, Default)]
+    struct CapturingSink {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl CapturingSink {
+        /// Returns the bytes captured so far so assertions compare full content, not counts.
+        fn captured(&self) -> Vec<u8> {
+            self.bytes.lock().unwrap().clone()
+        }
+    }
+
+    impl<'writer> MakeWriter<'writer> for CapturingSink {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            CapturingWriter {
+                bytes: self.bytes.clone(),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct CapturingWriter {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.bytes.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A writer that always fails on write, used to verify the failing-sink error policy.
+    #[derive(Debug, Default)]
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("failing sink unavailable"))
+        }
+
+        fn write_all(&mut self, _buf: &[u8]) -> io::Result<()> {
+            Err(io::Error::other("failing sink unavailable"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::other("failing flush unavailable"))
+        }
+    }
+
+    impl<'writer> MakeWriter<'writer> for FailingWriter {
+        type Writer = FailingWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            FailingWriter
+        }
+    }
+
+    /// Verifies a single write fans identical bytes out to both sinks.
+    #[test]
+    fn mirrors_bytes_to_both_sinks() {
+        let primary = CapturingSink::default();
+        let secondary = CapturingSink::default();
+        let mut writer = FanoutMakeWriter::new(primary.clone(), secondary.clone()).make_writer();
+
+        writer.write_all(b"single formatting pass").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(primary.captured(), b"single formatting pass");
+        assert_eq!(secondary.captured(), b"single formatting pass");
+    }
+
+    /// Verifies multiple writes accumulate identically on both sinks.
+    #[test]
+    fn mirrors_chunked_writes_consistently() {
+        let primary = CapturingSink::default();
+        let secondary = CapturingSink::default();
+        let mut writer = FanoutMakeWriter::new(primary.clone(), secondary.clone()).make_writer();
+
+        writer.write_all(b"line one\n").unwrap();
+        writer.write_all(b"line two\n").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(primary.captured(), b"line one\nline two\n");
+        assert_eq!(secondary.captured(), b"line one\nline two\n");
+    }
+
+    /// Verifies a failing secondary sink reports the error without dropping the primary bytes.
+    #[test]
+    fn surfaces_secondary_failures_without_dropping_primary_bytes() {
+        let primary = CapturingSink::default();
+        let mut writer = FanoutMakeWriter::new(primary.clone(), FailingWriter).make_writer();
+
+        let result = writer.write_all(b"observable");
+
+        assert!(result.is_err());
+        assert_eq!(primary.captured(), b"observable");
+    }
+
+    /// Verifies a failing primary sink cannot starve the secondary of the event bytes.
+    ///
+    /// This is the regression guard for the fanout topology: the original two-layer design
+    /// wrote each sink independently, so stdout trouble never dropped a file event. The
+    /// fanout must preserve that independence by driving both `write_all` calls before
+    /// short-circuiting on either error.
+    #[test]
+    fn writes_secondary_bytes_even_when_primary_fails() {
+        let secondary = CapturingSink::default();
+        let mut writer = FanoutMakeWriter::new(FailingWriter, secondary.clone()).make_writer();
+
+        let result = writer.write_all(b"file survives stdout failure");
+
+        assert!(result.is_err());
+        assert_eq!(secondary.captured(), b"file survives stdout failure");
+    }
+
+    /// Verifies per-event writer selection on a wrapped sink survives the fanout.
+    ///
+    /// The fmt layer builds its writer through `make_writer_for`, and combinators such as
+    /// `with_max_level` implement their filtering there rather than in `make_writer`. Without
+    /// forwarding the metadata the wrapped sink resolves without level context and drops every
+    /// event, so this test fails if the fanout ever inherits the default implementation.
+    #[test]
+    fn honors_per_event_writer_selection_on_each_sink() {
+        let warn_only = CapturingSink::default();
+        let unfiltered = CapturingSink::default();
+        let fanout = FanoutMakeWriter::new(
+            warn_only.clone().with_max_level(Level::WARN),
+            unfiltered.clone(),
+        );
+
+        with_recorded_trace_logging(layer().with_writer(fanout).with_ansi(false), || {
+            tracing::info!("below the filtered sink's level");
+            tracing::warn!("above the filtered sink's level");
+        });
+
+        assert_eq!(captured_line_count(&warn_only), 1);
+        assert_eq!(captured_line_count(&unfiltered), 2);
+    }
+
+    /// Counts the events a sink captured so level assertions do not depend on the event format.
+    fn captured_line_count(sink: &CapturingSink) -> usize {
+        String::from_utf8(sink.captured())
+            .unwrap()
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .count()
+    }
+}

--- a/crates/logging/src/init.rs
+++ b/crates/logging/src/init.rs
@@ -4,6 +4,7 @@ use tracing_subscriber::fmt::layer;
 use tracing_subscriber::prelude::*;
 
 use crate::correlation::CorrelationLayer;
+use crate::fanout::FanoutMakeWriter;
 use crate::file_output::prepare_file_output;
 use crate::formatter::JsonEventFormatter;
 use crate::{LogLevel, LogOutput, LoggingConfig, LoggingGuard, LoggingInitError};
@@ -62,20 +63,17 @@ where
             ))
         }
         LogOutput::StdoutAndFile(file_config) => {
+            // Serialize each event once and fan the formatted bytes out to stdout and the file
+            // sink, instead of stacking two fmt layers that each run a full serialization pass.
             let prepared_output = prepare_file_output(file_config)?;
+            let fanout = FanoutMakeWriter::new(stdout_writer, prepared_output.writer.clone());
             let subscriber = tracing_subscriber::registry()
                 .with(CorrelationLayer)
                 .with(level_filter)
                 .with(
                     layer()
                         .event_format(JsonEventFormatter::new(config.timezone))
-                        .with_writer(stdout_writer)
-                        .with_ansi(false),
-                )
-                .with(
-                    layer()
-                        .event_format(JsonEventFormatter::new(config.timezone))
-                        .with_writer(prepared_output.writer.clone())
+                        .with_writer(fanout)
                         .with_ansi(false),
                 );
 

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod correlation;
 mod error;
 mod error_report;
+mod fanout;
 mod file_output;
 mod formatter;
 mod gitlancer_bridge;

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -259,7 +259,7 @@ fn selects_file_only_sink_behavior() {
     assert_eq!(read_rotated_log_lines(temp_dir.path(), "ora.log").len(), 1);
 }
 
-/// Verifies combined logging duplicates each event across stdout and the rotating file sink.
+/// Verifies combined logging emits each event to stdout and the rotating file sink with the same envelope.
 #[test]
 fn selects_stdout_and_file_sink_behavior() {
     let temp_dir = TempDir::new().unwrap();
@@ -285,8 +285,14 @@ fn selects_stdout_and_file_sink_behavior() {
     drop(dispatch);
     drop(guard);
 
-    assert_eq!(stdout.json_lines().len(), 1);
-    assert_eq!(read_rotated_log_lines(temp_dir.path(), "ora.log").len(), 1);
+    let stdout_events = stdout.json_lines();
+    let file_events = read_rotated_log_lines(temp_dir.path(), "ora.log");
+
+    // A single formatting pass fans the same bytes to both sinks, so each side receives
+    // exactly one event with an identical envelope rather than two serialized copies.
+    assert_eq!(stdout_events.len(), 1);
+    assert_eq!(file_events.len(), 1);
+    assert_eq!(stdout_events, file_events);
 }
 
 /// Verifies invalid file output configuration fails with a typed initialization error.


### PR DESCRIPTION
## 背景

`stdout_and_file` 模式叠了两个独立的 fmt layer，各自持有一个 `JsonEventFormatter`。tracing-subscriber 的 fmt layer 对每条事件独立调用一次 `format_event`（序列化进内部 buffer），再 `make_writer_for(meta).write_all(buf)`（`fmt_layer.rs:1049-1050`）。因此同一条事件在调用线程上被完整序列化两次——两次 span scope 遍历、两次字段访问、两次 `serde_json` 序列化、两次字符串分配。两个 sink 产出的 envelope 完全一致，所以第二遍纯属同步路径上的浪费。

本 PR 接续 #237（该 PR 不再合入），实现搬运自 #237 并按 review 意见补齐。原作者以 `Co-authored-by` 保留在 commit 中。

## 修改内容

1. **新增 `crates/logging/src/fanout.rs`**
   - `FanoutMakeWriter<A, B>`：组合两个 writer 工厂的 `MakeWriter`。
   - `FanoutWriter<A, B>`：实现 `Write`，`write_all` 独立地把同一份已格式化字节写入两个 sink，再短路返回错误；`write` 委托给 `write_all` 共享同一条驱动路径与错误语义；`flush` 双刷后再短路。
2. **`crates/logging/src/init.rs`**：`StdoutAndFile` 分支由「两个 layer + 各自 formatter」改为「单个 layer + `FanoutMakeWriter::new(stdout_writer, file_writer)`」，`format_event` 只跑一次。
3. **`crates/logging/src/lib.rs`**：注册 `mod fanout;`。
4. **`crates/logging/src/tests.rs`**：`selects_stdout_and_file_sink_behavior` 由仅校验数量升级为深比较两端完整 JSON envelope（`assert_eq!(stdout_events, file_events)`）。

## 相对 #237 的增量：`make_writer_for` 转发

#237 只实现了 `make_writer`，`make_writer_for` 走 tracing-subscriber 的默认实现（`writer.rs:208`，丢弃 metadata 直接转调 `make_writer`）。而 fmt layer 走的正是 `make_writer_for(event.metadata())`。

今天不出问题——`fn() -> Stdout` 和 `tracing_appender::NonBlocking` 都没覆盖 `make_writer_for`。但这是个静默陷阱：一旦给任一 sink 套上 `MakeWriterExt` 组合器，逐事件路由就会被绕过，而且失败方向比"过滤失效"更糟。以 `with_max_level` 为例（`writer.rs:944-951`）：

```rust
fn make_writer(&'a self) -> Self::Writer {
    // If we don't know the level, assume it's disabled.
    OptionalWriter::none()
}
```

即拿不到 metadata 时它认定 sink 关闭，**该 sink 会静默丢掉全部事件**。

本 PR 补上六行转发，并加 `honors_per_event_writer_selection_on_each_sink` 锁死行为：把 primary 包一层 `with_max_level(WARN)`，发 1 条 INFO + 1 条 WARN，断言 primary 收 1 条、secondary 收 2 条。**已实测该测试在移除 `make_writer_for` 后失败**（primary 实收 0 条），是有效回归守卫而非摆设。

## 保留的关键设计（沿用 #237）

- **故障隔离优先**：`write_all` 先驱动两个 sink 再短路，等价于原双 layer 拓扑——stdout 出问题不丢文件事件，文件出问题不压制可观测的 stdout 流。有专门的回归测试 `writes_secondary_bytes_even_when_primary_fails`。
- **primary 错误优先**：两者都失败时上报 stdout 的错误，因为它是用户可见 sink。

## 已知的后续协调点（原 review 提出，此处如实带过来）

- **与 #222 是语义冲突，不只是文本冲突**：#222 把 `build_dispatch` 的约束从 `W: MakeWriter + Clone` 改为 `W: Write + Send + 'static`，而 fanout 要求 `stdout_writer: MakeWriter`。谁后合并都要改代码，git 自动合并解决不了。建议先合本 PR（自包含、改动面小），#222 再 rebase——届时 fanout 的 primary 变成 `NonBlocking`（它实现了 `MakeWriter`，可直接接上）。#235 同样触碰该分支，一并对齐顺序。
- **#222 合并后需复核「primary 错误优先」约定**：stdout 变 lossy 非阻塞后 `write_all` 近乎永不失败，该约定将退化为纯文档表述。
- **"开销减半"是结构性结论**（两次格式化 → 一次），未做 benchmark 数字背书。

## 文档

`docs/runtime-logging.md` 与 `crates/logging/README.md` 只描述契约「emits every event to both sinks using the same envelope」，不描述 layer 拓扑；该表述未变且现在名副其实。fanout 属实现细节，按 AGENTS.md 放在代码注释里。`fanout.rs` 是单文件模块，无需新建 README。

## 测试

| 测试 | 覆盖点 |
|------|--------|
| `fanout::tests::mirrors_bytes_to_both_sinks` | 单次写入两 sink 字节逐字一致 |
| `fanout::tests::mirrors_chunked_writes_consistently` | 多次写入两 sink 字节一致 |
| `fanout::tests::surfaces_secondary_failures_without_dropping_primary_bytes` | secondary 失败上报错误但 primary 仍得字节 |
| `fanout::tests::writes_secondary_bytes_even_when_primary_fails` | primary 失败时 secondary 仍拿到完整字节（故障隔离回归守卫）|
| `fanout::tests::honors_per_event_writer_selection_on_each_sink` | metadata 转发；移除 `make_writer_for` 即失败 |
| `tests::selects_stdout_and_file_sink_behavior` | stdout 与文件两端 envelope 深比较相等 |

本地执行结果：

- `cargo fmt --all` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅（`ora-logging` 31 passed / 0 failed，其余 crate 全绿）

Closes #207
Supersedes #237
