### PR TITLE
fix: use local branches for worktree bases

### DIFF
--- a/crates/application/src/project/README.md
+++ b/crates/application/src/project/README.md
@@ -6,13 +6,13 @@ This module owns the transport-independent project use cases and the shared `Clo
 
 - `CreateProjectHandler` assigns a new `ProjectId`, timestamps the domain entity, and persists it through `ProjectRepository`.
 - Get and list handlers return only repository-visible projects.
-- `ListProjectBranchesHandler` joins refreshed branch refs with project-owned task and worktree records so Ora-managed branches use task titles.
+- `ListProjectBranchesHandler` joins local branch refs with project-owned task and worktree records so Ora-managed branches use task titles.
 - `UpdateProjectHandler` changes the project name while preserving its id, root path, creation timestamp, and deletion state.
 - Domain values are mapped to the shared project contract before leaving the application layer.
 - Repository and not-found failures are normalized as `ApplicationError`; request lifecycle adapters own correlated completion events.
 
 The module does not execute Git commands, create Git repositories, manage worktrees, or delete project aggregates. Backend composition implements `BranchLister`, while the database cascade path owns project deletion.
 
-`ProjectRepository`, `BranchLister`, `ProjectIdGenerator`, and `Clock` keep persistence, Git inspection, identity, and time injectable. Implementations must preserve the visible-record, ref freshness, and soft-delete semantics expected by the handlers.
+`ProjectRepository`, `BranchLister`, `ProjectIdGenerator`, and `Clock` keep persistence, Git inspection, identity, and time injectable. Implementations must preserve the visible-record, local-ref, and soft-delete semantics expected by the handlers.
 
 See the [ora-application overview](../../README.md) and [Application and Contracts Boundary](../../../../docs/application-contracts.md).

--- a/crates/application/src/project/branch_listing.rs
+++ b/crates/application/src/project/branch_listing.rs
@@ -57,7 +57,7 @@ where
     WorktreeRepositoryPort: WorktreeRepository,
     BranchListerPort: BranchLister,
 {
-    /// Lists refreshed branch refs and replaces Ora-managed branch labels with task titles.
+    /// Lists local branch refs and replaces Ora-managed branch labels with task titles.
     pub fn handle(
         &self,
         request: ListProjectBranchesRequest,

--- a/crates/application/src/project/ports.rs
+++ b/crates/application/src/project/ports.rs
@@ -3,17 +3,17 @@ use ora_domain::{Project, ProjectId};
 use std::path::Path;
 use thiserror::Error;
 
-/// Describes one logical branch and the exact local or remote-tracking ref Git should resolve.
+/// Describes one logical branch and the exact local ref Git should resolve.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BranchReference {
     pub name: String,
     pub ref_name: String,
 }
 
-/// Supplies refreshed Git branches without coupling project use cases to a Git implementation.
+/// Supplies local Git branches without coupling project use cases to a Git implementation.
 ///
-/// Implementations are expected to return resolvable ref names and to apply their own
-/// freshness policy before exposing branches to the application layer.
+/// Implementations are expected to return resolvable local ref names without changing
+/// repository state while exposing branches to the application layer.
 pub trait BranchLister {
     /// Lists selectable branch references for the repository rooted at the supplied path.
     fn list_branches(

--- a/crates/application/src/task/README.md
+++ b/crates/application/src/task/README.md
@@ -5,7 +5,7 @@ This module coordinates task CRUD with optional backend-owned Git worktree provi
 ## Creation modes
 
 - Root-mode tasks use the project checkout directly and persist no worktree id.
-- Worktree-mode tasks require a valid Git repository and a selected base ref, reserve a non-colliding task id/branch prefix, resolve the selected local or refreshed remote ref to an immutable commit id, create a linked worktree from that commit, persist only that commit id in the `Worktree` record, and then persist the `Task` that owns it.
+- Worktree-mode tasks require a valid Git repository and a selected local base ref, reserve a non-colliding task id/branch prefix, resolve that local ref to an immutable commit id, create a linked worktree from that commit, persist only that commit id in the `Worktree` record, and then persist the `Task` that owns it.
 - Worktree paths are composed only during creation from the configured worktree root and full task id. Existing paths are resolved from persisted branch identity and Git metadata elsewhere.
 - If persistence fails after Git resources are created, the handler attempts compensating soft deletion and forced worktree cleanup while preserving the original stable application error.
 
@@ -17,6 +17,6 @@ Task updates preserve project ownership and the existing worktree association. A
 
 Branch creation uses a short task-id prefix, so creation checks both existing task worktree directories and repository branches before accepting an id. Worktree mode fails explicitly when the project root is not a Git repository.
 
-The frontend lists refreshed remote and local project refs before creation. Ora-managed `ora/<prefix>` branches retain their Git identity in requests but use the owning task title as their display label; local Ora refs remain selectable so an existing worktree can seed another one.
+The frontend lists local project refs before creation. Ora-managed `ora/<prefix>` branches retain their Git identity in requests but use the owning task title as their display label, so an existing worktree can seed another one without any implicit remote refresh.
 
 See the [ora-application overview](../../README.md) and [Application and Contracts Boundary](../../../../docs/application-contracts.md).

--- a/crates/backend/src/project.rs
+++ b/crates/backend/src/project.rs
@@ -145,7 +145,7 @@ impl ProjectApi {
     }
 }
 
-/// Adapts Gitlancer's refreshed worktree bases to the application branch-listing port.
+/// Adapts Gitlancer's local worktree bases to the application branch-listing port.
 #[derive(Debug, Clone, Copy)]
 struct GitBranchLister;
 

--- a/crates/contracts/src/project.rs
+++ b/crates/contracts/src/project.rs
@@ -66,7 +66,7 @@ pub struct ListProjectBranchesRequest {
     pub project_id: String,
 }
 
-/// Returns refreshed remote branches plus local-only branches that can seed a new worktree.
+/// Returns local branches that can seed a new worktree.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "project.ts")]

--- a/crates/gitlancer/src/git/README.md
+++ b/crates/gitlancer/src/git/README.md
@@ -7,7 +7,7 @@ This module exposes the operations callers perform through `Git<R: GitRunner>` a
 - Repository operations discover a Git root, open an already validated repository, and list its worktrees.
 - Worktree operations resolve by path or branch and create or delete linked worktrees with explicit deletion modes.
 - Branch operations list, validate, create, and delete local branches with checked or forced semantics.
-- Worktree-base operations refresh the preferred remote, combine it with local refs, and resolve a selected base to an immutable commit.
+- Worktree-base operations list local refs and resolve a selected base to an immutable commit without network or repository-state side effects.
 - Diff operations produce standard unified patches for branch, unstaged, staged, and committed scopes, including untracked files without modifying the caller's index.
 - Commit operations stage `RepoRelativePath` values, create commits without GPG signing, and return typed commit metadata.
 - Push operations publish the verified checked-out branch to its default remote without enabling credential prompts.

--- a/crates/gitlancer/src/git/base_branch.rs
+++ b/crates/gitlancer/src/git/base_branch.rs
@@ -1,241 +1,125 @@
-use std::collections::BTreeMap;
-
 use crate::domain::refs::{BranchName, CommitId};
 use crate::domain::repo::Repository;
-use crate::error::{DomainError, GitlancerError};
+use crate::error::{DomainError, GitExecError, GitlancerError};
 use crate::exec::command::{GitCommand, GitIntent};
 use crate::exec::env::GitEnv;
 use crate::exec::runner::GitRunner;
 use crate::git::Git;
 
-const UPSTREAM_REMOTE: &str = "upstream";
-const ORIGIN_REMOTE: &str = "origin";
-
-/// Identifies a selectable worktree base without conflating its display name with its Git ref.
+/// Identifies a selectable local branch without conflating its display name with its Git ref.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorktreeBase {
-    Local {
-        branch_name: BranchName,
-    },
-    Remote {
-        remote_name: String,
-        branch_name: BranchName,
-    },
+    Local { branch_name: BranchName },
 }
 
 impl WorktreeBase {
-    /// Returns the logical branch name shared by local and remote-tracking refs.
+    /// Returns the branch name shown to callers and used when resolving the local ref.
     pub fn branch_name(&self) -> &BranchName {
         match self {
-            Self::Local { branch_name } | Self::Remote { branch_name, .. } => branch_name,
+            Self::Local { branch_name } => branch_name,
         }
     }
 
-    /// Returns the unambiguous ref spelling that Git should resolve for this base.
+    /// Returns the local ref spelling that Git should resolve for this base.
     pub fn reference_name(&self) -> String {
-        match self {
-            Self::Local { branch_name } => branch_name.as_str().to_string(),
-            Self::Remote {
-                remote_name,
-                branch_name,
-            } => format!("{remote_name}/{}", branch_name.as_str()),
-        }
+        self.branch_name().as_str().to_string()
     }
 }
 
-/// Carries the repository whose current local and preferred-remote bases should be listed.
+/// Carries the repository whose local branch bases should be listed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListWorktreeBasesRequest<'a> {
     pub repository: &'a Repository,
 }
 
-/// Returns one preferred ref per logical branch name so callers never see stale local duplicates.
+/// Returns the local branch refs available as worktree bases.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListWorktreeBasesResponse {
     pub bases: Vec<WorktreeBase>,
 }
 
-/// Carries the exact worktree-base ref that should be refreshed and resolved.
+/// Carries the selected local branch ref that should be resolved to an immutable commit.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolveWorktreeBaseCommitRequest<'a> {
     pub repository: &'a Repository,
     pub reference_name: &'a BranchName,
 }
 
-/// Returns the immutable commit referenced by a freshly refreshed worktree base.
+/// Returns the immutable commit referenced by a local worktree base.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolveWorktreeBaseCommitResponse {
     pub commit_id: CommitId,
 }
 
 impl<R: GitRunner> Git<R> {
-    /// Fetches the preferred remote and merges its branches with local-only branches.
+    /// Lists only local branch refs so opening the selector never changes repository state or needs a network.
     pub fn list_worktree_bases(
         &self,
         request: ListWorktreeBasesRequest<'_>,
     ) -> Result<ListWorktreeBasesResponse, GitlancerError> {
-        let remote_name = self.preferred_base_remote(request.repository)?;
-        if let Some(remote_name) = remote_name.as_deref() {
-            self.fetch_base_remote(request.repository, remote_name)?;
-        }
-
-        let output = self.runner().run(&build_list_worktree_bases_command(
-            request.repository,
-            remote_name.as_deref(),
-        ))?;
-        let bases = parse_worktree_bases(&output.stdout, remote_name.as_deref());
+        let output = self
+            .runner()
+            .run(&build_list_worktree_bases_command(request.repository))?;
+        let bases = parse_worktree_bases(&output.stdout);
 
         Ok(ListWorktreeBasesResponse { bases })
     }
 
-    /// Refreshes selectable refs again at creation time before resolving the requested base.
+    /// Resolves the selected local branch directly without refreshing or merging remote refs.
     pub fn resolve_worktree_base_commit(
         &self,
         request: ResolveWorktreeBaseCommitRequest<'_>,
     ) -> Result<ResolveWorktreeBaseCommitResponse, GitlancerError> {
-        let bases = self.list_worktree_bases(ListWorktreeBasesRequest {
-            repository: request.repository,
-        })?;
-        if !bases
-            .bases
-            .iter()
-            .any(|base| base.reference_name() == request.reference_name.as_str())
-        {
-            return Err(GitlancerError::Domain(DomainError::BranchNotFound {
-                repo: request.repository.root().as_path().to_path_buf(),
-                branch: request.reference_name.as_str().to_string(),
-            }));
-        }
-
-        let output = self.runner().run(&GitCommand::new(
-            request.repository.root().as_path().to_path_buf(),
-            vec![
-                "rev-parse".to_string(),
-                format!("{}^{{commit}}", request.reference_name.as_str()),
-            ],
-            GitEnv::default(),
-            GitIntent::ReadOnly,
-        ))?;
+        let output = self
+            .runner()
+            .run(&GitCommand::new(
+                request.repository.root().as_path().to_path_buf(),
+                vec![
+                    "rev-parse".to_string(),
+                    format!("{}^{{commit}}", request.reference_name.as_str()),
+                ],
+                GitEnv::default(),
+                GitIntent::ReadOnly,
+            ))
+            .map_err(|error| match error {
+                GitExecError::NonZeroExit { .. } => {
+                    GitlancerError::Domain(DomainError::BranchNotFound {
+                        repo: request.repository.root().as_path().to_path_buf(),
+                        branch: request.reference_name.as_str().to_string(),
+                    })
+                }
+                other => GitlancerError::Exec(other),
+            })?;
         let commit_id = crate::parse::commit::parse_commit_id(&output.stdout)?;
 
         Ok(ResolveWorktreeBaseCommitResponse { commit_id })
     }
-
-    /// Selects the canonical collaboration remote without guessing among arbitrary remotes.
-    fn preferred_base_remote(
-        &self,
-        repository: &Repository,
-    ) -> Result<Option<String>, GitlancerError> {
-        let output = self.runner().run(&GitCommand::new(
-            repository.root().as_path().to_path_buf(),
-            vec!["remote".to_string()],
-            GitEnv::default(),
-            GitIntent::ReadOnly,
-        ))?;
-        let remotes = output
-            .stdout
-            .lines()
-            .map(str::trim)
-            .filter(|remote| !remote.is_empty())
-            .collect::<Vec<_>>();
-
-        Ok(if remotes.contains(&UPSTREAM_REMOTE) {
-            Some(UPSTREAM_REMOTE.to_string())
-        } else if remotes.contains(&ORIGIN_REMOTE) {
-            Some(ORIGIN_REMOTE.to_string())
-        } else {
-            None
-        })
-    }
-
-    /// Updates remote-tracking refs before they are exposed as worktree bases.
-    fn fetch_base_remote(
-        &self,
-        repository: &Repository,
-        remote_name: &str,
-    ) -> Result<(), GitlancerError> {
-        self.runner().run(&GitCommand::new(
-            repository.root().as_path().to_path_buf(),
-            vec![
-                "fetch".to_string(),
-                "--prune".to_string(),
-                remote_name.to_string(),
-            ],
-            GitEnv::default(),
-            GitIntent::Network,
-        ))?;
-        Ok(())
-    }
 }
 
-/// Builds one ref query whose fully qualified output preserves local-versus-remote identity.
-fn build_list_worktree_bases_command(
-    repository: &Repository,
-    remote_name: Option<&str>,
-) -> GitCommand {
-    let mut args = vec![
-        "for-each-ref".to_string(),
-        "--format=%(refname)".to_string(),
-        "refs/heads".to_string(),
-    ];
-    if let Some(remote_name) = remote_name {
-        args.push(format!("refs/remotes/{remote_name}"));
-    }
-
+/// Builds the read-only ref query used to enumerate local worktree bases.
+fn build_list_worktree_bases_command(repository: &Repository) -> GitCommand {
     GitCommand::new(
         repository.root().as_path().to_path_buf(),
-        args,
+        vec![
+            "for-each-ref".to_string(),
+            "--format=%(refname:short)".to_string(),
+            "refs/heads".to_string(),
+        ],
         GitEnv::default(),
         GitIntent::ReadOnly,
     )
 }
 
-/// Parses refs into one logical branch map while preserving local Ora task branches.
-///
-/// Remote refs are preferred for ordinary branches because fetching is the freshness
-/// boundary. Ora-managed task branches are the exception: an existing worktree may
-/// contain local commits that have not been pushed, so replacing that ref with its
-/// remote-tracking counterpart would make “branch from this worktree” silently lose work.
-fn parse_worktree_bases(stdout: &str, remote_name: Option<&str>) -> Vec<WorktreeBase> {
-    let remote_prefix = remote_name.map(|remote_name| format!("refs/remotes/{remote_name}/"));
-    let mut bases = BTreeMap::<String, WorktreeBase>::new();
-
-    for reference in stdout
+/// Converts Git's short local branch output into typed worktree bases.
+fn parse_worktree_bases(stdout: &str) -> Vec<WorktreeBase> {
+    stdout
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
-    {
-        if let Some(branch_name) = reference.strip_prefix("refs/heads/") {
-            bases
-                .entry(branch_name.to_string())
-                .or_insert_with(|| WorktreeBase::Local {
-                    branch_name: BranchName::new(branch_name),
-                });
-            continue;
-        }
-
-        if let (Some(remote_name), Some(remote_prefix)) = (remote_name, remote_prefix.as_deref())
-            && let Some(branch_name) = reference.strip_prefix(remote_prefix)
-            && branch_name != "HEAD"
-        {
-            if branch_name.starts_with("ora/")
-                && matches!(bases.get(branch_name), Some(WorktreeBase::Local { .. }))
-            {
-                continue;
-            }
-
-            // A fetched remote-tracking ref is authoritative for ordinary new worktree bases.
-            bases.insert(
-                branch_name.to_string(),
-                WorktreeBase::Remote {
-                    remote_name: remote_name.to_string(),
-                    branch_name: BranchName::new(branch_name),
-                },
-            );
-        }
-    }
-
-    bases.into_values().collect()
+        .map(|branch_name| WorktreeBase::Local {
+            branch_name: BranchName::new(branch_name),
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -257,7 +141,7 @@ mod tests {
     use crate::git::Git;
     use crate::{GitEnv, GitExecError};
 
-    /// Captures command order while returning deterministic Git outputs.
+    /// Captures commands while returning deterministic Git outputs.
     #[derive(Debug, Default)]
     struct TestRunner {
         outputs: RefCell<Vec<GitOutput>>,
@@ -273,7 +157,7 @@ mod tests {
             }
         }
 
-        /// Returns all commands issued by the tested operation.
+        /// Returns every command issued by the tested operation.
         fn recorded_commands(&self) -> Vec<GitCommand> {
             self.commands.borrow().clone()
         }
@@ -301,163 +185,57 @@ mod tests {
         GitOutput::new(Some(0), stdout.to_string(), String::new(), 0)
     }
 
-    /// Verifies upstream is fetched and its refs replace stale local duplicates.
+    /// Verifies branch listing reads only local heads and never probes or updates a remote.
     #[test]
-    fn list_worktree_bases_prefers_fetched_upstream_refs() {
+    fn list_worktree_bases_lists_only_local_refs() {
         let repository = repository_fixture();
-        let git = Git::new(TestRunner::new(vec![
-            output("origin\nupstream\n"),
-            output(""),
-            output(
-                "refs/heads/local-only\nrefs/heads/main\nrefs/remotes/upstream/HEAD\nrefs/remotes/upstream/frontend\nrefs/remotes/upstream/main\n",
-            ),
-        ]));
+        let git = Git::new(TestRunner::new(vec![output("main\nfeature/runtime\n")]));
 
         let response = git
             .list_worktree_bases(ListWorktreeBasesRequest {
                 repository: &repository,
             })
-            .expect("list worktree bases");
+            .expect("list local worktree bases");
 
         assert_eq!(
             response.bases,
             vec![
-                WorktreeBase::Remote {
-                    remote_name: "upstream".to_string(),
-                    branch_name: BranchName::new("frontend"),
+                WorktreeBase::Local {
+                    branch_name: BranchName::new("main"),
                 },
                 WorktreeBase::Local {
-                    branch_name: BranchName::new("local-only"),
-                },
-                WorktreeBase::Remote {
-                    remote_name: "upstream".to_string(),
-                    branch_name: BranchName::new("main"),
+                    branch_name: BranchName::new("feature/runtime"),
                 },
             ]
         );
         assert_eq!(
             git.runner().recorded_commands(),
-            vec![
-                GitCommand::new(
-                    repository.root().as_path().to_path_buf(),
-                    vec!["remote".to_string()],
-                    GitEnv::default(),
-                    GitIntent::ReadOnly,
-                ),
-                GitCommand::new(
-                    repository.root().as_path().to_path_buf(),
-                    vec![
-                        "fetch".to_string(),
-                        "--prune".to_string(),
-                        "upstream".to_string(),
-                    ],
-                    GitEnv::default(),
-                    GitIntent::Network,
-                ),
-                build_list_worktree_bases_command(&repository, Some("upstream")),
-            ]
+            vec![build_list_worktree_bases_command(&repository)]
         );
     }
 
-    /// Verifies origin is used when the repository has no upstream remote.
+    /// Verifies creation-time resolution directly reads the selected local ref with one Git command.
     #[test]
-    fn list_worktree_bases_falls_back_to_origin() {
+    fn resolve_worktree_base_commit_reads_the_selected_local_ref() {
         let repository = repository_fixture();
-        let git = Git::new(TestRunner::new(vec![
-            output("fork\norigin\n"),
-            output(""),
-            output("refs/remotes/origin/feature/runtime\n"),
-        ]));
-
-        let response = git
-            .list_worktree_bases(ListWorktreeBasesRequest {
-                repository: &repository,
-            })
-            .expect("list worktree bases");
-
-        assert_eq!(
-            response.bases,
-            vec![WorktreeBase::Remote {
-                remote_name: "origin".to_string(),
-                branch_name: BranchName::new("feature/runtime"),
-            }]
-        );
-        assert_eq!(git.runner().recorded_commands()[1].args[2], "origin");
-    }
-
-    /// Verifies repositories without a canonical remote keep their local branches usable.
-    #[test]
-    fn list_worktree_bases_supports_local_only_repositories() {
-        let repository = repository_fixture();
-        let git = Git::new(TestRunner::new(vec![
-            output("backup\n"),
-            output("refs/heads/main\n"),
-        ]));
-
-        let response = git
-            .list_worktree_bases(ListWorktreeBasesRequest {
-                repository: &repository,
-            })
-            .expect("list worktree bases");
-
-        assert_eq!(
-            response.bases,
-            vec![WorktreeBase::Local {
-                branch_name: BranchName::new("main"),
-            }]
-        );
-        assert_eq!(
-            git.runner().recorded_commands()[1],
-            build_list_worktree_bases_command(&repository, None)
-        );
-    }
-
-    /// Verifies an existing Ora worktree keeps its local tip instead of a stale remote tip.
-    #[test]
-    fn list_worktree_bases_preserves_local_ora_task_branches() {
-        let bases = super::parse_worktree_bases(
-            "refs/heads/ora/task-branch\nrefs/remotes/upstream/ora/task-branch\n",
-            Some("upstream"),
-        );
-
-        assert_eq!(
-            bases,
-            vec![WorktreeBase::Local {
-                branch_name: BranchName::new("ora/task-branch"),
-            }]
-        );
-    }
-
-    /// Verifies creation-time resolution fetches again and resolves the exact remote ref.
-    #[test]
-    fn resolve_worktree_base_commit_refreshes_the_selected_remote_ref() {
-        let repository = repository_fixture();
-        let git = Git::new(TestRunner::new(vec![
-            output("upstream\n"),
-            output(""),
-            output("refs/heads/main\nrefs/remotes/upstream/main\n"),
-            output("0123456789abcdef\n"),
-        ]));
+        let git = Git::new(TestRunner::new(vec![output("0123456789abcdef\n")]));
 
         let response = git
             .resolve_worktree_base_commit(ResolveWorktreeBaseCommitRequest {
                 repository: &repository,
-                reference_name: &BranchName::new("upstream/main"),
+                reference_name: &BranchName::new("main"),
             })
-            .expect("resolve refreshed worktree base");
+            .expect("resolve local worktree base");
 
         assert_eq!(response.commit_id, CommitId::new("0123456789abcdef"));
         assert_eq!(
-            git.runner().recorded_commands()[3],
-            GitCommand::new(
+            git.runner().recorded_commands(),
+            vec![GitCommand::new(
                 repository.root().as_path().to_path_buf(),
-                vec![
-                    "rev-parse".to_string(),
-                    "upstream/main^{commit}".to_string(),
-                ],
+                vec!["rev-parse".to_string(), "main^{commit}".to_string()],
                 GitEnv::default(),
                 GitIntent::ReadOnly,
-            )
+            )]
         );
     }
 }

--- a/crates/gitlancer/tests/git_runtime.rs
+++ b/crates/gitlancer/tests/git_runtime.rs
@@ -401,91 +401,40 @@ fn runtime_creates_and_deletes_local_branches() {
     );
 }
 
-/// Verifies fetched remote refs replace stale local duplicates and expose remote-only branches.
+/// Verifies local worktree bases remain usable without contacting a configured remote.
 #[test]
-fn runtime_lists_and_resolves_fresh_remote_worktree_bases() {
-    let scaffold = TestScaffold::new("runtime-remote-worktree-bases").expect("create scaffold");
+fn runtime_lists_and_resolves_local_worktree_bases_without_fetching() {
+    let scaffold = TestScaffold::new("runtime-local-worktree-bases").expect("create scaffold");
     seed_repository(&scaffold);
-    let remote_path = scaffold.sandbox_root().join("remote.git");
+    let remote_path = scaffold.sandbox_root().join("missing-remote.git");
     let remote_path_arg = remote_path.to_string_lossy().into_owned();
-    scaffold
-        .run_git_in(
-            scaffold.sandbox_root(),
-            ["init", "--bare", "--initial-branch=main", &remote_path_arg],
-        )
-        .expect("create bare remote");
     scaffold
         .run_git(["remote", "add", "origin", &remote_path_arg])
         .expect("configure origin");
-    scaffold
-        .run_git(["push", "-u", "origin", "main"])
-        .expect("push initial main");
-
-    let stale_main_commit = scaffold
+    let local_main_commit = scaffold
         .run_git(["rev-parse", "main"])
-        .expect("resolve stale main");
-    scaffold
-        .run_git(["switch", "-c", "frontend"])
-        .expect("create frontend branch");
-    scaffold
-        .write_file(scaffold.repo_path(), "frontend.txt", "remote-only branch\n")
-        .expect("write frontend fixture");
-    scaffold
-        .stage_all_and_commit("add frontend branch")
-        .expect("commit frontend branch");
-    scaffold
-        .run_git(["push", "origin", "frontend"])
-        .expect("push frontend branch");
-    scaffold
-        .run_git(["switch", "main"])
-        .expect("switch back to main");
-    scaffold
-        .run_git(["branch", "-D", "frontend"])
-        .expect("delete local frontend branch");
-    scaffold
-        .write_file(scaffold.repo_path(), "latest.txt", "latest remote main\n")
-        .expect("write latest main fixture");
-    scaffold
-        .stage_all_and_commit("advance remote main")
-        .expect("commit latest main");
-    let fresh_main_commit = scaffold
-        .run_git(["rev-parse", "main"])
-        .expect("resolve fresh main");
-    scaffold
-        .run_git(["push", "origin", "main"])
-        .expect("push latest main");
-    scaffold
-        .run_git(["reset", "--hard", stale_main_commit.trim()])
-        .expect("restore stale local main");
+        .expect("resolve local main");
 
     let (git, repository) = runtime_repository(&scaffold);
     let bases = git
         .list_worktree_bases(ListWorktreeBasesRequest {
             repository: &repository,
         })
-        .expect("list refreshed worktree bases");
+        .expect("list local worktree bases");
     let resolved = git
         .resolve_worktree_base_commit(ResolveWorktreeBaseCommitRequest {
             repository: &repository,
-            reference_name: &BranchName::new("origin/main"),
+            reference_name: &BranchName::new("main"),
         })
-        .expect("resolve refreshed remote main");
+        .expect("resolve local main");
 
     assert_eq!(
         bases.bases,
-        vec![
-            WorktreeBase::Remote {
-                remote_name: "origin".to_string(),
-                branch_name: BranchName::new("frontend"),
-            },
-            WorktreeBase::Remote {
-                remote_name: "origin".to_string(),
-                branch_name: BranchName::new("main"),
-            },
-        ]
+        vec![WorktreeBase::Local {
+            branch_name: BranchName::new("main"),
+        }]
     );
-    assert_eq!(resolved.commit_id.as_str(), fresh_main_commit.trim());
-    assert_ne!(resolved.commit_id.as_str(), stale_main_commit.trim());
+    assert_eq!(resolved.commit_id.as_str(), local_main_commit.trim());
 }
 
 /// Verifies linked worktree lifecycle APIs create and delete linked worktrees through typed runtime requests.

--- a/docs/application-contracts.md
+++ b/docs/application-contracts.md
@@ -75,7 +75,7 @@ The handler set is intentionally narrower than full CRUD per entity, because som
 Notable consequences:
 
 - There is no delete handler for `project` or `task`. Aggregate deletion is a transactional cascade owned by `ora-backend` and `ora-db`, because it has to reject running descendants and update several tables atomically.
-- `ListProjectBranchesHandler` joins refreshed Git refs with project-owned task and worktree records so an Ora-managed branch keeps its resolvable ref while displaying the owning task title.
+- `ListProjectBranchesHandler` joins local Git refs with project-owned task and worktree records so an Ora-managed branch keeps its resolvable ref while displaying the owning task title.
 - Session creation, load, prompt, permission response, cancellation, stop, agent switching, and history recording belong to the backend agent runtime, not to `ora-application`. The session module supplies only the persistence-facing reads and soft deletion.
 - `worktree` has no handlers or transport contracts at all. Worktree records are internal metadata coordinated by the task module.
 - `task_diff` owns review use cases but not workspace selection. Backend composition resolves the task's live cwd and supplies the fixed baseline for isolated worktrees or the current `HEAD` for project-root tasks.
@@ -99,7 +99,7 @@ Bootstrap, migration, state-transition, and secondary-cleanup events remain inde
 - `UpdateTaskRequest` cannot change project ownership, and task updates preserve the existing worktree association.
 - Project and Task deletion soft-delete the complete Ora-owned aggregate in one SQLite transaction. A running Session rejects the operation with `resource_in_use`; stopped children are cascaded. These paths never call Git and never delete provider-owned ACP history, but they do remove the session history Ora itself recorded — see [ACP Agent Runtime](agent-runtime.md).
 - Task creation resolves the requested project's Git root at creation time. Deletion changes Ora database records only and deliberately leaves the linked Git worktree and its branch untouched.
-- Worktree task creation fetches `upstream`, or falls back to `origin`, before resolving the selected base ref to an immutable commit. Refreshed remote refs take precedence over stale same-named local branches, while local-only branches remain selectable.
+- Worktree task creation resolves the selected local base ref to an immutable commit. Branch listing and creation do not fetch or merge remote-tracking refs.
 - Worktree paths are composed only when creating a new worktree. Existing paths are resolved from the persisted branch name and Git's authoritative metadata, never reconstructed from the configured creation root.
 - Isolated task diffs compare against the worktree creation commit; project-root task diffs resolve `HEAD` on every read so external edits appear without mutating a persisted baseline. `diffId` includes the complete patch and rejects comments anchored to an older snapshot.
 - Workspace file paths are validated as relative paths, canonicalized before containment checks, and returned with slash separators. The filesystem crate is read-only, bounds file reads and search output, and reports native watcher changes as cache-invalidating batches. See [Task Workspace Files](task-workspace-files.md).

--- a/docs/gitlancer-architecture.md
+++ b/docs/gitlancer-architecture.md
@@ -38,7 +38,7 @@ It exists so upper layers can inject a fake runner in tests, record commands for
 
 Exposes the typed use cases Ora calls directly — repository discovery, worktree discovery and lifecycle, branch read and lifecycle, add/commit, diff, push, status, and global identity. Each takes a typed request and returns a typed response, which keeps option growth manageable and produces better call boundaries for agent orchestration.
 
-Worktree-base discovery is a separate branch read path because it has network semantics: it fetches `upstream`, or falls back to `origin`, then combines remote-tracking refs with local-only branches while preferring the refreshed remote ref for duplicate logical names.
+Worktree-base discovery is a separate local branch read path because worktree selection must not have network or repository-state side effects.
 
 ### `parse`
 
@@ -95,7 +95,7 @@ Three resolution paths exist:
 
 - `list_branches` returns each local branch as a `BranchName`.
 - `diff` returns a full-context unified patch for branch, unstaged, staged, or committed scopes. Untracked files are rendered without changing the caller's index, and output is bounded before it enters application memory.
-- `list_worktree_bases` fetches the preferred remote and returns remote-only plus local-only bases as `WorktreeBase` values. `resolve_worktree_base_commit` refreshes again, validates the selected ref, and resolves it to an immutable `CommitId`.
+- `list_worktree_bases` returns local `refs/heads` bases as `WorktreeBase` values. `resolve_worktree_base_commit` resolves the selected local ref directly to an immutable `CommitId`.
 - `status` returns one `StatusEntry` per porcelain-v2 record, from `git status --porcelain=v2 -z`.
 - `commit` returns the resulting `HEAD` commit id and the latest commit summary.
 - `push_branch` publishes the checked-out branch to `origin` with `GitIntent::Network` and prompts disabled.
@@ -178,7 +178,7 @@ Command telemetry is opt-in through `gitlancer::logging::register`; `ora-logging
 gitlancer relies on stable machine-readable outputs:
 
 - `git worktree list --porcelain` — repository discovery, worktree listing, and worktree resolution
-- `git for-each-ref` plus `git remote` and `git fetch` — refreshed worktree-base discovery across local and preferred-remote refs
+- `git for-each-ref refs/heads` — local worktree-base discovery without remote or repository-state side effects
 - `git rev-parse <ref>^{commit}` — immutable worktree-base resolution
 - `git status --porcelain=v2 -z` — status entries
 - `git rev-parse HEAD` and `git log -1 --pretty=%s` — commit id and summary after a commit
@@ -217,4 +217,4 @@ gitlancer is tested at three levels:
 2. Fake-runner tests for command assembly and option handling.
 3. Real Git integration tests for multi-worktree scenarios.
 
-Priority integration scenarios: open a repository from a nested directory, list main and linked worktrees, discover and resolve refreshed remote worktree bases, create branches and worktrees at explicit commits, add and commit from a linked worktree, detect worktree mismatch, parse `status --porcelain=v2 -z`, and handle linked-worktree `.git` indirection correctly.
+Priority integration scenarios: open a repository from a nested directory, list main and linked worktrees, discover and resolve local worktree bases, create branches and worktrees at explicit commits, add and commit from a linked worktree, detect worktree mismatch, parse `status --porcelain=v2 -z`, and handle linked-worktree `.git` indirection correctly.

--- a/docs/task-worktrees.md
+++ b/docs/task-worktrees.md
@@ -16,7 +16,7 @@ The public `Task` payload exposes `workspaceMode`, not `worktreeId`. `CreateTask
 `CreateTaskHandler` orchestrates the whole flow behind the `TaskWorktreeProvisioner` port, so no Git type reaches a request or response contract:
 
 1. Validate that the project root is a Git repository. Worktree mode fails explicitly when it is not.
-2. Refresh the preferred remote and resolve the selected base ref to an immutable commit id.
+2. Resolve the selected local base ref to an immutable commit id.
 3. Reserve a task identifier whose short branch prefix does not collide (below).
 4. Derive the branch name and the worktree directory from that identifier.
 5. Create the linked worktree and its branch at the resolved commit.
@@ -30,7 +30,7 @@ Because the branch name is shortened, collision checking has to cover both place
 
 ## Base selection and display labels
 
-Before listing bases, Gitlancer fetches `upstream` when configured or otherwise `origin`. The selector combines refreshed remote-tracking branches with local-only branches and prefers the remote ref for ordinary branches when both have the same logical name. Existing local `ora/<prefix>` task branches remain local so creating a worktree from an existing Ora worktree does not discard unpushed commits. Resolving the selection refreshes the preferred remote again so ordinary new task branches start at the selected ref's current commit even when another branch is checked out.
+Gitlancer lists only local branches from `refs/heads`. Opening the selector and creating a worktree never fetches, prunes, or otherwise changes remote-tracking refs, so local worktree creation remains available offline and always uses the branch state currently available in the repository.
 
 The application layer joins the available refs with project-owned task and worktree records. For an `ora/<prefix>` branch it returns the owning task title as `displayName`, while retaining the exact `refName` that Git must resolve. Creating a worktree invalidates that project's branch-list cache so a newly created Ora branch is immediately available as the next task's base.
 
@@ -39,7 +39,7 @@ The application layer joins the available refs with project-owned task and workt
 Git and database state must not drift apart, and a partially created workspace is never exposed.
 
 - If linked-worktree creation fails, the handler returns a stable application error and persists no task or worktree row.
-- If the selected base ref no longer exists after refresh, the handler returns `base_branch_not_found` before creating a task branch or worktree.
+- If the selected local base ref no longer exists, the handler returns `base_branch_not_found` before creating a task branch or worktree.
 - If persistence fails *after* the Git worktree was created, the handler attempts compensating cleanup — soft-deleting whatever record was written and removing the linked worktree with `TaskWorktreeDeletionMode::Force`, so a dirty checkout cannot block the rollback — and then returns the original application error rather than a cleanup error.
 
 The Web runtime maps these into typed `ContractError` values that identify task creation as failed without exposing raw Git command output or filesystem formatting.

--- a/packages/app-shell/src/state/hooks/use-project-branches.ts
+++ b/packages/app-shell/src/state/hooks/use-project-branches.ts
@@ -4,12 +4,12 @@ import { queryKeys } from "./query-keys";
 
 /**
  * Soft freshness window for branch lists.
- * Opening the picker still triggers a background refetch so newly pushed branches
- * appear without making the first paint wait on `git fetch`.
+ * Opening the picker still triggers a background refetch so newly created local
+ * branches appear without making the first paint wait on Git branch discovery.
  */
 const PROJECT_BRANCHES_STALE_MS = 60_000;
 
-/** Loads refreshed local and remote refs that can seed a new worktree for the selected project. */
+/** Loads local refs that can seed a new worktree for the selected project. */
 export function useProjectBranches(projectId: string | null) {
   const client = useContractsClient();
   return useQuery({

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -36,7 +36,7 @@ export type GetProjectResponse = { project: Project };
 export type ListProjectBranchesRequest = { projectId: string };
 
 /**
- * Returns refreshed remote branches plus local-only branches that can seed a new worktree.
+ * Returns local branches that can seed a new worktree.
  */
 export type ListProjectBranchesResponse = { branches: Array<ProjectBranch> };
 


### PR DESCRIPTION
Fixes #272

What changed:
- List only local refs under refs/heads for worktree base selection.
- Resolve the selected local ref directly without fetching, pruning, or merging remote-tracking refs.
- Add regression coverage for local-only resolution and update the related documentation.

Root cause:
Worktree base discovery refreshed upstream and origin remotes implicitly, which made branch selection mutate repository state and exposed remote-tracking branches.

Validation:
- cargo test -p gitlancer -p ora-application -p ora-backend -p ora-contracts
- cargo clippy -p gitlancer -p ora-application -p ora-backend -p ora-contracts --lib -- -D warnings