### PR TITLE
fix(logging): emit cancelled completion on stream client disconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,6 +1921,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "zip",
 ]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2978,6 +2978,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "urlencoding",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -41,3 +41,4 @@ urlencoding = "2"
 [dev-dependencies]
 pretty_assertions = "1"
 tauri = { version = "2.10.3", features = ["test"] }
+tracing-subscriber = { version = "0.3", features = ["registry"] }

--- a/apps/desktop/src-tauri/README.md
+++ b/apps/desktop/src-tauri/README.md
@@ -4,6 +4,8 @@
 
 The crate does not own domain persistence or agent execution semantics; those remain in the shared backend and contract crates. Desktop commands translate between Tauri IPC and those stable boundaries.
 
+Streaming commands retain one request lifecycle while forwarding ordered `data`, `error`, and `end` frames over a Tauri Channel. A terminal frame is offered to the channel before its forwarding task exits. Explicit cancellation and a failed non-terminal frame delivery complete the lifecycle as `cancelled`; an idle channel is not actively probed for liveness.
+
 Native marketplace windows use isolated browser profiles and provider-specific navigation policies. Their download events are routed into Ora-owned application data before the frontend is notified.
 
 On Windows, `build.rs` omits Tauri's resource-embedded app manifest and instead

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -780,14 +780,14 @@ where
             serde_json::json!({ "type": "end" })
         }
     };
-    if is_terminal {
-        return ControlFlow::Break(());
+    match (is_terminal, on_event.send_frame(frame)) {
+        (true, _) => ControlFlow::Break(()),
+        (false, Ok(())) => ControlFlow::Continue(()),
+        (false, Err(_)) => {
+            lifecycle.complete_cancellation();
+            ControlFlow::Break(())
+        }
     }
-    if on_event.send_frame(frame).is_err() {
-        lifecycle.complete_cancellation();
-        return ControlFlow::Break(());
-    }
-    ControlFlow::Continue(())
 }
 
 /// Why a workspace watch loop ended, so the completion outcome distinguishes an explicit
@@ -1582,10 +1582,8 @@ pub async fn set_worktree_root(
 #[cfg(test)]
 mod tests {
     use super::{FrameSendError, FrameSink, forward_frame};
-    use ora_backend::{
-        BackendError, ErrorClassification, RequestLifecycle, UuidRequestIdGenerator,
-    };
-    use ora_contracts::{EmptyErrorParams, PublicError};
+    use ora_backend::{BackendError, ErrorClassification, RequestIdGenerator, RequestLifecycle};
+    use ora_contracts::{EmptyErrorParams, PublicError, RequestId};
     use ora_logging::with_recorded_trace_logging;
     use pretty_assertions::assert_eq;
     use serde_json::Value;
@@ -1593,13 +1591,50 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use tracing_subscriber::layer::{Context, Layer};
 
-    /// A sink whose channel is already closed, simulating a disconnected frontend.
-    #[derive(Clone)]
-    struct ClosedSink;
+    /// Selects whether a recording sink accepts or rejects its attempted frame delivery.
+    #[derive(Clone, Copy)]
+    enum TestDelivery {
+        Accepted,
+        ChannelClosed,
+    }
 
-    impl FrameSink for ClosedSink {
-        fn send_frame(&self, _frame: Value) -> Result<(), FrameSendError> {
-            Err(FrameSendError)
+    /// Records attempted frames before returning the configured delivery result.
+    #[derive(Clone)]
+    struct RecordingSink {
+        attempted_frames: Arc<Mutex<Vec<Value>>>,
+        delivery: TestDelivery,
+    }
+
+    impl RecordingSink {
+        fn new(delivery: TestDelivery) -> Self {
+            Self {
+                attempted_frames: Arc::new(Mutex::new(Vec::new())),
+                delivery,
+            }
+        }
+
+        /// Returns every frame the forwarding seam attempted to deliver.
+        fn attempted_frames(&self) -> Vec<Value> {
+            self.attempted_frames.lock().unwrap().clone()
+        }
+    }
+
+    impl FrameSink for RecordingSink {
+        fn send_frame(&self, frame: Value) -> Result<(), FrameSendError> {
+            self.attempted_frames.lock().unwrap().push(frame);
+            match self.delivery {
+                TestDelivery::Accepted => Ok(()),
+                TestDelivery::ChannelClosed => Err(FrameSendError),
+            }
+        }
+    }
+
+    /// Generates the stable request id used by frame payload assertions.
+    struct FixedRequestIdGenerator(RequestId);
+
+    impl RequestIdGenerator for FixedRequestIdGenerator {
+        fn generate(&self) -> RequestId {
+            self.0
         }
     }
 
@@ -1607,48 +1642,83 @@ mod tests {
     #[test]
     fn send_failure_on_data_frame_emits_cancelled() {
         let recorder = OutcomeRecorder::default();
+        let sink = RecordingSink::new(TestDelivery::ChannelClosed);
         with_recorded_trace_logging(recorder.layer(), || {
-            let lifecycle = RequestLifecycle::start("test_stream", &UuidRequestIdGenerator);
+            let lifecycle = test_lifecycle();
             let flow = forward_frame::<Value, _>(
                 Some(Ok(serde_json::json!({ "n": 1 }))),
-                &ClosedSink,
+                &sink,
                 &lifecycle,
             );
             assert_eq!(flow, ControlFlow::Break(()));
         });
 
+        assert_eq!(
+            sink.attempted_frames(),
+            vec![serde_json::json!({
+                "type": "data",
+                "data": { "n": 1 },
+            })]
+        );
         assert_eq!(recorder.outcomes(), vec!["cancelled"]);
     }
 
-    /// Verifies a terminal event claims completion first, so a failed send never double-logs.
+    /// Verifies a normal terminal event delivers its `end` frame before the loop exits.
     #[test]
-    fn terminal_frame_with_send_failure_does_not_double_log() {
+    fn terminal_end_frame_is_sent_before_exit() {
         let recorder = OutcomeRecorder::default();
+        let sink = RecordingSink::new(TestDelivery::Accepted);
         with_recorded_trace_logging(recorder.layer(), || {
-            let lifecycle = RequestLifecycle::start("test_stream", &UuidRequestIdGenerator);
-            let flow = forward_frame::<Value, _>(None, &ClosedSink, &lifecycle);
+            let lifecycle = test_lifecycle();
+            let flow = forward_frame::<Value, _>(None, &sink, &lifecycle);
             assert_eq!(flow, ControlFlow::Break(()));
         });
 
+        assert_eq!(
+            sink.attempted_frames(),
+            vec![serde_json::json!({ "type": "end" })]
+        );
         assert_eq!(recorder.outcomes(), vec!["success"]);
     }
 
-    /// Verifies a typed error terminal frame records a `failure` and no `cancelled`.
+    /// Verifies a failed terminal delivery keeps the backend failure and still attempts its frame.
     #[test]
-    fn error_frame_with_send_failure_does_not_double_log() {
+    fn error_frame_with_send_failure_is_attempted_without_double_logging() {
         let recorder = OutcomeRecorder::default();
+        let sink = RecordingSink::new(TestDelivery::ChannelClosed);
         with_recorded_trace_logging(recorder.layer(), || {
-            let lifecycle = RequestLifecycle::start("test_stream", &UuidRequestIdGenerator);
+            let lifecycle = test_lifecycle();
             let error = BackendError::new(
                 ErrorClassification::Internal,
                 PublicError::InternalError(EmptyErrorParams {}),
                 "test failure",
             );
-            let flow = forward_frame::<Value, _>(Some(Err(error)), &ClosedSink, &lifecycle);
+            let flow = forward_frame::<Value, _>(Some(Err(error)), &sink, &lifecycle);
             assert_eq!(flow, ControlFlow::Break(()));
         });
 
+        assert_eq!(
+            sink.attempted_frames(),
+            vec![serde_json::json!({
+                "type": "error",
+                "error": {
+                    "code": "internal_error",
+                    "params": {},
+                    "requestId": "550e8400-e29b-41d4-a716-446655440000",
+                },
+            })]
+        );
         assert_eq!(recorder.outcomes(), vec!["failure"]);
+    }
+
+    /// Builds one lifecycle whose correlation id is stable in serialized frame assertions.
+    fn test_lifecycle() -> RequestLifecycle {
+        RequestLifecycle::start(
+            "test_stream",
+            &FixedRequestIdGenerator(
+                serde_json::from_str("\"550e8400-e29b-41d4-a716-446655440000\"").unwrap(),
+            ),
+        )
     }
 
     /// Records the `outcome` field of every completion event to assert disconnect semantics.
@@ -1658,17 +1728,20 @@ mod tests {
     }
 
     impl OutcomeRecorder {
+        /// Builds the scoped subscriber layer used by one test.
         fn layer(&self) -> OutcomeRecordingLayer {
             OutcomeRecordingLayer {
                 outcomes: self.outcomes.clone(),
             }
         }
 
+        /// Returns captured completion outcomes in emission order.
         fn outcomes(&self) -> Vec<String> {
             self.outcomes.lock().unwrap().clone()
         }
     }
 
+    /// Captures completion outcomes while leaving production formatting untouched.
     #[derive(Clone, Debug)]
     struct OutcomeRecordingLayer {
         outcomes: Arc<Mutex<Vec<String>>>,
@@ -1687,6 +1760,7 @@ mod tests {
         }
     }
 
+    /// Extracts the `outcome` field from one completion event.
     #[derive(Default)]
     struct OutcomeVisitor {
         outcome: Option<String>,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -6,6 +6,7 @@ use ora_backend::{Backend, BackendError, RequestLifecycle, UuidRequestIdGenerato
 use ora_contracts::*;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
+use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -701,18 +702,36 @@ pub async fn cancel_contract_stream(
     Ok(())
 }
 
+/// Delivery seam for NDJSON transport frames so forward loops can be unit-tested
+/// without a live Tauri webview.
+pub(crate) trait FrameSink: Clone {
+    /// Sends one frame; `Err` means the receiver is gone (client disconnected).
+    fn send_frame(&self, frame: serde_json::Value) -> Result<(), FrameSendError>;
+}
+
+/// Unit error marking a failed frame delivery (closed client channel).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FrameSendError;
+
+impl FrameSink for Channel<serde_json::Value> {
+    fn send_frame(&self, frame: serde_json::Value) -> Result<(), FrameSendError> {
+        self.send(frame).map_err(|_| FrameSendError)
+    }
+}
+
 /// Forwards ordered data/error/end frames and drops the backend stream on channel failure.
-async fn forward_contract_stream<Event>(
+async fn forward_contract_stream<Event, Sink>(
     mut stream: ora_backend::SessionEventStream<Event>,
     cancellation: CancellationToken,
     stream_call_id: String,
     registry: std::sync::Arc<
         std::sync::Mutex<std::collections::HashMap<String, CancellationToken>>,
     >,
-    on_event: Channel<serde_json::Value>,
+    on_event: Sink,
     lifecycle: RequestLifecycle,
 ) where
     Event: Serialize + Send + 'static,
+    Sink: FrameSink,
 {
     loop {
         tokio::select! {
@@ -721,22 +740,7 @@ async fn forward_contract_stream<Event>(
                 break;
             },
             event = stream.recv() => {
-                let is_terminal = matches!(&event, Some(Err(_)) | None);
-                let frame = match event {
-                    Some(Ok(data)) => serde_json::json!({ "type": "data", "data": data }),
-                    Some(Err(error)) => {
-                        lifecycle.complete_failure(&error);
-                        serde_json::json!({
-                            "type": "error",
-                            "error": error.contract_error(lifecycle.request_id()),
-                        })
-                    },
-                    None => {
-                        lifecycle.complete_success();
-                        serde_json::json!({ "type": "end" })
-                    },
-                };
-                if on_event.send(frame).is_err() || is_terminal {
+                if forward_frame(event, &on_event, &lifecycle).is_break() {
                     break;
                 }
             }
@@ -747,66 +751,111 @@ async fn forward_contract_stream<Event>(
     }
 }
 
-/// Forwards debounced native workspace changes until the Desktop stream is cancelled.
-pub(crate) async fn forward_workspace_watch(
+/// Forwards one backend event as a transport frame and reports whether the loop should continue.
+///
+/// A terminal event claims the lifecycle (success/failure) before the frame is sent, so a later
+/// channel-close cancellation is a no-op; a non-terminal frame whose send fails records a
+/// `cancelled` completion to match the explicit-cancellation path.
+fn forward_frame<Event, Sink>(
+    event: Option<Result<Event, BackendError>>,
+    on_event: &Sink,
+    lifecycle: &RequestLifecycle,
+) -> ControlFlow<()>
+where
+    Event: Serialize,
+    Sink: FrameSink,
+{
+    let is_terminal = matches!(&event, Some(Err(_)) | None);
+    let frame = match event {
+        Some(Ok(data)) => serde_json::json!({ "type": "data", "data": data }),
+        Some(Err(error)) => {
+            lifecycle.complete_failure(&error);
+            serde_json::json!({
+                "type": "error",
+                "error": error.contract_error(lifecycle.request_id()),
+            })
+        }
+        None => {
+            lifecycle.complete_success();
+            serde_json::json!({ "type": "end" })
+        }
+    };
+    if is_terminal {
+        return ControlFlow::Break(());
+    }
+    if on_event.send_frame(frame).is_err() {
+        lifecycle.complete_cancellation();
+        return ControlFlow::Break(());
+    }
+    ControlFlow::Continue(())
+}
+
+/// Why a workspace watch loop ended, so the completion outcome distinguishes an explicit
+/// cancellation from a closed frontend channel (the latter must not be logged as `success`).
+enum WatchEnd {
+    Cancelled,
+    ChannelClosed,
+}
+
+/// Forwards debounced native workspace changes until the Desktop stream is cancelled or the
+/// frontend disconnects.
+pub(crate) async fn forward_workspace_watch<Sink>(
     watcher: ora_fs::WorkspaceWatcher,
     cancellation: CancellationToken,
     stream_call_id: String,
     registry: std::sync::Arc<
         std::sync::Mutex<std::collections::HashMap<String, CancellationToken>>,
     >,
-    on_event: Channel<serde_json::Value>,
+    on_event: Sink,
     lifecycle: RequestLifecycle,
-) {
+) where
+    Sink: FrameSink + Send + 'static,
+{
     let watch_cancellation = cancellation.clone();
     let terminal_channel = on_event.clone();
-    let result = tauri::async_runtime::spawn_blocking(move || {
-        while !watch_cancellation.is_cancelled() {
-            match watcher.receive_batch(Duration::from_millis(100)) {
-                Ok(Some(changes)) if !changes.is_empty() => {
-                    let data = WorkspaceFileEventBatch {
-                        changes: changes.into_iter().map(to_contract_change).collect(),
-                    };
-                    if on_event
-                        .send(serde_json::json!({ "type": "data", "data": data }))
-                        .is_err()
-                    {
-                        break;
+    let result = tauri::async_runtime::spawn_blocking(
+        move || -> Result<WatchEnd, ora_fs::WorkspaceFileSystemError> {
+            while !watch_cancellation.is_cancelled() {
+                match watcher.receive_batch(Duration::from_millis(100)) {
+                    Ok(Some(changes)) if !changes.is_empty() => {
+                        let data = WorkspaceFileEventBatch {
+                            changes: changes.into_iter().map(to_contract_change).collect(),
+                        };
+                        if on_event
+                            .send_frame(serde_json::json!({ "type": "data", "data": data }))
+                            .is_err()
+                        {
+                            return Ok(WatchEnd::ChannelClosed);
+                        }
                     }
+                    Ok(Some(_)) | Ok(None) => {}
+                    Err(error) => return Err(error),
                 }
-                Ok(Some(_)) | Ok(None) => {}
-                Err(error) => return Err(error),
             }
-        }
-        Ok::<(), ora_fs::WorkspaceFileSystemError>(())
-    })
+            Ok(WatchEnd::Cancelled)
+        },
+    )
     .await;
 
-    if cancellation.is_cancelled() {
-        lifecycle.complete_cancellation();
-    } else {
-        match result {
-            Ok(Ok(())) => {
-                lifecycle.complete_success();
-                let _ = terminal_channel.send(serde_json::json!({ "type": "end" }));
-            }
-            Ok(Err(error)) => {
-                let backend_error = workspace_file_backend_error(error);
-                lifecycle.complete_failure(&backend_error);
-                let _ = terminal_channel.send(serde_json::json!({
-                    "type": "error",
-                    "error": backend_error.contract_error(lifecycle.request_id()),
-                }));
-            }
-            Err(error) => {
-                let backend_error =
-                    BackendError::internal("Desktop workspace watcher failed", error);
-                lifecycle.complete_failure(&backend_error);
-                let _ = terminal_channel.send(serde_json::json!({
-                    "type": "error",
-                    "error": backend_error.contract_error(lifecycle.request_id()),
-                }));
-            }
+    match result {
+        Ok(Ok(WatchEnd::Cancelled)) | Ok(Ok(WatchEnd::ChannelClosed)) => {
+            lifecycle.complete_cancellation()
+        }
+        Ok(Err(error)) => {
+            let backend_error = workspace_file_backend_error(error);
+            lifecycle.complete_failure(&backend_error);
+            let _ = terminal_channel.send_frame(serde_json::json!({
+                "type": "error",
+                "error": backend_error.contract_error(lifecycle.request_id()),
+            }));
+        }
+        Err(error) => {
+            let backend_error = BackendError::internal("Desktop workspace watcher failed", error);
+            lifecycle.complete_failure(&backend_error);
+            let _ = terminal_channel.send_frame(serde_json::json!({
+                "type": "error",
+                "error": backend_error.contract_error(lifecycle.request_id()),
+            }));
         }
     }
     if let Ok(mut registrations) = registry.lock() {
@@ -1528,4 +1577,128 @@ pub async fn set_worktree_root(
     }
     .instrument(request_span)
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FrameSendError, FrameSink, forward_frame};
+    use ora_backend::{
+        BackendError, ErrorClassification, RequestLifecycle, UuidRequestIdGenerator,
+    };
+    use ora_contracts::{EmptyErrorParams, PublicError};
+    use ora_logging::with_recorded_trace_logging;
+    use pretty_assertions::assert_eq;
+    use serde_json::Value;
+    use std::ops::ControlFlow;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::layer::{Context, Layer};
+
+    /// A sink whose channel is already closed, simulating a disconnected frontend.
+    #[derive(Clone)]
+    struct ClosedSink;
+
+    impl FrameSink for ClosedSink {
+        fn send_frame(&self, _frame: Value) -> Result<(), FrameSendError> {
+            Err(FrameSendError)
+        }
+    }
+
+    /// Verifies a data frame that fails to send records a `cancelled` completion.
+    #[test]
+    fn send_failure_on_data_frame_emits_cancelled() {
+        let recorder = OutcomeRecorder::default();
+        with_recorded_trace_logging(recorder.layer(), || {
+            let lifecycle = RequestLifecycle::start("test_stream", &UuidRequestIdGenerator);
+            let flow = forward_frame::<Value, _>(
+                Some(Ok(serde_json::json!({ "n": 1 }))),
+                &ClosedSink,
+                &lifecycle,
+            );
+            assert_eq!(flow, ControlFlow::Break(()));
+        });
+
+        assert_eq!(recorder.outcomes(), vec!["cancelled"]);
+    }
+
+    /// Verifies a terminal event claims completion first, so a failed send never double-logs.
+    #[test]
+    fn terminal_frame_with_send_failure_does_not_double_log() {
+        let recorder = OutcomeRecorder::default();
+        with_recorded_trace_logging(recorder.layer(), || {
+            let lifecycle = RequestLifecycle::start("test_stream", &UuidRequestIdGenerator);
+            let flow = forward_frame::<Value, _>(None, &ClosedSink, &lifecycle);
+            assert_eq!(flow, ControlFlow::Break(()));
+        });
+
+        assert_eq!(recorder.outcomes(), vec!["success"]);
+    }
+
+    /// Verifies a typed error terminal frame records a `failure` and no `cancelled`.
+    #[test]
+    fn error_frame_with_send_failure_does_not_double_log() {
+        let recorder = OutcomeRecorder::default();
+        with_recorded_trace_logging(recorder.layer(), || {
+            let lifecycle = RequestLifecycle::start("test_stream", &UuidRequestIdGenerator);
+            let error = BackendError::new(
+                ErrorClassification::Internal,
+                PublicError::InternalError(EmptyErrorParams {}),
+                "test failure",
+            );
+            let flow = forward_frame::<Value, _>(Some(Err(error)), &ClosedSink, &lifecycle);
+            assert_eq!(flow, ControlFlow::Break(()));
+        });
+
+        assert_eq!(recorder.outcomes(), vec!["failure"]);
+    }
+
+    /// Records the `outcome` field of every completion event to assert disconnect semantics.
+    #[derive(Clone, Debug, Default)]
+    struct OutcomeRecorder {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl OutcomeRecorder {
+        fn layer(&self) -> OutcomeRecordingLayer {
+            OutcomeRecordingLayer {
+                outcomes: self.outcomes.clone(),
+            }
+        }
+
+        fn outcomes(&self) -> Vec<String> {
+            self.outcomes.lock().unwrap().clone()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct OutcomeRecordingLayer {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S> Layer<S> for OutcomeRecordingLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
+            let mut visitor = OutcomeVisitor::default();
+            event.record(&mut visitor);
+            if let Some(outcome) = visitor.outcome {
+                self.outcomes.lock().unwrap().push(outcome);
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct OutcomeVisitor {
+        outcome: Option<String>,
+    }
+
+    impl tracing::field::Visit for OutcomeVisitor {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "outcome" {
+                self.outcome = Some(value.to_string());
+            }
+        }
+
+        fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+    }
 }

--- a/apps/web/server/Cargo.toml
+++ b/apps/web/server/Cargo.toml
@@ -36,4 +36,5 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
+tracing-subscriber = { workspace = true }
 zip = { workspace = true }

--- a/apps/web/server/src/handlers/sessions.rs
+++ b/apps/web/server/src/handlers/sessions.rs
@@ -5,7 +5,7 @@ use axum::body::{Body, Bytes};
 use axum::extract::{Path, State};
 use axum::http::{HeaderValue, Response, header};
 use futures_util::stream;
-use ora_backend::{BackendError, SessionEventStream};
+use ora_backend::{BackendError, SessionEventStream, StreamCompletionGuard};
 use ora_contracts::{
     AgentCli, AttachSessionRequest, AttachSessionResponse, ContractError, DeleteSessionRequest,
     DeleteSessionResponse, EmptyErrorParams, GetAgentRuntimeStatusRequest,
@@ -280,9 +280,12 @@ where
     Event: Serialize + Send + 'static,
 {
     let lifecycle = current_lifecycle();
+    // Records a `cancelled` completion when the body is dropped early (client disconnect),
+    // because `complete_*` only runs on `events.recv()` returning, never on a dropped future.
+    let completion_guard = StreamCompletionGuard::new(lifecycle.clone());
     let body_stream = stream::unfold(
-        (events, false, lifecycle),
-        |(mut events, ended, lifecycle)| async move {
+        (events, false, lifecycle, completion_guard),
+        |(mut events, ended, lifecycle, completion_guard)| async move {
             if ended {
                 return None;
             }
@@ -316,7 +319,7 @@ where
             bytes.push(b'\n');
             Some((
                 Ok::<Bytes, Infallible>(Bytes::from(bytes)),
-                (events, next_ended, lifecycle),
+                (events, next_ended, lifecycle, completion_guard),
             ))
         },
     );

--- a/apps/web/server/src/handlers/workspace_files.rs
+++ b/apps/web/server/src/handlers/workspace_files.rs
@@ -5,7 +5,7 @@ use axum::body::{Body, Bytes};
 use axum::extract::{Path, State};
 use axum::http::{HeaderValue, Response, header};
 use futures_util::stream;
-use ora_backend::BackendError;
+use ora_backend::{BackendError, StreamCompletionGuard};
 use ora_contracts::{
     ContractError, EmptyErrorParams, ListWorkspaceDirectoryResponse, PublicError,
     ReadWorkspaceFileResponse, SearchWorkspaceResponse, WorkspaceFileChange,
@@ -175,9 +175,12 @@ pub(crate) fn stream_response(
     receiver: tokio::sync::mpsc::Receiver<Result<WorkspaceFileEventBatch, BackendError>>,
 ) -> Response<Body> {
     let lifecycle = current_lifecycle();
+    // Records a `cancelled` completion when the body is dropped early (client disconnect),
+    // because `complete_*` only runs on `receiver.recv()` returning, never on a dropped future.
+    let completion_guard = StreamCompletionGuard::new(lifecycle.clone());
     let body_stream = stream::unfold(
-        (receiver, false, lifecycle),
-        |(mut receiver, ended, lifecycle)| async move {
+        (receiver, false, lifecycle, completion_guard),
+        |(mut receiver, ended, lifecycle, completion_guard)| async move {
             if ended {
                 return None;
             }
@@ -211,7 +214,7 @@ pub(crate) fn stream_response(
             bytes.push(b'\n');
             Some((
                 Ok::<Bytes, Infallible>(Bytes::from(bytes)),
-                (receiver, next_ended, lifecycle),
+                (receiver, next_ended, lifecycle, completion_guard),
             ))
         },
     );

--- a/apps/web/server/src/routes.rs
+++ b/apps/web/server/src/routes.rs
@@ -265,21 +265,25 @@ fn skill_imports_router() -> Router<AppState> {
 mod tests {
     use super::build_router;
     use crate::bootstrap::build_app_state_for_database;
+    use crate::error::DeferredCompletion;
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request, StatusCode};
     use ora_application::WorktreeRepository;
     use ora_contracts::{
-        FileSystemBreadcrumb, FileSystemEntry, FileSystemEntryKind, ListDirectoryResponse,
-        RequestId,
+        APP_EVENT_WATCH_PATH, FileSystemBreadcrumb, FileSystemEntry, FileSystemEntryKind,
+        ListDirectoryResponse, RequestId,
     };
     use ora_db::{DatabaseBootstrapper, DatabaseLocation, SqliteWorktreeRepository};
     use ora_domain::WorktreeId;
+    use ora_logging::with_recorded_trace_logging;
     use pretty_assertions::assert_eq;
     use serde_json::{Value, json};
     use std::fs;
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
     use tower::util::ServiceExt;
+    use tracing_subscriber::layer::{Context, Layer};
 
     /// Verifies the liveness route reports process health without bootstrap state.
     #[tokio::test]
@@ -1737,5 +1741,88 @@ mod tests {
             .expect("contract error requestId must be a UUID");
         assert!(body.get("message").is_none());
         assert!(body.get("error").is_none());
+    }
+
+    /// Verifies dropping a streaming response body (client disconnect) records a `cancelled` completion.
+    ///
+    /// `watch_app_events` is an unbounded stream whose only terminal state is the client dropping
+    /// the connection, so this exercises the real axum body-drop → guard path end to end.
+    #[tokio::test]
+    async fn watch_stream_disconnect_emits_cancelled() {
+        let (_temp_dir, _database_path, app) = test_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(APP_EVENT_WATCH_PATH)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap_or_else(|error| panic!("request failed: {error}"));
+
+        assert!(response.extensions().get::<DeferredCompletion>().is_some());
+
+        let recorder = OutcomeRecorder::default();
+        with_recorded_trace_logging(recorder.layer(), || {
+            drop(response);
+        });
+
+        assert_eq!(recorder.outcomes(), vec!["cancelled"]);
+    }
+
+    /// Records the `outcome` field of every completion event to assert disconnect semantics.
+    #[derive(Clone, Debug, Default)]
+    struct OutcomeRecorder {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl OutcomeRecorder {
+        /// Builds the scoped subscriber layer used by one test.
+        fn layer(&self) -> OutcomeRecordingLayer {
+            OutcomeRecordingLayer {
+                outcomes: self.outcomes.clone(),
+            }
+        }
+
+        /// Returns captured completion outcomes in emission order.
+        fn outcomes(&self) -> Vec<String> {
+            self.outcomes.lock().unwrap().clone()
+        }
+    }
+
+    /// Captures the `outcome` field of completion events, ignoring events that carry none.
+    #[derive(Clone, Debug)]
+    struct OutcomeRecordingLayer {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S> Layer<S> for OutcomeRecordingLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
+            let mut visitor = OutcomeVisitor::default();
+            event.record(&mut visitor);
+            if let Some(outcome) = visitor.outcome {
+                self.outcomes.lock().unwrap().push(outcome);
+            }
+        }
+    }
+
+    /// Extracts the `outcome` field from a completion event.
+    #[derive(Default)]
+    struct OutcomeVisitor {
+        outcome: Option<String>,
+    }
+
+    impl tracing::field::Visit for OutcomeVisitor {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "outcome" {
+                self.outcome = Some(value.to_string());
+            }
+        }
+
+        fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
     }
 }

--- a/crates/backend/README.md
+++ b/crates/backend/README.md
@@ -13,7 +13,7 @@
 - Task diff reads, commits, pushes, and comments preserve the same public error projection as the rest of the backend. Git and SQLite sources remain internal diagnostics and are rendered once by the adapter-owned request lifecycle.
 - Session creation, loading, structured ACP prompting, permissions, stopping, deletion, and model discovery delegate to the agent runtime. Creation also returns the provider's setup-time available-command catalog.
 - `BackendError` retains the internal source chain while exhaustively projecting semantic failures into a typed `PublicError` and one transport-neutral `ErrorClassification`. HTTP derives status from the classification; all adapters serialize the same direct `ContractError`.
-- `RequestLifecycle` gives Web, Tauri, and stream seams one generated request id and an exactly-once success, failure, or cancellation completion event. Failure log levels derive from `ErrorClassification`.
+- `RequestLifecycle` gives Web, Tauri, and stream seams one generated request id and an exactly-once success, failure, or cancellation completion event. `StreamCompletionGuard` adds cancellation-on-drop for adapter-owned stream state; adapters retain it until a terminal completion has claimed the lifecycle. Failure log levels derive from `ErrorClassification`.
 - The configured worktree root affects only task creations that begin after an update. Existing task paths are resolved from persisted worktree identity and Git's authoritative metadata.
 
 ## Ownership boundaries

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -25,5 +25,7 @@ pub use agent_runtime::{SessionEventStream, SessionLocator};
 pub use app_event::AppEventHub;
 pub use bootstrap::{Backend, BackendBootstrapError, BackendPaths};
 pub use error::{BackendError, ErrorClassification};
-pub use request_lifecycle::{RequestIdGenerator, RequestLifecycle, UuidRequestIdGenerator};
+pub use request_lifecycle::{
+    RequestIdGenerator, RequestLifecycle, StreamCompletionGuard, UuidRequestIdGenerator,
+};
 pub use skill_reconciliation::SkillStorageReconciliationError;

--- a/crates/backend/src/request_lifecycle.rs
+++ b/crates/backend/src/request_lifecycle.rs
@@ -156,9 +156,29 @@ impl RequestLifecycle {
     }
 }
 
+/// Records a `cancelled` completion when dropped, so a streaming request torn down by
+/// client disconnect or server shutdown still emits its one completion event.
+///
+/// `RequestLifecycle` already enforces exactly-once completion through `claim_completion`,
+/// so dropping this guard after a normal `complete_success`/`complete_failure` is a no-op.
+pub struct StreamCompletionGuard(RequestLifecycle);
+
+impl StreamCompletionGuard {
+    /// Attaches cancellation-on-drop semantics to a cloned lifecycle.
+    pub fn new(lifecycle: RequestLifecycle) -> Self {
+        Self(lifecycle)
+    }
+}
+
+impl Drop for StreamCompletionGuard {
+    fn drop(&mut self) {
+        self.0.complete_cancellation();
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{RequestIdGenerator, RequestLifecycle};
+    use super::{RequestIdGenerator, RequestLifecycle, StreamCompletionGuard};
     use crate::{BackendError, ErrorClassification};
     use ora_contracts::{EmptyErrorParams, PublicError, RequestId};
     use ora_logging::with_recorded_trace_logging;
@@ -317,5 +337,111 @@ mod tests {
         fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
             self.levels.lock().unwrap().push(*event.metadata().level());
         }
+    }
+
+    /// Verifies dropping a guard before any completion records exactly one `cancelled` outcome.
+    #[test]
+    fn stream_completion_guard_without_completion_emits_cancelled() {
+        let recorder = OutcomeRecorder::default();
+        with_recorded_trace_logging(recorder.layer(), || {
+            let lifecycle = RequestLifecycle::start(
+                "test_operation",
+                &FixedRequestIdGenerator(test_request_id()),
+            );
+            let guard = StreamCompletionGuard::new(lifecycle.clone());
+            drop(guard);
+        });
+
+        assert_eq!(recorder.outcomes(), vec!["cancelled"]);
+    }
+
+    /// Verifies a normal success claims completion before the guard drop, so no `cancelled` is emitted.
+    #[test]
+    fn stream_completion_guard_after_success_is_noop() {
+        let recorder = OutcomeRecorder::default();
+        with_recorded_trace_logging(recorder.layer(), || {
+            let lifecycle = RequestLifecycle::start(
+                "test_operation",
+                &FixedRequestIdGenerator(test_request_id()),
+            );
+            let guard = StreamCompletionGuard::new(lifecycle.clone());
+            lifecycle.complete_success();
+            drop(guard);
+        });
+
+        assert_eq!(recorder.outcomes(), vec!["success"]);
+    }
+
+    /// Verifies an explicit cancellation and a subsequent guard drop still log only once.
+    #[test]
+    fn stream_completion_guard_after_cancellation_is_idempotent() {
+        let recorder = OutcomeRecorder::default();
+        with_recorded_trace_logging(recorder.layer(), || {
+            let lifecycle = RequestLifecycle::start(
+                "test_operation",
+                &FixedRequestIdGenerator(test_request_id()),
+            );
+            let guard = StreamCompletionGuard::new(lifecycle.clone());
+            lifecycle.complete_cancellation();
+            drop(guard);
+        });
+
+        assert_eq!(recorder.outcomes(), vec!["cancelled"]);
+    }
+
+    /// Records the `outcome` string of every completion event to assert disconnect semantics.
+    #[derive(Clone, Debug, Default)]
+    struct OutcomeRecorder {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl OutcomeRecorder {
+        /// Builds the scoped subscriber layer used by one test.
+        fn layer(&self) -> OutcomeRecordingLayer {
+            OutcomeRecordingLayer {
+                outcomes: self.outcomes.clone(),
+            }
+        }
+
+        /// Returns captured completion outcomes in emission order.
+        fn outcomes(&self) -> Vec<String> {
+            self.outcomes.lock().unwrap().clone()
+        }
+    }
+
+    /// Captures the `outcome` field of completion events for disconnect-semantics assertions.
+    #[derive(Clone, Debug)]
+    struct OutcomeRecordingLayer {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S> Layer<S> for OutcomeRecordingLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
+            let mut visitor = OutcomeVisitor::default();
+            event.record(&mut visitor);
+            self.outcomes
+                .lock()
+                .unwrap()
+                .push(visitor.outcome.unwrap_or_default());
+        }
+    }
+
+    /// Extracts the `outcome` field from a completion event.
+    #[derive(Default)]
+    struct OutcomeVisitor {
+        outcome: Option<String>,
+    }
+
+    impl tracing::field::Visit for OutcomeVisitor {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "outcome" {
+                self.outcome = Some(value.to_string());
+            }
+        }
+
+        fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
     }
 }

--- a/docs/desktop-runtime.md
+++ b/docs/desktop-runtime.md
@@ -9,6 +9,9 @@ request id, opens the request span, invokes unary business logic, projects any b
 records at most one completion event. Session load, prompt, and `watchAppEvents` operations use `stream_contract`, which
 forwards ordered `data`, `error`, and `end` frames over a Tauri Channel. A private call id allows an
 `AbortSignal` to cancel only that stream, while one separate request id correlates the complete stream.
+Every terminal frame is offered to the Channel before the forwarding task exits. Explicit cancellation
+and a failed non-terminal delivery record `cancelled`; the runtime does not actively probe an idle
+Channel, so a client that disappears without cancelling is observed only when a later delivery fails.
 
 The frontend injects `createTauriTransport()` into `createContractsClient`. The transport maps contract operation names to Tauri commands and forwards the original request DTO unchanged. Shared backend failures use the same direct `{ code, params, requestId }` payload as Web, without a public message or outer envelope. Tauri and fetch reuse the same runtime decoder; local Tauri invocation failures have no HTTP status and never invent a request id.
 
@@ -62,7 +65,8 @@ Desktop initializes `ora-logging` before opening the backend and registers the G
 
 Each unary command or stream emits at most one request-completion event using the same request id as
 its public failure payload or error frame. Cancellation is completed at `DEBUG` and is not projected
-as `internal_error`. If rollback or cleanup also fails, Desktop retains the primary response and
+as `internal_error`. For streams, this covers explicit cancellation and channel closure observed while
+delivering a non-terminal frame. If rollback or cleanup also fails, Desktop retains the primary response and
 source chain and records the secondary failure as a separate operation with the same request id.
 
 At startup, Desktop reads the operating system's IANA timezone and fixes it for the process

--- a/docs/runtime-logging.md
+++ b/docs/runtime-logging.md
@@ -67,7 +67,7 @@ The RFC 3339 timestamp uses the configured process timezone and includes its UTC
 
 ## Request completion and errors
 
-Long-lived streams, including task workspace watching, mark the response as deferred and emit completion only when the stream ends or reports its typed contract error.
+Long-lived streams, including task workspace watching, mark the response as deferred and emit completion when the stream ends, reports its typed contract error, or is disconnected by the client. A client disconnect records a `cancelled` completion at `DEBUG` level, matching the explicit-cancellation path, so a dropped connection never silently erases the request from the completion log.
 
 Ora frontend requests receive a canonical UUID v4 at the Web, Tauri, or stream entry seam. The same identifier correlates the request span, public error payload or stream error frame, and completion event; Web also returns it through `X-Request-Id`. Client-provided request identifiers are never canonical.
 

--- a/docs/runtime-logging.md
+++ b/docs/runtime-logging.md
@@ -67,7 +67,7 @@ The RFC 3339 timestamp uses the configured process timezone and includes its UTC
 
 ## Request completion and errors
 
-Long-lived streams, including task workspace watching, mark the response as deferred and emit completion when the stream ends, reports its typed contract error, or is disconnected by the client. A client disconnect records a `cancelled` completion at `DEBUG` level, matching the explicit-cancellation path, so a dropped connection never silently erases the request from the completion log.
+Long-lived streams, including task workspace watching, defer completion until the stream ends, reports its typed contract error, or observes cancellation. Web response-body drop records `cancelled`, while Desktop records it for explicit cancellation or a failed non-terminal Channel delivery. These observed disconnect paths complete at `DEBUG` level instead of silently erasing the request from the completion log. Desktop does not actively probe an idle Channel, so a client that disappears without explicit cancellation is detected only when a later delivery fails.
 
 Ora frontend requests receive a canonical UUID v4 at the Web, Tauri, or stream entry seam. The same identifier correlates the request span, public error payload or stream error frame, and completion event; Web also returns it through `X-Request-Id`. Client-provided request identifiers are never canonical.
 


### PR DESCRIPTION
## 背景

解决 issue #200（`pr-review-twice`）。

PR #185 的运行时日志改造目标是「每个请求恰好一条带 request_id 的完成日志」，但存在一个设计缺口：**流式请求在客户端断连时丢失完成事件**，且 Web 与 Tauri 两端不对称。

- **Web**：`stream_response`（`sessions.rs` / `workspace_files.rs`）用 `stream::unfold`，`complete_*` 只在 `events.recv().await` 有返回值时才调用。客户端断开 HTTP 连接时，axum drop 掉 `Body::from_stream` 的 future → `unfold` 在 `recv().await` 中途被 drop → `lifecycle` 被 drop → `complete_*` 从未调用 → 中间件看到 `DeferredCompletion` 也不补完成 → **该请求在完成日志中完全消失**。
- **Tauri**：`forward_contract_stream` 的 `on_event.send(frame).is_err()`（客户端关闭 Channel）分支直接 `break`，未调任何 `complete_*`；`forward_workspace_watch` 更严重，断连被**误记成 `success`**。

## 改动方案

### Web：Drop guard 补记 cancelled

新增 `StreamCompletionGuard`（`crates/backend/src/request_lifecycle.rs`），`Drop` 时调用 `complete_cancellation()`，塞进 `unfold` 的 state。利用 `RequestLifecycle` 已有的 exactly-once CAS 保护：

- 正常结束：`complete_success/failure` 先认领 → guard 是 no-op。
- 断连：无 `complete_*` 被调 → guard 补记一条 `cancelled`。

无需 async Drop：`complete_cancellation` 是同步的 tracing 写入 + 原子 CAS。

### Tauri：FrameSink 接缝 + 发送失败补 cancelled

- 引入 `FrameSink` trait 作为帧投递接缝，让发送失败路径可稳定单测。
- 抽出同步 `forward_frame(event, sink, lifecycle) -> ControlFlow<()>`：非终态帧发送失败时调用 `complete_cancellation()`。
- `forward_workspace_watch` 用 `WatchEnd` 枚举区分「取消」与「通道关闭」，后者映射为 `cancelled`。

### 文档

更新 `docs/runtime-logging.md`，明确客户端断连会产生 `cancelled` 完成日志。

## 测试

- 单测：guard 三个不变量（success 后 no-op / 无完成时 cancelled / 幂等）；Tauri 发送失败 → cancelled、终态帧不双记。
- 集成：`watch_stream_disconnect_emits_cancelled` 走真实 axum body-drop 路径断言 `cancelled`。
- 全量：backend 112 / web 38 / desktop 42 测试通过，clippy + fmt 干净。
- 手动：对话中关闭会话面板，日志出现 `POST /api/sessions/.../prompt` → `outcome=cancelled`（DEBUG）。

Closes #200
