### PR TITLE
fix(app-shell): size and slide the review panel responsively

### DIFF
--- a/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
+++ b/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
@@ -7,6 +7,7 @@ import { AppI18nProvider } from "../../i18n/i18n";
 import { createStubPlatform } from "../../test/stub-platform";
 import { useTaskChangesNavigation } from "./task-changes-navigation-context";
 import { WorkspaceReviewLayout } from "../workspace/workspace-review-layout";
+import { responsiveReviewWidth } from "../workspace/workspace-review-layout-utils";
 
 vi.mock("./task-diff-view", () => ({
   TaskDiffView: ({
@@ -59,6 +60,26 @@ const taskContext = {
   projectId: "project-1",
   projectRootPath: "C:/project",
 };
+
+describe("responsiveReviewWidth", () => {
+  it("narrows the opening panel on small windows", () => {
+    expect(responsiveReviewWidth(960)).toBe(460);
+    expect(responsiveReviewWidth(1120)).toBe(460);
+  });
+
+  it("keeps the fuller ratio once the host is maximized-wide", () => {
+    expect(responsiveReviewWidth(1600)).toBe(720);
+    expect(responsiveReviewWidth(2600)).toBe(1170);
+  });
+
+  it("keeps the conversation floor on very narrow windows", () => {
+    expect(responsiveReviewWidth(800)).toBe(440);
+  });
+
+  it("falls back to the default when the host cannot be measured", () => {
+    expect(responsiveReviewWidth(0)).toBe(640);
+  });
+});
 
 describe("WorkspaceReviewLayout", () => {
   it("positions the closed Changes trigger at the diff-toolbar coordinates", () => {

--- a/packages/app-shell/src/features/diff/task-diff-view.tsx
+++ b/packages/app-shell/src/features/diff/task-diff-view.tsx
@@ -60,6 +60,14 @@ import { createCommentAnchor } from "./task-diff-comment-anchor";
 import { diffFilePath } from "./task-diff-file-tree-utils";
 import { TaskDiffFileTree } from "./task-diff-file-tree";
 import { TaskGitActions } from "./task-git-actions";
+import { animatePanelWidth, cancelPanelWidthAnimation } from "../../lib/panel-motion";
+
+/** Matches the review panel slide so the file tree toggle feels consistent. */
+const FILE_TREE_SLIDE_MS = 180;
+const FILE_TREE_WIDTH = 240;
+/** Narrowest tree width a user resize settles on; below it the tree collapses. */
+const FILE_TREE_MIN_WIDTH = 180;
+const FILE_TREE_COLLAPSE_THRESHOLD = FILE_TREE_MIN_WIDTH / 2;
 
 interface TaskDiffViewProps {
   taskId: string;
@@ -106,6 +114,8 @@ export function TaskDiffView({
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const fileElementsRef = useRef(new Map<string, HTMLDivElement>());
   const fileTreePanelRef = useRef<ResizablePanelHandle | null>(null);
+  const fileTreeAnimationRef = useRef<number | null>(null);
+  const fileTreeWidthRef = useRef(FILE_TREE_WIDTH);
 
   const files = useMemo(
     () => diffQuery.data === undefined ? [] : parseTaskDiffPatch(diffQuery.data.patch),
@@ -150,11 +160,32 @@ export function TaskDiffView({
   }, [fileRequest, filePaths, files.length, selectFile]);
 
   useEffect(() => {
-    const panel = fileTreePanelRef.current;
-    if (panel === null) return;
-    if (fileTreeOpen && panel.isCollapsed()) panel.expand();
-    if (!fileTreeOpen && !panel.isCollapsed()) panel.collapse();
+    // The tree panel mounts collapsed alongside the diff, so toggling (or a late
+    // mount once the patch arrives) slides it instead of snapping the diff width.
+    cancelPanelWidthAnimation(fileTreeAnimationRef);
+    animatePanelWidth({
+      animationRef: fileTreeAnimationRef,
+      duration: FILE_TREE_SLIDE_MS,
+      panel: fileTreePanelRef.current,
+      targetWidth: fileTreeOpen ? FILE_TREE_WIDTH : 0,
+    });
   }, [fileTreeOpen, files.length]);
+
+  // Never let a pending slide write to a panel that already left the tree.
+  useEffect(() => () => cancelPanelWidthAnimation(fileTreeAnimationRef), []);
+
+  /** Snaps an undersized tree after release so direct dragging stays linear. */
+  const settleFileTreeAfterResize = useCallback(() => {
+    const width = fileTreeWidthRef.current;
+    if (width <= 0 || width >= FILE_TREE_MIN_WIDTH) return;
+    cancelPanelWidthAnimation(fileTreeAnimationRef);
+    animatePanelWidth({
+      animationRef: fileTreeAnimationRef,
+      duration: FILE_TREE_SLIDE_MS,
+      panel: fileTreePanelRef.current,
+      targetWidth: width < FILE_TREE_COLLAPSE_THRESHOLD ? 0 : FILE_TREE_MIN_WIDTH,
+    });
+  }, []);
 
   useEffect(() => {
     const root = scrollContainerRef.current;
@@ -414,12 +445,17 @@ export function TaskDiffView({
         {files.length === 0 ? (
           <DiffMessage title={t("diff.noChanges")} detail={t("diff.noChangesDetail")} />
         ) : (
-          <ResizablePanelGroup orientation="horizontal">
+          <ResizablePanelGroup
+            orientation="horizontal"
+            onLayoutChanged={(_layout, meta) => {
+              if (meta.isUserInteraction) settleFileTreeAfterResize();
+            }}
+          >
             <ResizablePanel
               id="task-diff-content"
               className="flex min-h-0 overflow-hidden"
               style={{ height: "100%", overflow: "hidden" }}
-              minSize={320}
+              minSize={280}
             >
               <div
                 ref={scrollContainerRef}
@@ -481,20 +517,29 @@ export function TaskDiffView({
               withHandle
               aria-label={t("diff.resizeFileTree")}
               title={t("diff.resizeFileTree")}
-              className={`${fileTreeOpen ? "" : "hidden"} z-10 transition-colors hover:bg-ring focus-visible:bg-ring`}
+              // Always visible so a collapsed tree can be dragged back open.
+              className="z-10 transition-colors hover:bg-ring focus-visible:bg-ring"
+              onPointerDown={() => cancelPanelWidthAnimation(fileTreeAnimationRef)}
             />
             <ResizablePanel
               id="task-diff-files"
               panelRef={fileTreePanelRef}
               className="flex min-h-0 overflow-hidden"
               style={{ height: "100%", overflow: "hidden" }}
-              defaultSize={fileTreeOpen ? 240 : 0}
-              minSize={200}
+              defaultSize={fileTreeOpen ? FILE_TREE_WIDTH : 0}
+              // A pixel min would snap scripted slides onto it; the settle
+              // callback restores the effective minimum after the user lets go.
+              minSize={1}
               maxSize={400}
               collapsible
               collapsedSize={0}
               groupResizeBehavior="preserve-pixel-size"
               onResize={(size) => {
+                fileTreeWidthRef.current = size.inPixels;
+                // Scripted slides (and lagging observer deliveries) report
+                // transient sizes; only settled ones may flip the toolbar state,
+                // or the toggle fights the slide and the tree won't reopen.
+                if (fileTreeAnimationRef.current !== null) return;
                 const open = size.inPixels > 0;
                 if (open !== fileTreeOpen) onFileTreeOpenChange(open);
               }}

--- a/packages/app-shell/src/features/files/workspace-files-view.tsx
+++ b/packages/app-shell/src/features/files/workspace-files-view.tsx
@@ -175,7 +175,7 @@ export function WorkspaceFilesView({
   const body = (
       <div className="min-h-0 flex-1">
         <ResizablePanelGroup orientation="horizontal" className="min-h-0">
-        <ResizablePanel id="workspace-file-content" minSize={420}>
+        <ResizablePanel id="workspace-file-content" minSize={280}>
         <div className="flex h-full min-w-0 flex-col">
           {selectedPath === null ? (
             <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
@@ -229,9 +229,9 @@ export function WorkspaceFilesView({
         />
         <ResizablePanel
           id="workspace-file-tree"
-          defaultSize={320}
-          minSize={240}
-          maxSize={520}
+          defaultSize={260}
+          minSize={180}
+          maxSize={480}
           className="border-l border-border"
         >
         <aside className="flex h-full min-w-0 flex-col">

--- a/packages/app-shell/src/features/settings/workflow-settings.tsx
+++ b/packages/app-shell/src/features/settings/workflow-settings.tsx
@@ -75,9 +75,9 @@ import {
 import { WorkflowDraftSaveStatusLabel } from "./workflow-draft-save-status";
 import { useWorkflowDraftAutosave } from "./use-workflow-draft-autosave";
 import {
-  animateWorkflowPanel,
-  cancelWorkflowPanelAnimation,
-} from "./workflow-panel-motion";
+  animatePanelWidth as animateWorkflowPanel,
+  cancelPanelWidthAnimation as cancelWorkflowPanelAnimation,
+} from "../../lib/panel-motion";
 import { DeployWorkflowButton } from "../workflow-run/deploy-to-project-dialog";
 
 const DEFAULT_WORKFLOW_LIBRARY_WIDTH = 220;

--- a/packages/app-shell/src/features/specs/specs-view.tsx
+++ b/packages/app-shell/src/features/specs/specs-view.tsx
@@ -174,7 +174,7 @@ export const SpecsContent = forwardRef<SpecsContentHandle, SpecsContentProps>(fu
   return (
     <>
       <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
-        <ResizablePanel id="spec-content" minSize={420}>
+        <ResizablePanel id="spec-content" minSize={280}>
           <div className="flex h-full min-w-0 flex-col">
             {activeSelectedPath !== null && (
               <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-3">
@@ -197,7 +197,7 @@ export const SpecsContent = forwardRef<SpecsContentHandle, SpecsContentProps>(fu
           </div>
         </ResizablePanel>
         <ResizableHandle withHandle aria-label={t("specs.resizeTree")} />
-        <ResizablePanel id="spec-tree" defaultSize={320} minSize={240} maxSize={520}>
+        <ResizablePanel id="spec-tree" defaultSize={260} minSize={180} maxSize={480}>
           <div className="flex h-full min-h-0 flex-col border-l border-border">
             <div className="flex items-center gap-2 border-b border-border p-2">
               <div className="relative min-w-0 flex-1">

--- a/packages/app-shell/src/features/workspace/workspace-review-layout-utils.ts
+++ b/packages/app-shell/src/features/workspace/workspace-review-layout-utils.ts
@@ -1,0 +1,23 @@
+/** Fallback opening width when the host cannot be measured (e.g. tests). */
+export const DEFAULT_REVIEW_WIDTH = 640;
+/** Narrowest review width a user resize settles on; below it the panel collapses. */
+export const MIN_REVIEW_WIDTH = 460;
+/** Caps the panel so an ultrawide window cannot push the conversation aside. */
+export const MAX_REVIEW_WIDTH = 1200;
+/** Matches the conversation panel's min so the chat never loses its floor. */
+export const MIN_CONVERSATION_WIDTH = 360;
+/** Host width below which the panel opens at a leaner ratio (small windows). */
+const SMALL_HOST_WIDTH = 1200;
+
+/**
+ * Picks the opening width from the space next to the conversation: a leaner
+ * ratio on ordinary windows, a fuller one once the host is maximized-wide, all
+ * clamped so the chat keeps at least its minimum.
+ */
+export function responsiveReviewWidth(available: number): number {
+  if (available <= 0) return DEFAULT_REVIEW_WIDTH;
+  const ratio = available <= SMALL_HOST_WIDTH ? 0.4 : 0.45;
+  const ideal = Math.round(available * ratio);
+  const conversationFloor = Math.max(0, available - MIN_CONVERSATION_WIDTH);
+  return Math.min(Math.max(MIN_REVIEW_WIDTH, ideal), MAX_REVIEW_WIDTH, conversationFloor);
+}

--- a/packages/app-shell/src/features/workspace/workspace-review-layout.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-review-layout.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { Button, ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@ora/ui";
+﻿import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  Button,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  type ResizablePanelHandle,
+} from "@ora/ui";
 import {
   IconArrowsMaximize,
   IconArrowsMinimize,
@@ -13,9 +19,19 @@ import { useTranslation } from "react-i18next";
 import { TaskDiffView, type TaskDiffFileRequest, type TaskDiffViewType } from "../diff/task-diff-view";
 import { TaskChangesNavigationProvider } from "../diff/task-changes-navigation";
 import { WorkspaceReviewFilesPanel } from "../files/workspace-review-files-panel";
+import { animatePanelWidth, cancelPanelWidthAnimation } from "../../lib/panel-motion";
+import {
+  DEFAULT_REVIEW_WIDTH,
+  MAX_REVIEW_WIDTH,
+  MIN_REVIEW_WIDTH,
+  responsiveReviewWidth,
+} from "./workspace-review-layout-utils";
 import "./workspace-review-layout.css";
 
 const EXPANDED_PANEL_EXIT_MS = 180;
+/** Matches the workflow editor's panel settle so the review slide feels identical. */
+const REVIEW_PANEL_SLIDE_MS = 180;
+const REVIEW_PANEL_COLLAPSE_THRESHOLD = MIN_REVIEW_WIDTH / 2;
 
 export type WorkspaceReviewContext =
   | { kind: "none" }
@@ -50,6 +66,16 @@ export function WorkspaceReviewLayout({
   const fileRequestSequence = useRef(0);
   const onOpenChangeRef = useRef(onOpenChange);
   const skipOpenNotifyRef = useRef(true);
+  const panelRef = useRef<ResizablePanelHandle | null>(null);
+  const panelAnimationRef = useRef<number | null>(null);
+  /** Remembers the width the user last settled on, so reopen and restore reuse it. */
+  const panelWidthRef = useRef(DEFAULT_REVIEW_WIDTH);
+  /** Mirrors the live width (including transient drag values) for settle decisions. */
+  const panelCurrentWidthRef = useRef(DEFAULT_REVIEW_WIDTH);
+  /** Once the user drags (or a settle lands), stop re-adapting to the window. */
+  const panelWidthTouchedRef = useRef(false);
+  /** Host whose width drives the responsive opening width. */
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const taskId = context.kind === "task" ? context.taskId : undefined;
   const contextKey = context.kind === "none" ? "none" : context.kind === "project" ? `project:${context.projectId}` : `task:${context.taskId}`;
 
@@ -72,14 +98,60 @@ export function WorkspaceReviewLayout({
     onOpenChangeRef.current?.(open);
   }, [open]);
 
-  const close = useCallback(() => {
+  /** Tears the review surface down after its closing slide (or at once when already collapsed). */
+  const finalizeClose = useCallback(() => {
     if (closeTimer.current !== null) clearTimeout(closeTimer.current);
     closeTimer.current = null;
     setReviewOpen(false);
     setExpanded(false);
     setClosing(false);
     setViewType("unified");
-  }, [setReviewOpen]);
+  }, []);
+
+  const close = useCallback(() => {
+    cancelPanelWidthAnimation(panelAnimationRef);
+    if (expanded) {
+      // The overlay already covers the side panel, so a hidden slide adds nothing.
+      finalizeClose();
+      return;
+    }
+    animatePanelWidth({
+      animationRef: panelAnimationRef,
+      duration: REVIEW_PANEL_SLIDE_MS,
+      panel: panelRef.current,
+      targetWidth: 0,
+      onComplete: finalizeClose,
+    });
+  }, [expanded, finalizeClose]);
+
+  /** Slides the review panel out: the user's settled width, or a window-fit one until first use. */
+  const slidePanelOpen = useCallback(() => {
+    cancelPanelWidthAnimation(panelAnimationRef);
+    const targetWidth = panelWidthTouchedRef.current
+      ? panelWidthRef.current
+      : responsiveReviewWidth(contentRef.current?.clientWidth ?? 0);
+    animatePanelWidth({
+      animationRef: panelAnimationRef,
+      duration: REVIEW_PANEL_SLIDE_MS,
+      panel: panelRef.current,
+      targetWidth,
+    });
+  }, []);
+
+  /** Snaps an undersized panel after release so direct dragging stays linear. */
+  const settleReviewAfterResize = useCallback(() => {
+    const width = panelCurrentWidthRef.current;
+    if (width <= 0 || width >= MIN_REVIEW_WIDTH) return;
+    animatePanelWidth({
+      animationRef: panelAnimationRef,
+      duration: REVIEW_PANEL_SLIDE_MS,
+      panel: panelRef.current,
+      targetWidth: width < REVIEW_PANEL_COLLAPSE_THRESHOLD ? 0 : MIN_REVIEW_WIDTH,
+      onComplete: () => {
+        if (width < REVIEW_PANEL_COLLAPSE_THRESHOLD) finalizeClose();
+      },
+    });
+  }, [finalizeClose]);
 
   // React permits guarded render-time adjustment for state that is directly tied to
   // a prop. Closing here prevents one frame of stale review UI without an effect loop.
@@ -87,6 +159,7 @@ export function WorkspaceReviewLayout({
   if (context.kind !== previousContextKind) {
     setPreviousContextKind(context.kind);
     if (context.kind === "none") {
+      // A pending slide aborts itself once the panel leaves the tree.
       setOpen(false);
       setExpanded(false);
       setClosing(false);
@@ -100,7 +173,43 @@ export function WorkspaceReviewLayout({
     setFileRequest({ path, requestId: fileRequestSequence.current });
     setPanel("changes");
     setReviewOpen(true);
-  }, [setReviewOpen, taskId]);
+    // A close slide may still be in flight; switch it back to opening.
+    if (panelAnimationRef.current !== null) slidePanelOpen();
+  }, [setReviewOpen, slidePanelOpen, taskId]);
+
+  // The panel mounts collapsed, so opening (or re-opening after a context switch)
+  // slides it out to the last settled width instead of snapping the conversation.
+  useEffect(() => {
+    if (!open) return;
+    slidePanelOpen();
+  }, [contextKey, open, slidePanelOpen]);
+
+  // Before the user picks a width, keep the panel matched to the window: maximizing
+  // opens it wider, restoring snaps it narrower, without ever fighting a drag.
+  useEffect(() => {
+    if (!open || typeof ResizeObserver === "undefined") return;
+    const content = contentRef.current;
+    if (content === null) return;
+    let lastWidth = content.clientWidth;
+    const observer = new ResizeObserver(() => {
+      if (panelWidthTouchedRef.current) return;
+      const nextWidth = content.clientWidth;
+      if (Math.abs(nextWidth - lastWidth) < 8) return;
+      lastWidth = nextWidth;
+      cancelPanelWidthAnimation(panelAnimationRef);
+      animatePanelWidth({
+        animationRef: panelAnimationRef,
+        duration: REVIEW_PANEL_SLIDE_MS,
+        panel: panelRef.current,
+        targetWidth: responsiveReviewWidth(nextWidth),
+      });
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [open]);
+
+  // Never let a pending slide write to a panel that already left the tree.
+  useEffect(() => () => cancelPanelWidthAnimation(panelAnimationRef), []);
 
   const toggleExpanded = () => {
     if (!expanded) {
@@ -122,6 +231,8 @@ export function WorkspaceReviewLayout({
     else {
       setPanel(next);
       setReviewOpen(true);
+      // A close slide may still be in flight; switch it back to opening.
+      if (panelAnimationRef.current !== null) slidePanelOpen();
     }
   };
 
@@ -167,12 +278,49 @@ export function WorkspaceReviewLayout({
     />
   );
 
-  const workspaceContent = context.kind === "none" || !open || expanded ? children : (
-    <ResizablePanelGroup orientation="horizontal" className="min-h-0 min-w-0 flex-1">
+  // The group stays mounted while open (even under the expanded overlay) so the
+  // review panel keeps its settled width; only its content yields to the overlay
+  // to avoid mounting the same diff/file surface twice.
+  const workspaceContent = context.kind === "none" || !open ? children : (
+    <ResizablePanelGroup
+      orientation="horizontal"
+      className="min-h-0 min-w-0 flex-1"
+      onLayoutChanged={(_layout, meta) => {
+        if (meta.isUserInteraction) settleReviewAfterResize();
+      }}
+    >
       <ResizablePanel id="workspace-primary" minSize={360}>{children}</ResizablePanel>
-      <ResizableHandle withHandle aria-label={t("diff.resizePanel")} title={t("diff.resizePanel")} className="z-10 transition-colors hover:bg-ring focus-visible:bg-ring" />
-      <ResizablePanel id="workspace-review" className="ora-review-side-panel" defaultSize={900} minSize={620} maxSize={1300} collapsible collapsedSize={0} groupResizeBehavior="preserve-pixel-size" onResize={(size) => { if (size.inPixels === 0) close(); }}>
-        {panelContent}
+      <ResizableHandle
+        withHandle
+        aria-label={t("diff.resizePanel")}
+        title={t("diff.resizePanel")}
+        className="z-10 transition-colors hover:bg-ring focus-visible:bg-ring"
+        onPointerDown={() => cancelPanelWidthAnimation(panelAnimationRef)}
+      />
+      <ResizablePanel
+        id="workspace-review"
+        panelRef={panelRef}
+        className="ora-review-side-panel"
+        defaultSize={0}
+        // A pixel min would snap scripted slides onto it; the settle callback
+        // restores the effective minimum after the user lets go (workflow pattern).
+        minSize={1}
+        maxSize={MAX_REVIEW_WIDTH}
+        collapsible
+        collapsedSize={0}
+        groupResizeBehavior="preserve-pixel-size"
+        onResize={(size) => {
+          // Scripted slides report intermediate sizes; only settle on stable ones.
+          if (panelAnimationRef.current !== null) return;
+          panelCurrentWidthRef.current = size.inPixels;
+          if (size.inPixels === 0) close();
+          else if (size.inPixels >= MIN_REVIEW_WIDTH) {
+            panelWidthTouchedRef.current = true;
+            panelWidthRef.current = size.inPixels;
+          }
+        }}
+      >
+        {expanded ? null : panelContent}
       </ResizablePanel>
     </ResizablePanelGroup>
   );
@@ -182,7 +330,7 @@ export function WorkspaceReviewLayout({
       <div className="relative flex min-h-0 min-w-0 flex-1">
         {context.kind !== "none" && !open && <div className="absolute right-4 top-2 z-30">{controls}</div>}
         <div className="relative flex min-h-0 min-w-0 flex-1">
-          <div className="flex min-h-0 min-w-0 flex-1" aria-hidden={expanded || undefined} inert={expanded || undefined}>{workspaceContent}</div>
+          <div ref={contentRef} className="flex min-h-0 min-w-0 flex-1" aria-hidden={expanded || undefined} inert={expanded || undefined}>{workspaceContent}</div>
           {context.kind !== "none" && open && expanded && (
             <>
               <button type="button" aria-label={t("diff.closeExpandedPanel")} className={`ora-review-backdrop absolute inset-0 z-40 bg-background/45 backdrop-blur-[1.5px] ${closing ? "is-closing" : ""}`} onClick={toggleExpanded} />

--- a/packages/app-shell/src/lib/panel-motion.ts
+++ b/packages/app-shell/src/lib/panel-motion.ts
@@ -1,17 +1,17 @@
 import type { MutableRefObject } from "react";
 import type { ResizablePanelHandle } from "@ora/ui";
 
-interface AnimateWorkflowPanelOptions {
+interface PanelWidthAnimationOptions {
   animationRef: MutableRefObject<number | null>;
   duration: number;
-  onCollapsed: () => void;
-  onComplete?: () => void;
   panel: ResizablePanelHandle | null;
   targetWidth: number;
+  onCollapsed?: () => void;
+  onComplete?: () => void;
 }
 
 /** Stops a scripted panel settle so direct pointer input always takes priority. */
-export function cancelWorkflowPanelAnimation(
+export function cancelPanelWidthAnimation(
   animationRef: MutableRefObject<number | null>,
 ): void {
   if (animationRef.current === null) {
@@ -22,19 +22,29 @@ export function cancelWorkflowPanelAnimation(
 }
 
 /** Settles a panel width with an interruptible ease-out and accessible motion fallback. */
-export function animateWorkflowPanel({
+export function animatePanelWidth({
   animationRef,
   duration,
   onCollapsed,
   onComplete,
   panel,
   targetWidth,
-}: AnimateWorkflowPanelOptions): void {
+}: PanelWidthAnimationOptions): void {
   if (panel === null) {
     return;
   }
-  cancelWorkflowPanelAnimation(animationRef);
-  const startWidth = panel.getSize().inPixels;
+  cancelPanelWidthAnimation(animationRef);
+  let startWidth = 0;
+  try {
+    startWidth = panel.getSize().inPixels;
+  } catch {
+    // The panel can detach from its group while a settle is being queued
+    // (e.g. the host unmounted mid-animation); jumping to the target then is
+    // still the closest to the requested end state.
+    panel.resize(targetWidth);
+    onComplete?.();
+    return;
+  }
   const reducedMotion =
     window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
@@ -42,7 +52,7 @@ export function animateWorkflowPanel({
     if (targetWidth === 0) {
       // The primitive tracks collapsed state separately from a zero resize.
       panel.collapse();
-      onCollapsed();
+      onCollapsed?.();
     }
     onComplete?.();
   };
@@ -59,7 +69,14 @@ export function animateWorkflowPanel({
   const animate = (now: number): void => {
     const progress = Math.min(1, (now - startedAt) / duration);
     const easedProgress = 1 - (1 - progress) ** 3;
-    panel.resize(startWidth + (targetWidth - startWidth) * easedProgress);
+    try {
+      panel.resize(startWidth + (targetWidth - startWidth) * easedProgress);
+    } catch {
+      // The group registry can drop the panel before the next frame (unmount or
+      // jsdom teardown); a detached panel has no width left to animate.
+      animationRef.current = null;
+      return;
+    }
     if (progress < 1) {
       animationRef.current = window.requestAnimationFrame(animate);
       return;


### PR DESCRIPTION
## What

The task review panel (Changes / Files) opened at a fixed 900px and snapped open/closed, squeezing the conversation pane on any window size. The diff file tree also collapsed without a way to drag it back.

## Changes

- **Responsive opening width**: the panel now opens at ~45% of the space next to the conversation (leaner 40% + 460px floor on ordinary windows, fuller on maximized ones), always keeping the conversation's 360px minimum. It re-adapts while the window is maximized/restored until the user drags it.
- **Smooth slide**: opening/closing animates with the same rAF ease-out the workflow editor's inspector uses (extracted to a shared \lib/panel-motion.ts\); the slide is interruptible by dragging, and the panel remembers the width the user settled on (including across the expanded overlay).
- **Reliable file tree**: toggling the changed-files tree slides it instead of snapping; its resize handle stays visible so a collapsed tree can always be dragged back open, and transient animation sizes can no longer fight the toggle state.
- **Inner panels** (diff / files / specs) got matching narrower minimums so the review panel can be shrunk without clipping content.

## Verification

- app-shell: 55 files / 376 tests pass with a clean-stderr gate; \lint\ (tsc + eslint) clean.