### PR TITLE
fix(skill): flush package promotes before the catalog commit

### DIFF
--- a/crates/application/src/skill/README.md
+++ b/crates/application/src/skill/README.md
@@ -41,6 +41,15 @@ on-disk packages.
   that a mutation still expected is `SkillStorageInconsistent`.
 - Domain validation (`ora-domain::Skill`) enforces the ASCII slug name rules and the 4096-byte
   description limit shared by create, update, and import.
+- Power-loss durability is part of package atomicity. Package files, journal markers, and
+  directory promotes are flushed before the database commit so the remaining crash window is
+  "directory exists, row not yet committed", which startup reconciliation already repairs by
+  removing unowned packages. SQLite uses `synchronous=NORMAL`, so a power loss may drop the
+  last COMMIT and leave an unowned directory, which reconciliation removes. Mutation-time
+  directory fsync is a hard error on Unix; startup recovery treats an unsupported directory fsync
+  as best-effort so restoring a valid backup cannot permanently block startup. Windows cannot
+  reliably flush directory metadata, so that flush is best-effort there, and macOS `sync_all` is
+  `fsync` rather than `F_FULLFSYNC`.
 
 ## Atomicity and recovery model
 

--- a/crates/application/src/skill/durability.rs
+++ b/crates/application/src/skill/durability.rs
@@ -1,0 +1,299 @@
+//! Directory and file durability barriers for skill package promotion.
+//!
+//! Process crashes are recovered from journals. Power-loss atomicity additionally requires
+//! package files, the journal file, and the renamed directory's parents to reach stable storage
+//! before SQLite commits the catalog row. That ordering makes the remaining crash window
+//! "directory exists, row not committed", which startup reconciliation already repairs.
+
+use std::fs::{self, File};
+use std::io;
+use std::path::Path;
+
+/// Flushes one regular file to stable storage, then flushes its parent directory.
+///
+/// Skill transaction journals use this so recovery can still see the marker after a power
+/// loss. The parent flush is best-effort on platforms that cannot fsync directories.
+pub(crate) fn persist_file(path: &Path) -> io::Result<()> {
+    File::options().write(true).open(path)?.sync_all()?;
+    if let Some(parent) = path.parent() {
+        sync_directory(parent)?;
+    }
+    Ok(())
+}
+
+/// Flushes one package file and every directory entry from its parent through `package_root`.
+///
+/// A file in `scripts/lib/helper.py` needs more than the file and `lib` directory flushed:
+/// `scripts` must also persist its `lib` entry before the staging root can be promoted safely.
+pub(crate) fn persist_package_file(path: &Path, package_root: &Path) -> io::Result<()> {
+    File::options().write(true).open(path)?.sync_all()?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "package file has no parent"))?;
+    sync_directory_chain(parent, package_root, sync_directory)
+}
+
+/// Renames a directory and flushes both parents so the new entry survives power loss.
+///
+/// A successful return means the destination name is visible in its parent on platforms that
+/// support directory fsync. If the metadata flush fails, this attempts to undo the rename so
+/// callers do not proceed to a database commit against an undurable promote.
+pub(crate) fn rename_directory_persistently(from: &Path, to: &Path) -> io::Result<()> {
+    rename_directory_persistently_with(from, to, sync_directory)
+}
+
+/// Renames a directory for startup recovery, tolerating hosts without directory fsync.
+///
+/// Mutation commit paths remain strict on Unix because they can abort before the database commit.
+/// Recovery has no such option: an unsupported metadata flush must not make the backend
+/// permanently unavailable while a valid backup can still be restored.
+pub(crate) fn rename_directory_for_recovery(from: &Path, to: &Path) -> io::Result<()> {
+    rename_directory_for_recovery_with(from, to, sync_directory)
+}
+
+/// Implements a recovery rename with an injectable directory barrier for deterministic tests.
+fn rename_directory_for_recovery_with(
+    from: &Path,
+    to: &Path,
+    sync: impl FnMut(&Path) -> io::Result<()>,
+) -> io::Result<()> {
+    match rename_directory_persistently_with(from, to, sync) {
+        Ok(()) => Ok(()),
+        Err(error) if directory_sync_is_unsupported(&error) => {
+            if to.exists() && !from.exists() {
+                Ok(())
+            } else {
+                fs::rename(from, to)
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Implements a durable rename with an injectable directory barrier for deterministic tests.
+fn rename_directory_persistently_with(
+    from: &Path,
+    to: &Path,
+    mut sync: impl FnMut(&Path) -> io::Result<()>,
+) -> io::Result<()> {
+    if from.is_dir() {
+        sync(from)?;
+    }
+    fs::rename(from, to)?;
+    if let Err(error) = persist_rename_parents_with(from, to, &mut sync) {
+        let _ = fs::rename(to, from);
+        return Err(error);
+    }
+    Ok(())
+}
+
+/// Flushes the destination parent and, when it differs, the source parent of a rename.
+fn persist_rename_parents_with(
+    from: &Path,
+    to: &Path,
+    mut sync: impl FnMut(&Path) -> io::Result<()>,
+) -> io::Result<()> {
+    if let Some(parent) = to.parent() {
+        sync(parent)?;
+    }
+    // The source parent records the removal; skip it when both names share one directory.
+    if let Some(source) = from.parent()
+        && to.parent() != Some(source)
+    {
+        sync(source)?;
+    }
+    Ok(())
+}
+
+/// Flushes a directory and each ancestor through the package root, deepest first.
+fn sync_directory_chain(
+    start: &Path,
+    package_root: &Path,
+    mut sync: impl FnMut(&Path) -> io::Result<()>,
+) -> io::Result<()> {
+    if !start.starts_with(package_root) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "package file is outside its package root",
+        ));
+    }
+    let mut current = start;
+    loop {
+        sync(current)?;
+        if current == package_root {
+            return Ok(());
+        }
+        current = current.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "package root is not an ancestor of the package file",
+            )
+        })?;
+    }
+}
+
+/// Flushes directory metadata so a preceding create, rename, or unlink can survive power loss.
+///
+/// Linux and other Unix platforms treat a failed directory fsync as a hard error: continuing
+/// would re-open the "row committed, directory missing" window. Windows cannot reliably fsync
+/// directories, so an unsupported flush is ignored and documented as a platform limit rather
+/// than failing every promote.
+pub(crate) fn sync_directory(path: &Path) -> io::Result<()> {
+    match sync_directory_inner(path) {
+        Ok(()) => Ok(()),
+        #[cfg(windows)]
+        Err(error) if directory_sync_is_unsupported(&error) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Opens a directory and requests a full metadata flush.
+fn sync_directory_inner(path: &Path) -> io::Result<()> {
+    #[cfg(windows)]
+    {
+        use std::fs::OpenOptions;
+        use std::os::windows::fs::OpenOptionsExt;
+        // FILE_FLAG_BACKUP_SEMANTICS is required to open a directory handle on Windows.
+        const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+        OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+            .open(path)?
+            .sync_all()
+    }
+    #[cfg(not(windows))]
+    {
+        File::open(path)?.sync_all()
+    }
+}
+
+/// Returns whether a directory flush failed because the host cannot fsync directories.
+fn directory_sync_is_unsupported(error: &io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        io::ErrorKind::InvalidInput | io::ErrorKind::Unsupported
+    ) {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        matches!(error.kind(), io::ErrorKind::PermissionDenied)
+            || matches!(error.raw_os_error(), Some(1 | 5 | 6 | 50 | 87))
+    }
+    #[cfg(not(windows))]
+    {
+        // EINVAL plus the Linux and macOS ENOTSUP values cover filesystems that accept opening a
+        // directory but reject fsync on it (for example some overlay or network mounts).
+        matches!(error.raw_os_error(), Some(22 | 45 | 95))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        persist_file, rename_directory_for_recovery_with, rename_directory_persistently,
+        rename_directory_persistently_with, sync_directory, sync_directory_chain,
+    };
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sync_directory_accepts_a_temporary_directory() {
+        let temp = TempDir::new().unwrap();
+        sync_directory(temp.path()).unwrap();
+    }
+
+    #[test]
+    fn persist_file_flushes_a_regular_file() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("marker.json");
+        fs::write(&path, "{}").unwrap();
+        persist_file(&path).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{}");
+    }
+
+    #[test]
+    fn rename_directory_persistently_moves_a_directory_into_its_parent() {
+        let temp = TempDir::new().unwrap();
+        let skills_root = temp.path().join("skills");
+        let staging_root = skills_root.join(".ora-staging");
+        fs::create_dir_all(&staging_root).unwrap();
+        let staging = staging_root.join("txn");
+        fs::create_dir_all(&staging).unwrap();
+        fs::write(staging.join("SKILL.md"), "body").unwrap();
+
+        let formal = skills_root.join("grilling");
+        rename_directory_persistently(&staging, &formal).unwrap();
+
+        assert!(formal.join("SKILL.md").is_file());
+        assert!(!staging.exists());
+    }
+
+    #[test]
+    fn sync_directory_chain_flushes_every_nested_parent_through_the_package_root() {
+        let root = Path::new("staging");
+        let start = root.join("scripts").join("lib");
+        let mut visited = Vec::new();
+
+        sync_directory_chain(&start, root, |path| {
+            visited.push(path.to_path_buf());
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            visited,
+            vec![
+                root.join("scripts").join("lib"),
+                root.join("scripts"),
+                root.to_path_buf(),
+            ]
+        );
+    }
+
+    #[test]
+    fn durable_rename_undoes_the_move_when_a_parent_barrier_fails() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "body").unwrap();
+        let mut barriers = 0;
+
+        let error = rename_directory_persistently_with(&source, &destination, |_| {
+            barriers += 1;
+            if barriers == 2 {
+                Err(std::io::Error::other("injected directory flush failure"))
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "injected directory flush failure");
+        assert!(source.join("SKILL.md").is_file());
+        assert!(!destination.exists());
+    }
+
+    #[test]
+    fn recovery_rename_continues_when_directory_fsync_is_unsupported() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("backup");
+        let destination = temp.path().join("grilling");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "body").unwrap();
+
+        rename_directory_for_recovery_with(&source, &destination, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "injected unsupported directory fsync",
+            ))
+        })
+        .unwrap();
+
+        assert!(destination.join("SKILL.md").is_file());
+        assert!(!source.exists());
+    }
+}

--- a/crates/application/src/skill/filesystem_storage.rs
+++ b/crates/application/src/skill/filesystem_storage.rs
@@ -7,20 +7,47 @@ use ora_utils::path::StrictRelativePath;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 /// Default filesystem implementation of [`SkillStorage`] rooted at the formal skills tree.
 ///
 /// All transaction artifacts live under `<skills_root>/<reserved>/` so renames stay on the
 /// same filesystem and startup recovery can deterministically resolve interrupted mutations.
+/// Journal writes and directory promotes flush metadata before returning so a later database
+/// commit cannot land without a durable package directory on platforms that support it.
 #[derive(Debug, Clone)]
 pub struct FilesystemSkillStorage {
     skills_root: PathBuf,
+    #[cfg(test)]
+    fail_next_journal_phase_update: Arc<AtomicBool>,
+}
+
+/// Selects whether a recursive package copy participates in a durable mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CopyDurability {
+    Durable,
+    Transient,
 }
 
 impl FilesystemSkillStorage {
     /// Builds storage rooted at the formal skill directory parent.
     pub fn new(skills_root: PathBuf) -> Self {
-        Self { skills_root }
+        Self {
+            skills_root,
+            #[cfg(test)]
+            fail_next_journal_phase_update: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Injects one journal phase-write failure for rollback tests.
+    #[cfg(test)]
+    fn fail_next_journal_phase_update(&self) {
+        self.fail_next_journal_phase_update
+            .store(true, Ordering::SeqCst);
     }
 
     /// Returns the formal directory for one skill name.
@@ -45,7 +72,7 @@ impl FilesystemSkillStorage {
             });
         }
         fs::create_dir_all(destination).map_err(map_storage_error)?;
-        copy_dir_contents(&source, destination).map_err(|source| {
+        copy_dir_contents(&source, destination, CopyDurability::Transient).map_err(|source| {
             SkillStorageError::OperationFailed {
                 message: format!(
                     "failed to copy skill {name} to {}: {source}",
@@ -64,7 +91,12 @@ impl FilesystemSkillStorage {
             serde_json::to_string(journal).map_err(|error| SkillStorageError::OperationFailed {
                 message: format!("failed to serialize transaction journal: {error}"),
             })?;
-        fs::write(&journal.file, payload).map_err(map_storage_error)
+        fs::write(&journal.file, payload).map_err(map_storage_error)?;
+        // Journals must hit disk before the filesystem swap so power-loss recovery can still
+        // distinguish Prepared from Swapped after the process is gone. A flush failure must
+        // leave the written marker in place: callers may already have renamed directories,
+        // and deleting the journal would let startup backup cleanup destroy the original package.
+        super::durability::persist_file(Path::new(&journal.file)).map_err(map_storage_error)
     }
 
     /// Builds a journal marker for one transaction with deterministic paths.
@@ -105,6 +137,15 @@ impl FilesystemSkillStorage {
         phase: JournalPhase,
     ) -> Result<(), SkillStorageError> {
         journal.phase = phase;
+        #[cfg(test)]
+        if self
+            .fail_next_journal_phase_update
+            .swap(false, Ordering::SeqCst)
+        {
+            return Err(SkillStorageError::OperationFailed {
+                message: "injected journal phase update failure".to_string(),
+            });
+        }
         self.write_journal(journal)
     }
 }
@@ -125,7 +166,7 @@ impl SkillStorage for FilesystemSkillStorage {
                 name: name.to_string(),
             });
         }
-        copy_dir_contents(&source, staging).map_err(map_storage_error)
+        copy_dir_contents(&source, staging, CopyDurability::Durable).map_err(map_storage_error)
     }
 
     fn write_file(
@@ -141,7 +182,8 @@ impl SkillStorage for FilesystemSkillStorage {
                 message: "staging file path has no parent".to_string(),
             })?;
         fs::create_dir_all(parent).map_err(map_storage_error)?;
-        fs::write(&destination, bytes).map_err(map_storage_error)
+        fs::write(&destination, bytes).map_err(map_storage_error)?;
+        super::durability::persist_package_file(&destination, staging).map_err(map_storage_error)
     }
 
     fn copy_file(
@@ -157,14 +199,18 @@ impl SkillStorage for FilesystemSkillStorage {
                 message: "staging file path has no parent".to_string(),
             })?;
         fs::create_dir_all(parent).map_err(map_storage_error)?;
-        let mut input = fs::File::open(source).map_err(map_storage_error)?;
-        let mut output = fs::File::create(&destination).map_err(map_storage_error)?;
-        std::io::copy(&mut input, &mut output).map_err(map_storage_error)?;
-        Ok(())
+        {
+            let mut input = fs::File::open(source).map_err(map_storage_error)?;
+            let mut output = fs::File::create(&destination).map_err(map_storage_error)?;
+            std::io::copy(&mut input, &mut output).map_err(map_storage_error)?;
+        }
+        super::durability::persist_package_file(&destination, staging).map_err(map_storage_error)
     }
 
     fn write_manifest(&self, staging: &Path, content: &[u8]) -> Result<(), SkillStorageError> {
-        fs::write(staging.join("SKILL.md"), content).map_err(map_storage_error)
+        let manifest = staging.join("SKILL.md");
+        fs::write(&manifest, content).map_err(map_storage_error)?;
+        super::durability::persist_package_file(&manifest, staging).map_err(map_storage_error)
     }
 
     fn commit_create(
@@ -182,11 +228,16 @@ impl SkillStorage for FilesystemSkillStorage {
         let mut journal =
             self.new_journal(JournalOp::Create, skill_id, name, name, Some(staging), None);
         self.write_journal(&journal)?;
-        if let Err(error) = fs::rename(staging, &formal) {
-            let _ = fs::remove_file(&journal.file);
+        if let Err(error) = rename_persistently(staging, &formal) {
+            abandon_journal_after_rename_failure(&journal.file, staging, &formal);
             return Err(map_promote_error(error, name));
         }
-        self.update_journal_phase(&mut journal, JournalPhase::Swapped)?;
+        if let Err(error) = self.update_journal_phase(&mut journal, JournalPhase::Swapped) {
+            if fs::rename(&formal, staging).is_ok() {
+                let _ = fs::remove_file(&journal.file);
+            }
+            return Err(error);
+        }
         Ok(CreateHandle {
             name: name.to_string(),
             staging: staging.to_path_buf(),
@@ -248,16 +299,19 @@ impl SkillStorage for FilesystemSkillStorage {
             fs::create_dir_all(parent).map_err(map_storage_error)?;
         }
 
-        if let Err(error) = fs::rename(&from_formal, &backup) {
-            let _ = fs::remove_file(&journal.file);
+        if let Err(error) = rename_persistently(&from_formal, &backup) {
+            abandon_journal_after_rename_failure(&journal.file, &from_formal, &backup);
             return Err(map_storage_error(error));
         }
-        if let Err(error) = fs::rename(staging, &target_formal) {
-            let _ = fs::rename(&backup, &from_formal);
-            let _ = fs::remove_file(&journal.file);
+        if let Err(error) = rename_persistently(staging, &target_formal) {
+            restore_backup_or_keep_journal(&backup, &from_formal, &journal.file);
             return Err(map_promote_error(error, name));
         }
-        self.update_journal_phase(&mut journal, JournalPhase::Swapped)?;
+        if let Err(error) = self.update_journal_phase(&mut journal, JournalPhase::Swapped) {
+            let _ = fs::remove_dir_all(&target_formal);
+            restore_backup_or_keep_journal(&backup, &from_formal, &journal.file);
+            return Err(error);
+        }
         Ok(SwapHandle {
             name: name.to_string(),
             from_name: from_name.to_string(),
@@ -308,11 +362,14 @@ impl SkillStorage for FilesystemSkillStorage {
         if let Some(parent) = backup.parent() {
             fs::create_dir_all(parent).map_err(map_storage_error)?;
         }
-        if let Err(error) = fs::rename(&formal, &backup) {
-            let _ = fs::remove_file(&journal.file);
+        if let Err(error) = rename_persistently(&formal, &backup) {
+            abandon_journal_after_rename_failure(&journal.file, &formal, &backup);
             return Err(map_storage_error(error));
         }
-        self.update_journal_phase(&mut journal, JournalPhase::Swapped)?;
+        if let Err(error) = self.update_journal_phase(&mut journal, JournalPhase::Swapped) {
+            restore_backup_or_keep_journal(&backup, &formal, &journal.file);
+            return Err(error);
+        }
         Ok(DeleteHandle {
             name: name.to_string(),
             backup,
@@ -373,7 +430,8 @@ impl SkillStorage for FilesystemSkillStorage {
     }
 
     fn restore_backup(&self, backup: &Path, name: &str) -> Result<(), SkillStorageError> {
-        fs::rename(backup, self.formal_path(name)).map_err(map_storage_error)
+        super::durability::rename_directory_for_recovery(backup, &self.formal_path(name))
+            .map_err(map_storage_error)
     }
 
     fn remove_dir(&self, path: &Path) -> Result<(), SkillStorageError> {
@@ -454,7 +512,11 @@ fn best_effort_cleanup(journal: &Path, leftover: &Path) {
 /// Symbolic links and special files are not recreated. Files are written through a fresh
 /// `File::create` so the destination gets application-defined default permissions rather than
 /// inheriting the source's ownership, mode, or timestamps (spec: no metadata preservation).
-fn copy_dir_contents(source: &Path, destination: &Path) -> std::io::Result<()> {
+fn copy_dir_contents(
+    source: &Path,
+    destination: &Path,
+    durability: CopyDurability,
+) -> std::io::Result<()> {
     for entry in fs::read_dir(source)? {
         let entry = entry?;
         let source_path = entry.path();
@@ -462,14 +524,58 @@ fn copy_dir_contents(source: &Path, destination: &Path) -> std::io::Result<()> {
         let file_type = entry.file_type()?;
         if file_type.is_dir() {
             fs::create_dir_all(&destination_path)?;
-            copy_dir_contents(&source_path, &destination_path)?;
+            copy_dir_contents(&source_path, &destination_path, durability)?;
+            if durability == CopyDurability::Durable {
+                super::durability::sync_directory(&destination_path)?;
+            }
         } else if file_type.is_file() {
-            let mut input = fs::File::open(&source_path)?;
-            let mut output = fs::File::create(&destination_path)?;
-            std::io::copy(&mut input, &mut output)?;
+            {
+                let mut input = fs::File::open(&source_path)?;
+                let mut output = fs::File::create(&destination_path)?;
+                std::io::copy(&mut input, &mut output)?;
+            }
+            if durability == CopyDurability::Durable {
+                super::durability::persist_file(&destination_path)?;
+            }
         }
     }
     Ok(())
+}
+
+/// Promotes or restores a directory and flushes parent metadata before the caller continues.
+fn rename_persistently(from: &Path, to: &Path) -> io::Result<()> {
+    super::durability::rename_directory_persistently(from, to)
+}
+
+/// Drops a journal marker unless a failed durable rename left the source at its destination.
+///
+/// A pre-existing destination can make both paths exist after a rename failure. That is an
+/// occupancy conflict, not a partial promote, so retaining a Prepared journal would let startup
+/// recovery delete the directory that won the race. The marker remains only when the source is
+/// gone and the destination exists, which means the rename happened but its compensation failed.
+fn abandon_journal_after_rename_failure(
+    journal: impl AsRef<Path>,
+    source: &Path,
+    destination: &Path,
+) {
+    if source.exists() || !destination.exists() {
+        let _ = fs::remove_file(journal);
+    }
+}
+
+/// Restores a compensation backup and drops the journal only when the original path is back
+/// and the backup is gone.
+///
+/// If the formal path already has a directory but the backup is still present (a failed
+/// overwrite undo), the journal must stay: startup recovery uses it to put the original
+/// package back. Dropping the marker would let leftover-backup cleanup destroy that copy.
+fn restore_backup_or_keep_journal(backup: &Path, original: &Path, journal: impl AsRef<Path>) {
+    if !original.exists() {
+        let _ = fs::rename(backup, original);
+    }
+    if original.exists() && !backup.exists() {
+        let _ = fs::remove_file(journal);
+    }
 }
 
 /// Converts filesystem failures into stable storage-port errors.
@@ -499,12 +605,19 @@ fn map_promote_error(error: io::Error, name: &str) -> SkillStorageError {
 #[cfg(test)]
 mod tests {
     use super::{FilesystemSkillStorage, map_promote_error};
-    use crate::skill::{SkillStorage, SkillStorageError};
+    use crate::skill::{JOURNAL_DIR_NAME, SkillStorage, SkillStorageError};
     use ora_domain::SkillId;
     use pretty_assertions::assert_eq;
     use std::fs;
     use std::io;
     use tempfile::TempDir;
+
+    /// Creates one storage root and its formal parent for transaction tests.
+    fn storage(temp: &TempDir) -> FilesystemSkillStorage {
+        let root = temp.path().join("skills");
+        fs::create_dir_all(&root).unwrap();
+        FilesystemSkillStorage::new(root)
+    }
 
     #[test]
     fn commit_create_returns_typed_conflict_when_destination_exists() {
@@ -552,6 +665,169 @@ mod tests {
             SkillStorageError::OperationFailed {
                 message: "disk full".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn keeps_journal_when_failed_rename_reached_its_destination() {
+        let temp = TempDir::new().unwrap();
+        let journal = temp.path().join("txn.json");
+        let source = temp.path().join("staging");
+        let promoted = temp.path().join("grilling");
+        fs::write(&journal, "{}").unwrap();
+        fs::create_dir_all(&promoted).unwrap();
+
+        super::abandon_journal_after_rename_failure(&journal, &source, &promoted);
+
+        assert!(journal.is_file());
+        assert!(!source.exists());
+        assert!(promoted.is_dir());
+    }
+
+    #[test]
+    fn drops_journal_when_destination_occupancy_prevented_the_rename() {
+        let temp = TempDir::new().unwrap();
+        let journal = temp.path().join("txn.json");
+        let source = temp.path().join("staging");
+        let promoted = temp.path().join("grilling");
+        fs::write(&journal, "{}").unwrap();
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&promoted).unwrap();
+
+        super::abandon_journal_after_rename_failure(&journal, &source, &promoted);
+
+        assert!(!journal.exists());
+        assert!(source.is_dir());
+        assert!(promoted.is_dir());
+    }
+
+    #[test]
+    fn drops_journal_when_failed_rename_left_no_destination() {
+        let temp = TempDir::new().unwrap();
+        let journal = temp.path().join("txn.json");
+        let source = temp.path().join("staging");
+        fs::write(&journal, "{}").unwrap();
+        fs::create_dir_all(&source).unwrap();
+
+        super::abandon_journal_after_rename_failure(
+            &journal,
+            &source,
+            &temp.path().join("missing"),
+        );
+
+        assert!(!journal.exists());
+    }
+
+    #[test]
+    fn restores_backup_and_drops_journal_when_original_is_missing() {
+        let temp = TempDir::new().unwrap();
+        let original = temp.path().join("grilling");
+        let backup = temp.path().join("backup");
+        let journal = temp.path().join("txn.json");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("SKILL.md"), "body").unwrap();
+        fs::write(&journal, "{}").unwrap();
+
+        super::restore_backup_or_keep_journal(&backup, &original, &journal);
+
+        assert!(original.join("SKILL.md").is_file());
+        assert!(!backup.exists());
+        assert!(!journal.exists());
+    }
+
+    #[test]
+    fn keeps_journal_when_original_exists_and_backup_remains() {
+        let temp = TempDir::new().unwrap();
+        let original = temp.path().join("grilling");
+        let backup = temp.path().join("backup");
+        let journal = temp.path().join("txn.json");
+        fs::create_dir_all(&original).unwrap();
+        fs::write(original.join("SKILL.md"), "new").unwrap();
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("SKILL.md"), "old").unwrap();
+        fs::write(&journal, "{}").unwrap();
+
+        super::restore_backup_or_keep_journal(&backup, &original, &journal);
+
+        assert_eq!(
+            fs::read_to_string(original.join("SKILL.md")).unwrap(),
+            "new"
+        );
+        assert!(backup.join("SKILL.md").is_file());
+        assert!(journal.is_file());
+    }
+
+    #[test]
+    fn create_restores_staging_when_the_swapped_phase_cannot_be_written() {
+        let temp = TempDir::new().unwrap();
+        let storage = storage(&temp);
+        let staging = storage.create_staging().unwrap();
+        storage.write_manifest(&staging, b"new").unwrap();
+        storage.fail_next_journal_phase_update();
+
+        let error = storage
+            .commit_create("grilling", &SkillId::new("skill-1"), &staging)
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "skill storage operation failed: injected journal phase update failure"
+        );
+        assert!(staging.join("SKILL.md").is_file());
+        assert!(!temp.path().join("skills/grilling").exists());
+        assert_eq!(storage.list_journals().unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn swap_restores_the_original_when_the_swapped_phase_cannot_be_written() {
+        let temp = TempDir::new().unwrap();
+        let storage = storage(&temp);
+        let formal = temp.path().join("skills/grilling");
+        fs::create_dir(&formal).unwrap();
+        fs::write(formal.join("SKILL.md"), "old").unwrap();
+        let staging = storage.create_staging().unwrap();
+        storage.write_manifest(&staging, b"new").unwrap();
+        storage.fail_next_journal_phase_update();
+        let previous_updated_at = Some(100);
+
+        storage
+            .commit_swap(
+                "grilling",
+                "grilling",
+                &SkillId::new("skill-1"),
+                previous_updated_at,
+                &staging,
+            )
+            .unwrap_err();
+
+        assert_eq!(fs::read_to_string(formal.join("SKILL.md")).unwrap(), "old");
+        assert!(!staging.exists());
+        assert_eq!(storage.list_journals().unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn delete_restores_the_original_when_the_swapped_phase_cannot_be_written() {
+        let temp = TempDir::new().unwrap();
+        let storage = storage(&temp);
+        let formal = temp.path().join("skills/grilling");
+        fs::create_dir(&formal).unwrap();
+        fs::write(formal.join("SKILL.md"), "old").unwrap();
+        storage.fail_next_journal_phase_update();
+
+        storage
+            .commit_delete("grilling", &SkillId::new("skill-1"))
+            .unwrap_err();
+
+        assert_eq!(fs::read_to_string(formal.join("SKILL.md")).unwrap(), "old");
+        assert_eq!(storage.list_journals().unwrap(), Vec::new());
+        assert!(
+            !temp
+                .path()
+                .join("skills")
+                .join(JOURNAL_DIR_NAME)
+                .read_dir()
+                .unwrap()
+                .any(|entry| entry.is_ok())
         );
     }
 }

--- a/crates/application/src/skill/mod.rs
+++ b/crates/application/src/skill/mod.rs
@@ -1,3 +1,4 @@
+mod durability;
 mod filesystem_storage;
 mod handlers;
 mod id_generator;

--- a/crates/application/src/skill_import/README.md
+++ b/crates/application/src/skill_import/README.md
@@ -18,7 +18,9 @@ from one folder tree or one supported archive (`.zip`, `.skill`, `.tar.gz`, `.tg
 - Commit (`commit`) validates that every conflict candidate has a decision, freezes the decisions,
   and starts a detached background task that processes candidates in stable source-path order.
   Each skill is staged under the formal skills root and promoted atomically with its database
-  write; one failed candidate never rolls back its siblings.
+  write. The promote flushes package files and directory metadata before the row is committed
+  on platforms that can fsync directories; Windows directory flush is best-effort. One failed
+  candidate never rolls back its siblings.
 - Sessions live only in memory and expire by idle time or absolute lifetime. Completed or
   cancelled sessions retain lightweight result metadata for the result-retention window so
   idempotent retries and progress recovery keep working.

--- a/docs/database-repositories.md
+++ b/docs/database-repositories.md
@@ -30,7 +30,7 @@ Adding an adapter never changes a port signature. Handlers keep depending on the
 - `busy_timeout = 5000` ms
 - `synchronous = NORMAL`
 
-Those PRAGMAs are applied in the connection manager rather than at call sites, so no repository can accidentally run with a different durability or concurrency profile. Pooling requires a file-backed `DatabaseLocation::Path`; `DatabaseLocation::InMemory` is for bootstrap and migration tests and returns `UnsupportedPooledLocation` if pooled.
+Those PRAGMAs are applied in the connection manager rather than at call sites, so no repository can accidentally run with a different durability or concurrency profile. `NORMAL` is crash-safe for process kills but may lose the last COMMIT on power loss. Skill package promotion flushes directory metadata _before_ that COMMIT, so a lost last transaction leaves an unowned package directory that startup reconciliation removes rather than a visible row without files. Pooling requires a file-backed `DatabaseLocation::Path`; `DatabaseLocation::InMemory` is for bootstrap and migration tests and returns `UnsupportedPooledLocation` if pooled.
 
 File-backed parent directories are not created here. The Desktop composition root prepares them before opening `ora-backend::Backend`.
 

--- a/docs/desktop-runtime.md
+++ b/docs/desktop-runtime.md
@@ -27,7 +27,10 @@ Desktop exposes the shared import session lifecycle through four unary Tauri com
 The frontend sends the system picker's local path inside `PrepareSkillImportRequest`; the Rust
 side reads the folder or archive, so file bytes (up to 200 MiB) are never serialized over Tauri
 IPC. Preparation, preview, conflict decisions, background commit, and result retention behave
-through the shared `ora-backend` composition.
+through the shared `ora-backend` composition. Before the catalog row is committed, package files,
+journal markers, and directory promotes are flushed on platforms that support directory fsync.
+Mutation-time directory fsync is a hard error on Unix and best-effort on Windows; macOS
+`sync_all` uses `fsync` rather than `F_FULLFSYNC`.
 
 The configured root is only a creation target. Existing worktree locations are resolved from the stored branch name and `git worktree list --porcelain` when an agent Session starts or loads. Task and project deletion never mutate Git.
 


### PR DESCRIPTION
Power loss could persist a SQLite row after rename while parent-directory metadata never reached disk, leaving a visible skill without its package. Flush files, journals, and directory promotes first so the remaining crash window is an unowned directory that startup reconciliation already removes.