### PR TITLE
feat(workflow): task Diff, worktree actions, and inspector coexistence in run workspace

### DIFF
--- a/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
+++ b/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PlatformProvider } from "@ora/platform";
 import type { ReactNode } from "react";
@@ -192,5 +192,31 @@ describe("WorkspaceReviewLayout", () => {
     );
     expect(screen.queryByRole("region", { name: "Task diff" })).not.toBeInTheDocument();
     expect(screen.getByText("Project")).toBeInTheDocument();
+  });
+
+  it("notifies when the review panel opens or closes", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext} onOpenChange={onOpenChange}>
+            <main>Workspace</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    await user.click(
+      within(screen.getByRole("group", { name: /工作区审查面板|Workspace review panels/ }))
+        .getByRole("button", { name: /^变更$|^Changes$/ }),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    await user.click(
+      within(screen.getByRole("group", { name: /工作区审查面板|Workspace review panels/ }))
+        .getByRole("button", { name: /^变更$|^Changes$/ }),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/app-shell/src/features/workflow-run/README.md
+++ b/packages/app-shell/src/features/workflow-run/README.md
@@ -127,8 +127,13 @@ Keep these stacks separate — shared chrome only where noted.
   emitted during setup are replayed instead of being lost or overwriting cache.
   Sidebar supports cancel (keep row) and delete (cancel then remove).
 - View toggle: Theater ↔ Overview. Overview node click returns to Theater
-  focused on that node and opens the act inspector. Header Theater toggle
-  does not force the rail open. Clicking Overview again while already there
+  focused on that node and opens the act inspector when the stage area is
+  wide enough (≥1000px); narrow windows skip the auto-open so the act card
+  stays readable. Header Theater toggle does not force the rail open.
+  Opening Changes/Files does not auto-open the act inspector (and seeded
+  Overview → Theater opens wait until Diff is closed). Clicking an act card
+  while Diff is open still opens the inspector beside Diff — they are not
+  mutually exclusive. Clicking Overview again while already there
   re-runs `fitView` and re-enables resize auto-fit after a manual pan/zoom.
   While Overview stays open, pane/window resize debounces a `fitView` so the
   graph stays framed — until the user pans or zooms, which pauses auto-fit.

--- a/packages/app-shell/src/features/workflow-run/README.md
+++ b/packages/app-shell/src/features/workflow-run/README.md
@@ -78,7 +78,9 @@ Keep these stacks separate — shared chrome only where noted.
 - Does not persist definitions in `@ora/workflow-mock` (that package stays
   session-demo + validation).
 - Does not own OpenSpec Spec-mode state.
-- Does not call Rust/contracts workflow APIs yet (F2 HTTP/NDJSON later).
+- Does not own Task Diff rendering (reuses `WorkspaceReviewLayout` /
+  `TaskDiffView` from chat); only supplies the run-task `taskId` context.
+- Does not implement session-scoped Diff for Theater stage mode yet.
 - Does not reuse settings `WorkflowCanvas` (no catalog / reconnect / delete).
 - Does not implement HITL timeout (always waits for submit; `HitlTimeoutPolicy`
   enum reserved for later).
@@ -101,6 +103,12 @@ Keep these stacks separate — shared chrome only where noted.
   run, select that run, and close settings. Kickoff input belongs in the main
   workspace UI later (`create` / path policy already accept `kickoffInput`).
 - Selection: `useWorkspaceSelectionStore.selectWorkflowRun`.
+- **Changes / Diff**: the run workspace wraps Theater and Overview in the same
+  `WorkspaceReviewLayout` used by chat. Scope is the run-task worktree
+  (`GetWorkflowRunResponse.taskId` → `TaskDiffView`), i.e. all file changes for
+  the run — not a single node session. Stage-scoped Diff is deferred until a
+  session-level Git Diff API (or turn-level filter) exists; `nodeStates.sessionId`
+  is projected for that follow-up.
 - Lists: react-query via `queryKeys.workflowMounts` /
   `workflowMountsByDefinition` / `workflowRuns`.
 - Runtime: `WorkflowRuntimeProvider` in `AppShell` injects

--- a/packages/app-shell/src/features/workflow-run/README.md
+++ b/packages/app-shell/src/features/workflow-run/README.md
@@ -109,6 +109,10 @@ Keep these stacks separate — shared chrome only where noted.
   the run — not a single node session. Stage-scoped Diff is deferred until a
   session-level Git Diff API (or turn-level filter) exists; `nodeStates.sessionId`
   is projected for that follow-up.
+- **Open location (Desktop)**: the run header reuses `LocationActionsButton`
+  (File Manager / Terminal / VS Code / Copy Path). Prefer
+  `GetWorkflowRunResponse.taskId` so opens target the run worktree; fall back to
+  the project root until that id is available. Hidden on Web (`unsupported`).
 - Lists: react-query via `queryKeys.workflowMounts` /
   `workflowMountsByDefinition` / `workflowRuns`.
 - Runtime: `WorkflowRuntimeProvider` in `AppShell` injects

--- a/packages/app-shell/src/features/workflow-run/run-theater.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-theater.tsx
@@ -39,8 +39,16 @@ interface RunTheaterProps {
   artifacts: WorkflowArtifact[];
   conversationByNodeId: Map<string, WorkflowNodeConversationItem[]>;
   revealedArtifactId: string | null;
-  /** Opens the companion rail once on mount (e.g. Overview → Theater via node click). */
+  /** Opens the companion rail once when seeded (Overview → Theater enter). */
   openInspectorOnMount?: boolean;
+  /** Clears the one-shot mount flag after the rail has been requested (or skipped). */
+  onOpenInspectorOnMountConsumed?: () => void;
+  /**
+   * When Changes/Files is open, suppress *automatic* inspector opens (seeded
+   * mount, artifact reveal). Intentional act clicks still open the rail so
+   * Diff and the inspector can coexist on the stage.
+   */
+  reviewPanelOpen?: boolean;
   /** Result act CTA — return to Overview path map. */
   onShowOverview: () => void;
   /** Which node's session dock is open — lifted across Overview remounts. */
@@ -62,6 +70,8 @@ export function RunTheater({
   conversationByNodeId,
   revealedArtifactId,
   openInspectorOnMount = false,
+  onOpenInspectorOnMountConsumed,
+  reviewPanelOpen = false,
   onShowOverview,
   sessionConversationNodeId = null,
   onSessionConversationNodeIdChange,
@@ -76,6 +86,8 @@ export function RunTheater({
   const [inspectorVisualWidth, setInspectorVisualWidth] = useState(0);
   const pathScrollOpenSigRef = useRef<string>("");
   const pathRailRef = useRef<HTMLDivElement | null>(null);
+  const reviewPanelOpenRef = useRef(reviewPanelOpen);
+  reviewPanelOpenRef.current = reviewPanelOpen;
 
   const focus = useMemo(
     () => resolveTheaterFocus(run, focusNodeId),
@@ -212,7 +224,14 @@ export function RunTheater({
     }
   }
 
-  function openInspector(): void {
+  /**
+   * Opens the act inspector. Automatic triggers stay quiet while Diff/Files is
+   * open; user clicks always open so the rail can sit beside an open Diff.
+   */
+  function openInspector(reason: "automatic" | "user"): void {
+    if (reason === "automatic" && reviewPanelOpenRef.current) {
+      return;
+    }
     if (hitlExpanded) {
       collapseHitl();
     }
@@ -246,6 +265,20 @@ export function RunTheater({
     closeInspector();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
   }, [hitlExpanded]);
+
+  // Seeded open from Overview → Theater. Skipped (and retried) while Diff/Files
+  // owns the workspace so opening Changes does not auto-pop the rail.
+  useEffect(() => {
+    if (!openInspectorOnMount || reviewPanelOpen) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      openInspector("automatic");
+      onOpenInspectorOnMountConsumed?.();
+    });
+    return () => window.cancelAnimationFrame(frame);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
+  }, [openInspectorOnMount, reviewPanelOpen]);
 
   function settleInspectorAfterUserResize(): void {
     const width = inspectorCurrentWidthRef.current;
@@ -295,17 +328,6 @@ export function RunTheater({
     settleInspectorAfterUserResize();
   }
 
-  useEffect(() => {
-    if (!openInspectorOnMount) {
-      return;
-    }
-    // Defer one frame so the rail animates in after first paint instead of
-    // mutating panel state synchronously within the mount effect.
-    const frame = window.requestAnimationFrame(() => openInspector());
-    return () => window.cancelAnimationFrame(frame);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
-  }, []);
-
   // Artifact reveal: open the rail only when the stage just moved onto the
   // producing act. If we were already there, skip — re-tweening the inspector
   // collapses HITL and flashes the card for no navigation benefit.
@@ -328,7 +350,7 @@ export function RunTheater({
     if (previousPrimary === artifact.nodeId) {
       return;
     }
-    openInspector();
+    openInspector("automatic");
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
   }, [
     revealedArtifactId,
@@ -382,7 +404,7 @@ export function RunTheater({
                         if (recent !== null) {
                           onFocusNode(recent.nodeId);
                         }
-                        openInspector();
+                        openInspector("user");
                       }
                       : undefined}
                   />
@@ -394,7 +416,7 @@ export function RunTheater({
                       acts={parallelActs}
                       primaryId={primaryId!}
                       onFocusNode={onFocusNode}
-                      onOpenInspector={openInspector}
+                      onOpenInspector={() => openInspector("user")}
                       sessionConversationNodeId={sessionConversationNodeId}
                       onSessionConversationNodeIdChange={onSessionConversationNodeIdChange}
                       primaryInteraction={primaryHasHitl
@@ -428,7 +450,7 @@ export function RunTheater({
                         );
                       }}
                       variant="stage"
-                      onSelect={openInspector}
+                      onSelect={() => openInspector("user")}
                       interaction={primaryHasHitl
                         ? ({ accessory }) => renderHitlComposer(accessory ?? undefined)
                         : undefined}

--- a/packages/app-shell/src/features/workflow-run/workflow-run-workspace.test.tsx
+++ b/packages/app-shell/src/features/workflow-run/workflow-run-workspace.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../test/hook-harness";
 import { createMockClient, createMockClientState } from "../../test/mock-client";
 import { createStubPlatform } from "../../test/stub-platform";
+import { useLocationActionsStore } from "../../state/stores/location-actions-store";
 import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
 import { WorkflowRunWorkspace } from "./workflow-run-workspace";
 
@@ -42,7 +43,59 @@ const GRAPH = JSON.stringify({
   description: "",
 });
 
-describe("WorkflowRunWorkspace Changes", () => {
+/** Seeds project + workflow + run-task so the workspace can load Changes and location actions. */
+function seedRunWithTask() {
+  const state = createMockClientState();
+  state.projects = [{ id: "p1", name: "Demo", rootPath: "/demo" }];
+  state.workflows = [{
+    workflow: {
+      id: "workflow-a",
+      name: "审查流程",
+      publishedSnapshotId: "snap-1",
+      createdAt: 1n,
+      updatedAt: 1n,
+    },
+    draft: {
+      id: "draft-1",
+      workflowId: "workflow-a",
+      version: "draft",
+      graph: GRAPH,
+      createdAt: 1n,
+      updatedAt: 1n,
+    },
+    published: [{
+      id: "snap-1",
+      workflowId: "workflow-a",
+      version: "v1",
+      graph: GRAPH,
+      createdAt: 1n,
+      updatedAt: null,
+    }],
+  }];
+  state.workflowRuns = [{
+    id: "run-1",
+    projectId: "p1",
+    workflowId: "workflow-a",
+    snapshotId: "snap-1",
+    name: "审查流程 1",
+    status: "pending",
+    taskId: "task-run-1",
+    createdAt: 1n,
+    updatedAt: 1n,
+  }];
+  state.tasks = [{
+    id: "task-run-1",
+    projectId: "p1",
+    title: "审查流程 1",
+    status: "todo",
+    workspaceMode: "worktree",
+    type: "workflow",
+    workflowRunId: "run-1",
+  }];
+  return state;
+}
+
+describe("WorkflowRunWorkspace", () => {
   beforeEach(() => {
     useWorkspaceSelectionStore.setState({
       selection: {
@@ -52,57 +105,11 @@ describe("WorkflowRunWorkspace Changes", () => {
         workflowRunId: "run-1",
       },
     });
+    useLocationActionsStore.setState({ defaultTarget: "explorer" });
   });
 
   it("exposes the run-task Changes panel once the worktree task id is loaded", async () => {
-    const state = createMockClientState();
-    state.projects = [{ id: "p1", name: "Demo", rootPath: "/demo" }];
-    state.workflows = [{
-      workflow: {
-        id: "workflow-a",
-        name: "审查流程",
-        publishedSnapshotId: "snap-1",
-        createdAt: 1n,
-        updatedAt: 1n,
-      },
-      draft: {
-        id: "draft-1",
-        workflowId: "workflow-a",
-        version: "draft",
-        graph: GRAPH,
-        createdAt: 1n,
-        updatedAt: 1n,
-      },
-      published: [{
-        id: "snap-1",
-        workflowId: "workflow-a",
-        version: "v1",
-        graph: GRAPH,
-        createdAt: 1n,
-        updatedAt: null,
-      }],
-    }];
-    state.workflowRuns = [{
-      id: "run-1",
-      projectId: "p1",
-      workflowId: "workflow-a",
-      snapshotId: "snap-1",
-      name: "审查流程 1",
-      status: "pending",
-      taskId: "task-run-1",
-      createdAt: 1n,
-      updatedAt: 1n,
-    }];
-    state.tasks = [{
-      id: "task-run-1",
-      projectId: "p1",
-      title: "审查流程 1",
-      status: "todo",
-      workspaceMode: "worktree",
-      type: "workflow",
-      workflowRunId: "run-1",
-    }];
-
+    const state = seedRunWithTask();
     const client = createMockClient(state);
     const runtime = createMemoryWorkflowRuntime();
     const Wrapper = createHookWrapper(
@@ -128,6 +135,54 @@ describe("WorkflowRunWorkspace Changes", () => {
 
     await user.click(screen.getByRole("button", { name: /变更|Changes/ }));
     expect(screen.getByRole("region", { name: "Task diff" })).toBeInTheDocument();
+
+    runtime.dispose();
+  });
+
+  it("exposes Desktop open-location actions against the run-task worktree", async () => {
+    const state = seedRunWithTask();
+    const client = createMockClient(state);
+    const runtime = createMemoryWorkflowRuntime();
+    const Wrapper = createHookWrapper(
+      client,
+      createTestQueryClient(),
+      createChatStore(client.session),
+      runtime,
+    );
+    const user = userEvent.setup();
+    const resolveTaskCwd = vi.fn(async () => "/demo/.ora/task-run-1");
+    const open = vi.fn(async () => undefined);
+    const platform = {
+      ...createStubPlatform(),
+      locationActions: {
+        kind: "supported" as const,
+        resolveTaskCwd,
+        open,
+      },
+    };
+
+    render(
+      <PlatformProvider adapter={platform}>
+        <Wrapper>
+          <WorkflowRunWorkspace runId="run-1" />
+        </Wrapper>
+      </PlatformProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("审查流程 1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("group", { name: /打开位置|Open location/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", {
+      name: /用 文件管理器 打开|Open in File Manager/,
+    }));
+
+    await waitFor(() => {
+      expect(resolveTaskCwd).toHaveBeenCalledWith("task-run-1");
+    });
+    expect(open).toHaveBeenCalledWith("explorer", "/demo/.ora/task-run-1");
 
     runtime.dispose();
   });

--- a/packages/app-shell/src/features/workflow-run/workflow-run-workspace.test.tsx
+++ b/packages/app-shell/src/features/workflow-run/workflow-run-workspace.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChatStore } from "@ora/chat";
+import { PlatformProvider } from "@ora/platform";
+import { createMemoryWorkflowRuntime } from "@ora/workflow-runtime/memory";
+import {
+  createHookWrapper,
+  createTestQueryClient,
+} from "../../test/hook-harness";
+import { createMockClient, createMockClientState } from "../../test/mock-client";
+import { createStubPlatform } from "../../test/stub-platform";
+import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
+import { WorkflowRunWorkspace } from "./workflow-run-workspace";
+
+vi.mock("../diff/task-diff-view", () => ({
+  TaskDiffView: ({ toolbar }: { toolbar?: ReactNode }) => (
+    <section aria-label="Task diff">
+      <header data-diff-toolbar>{toolbar}</header>
+    </section>
+  ),
+}));
+
+vi.mock("../files/workspace-review-files-panel", () => ({
+  WorkspaceReviewFilesPanel: ({ toolbar }: { toolbar?: ReactNode }) => (
+    <section aria-label="Files panel">{toolbar}</section>
+  ),
+}));
+
+const GRAPH = JSON.stringify({
+  nodes: [
+    {
+      id: "start",
+      type: "workflow",
+      position: { x: 0, y: 0 },
+      data: { kind: "start", title: "开始", description: "" },
+    },
+  ],
+  edges: [],
+  viewport: { x: 32, y: 32, zoom: 1 },
+  description: "",
+});
+
+describe("WorkflowRunWorkspace Changes", () => {
+  beforeEach(() => {
+    useWorkspaceSelectionStore.setState({
+      selection: {
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: "run-1",
+      },
+    });
+  });
+
+  it("exposes the run-task Changes panel once the worktree task id is loaded", async () => {
+    const state = createMockClientState();
+    state.projects = [{ id: "p1", name: "Demo", rootPath: "/demo" }];
+    state.workflows = [{
+      workflow: {
+        id: "workflow-a",
+        name: "审查流程",
+        publishedSnapshotId: "snap-1",
+        createdAt: 1n,
+        updatedAt: 1n,
+      },
+      draft: {
+        id: "draft-1",
+        workflowId: "workflow-a",
+        version: "draft",
+        graph: GRAPH,
+        createdAt: 1n,
+        updatedAt: 1n,
+      },
+      published: [{
+        id: "snap-1",
+        workflowId: "workflow-a",
+        version: "v1",
+        graph: GRAPH,
+        createdAt: 1n,
+        updatedAt: null,
+      }],
+    }];
+    state.workflowRuns = [{
+      id: "run-1",
+      projectId: "p1",
+      workflowId: "workflow-a",
+      snapshotId: "snap-1",
+      name: "审查流程 1",
+      status: "pending",
+      taskId: "task-run-1",
+      createdAt: 1n,
+      updatedAt: 1n,
+    }];
+    state.tasks = [{
+      id: "task-run-1",
+      projectId: "p1",
+      title: "审查流程 1",
+      status: "todo",
+      workspaceMode: "worktree",
+      type: "workflow",
+      workflowRunId: "run-1",
+    }];
+
+    const client = createMockClient(state);
+    const runtime = createMemoryWorkflowRuntime();
+    const Wrapper = createHookWrapper(
+      client,
+      createTestQueryClient(),
+      createChatStore(client.session),
+      runtime,
+    );
+    const user = userEvent.setup();
+
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <Wrapper>
+          <WorkflowRunWorkspace runId="run-1" />
+        </Wrapper>
+      </PlatformProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("审查流程 1")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /变更|Changes/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /变更|Changes/ }));
+    expect(screen.getByRole("region", { name: "Task diff" })).toBeInTheDocument();
+
+    runtime.dispose();
+  });
+});

--- a/packages/app-shell/src/features/workflow-run/workflow-run-workspace.tsx
+++ b/packages/app-shell/src/features/workflow-run/workflow-run-workspace.tsx
@@ -44,6 +44,7 @@ import { RunTheater } from "./run-theater";
 import { RunStatusBadge } from "./run-status-mark";
 import { isTerminalRunStatus, runStatusTone } from "./run-status-style";
 import type { WorkflowRunViewMode } from "./run-view-mode";
+import { LocationActionsButton } from "../workspace/location-actions-button";
 import {
   WorkspaceReviewLayout,
   type WorkspaceReviewContext,
@@ -499,6 +500,11 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
             </Button>
           )}
         </div>
+        {/* Prefer the run-task worktree; project root is the fallback before taskId loads. */}
+        <LocationActionsButton
+          taskId={runTaskId}
+          projectPath={project?.rootPath}
+        />
         <WindowControls />
       </header>
 

--- a/packages/app-shell/src/features/workflow-run/workflow-run-workspace.tsx
+++ b/packages/app-shell/src/features/workflow-run/workflow-run-workspace.tsx
@@ -50,6 +50,9 @@ import {
   type WorkspaceReviewContext,
 } from "../workspace/workspace-review-layout";
 
+/** Below this width, Overview → Theater skips auto-opening the act inspector. */
+const NARROW_THEATER_INSPECTOR_AUTO_OPEN_WIDTH = 1_000;
+
 interface WorkflowRunWorkspaceProps {
   runId: string;
 }
@@ -82,8 +85,11 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
   const [openInspectorOnTheaterEnter, setOpenInspectorOnTheaterEnter] = useState(
     false,
   );
+  /** True while Changes/Files review panel is open (side or expanded). */
+  const [reviewPanelOpen, setReviewPanelOpen] = useState(false);
   /** Re-fit Overview when the header control is activated (including while already there). */
   const [overviewFitRequestKey, setOverviewFitRequestKey] = useState(0);
+  const stageAreaRef = useRef<HTMLDivElement | null>(null);
 
   /** Same-node status edge: live pin just finished -> resume auto-follow. */
   const focusStatusSampleRef = useRef<TheaterFocusStatusSample | null>(null);
@@ -138,6 +144,8 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
     setConversationNodeId(null);
     setStopOpen(false);
     setOpenInspectorOnTheaterEnter(false);
+    setReviewPanelOpen(false);
+    setReviewCloseRequestId(0);
   }
   useEffect(() => {
     focusStatusSampleRef.current = null;
@@ -305,8 +313,12 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
     setConversationNodeId(null);
     setFocusNodeId(nodeId);
     const waiting = run !== null && run.nodeStates[nodeId]?.status === "awaiting_input";
+    const stageWidth = stageAreaRef.current?.getBoundingClientRect().width
+      ?? Number.POSITIVE_INFINITY;
+    // Narrow stages cannot host the act card and inspector without crushing the card.
+    const wideEnoughForInspector = stageWidth >= NARROW_THEATER_INSPECTOR_AUTO_OPEN_WIDTH;
     enterTheater({
-      openInspector: !waiting,
+      openInspector: !waiting && wideEnoughForInspector,
     });
   }
 
@@ -522,8 +534,12 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
           </div>
         )
         : (
-          <WorkspaceReviewLayout context={reviewContext}>
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <WorkspaceReviewLayout
+            key={runId}
+            context={reviewContext}
+            onOpenChange={setReviewPanelOpen}
+          >
+            <div ref={stageAreaRef} className="flex min-h-0 min-w-0 flex-1 flex-col">
               {viewMode === "theater"
                 ? (
                   <RunTheater
@@ -535,6 +551,10 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
                     conversationByNodeId={artifactsQuery.conversationByNodeId}
                     revealedArtifactId={artifactsQuery.revealedId}
                     openInspectorOnMount={openInspectorOnTheaterEnter}
+                    onOpenInspectorOnMountConsumed={() => {
+                      setOpenInspectorOnTheaterEnter(false);
+                    }}
+                    reviewPanelOpen={reviewPanelOpen}
                     sessionConversationNodeId={conversationNodeId}
                     onSessionConversationNodeIdChange={setSessionConversationNodeId}
                     onShowOverview={() => {

--- a/packages/app-shell/src/features/workflow-run/workflow-run-workspace.tsx
+++ b/packages/app-shell/src/features/workflow-run/workflow-run-workspace.tsx
@@ -31,6 +31,7 @@ import {
   useStartGraphWorkflowRun,
 } from "../../state/hooks/use-graph-workflow-runs";
 import { useRealWorkflowRun } from "../../state/hooks/use-workflow-runs";
+import { useProjects } from "../../state/hooks/use-projects";
 import {
   resolveStageFocusNodeId,
   resolveTheaterFocus,
@@ -43,6 +44,10 @@ import { RunTheater } from "./run-theater";
 import { RunStatusBadge } from "./run-status-mark";
 import { isTerminalRunStatus, runStatusTone } from "./run-status-style";
 import type { WorkflowRunViewMode } from "./run-view-mode";
+import {
+  WorkspaceReviewLayout,
+  type WorkspaceReviewContext,
+} from "../workspace/workspace-review-layout";
 
 interface WorkflowRunWorkspaceProps {
   runId: string;
@@ -57,8 +62,12 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
   const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
   const setSidebarCollapsed = useUiStore((s) => s.setSidebarCollapsed);
   const selectWorkflowRun = useWorkspaceSelectionStore((s) => s.selectWorkflowRun);
+  const projectId = useWorkspaceSelectionStore((s) => s.selection.projectId);
+  const projectsQuery = useProjects();
+  const project = projectsQuery.data?.find((item) => item.id === projectId);
   const runQuery = useRealWorkflowRun(runId);
-  const run = runQuery.data ?? null;
+  const run = runQuery.data?.run ?? null;
+  const runTaskId = runQuery.data?.taskId ?? null;
   const startRun = useStartGraphWorkflowRun();
   const cancelRun = useCancelGraphWorkflowRun();
   const rerun = useRerunGraphWorkflowRun();
@@ -264,6 +273,18 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
   const canRunAgain = run !== null && isTerminalRunStatus(run.status);
   const runTone = run !== null ? runStatusTone(run.status) : null;
   const actionBusy = startRun.isPending || cancelRun.isPending || rerun.isPending;
+
+  // Run-task worktree Diff / Files — same surface as chat Task Changes.
+  const reviewContext: WorkspaceReviewContext = runTaskId !== null
+      && projectId !== null
+      && project !== undefined
+    ? {
+      kind: "task",
+      taskId: runTaskId,
+      projectId,
+      projectRootPath: project.rootPath,
+    }
+    : { kind: "none" };
 
   // If the run finishes while the stop dialog is open, dismiss it so Confirm
   // (which preventDefault + early-returns when !canStop) cannot leave a stuck modal.
@@ -494,33 +515,39 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
             {t("workflowRun.missing")}
           </div>
         )
-        : viewMode === "theater"
-        ? (
-          <RunTheater
-            run={run}
-            focusNodeId={stageFocusNodeId}
-            onFocusNode={focusNode}
-            onClearFocus={clearPathFocus}
-            artifacts={artifactsQuery.artifacts}
-            conversationByNodeId={artifactsQuery.conversationByNodeId}
-            revealedArtifactId={artifactsQuery.revealedId}
-            openInspectorOnMount={openInspectorOnTheaterEnter}
-            sessionConversationNodeId={conversationNodeId}
-            onSessionConversationNodeIdChange={setSessionConversationNodeId}
-            onShowOverview={() => {
-              setOpenInspectorOnTheaterEnter(false);
-              setViewMode("overview");
-            }}
-          />
-        )
         : (
-          <RunOverviewCanvas
-            run={run}
-            focusedNodeId={stageFocusNodeId}
-            onFocusNode={focusNodeFromOverview}
-            artifacts={artifactsQuery.artifacts}
-            fitRequestKey={overviewFitRequestKey}
-          />
+          <WorkspaceReviewLayout context={reviewContext}>
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+              {viewMode === "theater"
+                ? (
+                  <RunTheater
+                    run={run}
+                    focusNodeId={stageFocusNodeId}
+                    onFocusNode={focusNode}
+                    onClearFocus={clearPathFocus}
+                    artifacts={artifactsQuery.artifacts}
+                    conversationByNodeId={artifactsQuery.conversationByNodeId}
+                    revealedArtifactId={artifactsQuery.revealedId}
+                    openInspectorOnMount={openInspectorOnTheaterEnter}
+                    sessionConversationNodeId={conversationNodeId}
+                    onSessionConversationNodeIdChange={setSessionConversationNodeId}
+                    onShowOverview={() => {
+                      setOpenInspectorOnTheaterEnter(false);
+                      setViewMode("overview");
+                    }}
+                  />
+                )
+                : (
+                  <RunOverviewCanvas
+                    run={run}
+                    focusedNodeId={stageFocusNodeId}
+                    onFocusNode={focusNodeFromOverview}
+                    artifacts={artifactsQuery.artifacts}
+                    fitRequestKey={overviewFitRequestKey}
+                  />
+                )}
+            </div>
+          </WorkspaceReviewLayout>
         )}
 
       <AlertDialog open={stopOpen} onOpenChange={setStopOpen}>

--- a/packages/app-shell/src/features/workspace/workspace-review-layout.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-review-layout.tsx
@@ -25,12 +25,18 @@ export type WorkspaceReviewContext =
 interface WorkspaceReviewLayoutProps {
   context: WorkspaceReviewContext;
   children: ReactNode;
+  /** Fires when the side/expanded review panel opens or closes (not on expand-only). */
+  onOpenChange?: (open: boolean) => void;
 }
 
 type ReviewPanel = "changes" | "files";
 
 /** Hosts every workspace review surface while preserving Ora's established panel interaction. */
-export function WorkspaceReviewLayout({ context, children }: WorkspaceReviewLayoutProps) {
+export function WorkspaceReviewLayout({
+  context,
+  children,
+  onOpenChange,
+}: WorkspaceReviewLayoutProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -42,23 +48,38 @@ export function WorkspaceReviewLayout({ context, children }: WorkspaceReviewLayo
   const [previousContextKind, setPreviousContextKind] = useState(context.kind);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileRequestSequence = useRef(0);
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
   const taskId = context.kind === "task" ? context.taskId : undefined;
   const contextKey = context.kind === "none" ? "none" : context.kind === "project" ? `project:${context.projectId}` : `task:${context.taskId}`;
+
+  const setReviewOpen = useCallback((next: boolean) => {
+    setOpen((current) => {
+      if (current === next) {
+        return current;
+      }
+      onOpenChangeRef.current?.(next);
+      return next;
+    });
+  }, []);
 
   const close = useCallback(() => {
     if (closeTimer.current !== null) clearTimeout(closeTimer.current);
     closeTimer.current = null;
-    setOpen(false);
+    setReviewOpen(false);
     setExpanded(false);
     setClosing(false);
     setViewType("unified");
-  }, []);
+  }, [setReviewOpen]);
 
   // React permits guarded render-time adjustment for state that is directly tied to
   // a prop. Closing here prevents one frame of stale review UI without an effect loop.
   if (context.kind !== previousContextKind) {
     setPreviousContextKind(context.kind);
     if (context.kind === "none") {
+      if (open) {
+        onOpenChangeRef.current?.(false);
+      }
       setOpen(false);
       setExpanded(false);
       setClosing(false);
@@ -71,8 +92,8 @@ export function WorkspaceReviewLayout({ context, children }: WorkspaceReviewLayo
     fileRequestSequence.current += 1;
     setFileRequest({ path, requestId: fileRequestSequence.current });
     setPanel("changes");
-    setOpen(true);
-  }, [taskId]);
+    setReviewOpen(true);
+  }, [setReviewOpen, taskId]);
 
   const toggleExpanded = () => {
     if (!expanded) {
@@ -93,7 +114,7 @@ export function WorkspaceReviewLayout({ context, children }: WorkspaceReviewLayo
     if (open && panel === next) close();
     else {
       setPanel(next);
-      setOpen(true);
+      setReviewOpen(true);
     }
   };
 

--- a/packages/app-shell/src/state/hooks/use-workflow-runs.test.ts
+++ b/packages/app-shell/src/state/hooks/use-workflow-runs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { renderHookWithClient } from "../../test/hook-harness";
 import { createMockClient, createMockClientState, type MockClientState } from "../../test/mock-client";
-import { buildDisplayRun, useDeleteWorkflowRun, useRenameWorkflowRun, useWorkflowRunsByProject } from "./use-workflow-runs";
+import { buildDisplayRun, useDeleteWorkflowRun, useRealWorkflowRun, useRenameWorkflowRun, useWorkflowRunsByProject } from "./use-workflow-runs";
 
 /** Seeds one persisted run and its run-task for hook tests. */
 function seededState(): MockClientState {
@@ -88,6 +88,23 @@ describe("buildDisplayRun", () => {
     expect(display.nodeStates.explore.startedAt).toBe(new Date(2).toISOString());
   });
 
+  it("projects node session ids for future stage-scoped Diff", () => {
+    const withSession = {
+      ...detail,
+      nodes: [{
+        nodeId: "explore",
+        status: "running",
+        startedAt: 2n,
+        finishedAt: null,
+        error: null,
+        output: null,
+        sessionId: "session-explore",
+      }],
+    };
+    const display = buildDisplayRun(withSession, GRAPH);
+    expect(display.nodeStates.explore.sessionId).toBe("session-explore");
+  });
+
   it("derives awaiting_input node state from a pending node-run", () => {
     const pendingDetail = {
       ...detail,
@@ -95,6 +112,44 @@ describe("buildDisplayRun", () => {
     };
     const display = buildDisplayRun(pendingDetail, GRAPH);
     expect(display.nodeStates.explore.status).toBe("awaiting_input");
+  });
+});
+
+describe("useRealWorkflowRun", () => {
+  it("returns the display run together with the run-task id", async () => {
+    const state = seededState();
+    state.projects = [{ id: "p1", name: "Demo", rootPath: "/demo" }];
+    state.workflows = [{
+      workflow: {
+        id: "workflow-a",
+        name: "审查流程",
+        publishedSnapshotId: "snap-1",
+        createdAt: 1n,
+        updatedAt: 1n,
+      },
+      draft: {
+        id: "draft-1",
+        workflowId: "workflow-a",
+        version: "draft",
+        graph: GRAPH,
+        createdAt: 1n,
+        updatedAt: 1n,
+      },
+      published: [{
+        id: "snap-1",
+        workflowId: "workflow-a",
+        version: "v1",
+        graph: GRAPH,
+        createdAt: 1n,
+        updatedAt: null,
+      }],
+    }];
+    const client = createMockClient(state);
+    const { result } = renderHookWithClient(() => useRealWorkflowRun("run-1"), client);
+    await vi.waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.taskId).toBe("t1");
+    expect(result.current.data?.run.id).toBe("run-1");
+    expect(result.current.data?.run.name).toBe("审查流程 1");
   });
 });
 

--- a/packages/app-shell/src/state/hooks/use-workflow-runs.ts
+++ b/packages/app-shell/src/state/hooks/use-workflow-runs.ts
@@ -98,28 +98,46 @@ export function useRenameWorkflowRun() {
  *
  * The backend run is lean (no name, graph, or node state), so the adapter composes the run
  * detail with its frozen snapshot graph and node-runs to satisfy the Theater/Overview canvas.
+ * `taskId` is the run-task that owns the Git worktree used by Task Diff.
  */
 export function useRealWorkflowRun(runId: string | null | undefined) {
   const client = useContractsClient();
   return useQuery({
     queryKey: runDetailKey(runId ?? ""),
-    queryFn: async () => {
+    queryFn: async (): Promise<RealWorkflowRunDetail> => {
       const detail = await client.workflowRun.get({ runId: runId! });
       const { snapshot } = await client.workflow.getSnapshot({
         snapshotId: detail.run.snapshotId,
       });
-      return buildDisplayRun(detail, snapshot.graph);
+      return {
+        run: buildDisplayRun(detail, snapshot.graph),
+        taskId: detail.taskId,
+      };
     },
     enabled: runId != null && runId !== "",
   });
 }
+
+/** Persisted run detail plus the run-task id used for worktree Diff / Files. */
+export type RealWorkflowRunDetail = {
+  run: GraphWorkflowRun;
+  taskId: string;
+};
 
 /** Projects a persisted run detail onto the Theater/Overview display model. */
 export function buildDisplayRun(
   detail: {
     run: { id: string; workflowId: string; status: string; state: string | null; startedAt: bigint | null; finishedAt: bigint | null; createdAt: bigint; updatedAt: bigint };
     name: string;
-    nodes: Array<{ nodeId: string; status: string; startedAt: bigint | null; finishedAt: bigint | null; error: string | null; output: string | null }>;
+    nodes: Array<{
+      nodeId: string;
+      status: string;
+      startedAt: bigint | null;
+      finishedAt: bigint | null;
+      error: string | null;
+      output: string | null;
+      sessionId?: string | null;
+    }>;
   },
   graph: string,
 ): GraphWorkflowRun {
@@ -142,6 +160,9 @@ export function buildDisplayRun(
       status: projectNodeStatus(
         nodeRun as { status: "pending" | "running" | "succeeded" | "failed" | "cancelled" } | null,
       ),
+      ...(nodeRun?.sessionId != null && nodeRun.sessionId !== ""
+        ? { sessionId: nodeRun.sessionId }
+        : {}),
       ...(nodeRun?.startedAt != null ? { startedAt: toIso(nodeRun.startedAt) } : {}),
       ...(nodeRun?.finishedAt != null ? { finishedAt: toIso(nodeRun.finishedAt) } : {}),
       ...(nodeRun?.error != null ? { errorMessage: nodeRun.error } : {}),


### PR DESCRIPTION
## Summary
- Mount task-scoped Changes Diff in the run workspace (`WorkspaceReviewLayout` + run `taskId`), so Overview/Theater can review the full worktree like chat
- Add Theater header worktree actions (File Manager / Terminal / VS Code) via `LocationActionsButton`
- Keep Diff and the act inspector coexistent: suppress auto-open while Diff is open, but intentional act clicks still open the rail; skip Overview→Theater auto-open on narrow stages (<1000px)