### PR TITLE
fix(skill): recover interrupted packages by journaled skill id

### DIFF
--- a/crates/application/src/skill/README.md
+++ b/crates/application/src/skill/README.md
@@ -27,7 +27,12 @@ on-disk packages.
 - `SkillStorage` isolates every filesystem mutation behind a statically dispatched port. The
   default `FilesystemSkillStorage` keeps staging, compensation backups, and journal markers under
   the reserved `<skills_root>/<.ora-staging|.ora-backup|.ora-journal>` directories so renames stay
-  on one filesystem and interrupted transactions can be recovered at startup.
+  on one filesystem and interrupted transactions can be recovered at startup. Each journal records
+  the immutable skill id so recovery attributes an in-flight directory to that identity rather
+  than to any visible row that happens to share the user-facing name. Swap journals for owned
+  packages also record the prior database version so a same-name update can distinguish an
+  uncommitted row write from
+  a fully committed or superseded update.
 - `SkillRepository` supplies case-insensitive name lookups used for global uniqueness and import
   conflict detection.
 - A destination claimed by another in-flight package transaction is a `SkillFolderConflict`,

--- a/crates/application/src/skill/filesystem_storage.rs
+++ b/crates/application/src/skill/filesystem_storage.rs
@@ -2,6 +2,7 @@ use super::storage::{
     BACKUP_DIR_NAME, CreateHandle, DeleteHandle, JOURNAL_DIR_NAME, JournalOp, JournalPhase,
     STAGING_DIR_NAME, SkillStorage, SkillStorageError, SwapHandle, TransactionJournal,
 };
+use ora_domain::SkillId;
 use ora_utils::path::StrictRelativePath;
 use std::fs;
 use std::io;
@@ -70,6 +71,7 @@ impl FilesystemSkillStorage {
     fn new_journal(
         &self,
         op: JournalOp,
+        skill_id: &SkillId,
         name: &str,
         from_name: &str,
         staging: Option<&Path>,
@@ -83,6 +85,7 @@ impl FilesystemSkillStorage {
             });
         TransactionJournal {
             op,
+            skill_id: skill_id.to_string(),
             name: name.to_string(),
             from_name: from_name.to_string(),
             staging: staging.map_or_else(String::new, |path| path.to_string_lossy().into_owned()),
@@ -164,14 +167,20 @@ impl SkillStorage for FilesystemSkillStorage {
         fs::write(staging.join("SKILL.md"), content).map_err(map_storage_error)
     }
 
-    fn commit_create(&self, name: &str, staging: &Path) -> Result<CreateHandle, SkillStorageError> {
+    fn commit_create(
+        &self,
+        name: &str,
+        skill_id: &SkillId,
+        staging: &Path,
+    ) -> Result<CreateHandle, SkillStorageError> {
         let formal = self.formal_path(name);
         if formal.exists() {
             return Err(SkillStorageError::FormalDirectoryExists {
                 name: name.to_string(),
             });
         }
-        let mut journal = self.new_journal(JournalOp::Create, name, name, Some(staging), None);
+        let mut journal =
+            self.new_journal(JournalOp::Create, skill_id, name, name, Some(staging), None);
         self.write_journal(&journal)?;
         if let Err(error) = fs::rename(staging, &formal) {
             let _ = fs::remove_file(&journal.file);
@@ -205,6 +214,8 @@ impl SkillStorage for FilesystemSkillStorage {
         &self,
         name: &str,
         from_name: &str,
+        skill_id: &SkillId,
+        previous_updated_at: Option<i64>,
         staging: &Path,
     ) -> Result<SwapHandle, SkillStorageError> {
         let target_formal = self.formal_path(name);
@@ -223,7 +234,10 @@ impl SkillStorage for FilesystemSkillStorage {
             .reserved_root(BACKUP_DIR_NAME)
             .join(new_transaction_id());
         let mut journal = self.new_journal(
-            JournalOp::Swap,
+            JournalOp::Swap {
+                previous_updated_at,
+            },
+            skill_id,
             name,
             from_name,
             Some(staging),
@@ -274,7 +288,11 @@ impl SkillStorage for FilesystemSkillStorage {
         Ok(())
     }
 
-    fn commit_delete(&self, name: &str) -> Result<DeleteHandle, SkillStorageError> {
+    fn commit_delete(
+        &self,
+        name: &str,
+        skill_id: &SkillId,
+    ) -> Result<DeleteHandle, SkillStorageError> {
         let formal = self.formal_path(name);
         if !formal.exists() {
             return Err(SkillStorageError::FormalDirectoryMissing {
@@ -284,7 +302,8 @@ impl SkillStorage for FilesystemSkillStorage {
         let backup = self
             .reserved_root(BACKUP_DIR_NAME)
             .join(new_transaction_id());
-        let mut journal = self.new_journal(JournalOp::Delete, name, name, None, Some(&backup));
+        let mut journal =
+            self.new_journal(JournalOp::Delete, skill_id, name, name, None, Some(&backup));
         self.write_journal(&journal)?;
         if let Some(parent) = backup.parent() {
             fs::create_dir_all(parent).map_err(map_storage_error)?;
@@ -481,6 +500,7 @@ fn map_promote_error(error: io::Error, name: &str) -> SkillStorageError {
 mod tests {
     use super::{FilesystemSkillStorage, map_promote_error};
     use crate::skill::{SkillStorage, SkillStorageError};
+    use ora_domain::SkillId;
     use pretty_assertions::assert_eq;
     use std::fs;
     use std::io;
@@ -497,7 +517,9 @@ mod tests {
         fs::write(staging.join("SKILL.md"), "incoming").unwrap();
 
         assert_eq!(
-            storage.commit_create("grilling", &staging).unwrap_err(),
+            storage
+                .commit_create("grilling", &SkillId::new("skill-1"), &staging)
+                .unwrap_err(),
             SkillStorageError::FormalDirectoryExists {
                 name: "grilling".to_string(),
             }

--- a/crates/application/src/skill/handlers.rs
+++ b/crates/application/src/skill/handlers.rs
@@ -104,7 +104,7 @@ where
         self.storage
             .write_manifest(&staging, manifest.as_bytes())
             .map_err(ApplicationError::from_skill_storage_error)?;
-        let promoted = commit_unclaimed_package(&self.storage, &skill.name, &staging)?;
+        let promoted = commit_unclaimed_package(&self.storage, &skill.id, &skill.name, &staging)?;
         let created = persist_promoted_package(&self.storage, &promoted, || {
             self.repository.create_skill(skill)
         })
@@ -264,6 +264,8 @@ where
             });
         }
 
+        let previous_updated_at = existing.audit_fields.updated_at;
+        let updated_at = next_updated_at(previous_updated_at, self.clock.now_timestamp_millis());
         let skill = Skill::new(
             skill_id,
             existing.namespace,
@@ -271,7 +273,7 @@ where
             request.description,
             AuditFields::new(
                 existing.audit_fields.created_at,
-                self.clock.now_timestamp_millis(),
+                updated_at,
                 /*is_deleted*/ false,
             ),
         )
@@ -306,8 +308,14 @@ where
         self.storage
             .write_manifest(&staging, rewritten.as_bytes())
             .map_err(ApplicationError::from_skill_storage_error)?;
-        let promoted =
-            commit_existing_package(&self.storage, &skill.name, &existing.name, &staging)?;
+        let promoted = commit_existing_package(
+            &self.storage,
+            &skill.id,
+            previous_updated_at,
+            &skill.name,
+            &existing.name,
+            &staging,
+        )?;
         let updated = persist_promoted_package(&self.storage, &promoted, || {
             self.repository.update_skill(skill)
         })
@@ -317,6 +325,11 @@ where
             skill: map_skill(updated, SkillAvailability::Available),
         })
     }
+}
+
+/// Returns a timestamp that always distinguishes an update from its previous database version.
+pub(crate) fn next_updated_at(previous_updated_at: i64, clock_updated_at: i64) -> i64 {
+    clock_updated_at.max(previous_updated_at.saturating_add(1))
 }
 
 /// Handles atomic soft deletion of reusable skill definitions and their formal directories.
@@ -356,7 +369,7 @@ where
                 skill_id: skill_id.to_string(),
             })?;
 
-        let handle = match self.storage.commit_delete(&existing.name) {
+        let handle = match self.storage.commit_delete(&existing.name, &skill_id) {
             Ok(handle) => Some(handle),
             Err(SkillStorageError::FormalDirectoryMissing { .. }) => None,
             Err(error) => return Err(ApplicationError::from_skill_storage_error(error)),
@@ -430,6 +443,8 @@ where
     Repository: SkillRepository,
     Storage: SkillStorage,
 {
+    let previous_updated_at = existing.audit_fields.updated_at;
+    let updated_at = next_updated_at(previous_updated_at, now);
     let skill = Skill::new(
         existing.id.clone(),
         existing.namespace.clone(),
@@ -437,7 +452,7 @@ where
         description,
         AuditFields::new(
             existing.audit_fields.created_at,
-            now,
+            updated_at,
             /*is_deleted*/ false,
         ),
     )
@@ -464,6 +479,8 @@ where
     let promoted = commit_restored_package(
         storage,
         &skill.namespace,
+        &skill.id,
+        previous_updated_at,
         &skill.name,
         &existing.name,
         &staging,

--- a/crates/application/src/skill/mod.rs
+++ b/crates/application/src/skill/mod.rs
@@ -10,6 +10,7 @@ mod storage;
 mod tests;
 
 pub use filesystem_storage::FilesystemSkillStorage;
+pub(crate) use handlers::next_updated_at;
 pub use handlers::{
     CreateSkillHandler, DeleteSkillHandler, GetSkillHandler, ListSkillsHandler, UpdateSkillHandler,
 };

--- a/crates/application/src/skill/package_health.rs
+++ b/crates/application/src/skill/package_health.rs
@@ -1,7 +1,7 @@
 use super::storage::{CreateHandle, JournalOp, SkillStorage, SwapHandle};
 use crate::ApplicationError;
 use ora_contracts::SkillAvailability;
-use ora_domain::Namespace;
+use ora_domain::{Namespace, SkillId};
 use ora_skill_package::Limits;
 use ora_skill_package::manifest::parse_manifest;
 use std::path::Path;
@@ -90,6 +90,7 @@ pub(crate) fn claim_untracked_name<Storage: SkillStorage>(
 /// database write commits.
 pub(crate) fn commit_unclaimed_package<Storage: SkillStorage>(
     storage: &Storage,
+    skill_id: &SkillId,
     name: &str,
     staging: &Path,
 ) -> Result<PromotedPackage, ApplicationError> {
@@ -99,7 +100,7 @@ pub(crate) fn commit_unclaimed_package<Storage: SkillStorage>(
             .map_err(ApplicationError::from_skill_storage_error)?
             .iter()
             .any(|journal| {
-                matches!(journal.op, JournalOp::Create | JournalOp::Swap)
+                matches!(journal.op, JournalOp::Create | JournalOp::Swap { .. })
                     && (journal.name == name || journal.from_name == name)
             })
     {
@@ -107,7 +108,7 @@ pub(crate) fn commit_unclaimed_package<Storage: SkillStorage>(
             name: name.to_string(),
         });
     }
-    promote_staging(storage, name, staging)
+    promote_staging(storage, skill_id, name, staging)
 }
 
 /// Promotes staging for an unavailable catalog row, optionally renaming its old package.
@@ -119,6 +120,8 @@ pub(crate) fn commit_unclaimed_package<Storage: SkillStorage>(
 pub(crate) fn commit_restored_package<Storage: SkillStorage>(
     storage: &Storage,
     namespace: &Namespace,
+    skill_id: &SkillId,
+    previous_updated_at: i64,
     name: &str,
     previous_name: &str,
     staging: &Path,
@@ -136,7 +139,15 @@ pub(crate) fn commit_restored_package<Storage: SkillStorage>(
         });
     }
 
-    promote_from(storage, name, previous_name, staging).map_err(|error| match error {
+    promote_from(
+        storage,
+        skill_id,
+        Some(previous_updated_at),
+        name,
+        previous_name,
+        staging,
+    )
+    .map_err(|error| match error {
         super::storage::SkillStorageError::FormalDirectoryExists { .. } => {
             ApplicationError::SkillNameConflict {
                 namespace: namespace.to_string(),
@@ -150,12 +161,21 @@ pub(crate) fn commit_restored_package<Storage: SkillStorage>(
 /// Promotes staging over an existing package when import overwrite has already revalidated it.
 pub(crate) fn commit_existing_package<Storage: SkillStorage>(
     storage: &Storage,
+    skill_id: &SkillId,
+    previous_updated_at: i64,
     name: &str,
     previous_name: &str,
     staging: &Path,
 ) -> Result<PromotedPackage, ApplicationError> {
-    promote_from(storage, name, previous_name, staging)
-        .map_err(ApplicationError::from_skill_storage_error)
+    promote_from(
+        storage,
+        skill_id,
+        Some(previous_updated_at),
+        name,
+        previous_name,
+        staging,
+    )
+    .map_err(ApplicationError::from_skill_storage_error)
 }
 
 /// Couples a promoted package with its repository write.
@@ -192,17 +212,18 @@ where
 /// Promotes staging into `<name>`, swapping when a leftover directory is already present.
 fn promote_staging<Storage: SkillStorage>(
     storage: &Storage,
+    skill_id: &SkillId,
     name: &str,
     staging: &Path,
 ) -> Result<PromotedPackage, ApplicationError> {
     if storage.formal_exists(name) {
         storage
-            .commit_swap(name, name, staging)
+            .commit_swap(name, name, skill_id, None, staging)
             .map(PromotedPackage::Replaced)
             .map_err(ApplicationError::from_skill_storage_error)
     } else {
         storage
-            .commit_create(name, staging)
+            .commit_create(name, skill_id, staging)
             .map(PromotedPackage::Created)
             .map_err(ApplicationError::from_skill_storage_error)
     }
@@ -211,17 +232,19 @@ fn promote_staging<Storage: SkillStorage>(
 /// Promotes staging from `previous_name`, using a journaled rename when that directory exists.
 fn promote_from<Storage: SkillStorage>(
     storage: &Storage,
+    skill_id: &SkillId,
+    previous_updated_at: Option<i64>,
     name: &str,
     previous_name: &str,
     staging: &Path,
 ) -> Result<PromotedPackage, super::storage::SkillStorageError> {
     if storage.formal_exists(previous_name) {
         storage
-            .commit_swap(name, previous_name, staging)
+            .commit_swap(name, previous_name, skill_id, previous_updated_at, staging)
             .map(PromotedPackage::Replaced)
     } else {
         storage
-            .commit_create(name, staging)
+            .commit_create(name, skill_id, staging)
             .map(PromotedPackage::Created)
     }
 }

--- a/crates/application/src/skill/storage.rs
+++ b/crates/application/src/skill/storage.rs
@@ -1,3 +1,4 @@
+use ora_domain::SkillId;
 use ora_utils::path::StrictRelativePath;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -14,10 +15,14 @@ pub use ora_domain::{BACKUP_DIR_NAME, JOURNAL_DIR_NAME, STAGING_DIR_NAME};
 /// Captures one durable intent record written before a formal skill mutation.
 ///
 /// The journal lets startup recovery restore or clean a transaction that was interrupted
-/// between the filesystem swap and the database write.
+/// between the filesystem swap and the database write. Ownership is recorded by immutable
+/// `skill_id` so recovery cannot attribute a directory to an unrelated row that happens to
+/// share the same user-facing name.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransactionJournal {
     pub op: JournalOp,
+    /// Immutable skill identity this transaction mutates.
+    pub skill_id: String,
     /// Target (new) skill name the transaction writes.
     pub name: String,
     /// Previous skill name before the transaction (equal to `name` for create/delete).
@@ -36,7 +41,12 @@ pub struct TransactionJournal {
 #[serde(rename_all = "lowercase")]
 pub enum JournalOp {
     Create,
-    Swap,
+    /// Replaces an existing package whose database row must advance beyond this version.
+    Swap {
+        /// Previous database version for an owned package update. `None` means a new skill is
+        /// atomically claiming an untracked package and therefore has no prior database row.
+        previous_updated_at: Option<i64>,
+    },
     Delete,
 }
 
@@ -90,8 +100,10 @@ pub enum SkillStorageError {
 /// Implementations must keep formal directories at `<skills_root>/<name>/` with a root
 /// `SKILL.md`, reserve transaction staging under `<skills_root>/<STAGING_DIR_NAME>`, keep
 /// compensation backups under `<skills_root>/<BACKUP_DIR_NAME>`, and record intent in
-/// `<skills_root>/<JOURNAL_DIR_NAME>`. All staging, backup, and journal paths live on the
-/// same filesystem as the formal tree so promotion uses rename instead of cross-device copies.
+/// `<skills_root>/<JOURNAL_DIR_NAME>`. Journals store the skill id so startup recovery can
+/// decide directory ownership without treating a same-named unrelated row as the owner.
+/// All staging, backup, and journal paths live on the same filesystem as the formal tree so
+/// promotion uses rename instead of cross-device copies.
 ///
 /// Reserved directory names and committed skill names occupy disjoint namespaces:
 /// [`ora_domain::validate_skill_name`] refuses every dot-prefixed name, which keeps any
@@ -131,7 +143,12 @@ pub trait SkillStorage {
     fn write_manifest(&self, staging: &Path, content: &[u8]) -> Result<(), SkillStorageError>;
 
     /// Promotes a staging directory to the formal `<name>` directory for a new skill.
-    fn commit_create(&self, name: &str, staging: &Path) -> Result<CreateHandle, SkillStorageError>;
+    fn commit_create(
+        &self,
+        name: &str,
+        skill_id: &SkillId,
+        staging: &Path,
+    ) -> Result<CreateHandle, SkillStorageError>;
 
     /// Removes a partially created formal directory and cleans the staging and journal.
     fn rollback_create(&self, handle: &CreateHandle) -> Result<(), SkillStorageError>;
@@ -144,6 +161,8 @@ pub trait SkillStorage {
         &self,
         name: &str,
         from_name: &str,
+        skill_id: &SkillId,
+        previous_updated_at: Option<i64>,
         staging: &Path,
     ) -> Result<SwapHandle, SkillStorageError>;
 
@@ -154,7 +173,11 @@ pub trait SkillStorage {
     fn finish_swap(&self, handle: &SwapHandle) -> Result<(), SkillStorageError>;
 
     /// Moves the formal `<name>` directory into a compensation backup for deletion.
-    fn commit_delete(&self, name: &str) -> Result<DeleteHandle, SkillStorageError>;
+    fn commit_delete(
+        &self,
+        name: &str,
+        skill_id: &SkillId,
+    ) -> Result<DeleteHandle, SkillStorageError>;
 
     /// Restores the formal directory after an interrupted delete.
     fn rollback_delete(&self, handle: &DeleteHandle) -> Result<(), SkillStorageError>;

--- a/crates/application/src/skill/tests.rs
+++ b/crates/application/src/skill/tests.rs
@@ -111,6 +111,24 @@ fn update_rejects_non_slug_name_without_mutating_catalog_or_package() {
 }
 
 #[test]
+fn update_advances_timestamp_past_the_previous_database_version() {
+    let repository = Rc::new(FakeSkillRepository::with_skills(vec![skill(
+        "skill-1", "review", "Reviews", 10, 20, false,
+    )]));
+    let storage = Rc::new(FakeSkillStorage::with_manifest("review", "Reviews"));
+
+    UpdateSkillHandler::new(repository.clone(), storage, FixedClock(20))
+        .handle(UpdateSkillRequest {
+            skill_id: "skill-1".to_string(),
+            name: "review".to_string(),
+            description: "Updated".to_string(),
+            content: None,
+        })
+        .unwrap();
+
+    assert_eq!(repository.skills.borrow()[0].audit_fields.updated_at, 21);
+}
+#[test]
 fn preserves_or_clears_skill_body_without_losing_unknown_front_matter() {
     let repository = Rc::new(FakeSkillRepository::with_skills(vec![skill(
         "skill-1", "review", "Reviews", 10, 20, false,
@@ -973,7 +991,12 @@ impl SkillStorage for Rc<FakeSkillStorage> {
             .insert(staging.to_path_buf(), content.to_vec());
         Ok(())
     }
-    fn commit_create(&self, name: &str, staging: &Path) -> Result<CreateHandle, SkillStorageError> {
+    fn commit_create(
+        &self,
+        name: &str,
+        _skill_id: &SkillId,
+        staging: &Path,
+    ) -> Result<CreateHandle, SkillStorageError> {
         self.take_fail()?;
         if self.formal.borrow().contains_key(name) {
             return Err(SkillStorageError::FormalDirectoryExists {
@@ -1000,6 +1023,8 @@ impl SkillStorage for Rc<FakeSkillStorage> {
         &self,
         name: &str,
         from_name: &str,
+        _skill_id: &SkillId,
+        _previous_updated_at: Option<i64>,
         staging: &Path,
     ) -> Result<SwapHandle, SkillStorageError> {
         self.take_fail()?;
@@ -1055,7 +1080,11 @@ impl SkillStorage for Rc<FakeSkillStorage> {
     fn finish_swap(&self, _handle: &SwapHandle) -> Result<(), SkillStorageError> {
         Ok(())
     }
-    fn commit_delete(&self, name: &str) -> Result<DeleteHandle, SkillStorageError> {
+    fn commit_delete(
+        &self,
+        name: &str,
+        _skill_id: &SkillId,
+    ) -> Result<DeleteHandle, SkillStorageError> {
         self.take_fail()?;
         if !self.formal.borrow().contains_key(name) {
             return Err(SkillStorageError::FormalDirectoryMissing {

--- a/crates/application/src/skill_import/commit.rs
+++ b/crates/application/src/skill_import/commit.rs
@@ -4,7 +4,7 @@ use super::ports::{
 };
 use crate::skill::{
     SkillStorage, commit_existing_package, commit_restored_package, commit_unclaimed_package,
-    has_usable_package, persist_promoted_package,
+    has_usable_package, next_updated_at, persist_promoted_package,
 };
 use crate::{ApplicationError, Clock, SkillRepository};
 use ora_domain::{AuditFields, Namespace, Skill, SkillId};
@@ -191,6 +191,9 @@ where
         }
     };
 
+    let updated_at = existing.as_ref().map_or(now, |skill| {
+        next_updated_at(skill.audit_fields.updated_at, now)
+    });
     let skill = match Skill::new(
         existing
             .as_ref()
@@ -204,7 +207,7 @@ where
                 .as_ref()
                 .map(|skill| skill.audit_fields.created_at)
                 .unwrap_or(now),
-            now,
+            updated_at,
             /*is_deleted*/ false,
         ),
     ) {
@@ -240,6 +243,8 @@ where
         match commit_restored_package(
             storage,
             &skill.namespace,
+            &skill.id,
+            existing.audit_fields.updated_at,
             &skill.name,
             &existing.name,
             &staging,
@@ -248,7 +253,7 @@ where
             Err(error) => return promote_failure(storage, &staging, error),
         }
     } else {
-        match commit_unclaimed_package(storage, &skill.name, &staging) {
+        match commit_unclaimed_package(storage, &skill.id, &skill.name, &staging) {
             Ok(promoted) => promoted,
             Err(error) => return promote_failure(storage, &staging, error),
         }
@@ -297,7 +302,11 @@ where
         frozen.namespace.clone(),
         candidate.name.clone(),
         candidate.description.clone(),
-        AuditFields::new(frozen.created_at, now, /*is_deleted*/ false),
+        AuditFields::new(
+            frozen.created_at,
+            next_updated_at(frozen.updated_at, now),
+            /*is_deleted*/ false,
+        ),
     ) {
         Ok(skill) => skill,
         Err(_) => {
@@ -319,8 +328,14 @@ where
         let _ = storage.remove_temp(&staging);
         return CandidateOutcome::Failed { error_code };
     }
-    let promoted = match commit_existing_package(storage, &candidate.name, &existing.name, &staging)
-    {
+    let promoted = match commit_existing_package(
+        storage,
+        &skill.id,
+        frozen.updated_at,
+        &candidate.name,
+        &existing.name,
+        &staging,
+    ) {
         Ok(promoted) => promoted,
         Err(error) => return promote_failure(storage, &staging, error),
     };
@@ -358,6 +373,7 @@ where
         id: current.id,
         namespace: current.namespace,
         created_at: current.audit_fields.created_at,
+        updated_at: current.audit_fields.updated_at,
     })
 }
 
@@ -366,6 +382,7 @@ struct SkillSnapshot {
     id: SkillId,
     namespace: Namespace,
     created_at: i64,
+    updated_at: i64,
 }
 
 /// Maps a promotion failure onto the candidate result and drops leftover staging.

--- a/crates/backend/src/skill.rs
+++ b/crates/backend/src/skill.rs
@@ -147,7 +147,7 @@ mod tests {
         DatabaseBootstrapper, DatabaseLocation, SqliteAgentDefinitionRepository,
         default_migration_catalog,
     };
-    use ora_domain::{AgentDefinition, AgentDefinitionId, AuditFields, Namespace};
+    use ora_domain::{AgentDefinition, AgentDefinitionId, AuditFields, Namespace, SkillId};
     use ora_logging::with_trace_logging;
     use ora_utils::path::StrictRelativePath;
     use pretty_assertions::assert_eq;
@@ -169,9 +169,10 @@ mod tests {
         fn commit_create(
             &self,
             name: &str,
+            skill_id: &SkillId,
             staging: &Path,
         ) -> Result<CreateHandle, SkillStorageError> {
-            let handle = self.inner.commit_create(name, staging)?;
+            let handle = self.inner.commit_create(name, skill_id, staging)?;
             // Enter the promote window, then hold it until the observing thread releases it.
             self.promote.wait();
             self.promote.wait();
@@ -220,9 +221,12 @@ mod tests {
             &self,
             name: &str,
             from_name: &str,
+            skill_id: &SkillId,
+            previous_updated_at: Option<i64>,
             staging: &Path,
         ) -> Result<SwapHandle, SkillStorageError> {
-            self.inner.commit_swap(name, from_name, staging)
+            self.inner
+                .commit_swap(name, from_name, skill_id, previous_updated_at, staging)
         }
 
         fn rollback_swap(&self, handle: &SwapHandle) -> Result<(), SkillStorageError> {
@@ -233,8 +237,12 @@ mod tests {
             self.inner.finish_swap(handle)
         }
 
-        fn commit_delete(&self, name: &str) -> Result<DeleteHandle, SkillStorageError> {
-            self.inner.commit_delete(name)
+        fn commit_delete(
+            &self,
+            name: &str,
+            skill_id: &SkillId,
+        ) -> Result<DeleteHandle, SkillStorageError> {
+            self.inner.commit_delete(name, skill_id)
         }
 
         fn rollback_delete(&self, handle: &DeleteHandle) -> Result<(), SkillStorageError> {

--- a/crates/backend/src/skill_reconciliation.rs
+++ b/crates/backend/src/skill_reconciliation.rs
@@ -3,7 +3,7 @@ use ora_application::{
     SkillRepository, SkillStorage, TransactionJournal,
 };
 use ora_db::{RepositoryPool, SqliteSkillRepository};
-use ora_domain::Namespace;
+use ora_domain::SkillId;
 use ora_logging::ora_warn;
 use std::collections::BTreeSet;
 use std::fs;
@@ -82,6 +82,9 @@ pub(crate) fn reconcile_skill_storage(
 }
 
 /// Applies one journal marker deterministically based on its phase and the database state.
+///
+/// Directory ownership is decided by the immutable id recorded in the journal. A visible row that
+/// only shares the user-facing name cannot claim an interrupted transaction's package.
 fn recover_journal(
     repository: &SqliteSkillRepository,
     storage: &FilesystemSkillStorage,
@@ -91,10 +94,9 @@ fn recover_journal(
     let staging = Path::new(&journal.staging).to_path_buf();
     let backup = Path::new(&journal.backup).to_path_buf();
     let formal_path = |name: &str| skills_root.join(name);
-    let target_visible = repository
-        .find_skill_by_name(&Namespace::local(), &journal.name)
-        .map_err(operation_failed)?
-        .is_some();
+    let owner = repository
+        .find_skill(&SkillId::new(&journal.skill_id))
+        .map_err(operation_failed)?;
 
     match journal.op {
         JournalOp::Create => match journal.phase {
@@ -108,46 +110,49 @@ fn recover_journal(
                 remove_if_present(storage, &staging)?;
             }
             JournalPhase::Swapped => {
-                // Keep the promoted directory only when a database record claims it.
-                if !target_visible && storage.formal_exists(&journal.name) {
+                // A same-named unrelated row cannot keep this interrupted create.
+                if owner.is_none() && storage.formal_exists(&journal.name) {
                     storage
                         .remove_dir(&formal_path(&journal.name))
                         .map_err(operation_failed)?;
                 }
             }
         },
-        JournalOp::Swap => match journal.phase {
+        JournalOp::Swap {
+            previous_updated_at,
+        } => match journal.phase {
             JournalPhase::Prepared => {
                 // The swap never reached its database write; restore the original directory.
-                if storage.formal_exists(&journal.name) {
-                    storage
-                        .remove_dir(&formal_path(&journal.name))
-                        .map_err(operation_failed)?;
-                }
-                if backup.exists() && !storage.formal_exists(&journal.from_name) {
-                    storage
-                        .restore_backup(&backup, &journal.from_name)
-                        .map_err(operation_failed)?;
-                }
+                restore_interrupted_swap(storage, journal, &backup, skills_root)?;
                 remove_if_present(storage, &staging)?;
             }
             JournalPhase::Swapped => {
-                if target_visible {
-                    // Fully committed; only the compensation backup remains.
+                let owner_name = owner.as_ref().map(|skill| skill.name.as_str());
+                let database_write_pending = previous_updated_at.is_some_and(|previous| {
+                    owner.as_ref().is_some_and(|skill| {
+                        skill.name == journal.from_name && skill.audit_fields.updated_at == previous
+                    })
+                });
+
+                if database_write_pending {
+                    // The exact pre-swap database version remains, so restore its package.
+                    restore_interrupted_swap(storage, journal, &backup, skills_root)?;
+                } else if owner_name == Some(journal.name.as_str()) {
+                    // The target version committed, or a later update superseded this journal.
                     remove_if_present(storage, &backup)?;
+                } else if previous_updated_at.is_none() && owner.is_none() {
+                    // A new row failed to claim an existing untracked package. Restore that
+                    // package instead of losing it; a same-named unrelated row is not the owner.
+                    restore_interrupted_swap(storage, journal, &backup, skills_root)?;
                 } else {
-                    // Database write never happened. Restore the original directory whether
-                    // a catalog row still owns `from_name` or the leftover was untracked.
+                    // The journaled owner no longer claims either path; discard transaction
+                    // leftovers without allowing a same-named unrelated row to inherit them.
                     if storage.formal_exists(&journal.name) {
                         storage
                             .remove_dir(&formal_path(&journal.name))
                             .map_err(operation_failed)?;
                     }
-                    if backup.exists() && !storage.formal_exists(&journal.from_name) {
-                        storage
-                            .restore_backup(&backup, &journal.from_name)
-                            .map_err(operation_failed)?;
-                    }
+                    remove_if_present(storage, &backup)?;
                 }
                 remove_if_present(storage, &staging)?;
             }
@@ -162,8 +167,8 @@ fn recover_journal(
                 }
             }
             JournalPhase::Swapped => {
-                if target_visible {
-                    // The soft delete never committed; restore the directory.
+                if owner.is_some() {
+                    // The soft delete never committed; restore the journal owner's directory.
                     if backup.exists() && !storage.formal_exists(&journal.name) {
                         storage
                             .restore_backup(&backup, &journal.name)
@@ -178,6 +183,25 @@ fn recover_journal(
     Ok(())
 }
 
+/// Restores the pre-swap package after recovery proves the database write never committed.
+fn restore_interrupted_swap(
+    storage: &FilesystemSkillStorage,
+    journal: &TransactionJournal,
+    backup: &Path,
+    skills_root: &Path,
+) -> Result<(), SkillStorageReconciliationError> {
+    if storage.formal_exists(&journal.name) {
+        storage
+            .remove_dir(&skills_root.join(&journal.name))
+            .map_err(operation_failed)?;
+    }
+    if backup.exists() && !storage.formal_exists(&journal.from_name) {
+        storage
+            .restore_backup(backup, &journal.from_name)
+            .map_err(operation_failed)?;
+    }
+    Ok(())
+}
 /// Removes one reserved directory when it still exists.
 fn remove_if_present(
     storage: &FilesystemSkillStorage,
@@ -310,7 +334,10 @@ mod tests {
         fs::write(backup.join("SKILL.md"), "old body").unwrap();
 
         let journal = TransactionJournal {
-            op: ora_application::JournalOp::Swap,
+            op: ora_application::JournalOp::Swap {
+                previous_updated_at: Some(100),
+            },
+            skill_id: "skill-1".to_string(),
             name: "review".to_string(),
             from_name: "review".to_string(),
             staging: staging.to_string_lossy().into_owned(),
@@ -351,6 +378,253 @@ mod tests {
         assert!(!skills_root.join(".ora-journal").join("txn.json").exists());
     }
 
+    #[test]
+    fn restores_same_name_swap_when_database_write_did_not_commit() {
+        let temp = TempDir::new().unwrap();
+        let skills_root = temp.path().join("atoms").join("skills");
+        let database_path = temp.path().join("ora.sqlite3");
+        let repository = SqliteSkillRepository::new(pool(&database_path));
+        repository
+            .create_skill(
+                Skill::new(
+                    SkillId::new("skill-1"),
+                    Namespace::local(),
+                    "review",
+                    "Old description",
+                    AuditFields::new(100, 100, false),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        create_formal(&skills_root, "review", "new body");
+        let backup = skills_root.join(".ora-backup").join("txn");
+        create_formal(&skills_root.join(".ora-backup"), "txn", "old body");
+        let journal = TransactionJournal {
+            op: ora_application::JournalOp::Swap {
+                previous_updated_at: Some(100),
+            },
+            skill_id: "skill-1".to_string(),
+            name: "review".to_string(),
+            from_name: "review".to_string(),
+            staging: String::new(),
+            backup: backup.to_string_lossy().into_owned(),
+            phase: ora_application::JournalPhase::Swapped,
+            file: skills_root
+                .join(".ora-journal")
+                .join("txn.json")
+                .to_string_lossy()
+                .into_owned(),
+        };
+        write_journal(&journal);
+
+        reconcile_skill_storage(&pool(&database_path), &skills_root).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(skills_root.join("review").join("SKILL.md")).unwrap(),
+            "old body"
+        );
+        assert!(!backup.exists());
+        assert!(!Path::new(&journal.file).exists());
+    }
+
+    #[test]
+    fn keeps_same_name_swap_when_database_write_committed() {
+        let temp = TempDir::new().unwrap();
+        let skills_root = temp.path().join("atoms").join("skills");
+        let database_path = temp.path().join("ora.sqlite3");
+        let repository = SqliteSkillRepository::new(pool(&database_path));
+        repository
+            .create_skill(
+                Skill::new(
+                    SkillId::new("skill-1"),
+                    Namespace::local(),
+                    "review",
+                    "New description",
+                    AuditFields::new(100, 200, false),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        create_formal(&skills_root, "review", "new body");
+        let backup = skills_root.join(".ora-backup").join("txn");
+        create_formal(&skills_root.join(".ora-backup"), "txn", "old body");
+        let journal = TransactionJournal {
+            op: ora_application::JournalOp::Swap {
+                previous_updated_at: Some(100),
+            },
+            skill_id: "skill-1".to_string(),
+            name: "review".to_string(),
+            from_name: "review".to_string(),
+            staging: String::new(),
+            backup: backup.to_string_lossy().into_owned(),
+            phase: ora_application::JournalPhase::Swapped,
+            file: skills_root
+                .join(".ora-journal")
+                .join("txn.json")
+                .to_string_lossy()
+                .into_owned(),
+        };
+        write_journal(&journal);
+
+        reconcile_skill_storage(&pool(&database_path), &skills_root).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(skills_root.join("review").join("SKILL.md")).unwrap(),
+            "new body"
+        );
+        assert!(!backup.exists());
+        assert!(!Path::new(&journal.file).exists());
+    }
+
+    #[test]
+    fn delete_recovery_does_not_restore_backup_for_unrelated_same_name_skill() {
+        let temp = TempDir::new().unwrap();
+        let skills_root = temp.path().join("atoms").join("skills");
+        let database_path = temp.path().join("ora.sqlite3");
+        let repository = SqliteSkillRepository::new(pool(&database_path));
+        repository
+            .create_skill(
+                Skill::new(
+                    SkillId::new("skill-unrelated"),
+                    Namespace::local(),
+                    "gone",
+                    "Unrelated",
+                    AuditFields::new(300, 300, false),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        create_formal(&skills_root, "gone", "unrelated body");
+        let backup = skills_root.join(".ora-backup").join("txn");
+        create_formal(
+            &skills_root.join(".ora-backup"),
+            "txn",
+            "deleted owner body",
+        );
+        let journal = TransactionJournal {
+            op: ora_application::JournalOp::Delete,
+            skill_id: "skill-deleted".to_string(),
+            name: "gone".to_string(),
+            from_name: "gone".to_string(),
+            staging: String::new(),
+            backup: backup.to_string_lossy().into_owned(),
+            phase: ora_application::JournalPhase::Swapped,
+            file: skills_root
+                .join(".ora-journal")
+                .join("txn.json")
+                .to_string_lossy()
+                .into_owned(),
+        };
+        write_journal(&journal);
+
+        reconcile_skill_storage(&pool(&database_path), &skills_root).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(skills_root.join("gone").join("SKILL.md")).unwrap(),
+            "unrelated body"
+        );
+        assert!(!backup.exists());
+        assert!(!Path::new(&journal.file).exists());
+    }
+
+    #[test]
+    fn removes_interrupted_create_not_owned_by_same_name_database_skill() {
+        let temp = TempDir::new().unwrap();
+        let skills_root = temp.path().join("atoms").join("skills");
+        let database_path = temp.path().join("ora.sqlite3");
+        let repository = SqliteSkillRepository::new(pool(&database_path));
+        repository
+            .create_skill(
+                Skill::new(
+                    SkillId::new("skill-db-only"),
+                    Namespace::local(),
+                    "review",
+                    "Pre-existing database row",
+                    AuditFields::new(100, 100, false),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        // Crash window: import promoted `review/` for a different skill id, then died
+        // before inserting that row. A same-named visible row must not inherit it.
+        create_formal(&skills_root, "review", "crashed import body");
+        let journal = TransactionJournal {
+            op: ora_application::JournalOp::Create,
+            skill_id: "skill-import".to_string(),
+            name: "review".to_string(),
+            from_name: "review".to_string(),
+            staging: String::new(),
+            backup: String::new(),
+            phase: ora_application::JournalPhase::Swapped,
+            file: skills_root
+                .join(".ora-journal")
+                .join("txn.json")
+                .to_string_lossy()
+                .into_owned(),
+        };
+        write_journal(&journal);
+
+        ora_logging::with_trace_logging(|| {
+            reconcile_skill_storage(&pool(&database_path), &skills_root).unwrap();
+        });
+
+        assert!(!skills_root.join("review").exists());
+        assert!(!Path::new(&journal.file).exists());
+        assert!(
+            repository
+                .find_skill(&SkillId::new("skill-db-only"))
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn keeps_promoted_create_when_journal_skill_id_exists() {
+        let temp = TempDir::new().unwrap();
+        let skills_root = temp.path().join("atoms").join("skills");
+        let database_path = temp.path().join("ora.sqlite3");
+        let repository = SqliteSkillRepository::new(pool(&database_path));
+        repository
+            .create_skill(
+                Skill::new(
+                    SkillId::new("skill-import"),
+                    Namespace::local(),
+                    "review",
+                    "Imported",
+                    AuditFields::new(100, 100, false),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        create_formal(&skills_root, "review", "imported body");
+        let journal = TransactionJournal {
+            op: ora_application::JournalOp::Create,
+            skill_id: "skill-import".to_string(),
+            name: "review".to_string(),
+            from_name: "review".to_string(),
+            staging: String::new(),
+            backup: String::new(),
+            phase: ora_application::JournalPhase::Swapped,
+            file: skills_root
+                .join(".ora-journal")
+                .join("txn.json")
+                .to_string_lossy()
+                .into_owned(),
+        };
+        write_journal(&journal);
+
+        reconcile_skill_storage(&pool(&database_path), &skills_root).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(skills_root.join("review").join("SKILL.md")).unwrap(),
+            "imported body"
+        );
+        assert!(!Path::new(&journal.file).exists());
+    }
     /// Verifies a reserved directory name survives a real import followed by startup reconciliation.
     ///
     /// This is the end-to-end shape of the original defect: a skill whose name matched a reserved
@@ -494,7 +768,10 @@ mod tests {
         create_formal(&skills_root, "stray", "new body");
 
         let journal = TransactionJournal {
-            op: ora_application::JournalOp::Swap,
+            op: ora_application::JournalOp::Swap {
+                previous_updated_at: None,
+            },
+            skill_id: "skill-import".to_string(),
             name: "stray".to_string(),
             from_name: "stray".to_string(),
             staging: staging.to_string_lossy().into_owned(),
@@ -664,6 +941,7 @@ mod tests {
         fs::rename(skills_root.join("gone"), &backup).unwrap();
         let journal = TransactionJournal {
             op: ora_application::JournalOp::Delete,
+            skill_id: "skill-1".to_string(),
             name: "gone".to_string(),
             from_name: "gone".to_string(),
             staging: String::new(),


### PR DESCRIPTION
Name-only startup reconciliation could keep a crashed import directory when an unrelated visible row shared that name. Record skill id in the transaction journal so recovery claims the directory by identity.