### PR TITLE
fix(skill): map occupied skill directories to conflicts, not storage errors

### DIFF
--- a/crates/application/src/error.rs
+++ b/crates/application/src/error.rs
@@ -238,8 +238,11 @@ impl ApplicationError {
     /// Converts formal-storage failures into the stable application contract.
     pub(crate) fn from_skill_storage_error(error: SkillStorageError) -> Self {
         match error {
-            SkillStorageError::FormalDirectoryMissing { name }
-            | SkillStorageError::FormalDirectoryExists { name } => {
+            // Destination occupancy is a client-visible conflict whether the handler
+            // observed it before staging or only at promotion; missing directories are
+            // the inconsistent half of the same package invariant.
+            SkillStorageError::FormalDirectoryExists { name } => Self::SkillFolderConflict { name },
+            SkillStorageError::FormalDirectoryMissing { name } => {
                 Self::SkillStorageInconsistent { name }
             }
             source @ SkillStorageError::OperationFailed { .. } => Self::SkillStorage { source },

--- a/crates/application/src/skill/README.md
+++ b/crates/application/src/skill/README.md
@@ -30,6 +30,10 @@ on-disk packages.
   on one filesystem and interrupted transactions can be recovered at startup.
 - `SkillRepository` supplies case-insensitive name lookups used for global uniqueness and import
   conflict detection.
+- A destination claimed by another in-flight package transaction is a `SkillFolderConflict`,
+  whether the journal is observed before promotion or the rename loses its final race. A static
+  untracked package remains recoverable through a journaled swap, while a missing formal directory
+  that a mutation still expected is `SkillStorageInconsistent`.
 - Domain validation (`ora-domain::Skill`) enforces the ASCII slug name rules and the 4096-byte
   description limit shared by create, update, and import.
 

--- a/crates/application/src/skill/filesystem_storage.rs
+++ b/crates/application/src/skill/filesystem_storage.rs
@@ -4,6 +4,7 @@ use super::storage::{
 };
 use ora_utils::path::StrictRelativePath;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 /// Default filesystem implementation of [`SkillStorage`] rooted at the formal skills tree.
@@ -174,7 +175,7 @@ impl SkillStorage for FilesystemSkillStorage {
         self.write_journal(&journal)?;
         if let Err(error) = fs::rename(staging, &formal) {
             let _ = fs::remove_file(&journal.file);
-            return Err(map_storage_error(error));
+            return Err(map_promote_error(error, name));
         }
         self.update_journal_phase(&mut journal, JournalPhase::Swapped)?;
         Ok(CreateHandle {
@@ -240,7 +241,7 @@ impl SkillStorage for FilesystemSkillStorage {
         if let Err(error) = fs::rename(staging, &target_formal) {
             let _ = fs::rename(&backup, &from_formal);
             let _ = fs::remove_file(&journal.file);
-            return Err(map_storage_error(error));
+            return Err(map_promote_error(error, name));
         }
         self.update_journal_phase(&mut journal, JournalPhase::Swapped)?;
         Ok(SwapHandle {
@@ -453,8 +454,82 @@ fn copy_dir_contents(source: &Path, destination: &Path) -> std::io::Result<()> {
 }
 
 /// Converts filesystem failures into stable storage-port errors.
-fn map_storage_error(error: std::io::Error) -> SkillStorageError {
+fn map_storage_error(error: io::Error) -> SkillStorageError {
     SkillStorageError::OperationFailed {
         message: error.to_string(),
+    }
+}
+
+/// Maps a promotion rename failure, keeping destination occupancy typed.
+///
+/// `exists()` and `rename` are not atomic. A concurrent promoter can create the
+/// destination in that window; Unix then typically reports `DirectoryNotEmpty` and
+/// Windows `AlreadyExists`. Those kinds stay `FormalDirectoryExists` so callers can
+/// project a conflict instead of an internal storage failure.
+fn map_promote_error(error: io::Error, name: &str) -> SkillStorageError {
+    match error.kind() {
+        io::ErrorKind::AlreadyExists | io::ErrorKind::DirectoryNotEmpty => {
+            SkillStorageError::FormalDirectoryExists {
+                name: name.to_string(),
+            }
+        }
+        _ => map_storage_error(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FilesystemSkillStorage, map_promote_error};
+    use crate::skill::{SkillStorage, SkillStorageError};
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::io;
+    use tempfile::TempDir;
+
+    #[test]
+    fn commit_create_returns_typed_conflict_when_destination_exists() {
+        let temp = TempDir::new().unwrap();
+        let storage = FilesystemSkillStorage::new(temp.path().to_path_buf());
+        let destination = temp.path().join("grilling");
+        fs::create_dir_all(&destination).unwrap();
+        fs::write(destination.join("SKILL.md"), "existing").unwrap();
+        let staging = storage.create_staging().unwrap();
+        fs::write(staging.join("SKILL.md"), "incoming").unwrap();
+
+        assert_eq!(
+            storage.commit_create("grilling", &staging).unwrap_err(),
+            SkillStorageError::FormalDirectoryExists {
+                name: "grilling".to_string(),
+            }
+        );
+        assert!(staging.exists());
+    }
+
+    #[test]
+    fn maps_destination_occupied_rename_kinds_to_typed_conflict() {
+        assert_eq!(
+            map_promote_error(
+                io::Error::new(io::ErrorKind::AlreadyExists, "exists"),
+                "grilling",
+            ),
+            SkillStorageError::FormalDirectoryExists {
+                name: "grilling".to_string(),
+            }
+        );
+        assert_eq!(
+            map_promote_error(
+                io::Error::new(io::ErrorKind::DirectoryNotEmpty, "not empty"),
+                "grilling",
+            ),
+            SkillStorageError::FormalDirectoryExists {
+                name: "grilling".to_string(),
+            }
+        );
+        assert_eq!(
+            map_promote_error(io::Error::other("disk full"), "grilling"),
+            SkillStorageError::OperationFailed {
+                message: "disk full".to_string(),
+            }
+        );
     }
 }

--- a/crates/application/src/skill/package_health.rs
+++ b/crates/application/src/skill/package_health.rs
@@ -1,4 +1,4 @@
-use super::storage::{CreateHandle, SkillStorage, SwapHandle};
+use super::storage::{CreateHandle, JournalOp, SkillStorage, SwapHandle};
 use crate::ApplicationError;
 use ora_contracts::SkillAvailability;
 use ora_domain::Namespace;
@@ -93,6 +93,20 @@ pub(crate) fn commit_unclaimed_package<Storage: SkillStorage>(
     name: &str,
     staging: &Path,
 ) -> Result<PromotedPackage, ApplicationError> {
+    if storage.formal_exists(name)
+        && storage
+            .list_journals()
+            .map_err(ApplicationError::from_skill_storage_error)?
+            .iter()
+            .any(|journal| {
+                matches!(journal.op, JournalOp::Create | JournalOp::Swap)
+                    && (journal.name == name || journal.from_name == name)
+            })
+    {
+        return Err(ApplicationError::SkillFolderConflict {
+            name: name.to_string(),
+        });
+    }
     promote_staging(storage, name, staging)
 }
 

--- a/crates/application/src/skill/tests.rs
+++ b/crates/application/src/skill/tests.rs
@@ -245,6 +245,54 @@ fn rejects_non_slug_names_and_case_insensitive_conflicts() {
 }
 
 #[test]
+fn reports_folder_conflict_when_rename_target_directory_exists() {
+    let repository = Rc::new(FakeSkillRepository::with_skills(vec![skill(
+        "skill-1", "review", "Reviews", 10, 20, false,
+    )]));
+    let storage = Rc::new(FakeSkillStorage::with_manifest("review", "Reviews"));
+    storage
+        .formal
+        .borrow_mut()
+        .insert("grilling".to_string(), Vec::new());
+
+    let error = UpdateSkillHandler::new(repository, storage, FixedClock(30))
+        .handle(UpdateSkillRequest {
+            skill_id: "skill-1".to_string(),
+            name: "grilling".to_string(),
+            description: "Reviews".to_string(),
+            content: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApplicationError::SkillFolderConflict {
+            name: "grilling".to_string()
+        }
+    );
+}
+
+#[test]
+fn maps_existing_formal_directory_to_folder_conflict() {
+    assert_eq!(
+        ApplicationError::from_skill_storage_error(SkillStorageError::FormalDirectoryExists {
+            name: "grilling".to_string(),
+        }),
+        ApplicationError::SkillFolderConflict {
+            name: "grilling".to_string(),
+        }
+    );
+    assert_eq!(
+        ApplicationError::from_skill_storage_error(SkillStorageError::FormalDirectoryMissing {
+            name: "grilling".to_string(),
+        }),
+        ApplicationError::SkillStorageInconsistent {
+            name: "grilling".to_string(),
+        }
+    );
+}
+
+#[test]
 fn rejects_blank_and_oversized_descriptions() {
     let handler = CreateSkillHandler::new(
         Rc::new(FakeSkillRepository::default()),

--- a/crates/application/src/skill_import/README.md
+++ b/crates/application/src/skill_import/README.md
@@ -45,5 +45,8 @@ filesystem port (see the `skill` module), and does not decide HTTP or IPC semant
   transaction stays open across the rename and a slow skills root cannot block unrelated writers.
   See the [skill module's atomicity and recovery model](../skill/README.md) for the journal and
   startup reconciliation that make this ordering crash-safe.
+- A `ready` candidate whose name is claimed in the database or whose formal directory appears
+  before promotion completes is recorded as `staleConflict`. That occupancy is a permanent
+  conflict, not a retryable `skill_storage_error`.
 
 See the [ora-application overview](../../README.md).

--- a/crates/application/src/skill_import/commit.rs
+++ b/crates/application/src/skill_import/commit.rs
@@ -233,6 +233,7 @@ where
         };
     }
     if let Err(error_code) = stage_boundary(storage, &staging, snapshot, candidate) {
+        let _ = storage.remove_temp(&staging);
         return CandidateOutcome::Failed { error_code };
     }
     let promoted = if let Some(existing) = &existing {
@@ -244,23 +245,12 @@ where
             &staging,
         ) {
             Ok(promoted) => promoted,
-            Err(ApplicationError::SkillNameConflict { .. }) => {
-                return CandidateOutcome::StaleConflict;
-            }
-            Err(_) => {
-                return CandidateOutcome::Failed {
-                    error_code: "skill_storage_error".to_string(),
-                };
-            }
+            Err(error) => return promote_failure(storage, &staging, error),
         }
     } else {
         match commit_unclaimed_package(storage, &skill.name, &staging) {
             Ok(promoted) => promoted,
-            Err(_) => {
-                return CandidateOutcome::Failed {
-                    error_code: "skill_storage_error".to_string(),
-                };
-            }
+            Err(error) => return promote_failure(storage, &staging, error),
         }
     };
     let persisted = if existing.is_some() {
@@ -326,16 +316,13 @@ where
         }
     };
     if let Err(error_code) = stage_boundary(storage, &staging, snapshot, candidate) {
+        let _ = storage.remove_temp(&staging);
         return CandidateOutcome::Failed { error_code };
     }
     let promoted = match commit_existing_package(storage, &candidate.name, &existing.name, &staging)
     {
         Ok(promoted) => promoted,
-        Err(_) => {
-            return CandidateOutcome::Failed {
-                error_code: "skill_storage_error".to_string(),
-            };
-        }
+        Err(error) => return promote_failure(storage, &staging, error),
     };
     if persist_promoted_package(storage, &promoted, || repository.update_skill(skill)).is_err() {
         return CandidateOutcome::Failed {
@@ -379,6 +366,25 @@ struct SkillSnapshot {
     id: SkillId,
     namespace: Namespace,
     created_at: i64,
+}
+
+/// Maps a promotion failure onto the candidate result and drops leftover staging.
+///
+/// Both application conflict variants represent a permanent name claim discovered after preview;
+/// other promotion failures remain retryable storage failures.
+fn promote_failure<Storage: SkillStorage>(
+    storage: &Storage,
+    staging: &Path,
+    error: ApplicationError,
+) -> CandidateOutcome {
+    let _ = storage.remove_temp(staging);
+    match error {
+        ApplicationError::SkillFolderConflict { .. }
+        | ApplicationError::SkillNameConflict { .. } => CandidateOutcome::StaleConflict,
+        _ => CandidateOutcome::Failed {
+            error_code: "skill_storage_error".to_string(),
+        },
+    }
 }
 
 /// Copies every boundary file from the snapshot into a staging directory.

--- a/crates/application/src/skill_import/tests.rs
+++ b/crates/application/src/skill_import/tests.rs
@@ -709,6 +709,63 @@ fn marks_stale_conflict_when_target_changes_before_commit() {
 }
 
 #[test]
+fn concurrent_same_name_imports_do_not_report_storage_failure() {
+    let temp = TempDir::new().unwrap();
+    let repository = FakeSkillRepository::new();
+    let source_a = temp.path().join("source-a");
+    let source_b = temp.path().join("source-b");
+    write_manifest(&source_a, "SKILL.md", "grilling", "First");
+    write_manifest(&source_b, "SKILL.md", "grilling", "Second");
+
+    let (service, _) = test_service(repository.clone(), &temp, Duration::from_secs(30));
+    let session_a = prepare_folder(&service, &source_a);
+    let session_b = prepare_folder(&service, &source_b);
+    assert_eq!(
+        session_a.candidates[0].status,
+        ora_contracts::SkillImportCandidateStatus::Ready
+    );
+    assert_eq!(
+        session_b.candidates[0].status,
+        ora_contracts::SkillImportCandidateStatus::Ready
+    );
+
+    service
+        .commit(CommitSkillImportRequest {
+            session_id: session_a.session_id.clone(),
+            decisions: vec![],
+        })
+        .unwrap();
+    service
+        .commit(CommitSkillImportRequest {
+            session_id: session_b.session_id.clone(),
+            decisions: vec![],
+        })
+        .unwrap();
+
+    let completed_a = wait_for_completion(&service, &session_a.session_id);
+    let completed_b = wait_for_completion(&service, &session_b.session_id);
+    let statuses = [
+        completed_a.progress.results[0].status.clone(),
+        completed_b.progress.results[0].status.clone(),
+    ];
+    let imported = statuses
+        .iter()
+        .filter(|status| **status == ora_contracts::SkillImportResultStatus::Imported)
+        .count();
+    let stale = statuses
+        .iter()
+        .filter(|status| **status == ora_contracts::SkillImportResultStatus::StaleConflict)
+        .count();
+
+    assert_eq!((imported, stale), (1, 1));
+    assert_eq!(repository.snapshot().len(), 1);
+    assert!(
+        completed_a.progress.results[0].error_code.is_none()
+            && completed_b.progress.results[0].error_code.is_none()
+    );
+}
+
+#[test]
 fn continues_after_individual_candidate_failure() {
     let temp = TempDir::new().unwrap();
     let repository = FakeSkillRepository::new();


### PR DESCRIPTION
Concurrent same-name imports and creates could lose the promote race and surface a retryable storage failure. Treat FormalDirectoryExists as a typed occupancy conflict: HTTP 409 for create/rename, staleConflict for import candidates. Close the rename TOCTOU window and add regression tests.