### PR TITLE
fix(workflow-run): cancel stops live sessions and run detail carries real project

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1179,13 +1179,21 @@ backend_command!(
     start_workflow_run,
     "Starts one workflow run through the shared Backend."
 );
-backend_command!(
-    cancel_workflow_run,
-    CancelWorkflowRunRequest,
-    CancelWorkflowRunResponse,
-    cancel_workflow_run,
-    "Cancels one workflow run through the shared Backend."
-);
+/// Cancels one workflow run through the shared Backend.
+///
+/// Not a `backend_command!` because cancelling also stops the run's live agent
+/// sessions, which is asynchronous.
+#[tauri::command]
+pub async fn cancel_workflow_run(
+    state: State<'_, DesktopState>,
+    request: CancelWorkflowRunRequest,
+) -> Result<CancelWorkflowRunResponse, CommandError> {
+    state
+        .backend
+        .cancel_workflow_run(request)
+        .await
+        .map_err(CommandError::from)
+}
 backend_command!(
     restart_workflow_run,
     RestartWorkflowRunRequest,

--- a/apps/web/server/src/handlers/workflow_runs.rs
+++ b/apps/web/server/src/handlers/workflow_runs.rs
@@ -74,6 +74,7 @@ pub async fn cancel_workflow_run(
         .cancel_workflow_run(CancelWorkflowRunRequest {
             run_id: path.run_id,
         })
+        .await
         .map(Json)
         .map_err(Into::into)
 }

--- a/crates/application/src/workflow_run/engine/engine.rs
+++ b/crates/application/src/workflow_run/engine/engine.rs
@@ -165,8 +165,9 @@ where
         }
     }
 
-    /// Cancels a running run. Stopping the running sessions is orchestrated by the backend before
-    /// this commits the `Cancelled` transition.
+    /// Cancels a running run. The backend orchestrates stopping the run's live sessions around
+    /// this; the `Cancelled` transition is committed here, and a late session stop makes the
+    /// executor's in-flight callbacks no-ops against the already-cancelled node runs.
     pub fn cancel(&self, run_id: &WorkflowRunId) -> Result<CancelWorkflowRunResult, EngineError> {
         let now = self.clock.now_timestamp_millis();
         Ok(self.repository.cancel_run(run_id, now)?)

--- a/crates/application/src/workflow_run/handlers.rs
+++ b/crates/application/src/workflow_run/handlers.rs
@@ -349,6 +349,7 @@ where
         Ok(GetWorkflowRunResponse {
             run: map_run(detail.run),
             name: detail.name,
+            project_id: detail.project_id.to_string(),
             task_id: detail.task_id.to_string(),
             nodes: detail.nodes.into_iter().map(map_node_run).collect(),
         })

--- a/crates/application/src/workflow_run/tests.rs
+++ b/crates/application/src/workflow_run/tests.rs
@@ -398,6 +398,7 @@ fn gets_run_detail() {
     repository.with_detail(WorkflowRunDetail {
         run: run.clone(),
         name: "Manual name".to_string(),
+        project_id: ProjectId::new("project-1"),
         task_id: TaskId::new("task-1".to_string()),
         nodes: vec![node.clone()],
     });
@@ -414,6 +415,7 @@ fn gets_run_detail() {
         GetWorkflowRunResponse {
             run: map_run(run),
             name: "Manual name".to_string(),
+            project_id: "project-1".to_string(),
             task_id: "task-1".to_string(),
             nodes: vec![map_node_run(node)],
         }

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -17,7 +17,7 @@ use ora_contracts::*;
 use ora_contracts::{EmptyErrorParams, PublicError};
 use ora_db::SqliteWorkflowRunEngineRepository;
 use ora_db::{DatabaseBootstrapper, DatabaseLocation, RepositoryPool, default_migration_catalog};
-use ora_logging::ora_error;
+use ora_logging::{ora_error, ora_warn};
 use ora_scheduler::Scheduler;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -167,14 +167,66 @@ impl Backend {
             .map_err(BackendError::from)
     }
 
-    /// Cancels a running workflow run.
-    pub fn cancel_workflow_run(
+    /// Cancels a running workflow run and stops its live node sessions.
+    ///
+    /// The engine commits the `Cancelled` transition first; then every session still bound to the
+    /// run's node runs is stopped. Without this second step the agent keeps executing its prompt
+    /// and the delete guard treats the lingering `Running` session as an active run.
+    pub async fn cancel_workflow_run(
         &self,
         request: CancelWorkflowRunRequest,
     ) -> Result<CancelWorkflowRunResponse, BackendError> {
-        self.workflow_run_engine
-            .cancel(request)
-            .map_err(BackendError::from)
+        let run_id = ora_domain::WorkflowRunId::new(&request.run_id);
+        let engine = self.workflow_run_engine.clone();
+        let response =
+            spawn_repository_work(move || engine.cancel(request).map_err(BackendError::from))
+                .await?;
+        self.stop_workflow_run_sessions(&run_id).await;
+        Ok(response)
+    }
+
+    /// Stops every agent session started for one run's node runs.
+    ///
+    /// Best-effort cleanup of an already-cancelled run: a session that cannot be stopped is logged
+    /// rather than failing the cancel request, and sessions whose rows were deleted since attach
+    /// surface as a warn because `stop_session` can no longer resolve them.
+    async fn stop_workflow_run_sessions(&self, run_id: &ora_domain::WorkflowRunId) {
+        let pool = self.pool.clone();
+        let run_id_for_query = run_id.clone();
+        let node_runs = match spawn_repository_work(move || {
+            SqliteWorkflowRunEngineRepository::new(pool)
+                .list_node_runs(&run_id_for_query)
+                .map_err(|source| {
+                    BackendError::from(ApplicationError::WorkflowRunRepository { source })
+                })
+        })
+        .await
+        {
+            Ok(node_runs) => node_runs,
+            Err(error) => {
+                ora_warn!(run_id = %run_id, error = %error, "cancel: failed to list node runs for session cleanup");
+                return;
+            }
+        };
+        for node_run in node_runs {
+            let Some(session_id) = node_run.session_id else {
+                continue;
+            };
+            if let Err(error) = self
+                .agent_runtime
+                .stop_session(StopSessionRequest {
+                    session_id: session_id.to_string(),
+                })
+                .await
+            {
+                ora_warn!(
+                    run_id = %run_id,
+                    session_id = %session_id,
+                    error = %error,
+                    "cancel: failed to stop workflow run session"
+                );
+            }
+        }
     }
 
     /// Restarts a finished workflow run.

--- a/crates/contracts/src/workflow_run.rs
+++ b/crates/contracts/src/workflow_run.rs
@@ -134,6 +134,7 @@ pub struct GetWorkflowRunRequest {
 pub struct GetWorkflowRunResponse {
     pub run: WorkflowRun,
     pub name: String,
+    pub project_id: String,
     pub task_id: String,
     pub nodes: Vec<WorkflowNodeRun>,
 }
@@ -419,6 +420,7 @@ mod tests {
             &GetWorkflowRunResponse {
                 run: run.clone(),
                 name: "Workflow workflow-1 30".to_string(),
+                project_id: "project-1".to_string(),
                 task_id: "task-1".to_string(),
                 nodes: vec![node.clone()],
             },
@@ -439,6 +441,7 @@ mod tests {
                     "updatedAt": 30,
                 },
                 "name": "Workflow workflow-1 30",
+                "projectId": "project-1",
                 "taskId": "task-1",
                 "nodes": [{
                     "id": "node-1",

--- a/crates/db/src/repository/workflow_run.rs
+++ b/crates/db/src/repository/workflow_run.rs
@@ -122,14 +122,20 @@ impl WorkflowRunRepository for SqliteWorkflowRunRepository {
                         None => return Ok(None),
                     }
                 };
-                // The display name and task id live on the run-task; a run created through
-                // create_run always has one, so an absent row degrades to empty values rather
-                // than corruption.
-                let (task_id, name) = connection
+                // The display name, task id, and owning project live on the run-task; a run
+                // created through create_run always has one, so an absent row degrades to empty
+                // values rather than corruption.
+                let (task_id, name, project_id) = connection
                     .query_row(
-                        "SELECT id, title FROM tasks WHERE workflow_run_id = ?1 AND is_deleted = 0",
+                        "SELECT id, title, project_id FROM tasks WHERE workflow_run_id = ?1 AND is_deleted = 0",
                         params![run_id.as_ref()],
-                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                        |row| {
+                            Ok((
+                                row.get::<_, String>(0)?,
+                                row.get::<_, String>(1)?,
+                                row.get::<_, String>(2)?,
+                            ))
+                        },
                     )
                     .optional()?
                     .unwrap_or_default();
@@ -137,6 +143,7 @@ impl WorkflowRunRepository for SqliteWorkflowRunRepository {
                 Ok(Some(WorkflowRunDetail {
                     run,
                     name,
+                    project_id: ProjectId::new(project_id),
                     task_id: TaskId::new(task_id),
                     nodes,
                 }))

--- a/crates/db/src/repository_tests.rs
+++ b/crates/db/src/repository_tests.rs
@@ -763,6 +763,7 @@ fn workflow_run_repository_creates_and_reads_run() {
         Some(WorkflowRunDetail {
             run: run.clone(),
             name: "Workflow workflow-a 30".to_string(),
+            project_id: ProjectId::new("project-1"),
             task_id: task_id.clone(),
             nodes: Vec::new(),
         })

--- a/crates/domain/src/workflow_run.rs
+++ b/crates/domain/src/workflow_run.rs
@@ -226,6 +226,8 @@ pub struct WorkflowRunSummary {
 pub struct WorkflowRunDetail {
     pub run: WorkflowRun,
     pub name: String,
+    /// The project owning the run-task, mirroring the summary's `project_id`.
+    pub project_id: ProjectId,
     pub task_id: TaskId,
     pub nodes: Vec<WorkflowNodeRun>,
 }

--- a/packages/app-shell/src/features/workflow-run/workflow-run-workspace.test.tsx
+++ b/packages/app-shell/src/features/workflow-run/workflow-run-workspace.test.tsx
@@ -186,4 +186,42 @@ describe("WorkflowRunWorkspace", () => {
 
     runtime.dispose();
   });
+
+  it("keeps the workspace project selected when restarting a run", async () => {
+    const state = seedRunWithTask();
+    // "Run again" is only offered on terminal runs.
+    state.workflowRuns[0].status = "cancelled";
+    const client = createMockClient(state);
+    const runtime = createMemoryWorkflowRuntime();
+    const Wrapper = createHookWrapper(
+      client,
+      createTestQueryClient(),
+      createChatStore(client.session),
+      runtime,
+    );
+    const user = userEvent.setup();
+
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <Wrapper>
+          <WorkflowRunWorkspace runId="run-1" />
+        </Wrapper>
+      </PlatformProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("审查流程 1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /再次运行|Run again/ }));
+
+    // Regression: the display run stubs projectId as "", and re-selecting with it
+    // would poison the workspace selection, making the next warm target an empty
+    // project root. Restart must keep the real project id.
+    await waitFor(() => {
+      expect(useWorkspaceSelectionStore.getState().selection.projectId).toBe("p1");
+    });
+
+    runtime.dispose();
+  });
 });

--- a/packages/app-shell/src/state/hooks/use-workflow-runs.test.ts
+++ b/packages/app-shell/src/state/hooks/use-workflow-runs.test.ts
@@ -1,8 +1,13 @@
 import { waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { renderHookWithClient } from "../../test/hook-harness";
 import { createMockClient, createMockClientState, type MockClientState } from "../../test/mock-client";
+import { useWorkspaceSelectionStore } from "../stores/workspace-selection-store";
 import { buildDisplayRun, useDeleteWorkflowRun, useRealWorkflowRun, useRenameWorkflowRun, useWorkflowRunsByProject } from "./use-workflow-runs";
+
+beforeEach(() => {
+  useWorkspaceSelectionStore.getState().clearSelection();
+});
 
 /** Seeds one persisted run and its run-task for hook tests. */
 function seededState(): MockClientState {
@@ -64,6 +69,7 @@ describe("buildDisplayRun", () => {
       updatedAt: 1n,
     },
     name: "审查流程 1",
+    projectId: "p1",
     nodes: [
       {
         nodeId: "explore",
@@ -80,6 +86,11 @@ describe("buildDisplayRun", () => {
   it("projects a paused pending run to awaiting_input", () => {
     const display = buildDisplayRun(detail, GRAPH);
     expect(display.status).toBe("awaiting_input");
+  });
+
+  it("carries the run-task's real project id onto the display run", () => {
+    const display = buildDisplayRun(detail, GRAPH);
+    expect(display.projectId).toBe("p1");
   });
 
   it("builds the definition snapshot and per-node states from the frozen graph", () => {
@@ -261,5 +272,28 @@ describe("persisted run hooks", () => {
     const { result } = renderHookWithClient(() => useDeleteWorkflowRun(), client);
     await result.current.mutateAsync({ runId: "run-1", projectId: "p1" });
     expect(state.workflowRuns).toEqual([]);
+  });
+
+  it("retires the selection when the deleted run is the one open in the workspace", async () => {
+    const state = seededState();
+    const client = createMockClient(state);
+    useWorkspaceSelectionStore.getState().selectWorkflowRun("run-1", "p1");
+    const { result } = renderHookWithClient(() => useDeleteWorkflowRun(), client);
+    await result.current.mutateAsync({ runId: "run-1", projectId: "p1" });
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual({
+      projectId: "p1",
+      taskId: null,
+      sessionId: null,
+      workflowRunId: null,
+    });
+  });
+
+  it("keeps the selection when a different run is deleted", async () => {
+    const state = seededState();
+    const client = createMockClient(state);
+    useWorkspaceSelectionStore.getState().selectWorkflowRun("run-other", "p1");
+    const { result } = renderHookWithClient(() => useDeleteWorkflowRun(), client);
+    await result.current.mutateAsync({ runId: "run-1", projectId: "p1" });
+    expect(useWorkspaceSelectionStore.getState().selection.workflowRunId).toBe("run-other");
   });
 });

--- a/packages/app-shell/src/state/hooks/use-workflow-runs.ts
+++ b/packages/app-shell/src/state/hooks/use-workflow-runs.ts
@@ -11,6 +11,7 @@ import {
 } from "@ora/workflow-runtime";
 import { useContractsClient } from "../../contracts-client-context";
 import { isTerminalRunStatus } from "../../features/workflow-run/run-status-style";
+import { useWorkspaceSelectionStore } from "../stores/workspace-selection-store";
 import type { WorkflowRunSummary } from "@ora/contracts";
 
 const runsByWorkflowKey = (workflowId: string) => ["workflowRun", "byWorkflow", workflowId] as const;
@@ -67,7 +68,15 @@ export function useCreateWorkflowRun() {
   });
 }
 
-/** Soft-deletes one non-active workflow run and refreshes its project's run list. */
+/**
+ * Soft-deletes one non-active workflow run and refreshes its project's run list.
+ *
+ * If the deleted run is the one open in the workspace, its selection must be
+ * retired too: `WorkspaceView` renders the run view for any non-null
+ * `workflowRunId`, and without a clear the graph would linger over the project
+ * after the sidebar row is gone. Mirrors the mock-engine delete, which clears
+ * the same selection leg.
+ */
 export function useDeleteWorkflowRun() {
   const client = useContractsClient();
   const queryClient = useQueryClient();
@@ -77,6 +86,15 @@ export function useDeleteWorkflowRun() {
     onSuccess: (_result, variables) => {
       if (variables.projectId != null) {
         void queryClient.invalidateQueries({ queryKey: runsByProjectKey(variables.projectId) });
+      }
+      // The run no longer exists; drop its detail cache so nothing can resurrect
+      // a stale graph after the selection clear unmounts the run workspace.
+      queryClient.removeQueries({ queryKey: runDetailKey(variables.runId) });
+      const selection = useWorkspaceSelectionStore.getState().selection;
+      if (selection.workflowRunId === variables.runId) {
+        useWorkspaceSelectionStore
+          .getState()
+          .clearWorkflowRunSelection(selection.projectId ?? "");
       }
     },
   });
@@ -194,6 +212,7 @@ export function buildDisplayRun(
   detail: {
     run: { id: string; workflowId: string; status: string; state: string | null; input: string | null; startedAt: bigint | null; finishedAt: bigint | null; createdAt: bigint; updatedAt: bigint };
     name: string;
+    projectId: string;
     nodes: Array<{
       nodeId: string;
       status: string;
@@ -263,7 +282,7 @@ export function buildDisplayRun(
   }
   return {
     id: detail.run.id,
-    projectId: "",
+    projectId: detail.projectId,
     definitionId: detail.run.workflowId,
     definitionSnapshot,
     name: detail.name,

--- a/packages/app-shell/src/test/mock-client.ts
+++ b/packages/app-shell/src/test/mock-client.ts
@@ -579,6 +579,7 @@ export function createMockClient(state: MockClientState): ContractsClient {
             updatedAt: record.updatedAt,
           },
           name: record.name,
+          projectId: record.projectId,
           taskId: record.taskId,
           nodes: [],
         };

--- a/packages/contracts/src/workflowRun.ts
+++ b/packages/contracts/src/workflowRun.ts
@@ -54,6 +54,7 @@ export type GetWorkflowRunRequest = { runId: string };
 export type GetWorkflowRunResponse = {
   run: WorkflowRun;
   name: string;
+  projectId: string;
   taskId: string;
   nodes: Array<WorkflowNodeRun>;
 };


### PR DESCRIPTION
## 背景

在**部署工作流 → 启动 → 终止 → 删除 task** 流程中，删除 run 会报 `workflow run is active and cannot be deleted`：`cancel` 只把 DB 状态改成 `Cancelled`，没有停掉还活着的 agent session，而删除守卫把「存在 Running 的 session」也判为 active，直到 agent 自然跑完（最长拖了 ~1分50秒）删除才放行。

## 改动内容

1. **cancel 停掉 live session**：`cancel_workflow_run` 改为 async，先提交 `Cancelled` 过渡，再列出 run 名下所有 node-run 绑定的 session 逐个 `stop_session`（best-effort，失败仅 warn）。actor 收到 Stop 会中断正在跑的 prompt 并持久化 `Stopped`，executor 迟到的回调是 no-op → 删除立即放行。
2. **删除打开的 run 时清空 workspace selection**：run detail 携带 run-task 的真实 projectId，删除打开的 run 时正确清空 workspace selection，避免残留的项目上下文让后续 warm session 朝空项目根请求失败（`task_project_root_unavailable`）。

## 涉及文件

- 后端：`bootstrap.rs`、`workflow_run` 各层（domain / db / application / contracts）、`web-server`、`desktop` 传输层
- 前端：`app-shell` 的 `use-workflow-runs.ts`、`workflow-run-workspace.tsx`、mock

## 验证

- `task test` 全绿（前端 / 后端 `cargo test --workspace` / 桌面）
- `task lint` 通过（0 error，仅 1 个存量 eslint warning，非本次改动引入）
- 实测日志确认：cancel 请求内出现 `cancelling prompt → session marked stopped`，随后 DELETE 全部一次成功；`task_project_root_unavailable` / `workflow_run_active` 均为 0 次

## 兼容性说明

- `GetWorkflowRunResponse` 新增一个字段（向后兼容）
- `cancel_workflow_run` 由同步改为 async（内部实现，调用方已同步更新）
