### PR TITLE
fix: map multipart rejections to contract errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,6 +1921,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "zip",
 ]

--- a/apps/web/server/Cargo.toml
+++ b/apps/web/server/Cargo.toml
@@ -35,5 +35,6 @@ pretty_assertions = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
 zip = { workspace = true }

--- a/apps/web/server/src/error.rs
+++ b/apps/web/server/src/error.rs
@@ -1,5 +1,6 @@
 use axum::Json;
 use axum::extract::Request;
+use axum::extract::multipart::MultipartRejection;
 use axum::extract::rejection::JsonRejection;
 use axum::http::{HeaderValue, StatusCode, header::HeaderName};
 use axum::middleware::Next;
@@ -199,8 +200,16 @@ impl From<JsonRejection> for WebApiError {
 }
 
 impl From<axum::extract::rejection::QueryRejection> for WebApiError {
+    /// Maps malformed query extraction into the stable invalid-request contract.
     fn from(_error: axum::extract::rejection::QueryRejection) -> Self {
         Self::invalid_request("failed to decode query request")
+    }
+}
+
+impl From<MultipartRejection> for WebApiError {
+    /// Maps invalid or missing multipart boundaries into the stable invalid-request contract.
+    fn from(_error: MultipartRejection) -> Self {
+        Self::invalid_request("failed to decode multipart request")
     }
 }
 
@@ -272,14 +281,19 @@ const fn status_for(classification: ErrorClassification) -> StatusCode {
 #[cfg(test)]
 mod tests {
     use super::{WebApiError, status_for};
-    use axum::body::to_bytes;
-    use axum::http::StatusCode;
+    use axum::body::{Body, to_bytes};
+    use axum::extract::{FromRequest, Multipart};
+    use axum::http::{Request, StatusCode, header::CONTENT_TYPE};
     use axum::response::IntoResponse;
     use ora_application::ApplicationError;
     use ora_backend::ErrorClassification;
     use ora_contracts::RequestId;
+    use ora_logging::with_recorded_trace_logging;
     use pretty_assertions::assert_eq;
     use serde_json::{Value, json};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::layer::{Context, Layer};
+    use tracing_subscriber::registry::LookupSpan;
 
     /// Verifies transport-only upload limits retain their native HTTP status.
     #[test]
@@ -324,5 +338,98 @@ mod tests {
                 "params": { "branchName": "ghost-branch" },
             })
         );
+    }
+
+    /// Verifies multipart extractor failures use the contract envelope and failure telemetry.
+    #[tokio::test]
+    async fn maps_multipart_rejection_to_contract_error_and_failure_telemetry() {
+        let request = Request::builder()
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::empty())
+            .expect("invalid multipart request should be constructible");
+        let rejection = match Multipart::from_request(request, &()).await {
+            Ok(_) => panic!("non-multipart content type must be rejected"),
+            Err(error) => error,
+        };
+        let recorder = OutcomeRecorder::default();
+        let response = with_recorded_trace_logging(recorder.layer(), || {
+            WebApiError::from(rejection).into_response()
+        });
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("error response should be readable");
+        let mut actual: Value =
+            serde_json::from_slice(&bytes).expect("error response should be valid JSON");
+        actual
+            .as_object_mut()
+            .expect("error response should be an object")
+            .remove("requestId");
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(actual, json!({ "code": "invalid_request", "params": {} }));
+        assert_eq!(recorder.outcomes(), vec!["failure"]);
+    }
+
+    /// Records request outcomes without depending on the process-global subscriber.
+    #[derive(Clone, Debug, Default)]
+    struct OutcomeRecorder {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl OutcomeRecorder {
+        /// Builds the tracing layer used by the scoped telemetry assertion.
+        fn layer(&self) -> OutcomeLayer {
+            OutcomeLayer {
+                outcomes: self.outcomes.clone(),
+            }
+        }
+
+        /// Returns the request outcomes observed by the recorder.
+        fn outcomes(&self) -> Vec<String> {
+            self.outcomes.lock().unwrap().clone()
+        }
+    }
+
+    /// Captures only the semantic outcome field from completion events.
+    #[derive(Clone, Debug)]
+    struct OutcomeLayer {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S> Layer<S> for OutcomeLayer
+    where
+        S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        /// Stores each emitted outcome so tests can distinguish failure from success.
+        fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
+            let mut visitor = OutcomeVisitor::default();
+            event.record(&mut visitor);
+            if let Some(outcome) = visitor.outcome {
+                self.outcomes.lock().unwrap().push(outcome);
+            }
+        }
+    }
+
+    /// Extracts the string value of the lifecycle outcome field.
+    #[derive(Default)]
+    struct OutcomeVisitor {
+        outcome: Option<String>,
+    }
+
+    impl tracing::field::Visit for OutcomeVisitor {
+        /// Preserves string-valued outcome fields exactly.
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "outcome" {
+                self.outcome = Some(value.to_string());
+            }
+        }
+
+        /// Handles outcome values emitted through debug formatting.
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "outcome" {
+                self.outcome = Some(format!("{value:?}").trim_matches('"').to_string());
+            }
+        }
     }
 }

--- a/apps/web/server/src/error.rs
+++ b/apps/web/server/src/error.rs
@@ -279,7 +279,77 @@ const fn status_for(classification: ErrorClassification) -> StatusCode {
 }
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::layer::{Context, Layer};
+    use tracing_subscriber::registry::LookupSpan;
+
+    /// Records request outcomes without depending on the process-global subscriber.
+    #[derive(Clone, Debug, Default)]
+    pub(crate) struct OutcomeRecorder {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl OutcomeRecorder {
+        /// Builds the tracing layer used by scoped telemetry assertions.
+        pub(crate) fn layer(&self) -> OutcomeLayer {
+            OutcomeLayer {
+                outcomes: self.outcomes.clone(),
+            }
+        }
+
+        /// Returns the request outcomes observed by the recorder.
+        pub(crate) fn outcomes(&self) -> Vec<String> {
+            self.outcomes.lock().unwrap().clone()
+        }
+    }
+
+    /// Captures only the semantic outcome field from completion events.
+    #[derive(Clone, Debug)]
+    pub(crate) struct OutcomeLayer {
+        outcomes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S> Layer<S> for OutcomeLayer
+    where
+        S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        /// Stores each emitted outcome so tests can distinguish failure from success.
+        fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
+            let mut visitor = OutcomeVisitor::default();
+            event.record(&mut visitor);
+            if let Some(outcome) = visitor.outcome {
+                self.outcomes.lock().unwrap().push(outcome);
+            }
+        }
+    }
+
+    /// Extracts the string value of the lifecycle outcome field.
+    #[derive(Default)]
+    struct OutcomeVisitor {
+        outcome: Option<String>,
+    }
+
+    impl tracing::field::Visit for OutcomeVisitor {
+        /// Preserves string-valued outcome fields exactly.
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "outcome" {
+                self.outcome = Some(value.to_string());
+            }
+        }
+
+        /// Handles outcome values emitted through debug formatting.
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "outcome" {
+                self.outcome = Some(format!("{value:?}").trim_matches('"').to_string());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use super::test_support::OutcomeRecorder;
     use super::{WebApiError, status_for};
     use axum::body::{Body, to_bytes};
     use axum::extract::{FromRequest, Multipart};
@@ -291,9 +361,6 @@ mod tests {
     use ora_logging::with_recorded_trace_logging;
     use pretty_assertions::assert_eq;
     use serde_json::{Value, json};
-    use std::sync::{Arc, Mutex};
-    use tracing_subscriber::layer::{Context, Layer};
-    use tracing_subscriber::registry::LookupSpan;
 
     /// Verifies transport-only upload limits retain their native HTTP status.
     #[test]
@@ -369,67 +436,5 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(actual, json!({ "code": "invalid_request", "params": {} }));
         assert_eq!(recorder.outcomes(), vec!["failure"]);
-    }
-
-    /// Records request outcomes without depending on the process-global subscriber.
-    #[derive(Clone, Debug, Default)]
-    struct OutcomeRecorder {
-        outcomes: Arc<Mutex<Vec<String>>>,
-    }
-
-    impl OutcomeRecorder {
-        /// Builds the tracing layer used by the scoped telemetry assertion.
-        fn layer(&self) -> OutcomeLayer {
-            OutcomeLayer {
-                outcomes: self.outcomes.clone(),
-            }
-        }
-
-        /// Returns the request outcomes observed by the recorder.
-        fn outcomes(&self) -> Vec<String> {
-            self.outcomes.lock().unwrap().clone()
-        }
-    }
-
-    /// Captures only the semantic outcome field from completion events.
-    #[derive(Clone, Debug)]
-    struct OutcomeLayer {
-        outcomes: Arc<Mutex<Vec<String>>>,
-    }
-
-    impl<S> Layer<S> for OutcomeLayer
-    where
-        S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
-    {
-        /// Stores each emitted outcome so tests can distinguish failure from success.
-        fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
-            let mut visitor = OutcomeVisitor::default();
-            event.record(&mut visitor);
-            if let Some(outcome) = visitor.outcome {
-                self.outcomes.lock().unwrap().push(outcome);
-            }
-        }
-    }
-
-    /// Extracts the string value of the lifecycle outcome field.
-    #[derive(Default)]
-    struct OutcomeVisitor {
-        outcome: Option<String>,
-    }
-
-    impl tracing::field::Visit for OutcomeVisitor {
-        /// Preserves string-valued outcome fields exactly.
-        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-            if field.name() == "outcome" {
-                self.outcome = Some(value.to_string());
-            }
-        }
-
-        /// Handles outcome values emitted through debug formatting.
-        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-            if field.name() == "outcome" {
-                self.outcome = Some(format!("{value:?}").trim_matches('"').to_string());
-            }
-        }
     }
 }

--- a/apps/web/server/src/handlers/skill_imports.rs
+++ b/apps/web/server/src/handlers/skill_imports.rs
@@ -2,6 +2,7 @@ use crate::app_state::AppState;
 use crate::error::WebApiError;
 use axum::Json;
 use axum::extract::Path as AxumPath;
+use axum::extract::multipart::MultipartRejection;
 use axum::extract::{Multipart, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -48,8 +49,9 @@ const MAX_FOLDER_UPLOAD_BYTES: u64 = 200 * 1024 * 1024;
 pub async fn prepare_skill_import(
     State(app_state): State<AppState>,
     Query(query): Query<PrepareSkillImportQuery>,
-    multipart: Multipart,
+    multipart: Result<Multipart, MultipartRejection>,
 ) -> Result<Json<PrepareSkillImportResponse>, WebApiError> {
+    let multipart = multipart?;
     let upload_root =
         std::env::temp_dir().join(format!("ora-skill-import-upload-{}", Uuid::new_v4()));
     fs::create_dir_all(&upload_root)

--- a/apps/web/server/src/routes.rs
+++ b/apps/web/server/src/routes.rs
@@ -1110,6 +1110,41 @@ mod tests {
         assert_contract_error(&response_json(get_response).await, "session_not_found");
     }
 
+    /// Verifies every multipart failure path returns the contract envelope instead of Axum text.
+    #[tokio::test]
+    async fn maps_multipart_failures_to_contract_errors() {
+        let (_temp_dir, _database_path, app) = test_router();
+        let requests = [
+            ("application/json", Body::empty()),
+            ("multipart/form-data", Body::empty()),
+            (
+                "multipart/form-data; boundary=boundary",
+                Body::from("malformed multipart body"),
+            ),
+        ];
+
+        for (content_type, body) in requests {
+            let response = match app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/api/skill-imports?mode=folder")
+                        .header("content-type", content_type)
+                        .body(body)
+                        .unwrap_or_else(|error| panic!("failed to build request: {error}")),
+                )
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => panic!("request failed: {error}"),
+            };
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert_contract_error(&response_json(response).await, "invalid_request");
+        }
+    }
+
     /// Verifies catalog routes address resources by identifier while names remain editable fields.
     #[tokio::test]
     async fn serves_skill_and_agent_crud_routes() {

--- a/apps/web/server/src/routes.rs
+++ b/apps/web/server/src/routes.rs
@@ -265,6 +265,7 @@ fn skill_imports_router() -> Router<AppState> {
 mod tests {
     use super::build_router;
     use crate::bootstrap::build_app_state_for_database;
+    use crate::error::test_support::OutcomeRecorder;
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request, StatusCode};
     use ora_application::WorktreeRepository;
@@ -1110,39 +1111,49 @@ mod tests {
         assert_contract_error(&response_json(get_response).await, "session_not_found");
     }
 
-    /// Verifies every multipart failure path returns the contract envelope instead of Axum text.
-    #[tokio::test]
-    async fn maps_multipart_failures_to_contract_errors() {
-        let (_temp_dir, _database_path, app) = test_router();
-        let requests = [
-            ("application/json", Body::empty()),
-            ("multipart/form-data", Body::empty()),
-            (
-                "multipart/form-data; boundary=boundary",
-                Body::from("malformed multipart body"),
-            ),
-        ];
+    /// Verifies every multipart failure path returns the contract envelope and failure telemetry.
+    #[test]
+    fn maps_multipart_failures_to_contract_errors() {
+        let recorder = OutcomeRecorder::default();
+        ora_logging::with_recorded_trace_logging(recorder.layer(), || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("multipart route test runtime should be constructible");
+            runtime.block_on(async {
+                let (_temp_dir, _database_path, app) = test_router();
+                let requests = [
+                    ("application/json", Body::empty()),
+                    ("multipart/form-data", Body::empty()),
+                    (
+                        "multipart/form-data; boundary=boundary",
+                        Body::from("malformed multipart body"),
+                    ),
+                ];
 
-        for (content_type, body) in requests {
-            let response = match app
-                .clone()
-                .oneshot(
-                    Request::builder()
-                        .method(Method::POST)
-                        .uri("/api/skill-imports?mode=folder")
-                        .header("content-type", content_type)
-                        .body(body)
-                        .unwrap_or_else(|error| panic!("failed to build request: {error}")),
-                )
-                .await
-            {
-                Ok(response) => response,
-                Err(error) => panic!("request failed: {error}"),
-            };
+                for (index, (content_type, body)) in requests.into_iter().enumerate() {
+                    let response = match app
+                        .clone()
+                        .oneshot(
+                            Request::builder()
+                                .method(Method::POST)
+                                .uri("/api/skill-imports?mode=folder")
+                                .header("content-type", content_type)
+                                .body(body)
+                                .unwrap_or_else(|error| panic!("failed to build request: {error}")),
+                        )
+                        .await
+                    {
+                        Ok(response) => response,
+                        Err(error) => panic!("request failed: {error}"),
+                    };
 
-            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-            assert_contract_error(&response_json(response).await, "invalid_request");
-        }
+                    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+                    assert_contract_error(&response_json(response).await, "invalid_request");
+                    assert_eq!(recorder.outcomes(), vec!["failure".to_string(); index + 1]);
+                }
+            });
+        });
     }
 
     /// Verifies catalog routes address resources by identifier while names remain editable fields.


### PR DESCRIPTION
## Summary

- Map multipart extractor rejections to the unified `ContractError` JSON envelope.
- Ensure invalid multipart requests complete request telemetry as failures.
- Add response and telemetry regression tests for invalid content type, missing boundary, and malformed multipart bodies.

## Root cause

Axum rejected invalid multipart headers before `prepare_skill_import` ran, so the default text response bypassed `WebApiError` and the request lifecycle recorded success.

## Validation

- `cargo test -p ora-web-server --bin ora_web_server maps_multipart`
- `cargo check -p ora-web-server --bin ora_web_server`
- `cargo fmt --all -- --check`
- `git diff --check`

The complete web-server suite currently has two pre-existing route test failures (`serves_spec_management_routes` and `serves_task_crud_routes`); the new #224 tests pass.

Fixes #224
