### PR TITLE
fix(workflow-run): order Theater path by topo then canvas position

### DIFF
--- a/packages/app-shell/src/features/workflow-run/README.md
+++ b/packages/app-shell/src/features/workflow-run/README.md
@@ -27,7 +27,10 @@ Keep these stacks separate — shared chrome only where noted.
 - Wire project mounts and `GraphWorkflowRun` lists through react-query hooks
   against the injected `WorkflowRuntime`.
 - Render the Run Workspace when `workflowRunId` is selected:
-  - **Theater**: focused act stage + path rail + live totals. Parallel
+  - **Theater**: focused act stage + path rail + live totals. The path rail
+    (and parallel act lists) use a derived order: topological constraints first,
+    then canvas position (`x`, then `y`, then id) among concurrently ready
+    nodes — not the frozen snapshot array order. Parallel
     `running` / `awaiting_input` nodes share a drag-to-switch stage carousel
     (chips + arrow keys for precise jumps). A soft right **act inspector**
     (settings-parity) opens as a right **overlay** from the stage card click

--- a/packages/app-shell/src/features/workflow-run/run-focus.test.ts
+++ b/packages/app-shell/src/features/workflow-run/run-focus.test.ts
@@ -159,6 +159,27 @@ describe("resolveTheaterFocus", () => {
     });
   });
 
+  it("orders parallel actives by path order even when the snapshot array is reversed", () => {
+    const snapshot = normalizeWorkflowDefinition(createMockWorkflowFixture("zh-CN"));
+    const reversed = {
+      ...snapshot,
+      nodes: [...snapshot.nodes].reverse(),
+    };
+    const run = baseRun({
+      definitionSnapshot: reversed,
+      nodeStates: {
+        start: { status: "succeeded", finishedAt: "a" },
+        understand: { status: "succeeded", finishedAt: "b" },
+        quality: { status: "succeeded", finishedAt: "c" },
+        tests: { status: "running", startedAt: "2026-08-01T12:00:10+08:00" },
+        review: { status: "running", startedAt: "2026-08-01T12:00:12+08:00" },
+        output: { status: "idle" },
+      },
+    });
+    expect(reversed.nodes.map((node) => node.id)[0]).toBe("output");
+    expect(resolveTheaterFocus(run, null).activeIds).toEqual(["tests", "review"]);
+  });
+
   it("prefers awaiting_input over running when choosing primary", () => {
     const run = baseRun({
       status: "awaiting_input",

--- a/packages/app-shell/src/features/workflow-run/run-focus.ts
+++ b/packages/app-shell/src/features/workflow-run/run-focus.ts
@@ -1,4 +1,8 @@
-import type { GraphWorkflowNodeStatus, GraphWorkflowRun } from "@ora/workflow-runtime";
+import {
+  workflowPathOrder,
+  type GraphWorkflowNodeStatus,
+  type GraphWorkflowRun,
+} from "@ora/workflow-runtime";
 import { isTerminalRunStatus } from "./run-status-style";
 
 const ACTIVE_STATUSES: ReadonlySet<GraphWorkflowNodeStatus> = new Set([
@@ -16,8 +20,9 @@ export interface TheaterFocus {
   /** Primary act shown large on stage. */
   primaryId: string | null;
   /**
-   * All currently active acts (running + awaiting_input), snapshot order.
-   * Length > 1 means genuine parallelism from the UI's point of view.
+   * All currently active acts (running + awaiting_input), path order
+   * (topo + canvas position). Length > 1 means genuine parallelism from
+   * the UI's point of view.
    */
   activeIds: string[];
 }
@@ -57,18 +62,16 @@ export function shouldReleaseFocusToFollow(
   return isActiveStatus(prev.status) && isTerminalNodeStatus(currentStatus);
 }
 
-/** Snapshot order keeps parallel chips stable across engine patches. */
+/** Path order keeps parallel chips stable and aligned with the Theater rail. */
 function orderedActiveIds(run: GraphWorkflowRun): string[] {
-  return run.definitionSnapshot.nodes
-    .map((node) => node.id)
-    .filter((nodeId) => {
-      const state = run.nodeStates[nodeId];
-      return state !== undefined && isActiveStatus(state.status);
-    });
+  return workflowPathOrder(run.definitionSnapshot).filter((nodeId) => {
+    const state = run.nodeStates[nodeId];
+    return state !== undefined && isActiveStatus(state.status);
+  });
 }
 
 /**
- * Among active acts, prefer awaiting_input, then latest startedAt, then snapshot order.
+ * Among active acts, prefer awaiting_input, then latest startedAt, then path order.
  */
 function pickPrimaryAmongActive(
   run: GraphWorkflowRun,
@@ -111,7 +114,7 @@ function pickFallbackPrimary(run: GraphWorkflowRun): string | null {
   if (latestSucceeded !== null) {
     return latestSucceeded.nodeId;
   }
-  return run.definitionSnapshot.nodes[0]?.id ?? null;
+  return workflowPathOrder(run.definitionSnapshot)[0] ?? null;
 }
 
 /**

--- a/packages/app-shell/src/features/workflow-run/run-theater-path-rail.test.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-theater-path-rail.test.tsx
@@ -84,6 +84,57 @@ function waitingRun(): { run: GraphWorkflowRun; request: HitlRequest } {
 }
 
 describe("RunTheaterPathRail", () => {
+  it("renders chips in path order when the snapshot array is reversed", () => {
+    const definition = normalizeWorkflowDefinition(createMockWorkflow("zh-CN"));
+    const reversed = {
+      ...definition,
+      nodes: [...definition.nodes].reverse(),
+    };
+    const run: GraphWorkflowRun = {
+      id: "run-1",
+      projectId: "p1",
+      definitionId: reversed.id,
+      definitionSnapshot: reversed,
+      name: reversed.name,
+      status: "running",
+      nodeStates: Object.fromEntries(
+        reversed.nodes.map((node) => [node.id, { status: "idle" as const }]),
+      ),
+      openHitls: [],
+      totals: {},
+      createdAt: "2026-08-04T12:00:00+08:00",
+      updatedAt: "2026-08-04T12:00:00+08:00",
+    };
+
+    render(
+      <AppI18nProvider>
+        <RunTheaterPathRail
+          run={run}
+          primaryId={null}
+          activeIds={[]}
+          openHitls={[]}
+          artifactCountByNode={{}}
+          showResultAct={false}
+          progress={{ done: 0, total: reversed.nodes.length, percent: 0 }}
+          pathRailRef={createRef()}
+          onFocusNode={vi.fn()}
+          onExpandHitl={vi.fn()}
+        />
+      </AppI18nProvider>,
+    );
+
+    const chips = within(screen.getByRole("list")).getAllByRole("button");
+    expect(chips.map((chip) => chip.getAttribute("data-path-node"))).toEqual([
+      "start",
+      "understand",
+      "quality",
+      "tests",
+      "review",
+      "output",
+    ]);
+    expect(reversed.nodes.map((node) => node.id)[0]).toBe("output");
+  });
+
   it("appends a status-toned Result chip after path nodes on terminal runs", async () => {
     const onShowResultAct = vi.fn();
     const onFocusNode = vi.fn();

--- a/packages/app-shell/src/features/workflow-run/run-theater-path-rail.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-theater-path-rail.tsx
@@ -3,7 +3,11 @@ import { useMemo, type RefObject } from "react";
 import { cn } from "@ora/ui";
 import { RunStatusMark } from "./run-status-mark";
 import { runStatusTone } from "./run-status-style";
-import type { GraphWorkflowRun, HitlRequest } from "@ora/workflow-runtime";
+import {
+  workflowPathNodes,
+  type GraphWorkflowRun,
+  type HitlRequest,
+} from "@ora/workflow-runtime";
 import "./theater-motion.css";
 
 interface RunTheaterPathRailProps {
@@ -25,6 +29,7 @@ interface RunTheaterPathRailProps {
 /**
  * Theater header: progress track + horizontal path chips.
  * Waiting chips expand HITL; others only change focus.
+ * Chip order follows {@link workflowPathNodes} (topo + canvas position).
  */
 export function RunTheaterPathRail({
   run,
@@ -40,6 +45,10 @@ export function RunTheaterPathRail({
   onShowResultAct,
 }: RunTheaterPathRailProps) {
   const { t } = useTranslation();
+  const pathNodes = useMemo(
+    () => workflowPathNodes(run.definitionSnapshot),
+    [run.definitionSnapshot],
+  );
   const activeIdSet = useMemo(() => new Set(activeIds), [activeIds]);
   const hitlByNodeId = useMemo(
     () => new Map(openHitls.map((request) => [request.nodeId, request])),
@@ -88,7 +97,7 @@ export function RunTheaterPathRail({
         </div>
         <div className="overflow-x-auto" ref={pathRailRef} data-slot="theater-path-rail">
           <ol className="flex w-max gap-2 pb-0.5">
-            {run.definitionSnapshot.nodes.map((node) => {
+            {pathNodes.map((node) => {
               const state = run.nodeStates[node.id] ?? { status: "idle" as const };
               const tone = runStatusTone(state.status);
               const selected = !showResultAct && node.id === primaryId;

--- a/packages/workflow-runtime/README.md
+++ b/packages/workflow-runtime/README.md
@@ -8,6 +8,9 @@ Transport-neutral Host/Run ports and an in-memory adapter for **graph workflow r
   (`GraphWorkflowRun*`, HITL, artifacts, `WorkflowRunEvent`).
 - Normalize editor graphs into serializable `WorkflowDefinition` snapshots so
   execution contracts never depend on React Flow runtime objects.
+- Derive a stable display path order (`workflowPathOrder`) for consumers that
+  need a linear node list: topological constraints first, canvas position as
+  the ready-set tie-break — without rewriting the frozen snapshot array.
 - Validate deployable definitions as non-empty DAGs with unique identifiers and
   resolvable edges, preventing invalid graphs from entering a stuck run state.
 - Provide `createMemoryWorkflowRuntime` that mounts `DemoWorkflow` snapshots,

--- a/packages/workflow-runtime/src/index.ts
+++ b/packages/workflow-runtime/src/index.ts
@@ -52,6 +52,7 @@ export {
   type WorkflowGraphEnvelope,
 } from "./graph-codec";
 export { projectNodeStatus, projectRunStatus } from "./run-projection";
+export { workflowPathNodes, workflowPathOrder } from "./workflow-path-order";
 
 export type {
   WorkflowHostRepository,

--- a/packages/workflow-runtime/src/workflow-path-order.test.ts
+++ b/packages/workflow-runtime/src/workflow-path-order.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { normalizeWorkflowDefinition } from "./definition";
+import { workflowPathNodes, workflowPathOrder } from "./workflow-path-order";
+import type { WorkflowDefinitionInput } from "./definition";
+
+/** Builds a tiny definition; node array order is intentionally not path order. */
+function definitionFrom(input: {
+  nodes: Array<{
+    id: string;
+    x: number;
+    y: number;
+    kind?: "start" | "agent" | "output";
+  }>;
+  edges: Array<{ source: string; target: string }>;
+}): ReturnType<typeof normalizeWorkflowDefinition> {
+  const payload: WorkflowDefinitionInput = {
+    id: "path-order-fixture",
+    name: "Path order",
+    description: "",
+    updatedAt: "2026-08-08T12:00:00+08:00",
+    viewport: { x: 0, y: 0, zoom: 1 },
+    nodes: input.nodes.map((node) => ({
+      id: node.id,
+      position: { x: node.x, y: node.y },
+      data: {
+        kind: node.kind ?? (node.id === "start" ? "start" : "agent"),
+        title: node.id,
+        description: "",
+        instruction: "",
+      },
+    })),
+    edges: input.edges.map((edge, index) => ({
+      id: `e-${index}`,
+      source: edge.source,
+      target: edge.target,
+      type: "workflow",
+    })),
+  };
+  return normalizeWorkflowDefinition(payload);
+}
+
+describe("workflowPathOrder", () => {
+  it("follows topology even when the snapshot array is reversed", () => {
+    const definition = definitionFrom({
+      // Array order C → B → A; dependency A → B → C; left-to-right layout.
+      nodes: [
+        { id: "c", x: 600, y: 100 },
+        { id: "b", x: 300, y: 100 },
+        { id: "a", x: 0, y: 100, kind: "start" },
+      ],
+      edges: [
+        { source: "a", target: "b" },
+        { source: "b", target: "c" },
+      ],
+    });
+
+    expect(workflowPathOrder(definition)).toEqual(["a", "b", "c"]);
+    expect(definition.nodes.map((node) => node.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("tie-breaks concurrent ready nodes by x then y then id", () => {
+    const definition = definitionFrom({
+      // Snapshot lists docs before security; canvas has security above docs.
+      nodes: [
+        { id: "start", x: 0, y: 200, kind: "start" },
+        { id: "docs", x: 300, y: 320, kind: "agent" },
+        { id: "security", x: 300, y: 80, kind: "agent" },
+        { id: "merge", x: 600, y: 200 },
+      ],
+      edges: [
+        { source: "start", target: "docs" },
+        { source: "start", target: "security" },
+        { source: "docs", target: "merge" },
+        { source: "security", target: "merge" },
+      ],
+    });
+
+    expect(workflowPathOrder(definition)).toEqual([
+      "start",
+      "security",
+      "docs",
+      "merge",
+    ]);
+  });
+
+  it("never lets position override a predecessor edge", () => {
+    const definition = definitionFrom({
+      // B is drawn left of A but depends on A.
+      nodes: [
+        { id: "b", x: 0, y: 100 },
+        { id: "a", x: 400, y: 100, kind: "start" },
+      ],
+      edges: [{ source: "a", target: "b" }],
+    });
+
+    expect(workflowPathOrder(definition)).toEqual(["a", "b"]);
+  });
+
+  it("resolves path nodes in the same order", () => {
+    const definition = definitionFrom({
+      nodes: [
+        { id: "end", x: 200, y: 0 },
+        { id: "start", x: 0, y: 0, kind: "start" },
+      ],
+      edges: [{ source: "start", target: "end" }],
+    });
+
+    expect(workflowPathNodes(definition).map((node) => node.id)).toEqual([
+      "start",
+      "end",
+    ]);
+  });
+});

--- a/packages/workflow-runtime/src/workflow-path-order.ts
+++ b/packages/workflow-runtime/src/workflow-path-order.ts
@@ -1,0 +1,77 @@
+import type { WorkflowDefinition, WorkflowDefinitionNode } from "./types";
+
+/**
+ * Linearizes a workflow DAG for path UI (Theater rail, parallel act lists).
+ *
+ * Topological constraints are absolute: a node never precedes a predecessor.
+ * Among nodes that are concurrently ready in Kahn's algorithm, order by canvas
+ * position (x, then y), then stable id — matching Overview reading order without
+ * mutating the frozen definition snapshot array.
+ */
+export function workflowPathOrder(definition: WorkflowDefinition): string[] {
+  const nodes = definition.nodes;
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const ids = nodes.map((node) => node.id);
+  const idSet = new Set(ids);
+  const indegree = new Map(ids.map((id) => [id, 0]));
+  const adjacency = new Map(ids.map((id) => [id, [] as string[]]));
+
+  for (const edge of definition.edges) {
+    if (!idSet.has(edge.source) || !idSet.has(edge.target)) {
+      continue;
+    }
+    adjacency.get(edge.source)!.push(edge.target);
+    indegree.set(edge.target, (indegree.get(edge.target) ?? 0) + 1);
+  }
+
+  /** Position tie-break for the Kahn ready set (and cycle leftovers). */
+  function compareReady(left: string, right: string): number {
+    const leftNode = byId.get(left);
+    const rightNode = byId.get(right);
+    const leftX = leftNode?.position.x ?? 0;
+    const rightX = rightNode?.position.x ?? 0;
+    if (leftX !== rightX) {
+      return leftX < rightX ? -1 : 1;
+    }
+    const leftY = leftNode?.position.y ?? 0;
+    const rightY = rightNode?.position.y ?? 0;
+    if (leftY !== rightY) {
+      return leftY < rightY ? -1 : 1;
+    }
+    return left.localeCompare(right);
+  }
+
+  const ready = ids.filter((id) => (indegree.get(id) ?? 0) === 0);
+  ready.sort(compareReady);
+
+  const order: string[] = [];
+  while (ready.length > 0) {
+    const id = ready.shift()!;
+    order.push(id);
+    for (const next of adjacency.get(id) ?? []) {
+      const nextDegree = (indegree.get(next) ?? 1) - 1;
+      indegree.set(next, nextDegree);
+      if (nextDegree === 0) {
+        ready.push(next);
+        ready.sort(compareReady);
+      }
+    }
+  }
+
+  // Cycles are rejected at deploy time; append any leftovers deterministically.
+  const leftovers = ids.filter((id) => !order.includes(id));
+  leftovers.sort(compareReady);
+  order.push(...leftovers);
+  return order;
+}
+
+/** Same order as {@link workflowPathOrder}, resolved to definition nodes. */
+export function workflowPathNodes(
+  definition: WorkflowDefinition,
+): WorkflowDefinitionNode[] {
+  const byId = new Map(definition.nodes.map((node) => [node.id, node]));
+  return workflowPathOrder(definition).flatMap((id) => {
+    const node = byId.get(id);
+    return node === undefined ? [] : [node];
+  });
+}


### PR DESCRIPTION
Derive path-rail and parallel act order from the frozen DAG (Kahn ready-set tie-break: x, y, id) instead of snapshot array order, so Overview and Theater stay aligned without rewriting definition snapshots.