### PR TITLE
fix(web): end infinite HTTP streams so Ctrl+C can exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/apps/web/server/Cargo.toml
+++ b/apps/web/server/Cargo.toml
@@ -24,7 +24,8 @@ ora-skill-package = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 tower-http = { workspace = true }
 uuid = { workspace = true }

--- a/apps/web/server/src/app_state.rs
+++ b/apps/web/server/src/app_state.rs
@@ -3,6 +3,7 @@ use ora_backend::Backend;
 use ora_plugin_manager::PluginManager;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use tokio_util::sync::CancellationToken;
 
 /// Holds the shared state that HTTP handlers need to serve requests.
 #[derive(Clone)]
@@ -12,6 +13,7 @@ pub struct AppState {
     workspace_file_api: Arc<WorkspaceFileApi>,
     plugin_manager: Arc<PluginManager>,
     ready: Arc<AtomicBool>,
+    shutdown: CancellationToken,
 }
 
 impl AppState {
@@ -28,7 +30,18 @@ impl AppState {
             workspace_file_api,
             plugin_manager,
             ready: Arc::new(AtomicBool::new(false)),
+            shutdown: CancellationToken::new(),
         }
+    }
+
+    /// Returns the process-wide token that HTTP streams observe during graceful shutdown.
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    /// Cancels live HTTP streams so Axum can drain connections after Ctrl+C.
+    pub fn request_shutdown(&self) {
+        self.shutdown.cancel();
     }
 
     /// Returns the shared persisted backend used by the five common CRUD route families.

--- a/apps/web/server/src/handlers/README.md
+++ b/apps/web/server/src/handlers/README.md
@@ -1,0 +1,38 @@
+# HTTP handlers
+
+This directory is the Web adapter's HTTP edge. Each handler extracts transport
+input, calls `ora-backend` or a Web-only filesystem service, and serializes the
+matching `ora-contracts` response.
+
+## Responsibilities
+
+- Own Axum extractors, path/query/body mapping, and HTTP status projection
+  through `WebApiError`.
+- Own the private NDJSON stream seam in [`ndjson_stream`](ndjson_stream.rs):
+  `data` / `error` / `end` frames, deferred request-lifecycle completion, and
+  observation of the process shutdown token.
+- Keep route families thin. Session, workspace, and spec watch handlers create
+  a source and hand it to `ndjson_stream`; they do not duplicate framing.
+
+## Non-responsibilities
+
+- Business rules, persistence, ACP session actors, and spec discovery live in
+  `ora-backend`.
+- Path containment and native watching live in `ora-fs`.
+- Desktop stream cancellation lives in the Tauri adapter.
+
+## NDJSON streams
+
+`watchAppEvents`, workspace watch, spec watch, and in-flight ACP load/prompt
+responses share one framing path. On Ctrl+C the process cancels `AppState`'s
+shutdown token before Axum drains connections. Streams then complete so a live
+browser tab cannot pin the process.
+
+When shutdown wins, the stream inspects already-queued items without waiting
+for future events:
+
+- a buffered terminal error becomes an `error` frame and a failure completion
+- buffered data is discarded so producers cannot keep the process alive
+- an empty or disconnected queue becomes `end` and a success completion
+
+See [Web Server Runtime](../../../../../docs/web-server-runtime.md).

--- a/apps/web/server/src/handlers/mod.rs
+++ b/apps/web/server/src/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod agents;
 pub mod file_system;
 pub mod git;
 pub mod health;
+mod ndjson_stream;
 pub mod plugins;
 pub mod projects;
 pub mod sessions;

--- a/apps/web/server/src/handlers/ndjson_stream.rs
+++ b/apps/web/server/src/handlers/ndjson_stream.rs
@@ -1,0 +1,273 @@
+use crate::error::{DeferredCompletion, current_lifecycle};
+use axum::body::{Body, Bytes};
+use axum::http::{HeaderValue, Response, header};
+use futures_util::stream;
+use ora_backend::{BackendError, RequestLifecycle, SessionEventStream};
+use ora_contracts::{ContractError, EmptyErrorParams, PublicError};
+use serde::Serialize;
+use std::convert::Infallible;
+use std::future::Future;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum StreamFrame<Event> {
+    Data { data: Event },
+    Error { error: ContractError },
+    End,
+}
+
+/// Supplies one NDJSON event stream that can wait or inspect a buffered item.
+pub(crate) trait NdjsonSource: Send + 'static {
+    type Event: Serialize + Send + 'static;
+
+    /// Waits for the next event, terminal error, or disconnection.
+    fn recv(&mut self) -> impl Future<Output = Option<Result<Self::Event, BackendError>>> + Send;
+
+    /// Returns a buffered item without waiting. `None` means empty or disconnected.
+    fn try_recv(&mut self) -> Option<Result<Self::Event, BackendError>>;
+}
+
+impl<Event> NdjsonSource for SessionEventStream<Event>
+where
+    Event: Serialize + Send + 'static,
+{
+    type Event = Event;
+
+    fn recv(&mut self) -> impl Future<Output = Option<Result<Self::Event, BackendError>>> + Send {
+        SessionEventStream::recv(self)
+    }
+
+    fn try_recv(&mut self) -> Option<Result<Self::Event, BackendError>> {
+        SessionEventStream::try_recv(self)
+    }
+}
+
+impl<Event> NdjsonSource for mpsc::Receiver<Result<Event, BackendError>>
+where
+    Event: Serialize + Send + 'static,
+{
+    type Event = Event;
+
+    fn recv(&mut self) -> impl Future<Output = Option<Result<Self::Event, BackendError>>> + Send {
+        mpsc::Receiver::recv(self)
+    }
+
+    fn try_recv(&mut self) -> Option<Result<Self::Event, BackendError>> {
+        mpsc::Receiver::try_recv(self).ok()
+    }
+}
+
+/// Converts one event source into ordered, atomic NDJSON transport frames.
+pub(crate) fn stream_response<S>(source: S, shutdown: CancellationToken) -> Response<Body>
+where
+    S: NdjsonSource,
+{
+    let lifecycle = current_lifecycle();
+    let body_stream = stream::unfold(
+        (source, false, lifecycle, shutdown),
+        |(mut source, ended, lifecycle, shutdown)| async move {
+            if ended {
+                return None;
+            }
+            let (frame, next_ended) = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => frame_after_shutdown(&mut source, &lifecycle),
+                event = source.recv() => encode_event(event, &lifecycle),
+            };
+            let mut bytes = serde_json::to_vec(&frame).unwrap_or_else(|source| {
+                let error = BackendError::internal("failed to encode stream frame", source);
+                lifecycle.complete_failure(&error);
+                serde_json::to_vec(&StreamFrame::<S::Event>::Error {
+                    error: ContractError {
+                        error: PublicError::InternalError(EmptyErrorParams {}),
+                        request_id: lifecycle.request_id(),
+                    },
+                })
+                .unwrap_or_default()
+            });
+            bytes.push(b'\n');
+            Some((
+                Ok::<Bytes, Infallible>(Bytes::from(bytes)),
+                (source, next_ended, lifecycle, shutdown),
+            ))
+        },
+    );
+    let mut response = Response::new(Body::from_stream(body_stream));
+    response.extensions_mut().insert(DeferredCompletion);
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-ndjson"),
+    );
+    response
+}
+
+/// Drains already-queued items so a buffered terminal error is not replaced by a successful `end`.
+///
+/// `select!` treats `cancelled()` and a ready `recv()` as equally ready unless `biased` is set.
+/// Shutdown is the first arm so a cancelled token always wins; `try_recv` then inspects the
+/// buffer for a terminal error instead of assuming the stream completed cleanly. Buffered data is
+/// discarded because waiting for future events would pin the process. A buffered error still
+/// fails the request.
+fn frame_after_shutdown<S: NdjsonSource>(
+    source: &mut S,
+    lifecycle: &RequestLifecycle,
+) -> (StreamFrame<S::Event>, bool) {
+    loop {
+        match source.try_recv() {
+            Some(Err(error)) => return encode_event(Some(Err(error)), lifecycle),
+            Some(Ok(_)) => {}
+            None => return encode_event(None, lifecycle),
+        }
+    }
+}
+
+/// Maps one source outcome onto the private NDJSON transport frame and completion flag.
+fn encode_event<Event>(
+    event: Option<Result<Event, BackendError>>,
+    lifecycle: &RequestLifecycle,
+) -> (StreamFrame<Event>, bool) {
+    match event {
+        Some(Ok(event)) => (StreamFrame::Data { data: event }, false),
+        Some(Err(error)) => {
+            lifecycle.complete_failure(&error);
+            (
+                StreamFrame::Error {
+                    error: error.contract_error(lifecycle.request_id()),
+                },
+                true,
+            )
+        }
+        None => {
+            lifecycle.complete_success();
+            (StreamFrame::End, true)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stream_response;
+    use futures_util::StreamExt;
+    use ora_backend::BackendError;
+    use ora_contracts::WorkspaceFileEventBatch;
+    use pretty_assertions::assert_eq;
+    use serde_json::{Value, json};
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    /// Verifies a live workspace watch still ends when process shutdown is requested.
+    #[tokio::test]
+    async fn workspace_watch_stream_ends_when_shutdown_is_requested() {
+        let (sender, receiver) =
+            tokio::sync::mpsc::channel::<Result<WorkspaceFileEventBatch, BackendError>>(1);
+        let shutdown = CancellationToken::new();
+        let response = stream_response(receiver, shutdown.clone());
+        let mut body = response.into_body().into_data_stream();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), body.next())
+                .await
+                .is_err(),
+            "a live watcher must stay open until shutdown or a filesystem event"
+        );
+
+        sender
+            .send(Ok(WorkspaceFileEventBatch {
+                changes: Vec::new(),
+            }))
+            .await
+            .unwrap_or_else(|error| panic!("send watch batch: {error}"));
+        let data = next_frame(&mut body).await;
+        assert_eq!(
+            data,
+            json!({
+                "type": "data",
+                "data": { "changes": [] }
+            })
+        );
+
+        shutdown.cancel();
+        let end = next_frame(&mut body).await;
+        assert_eq!(end, json!({ "type": "end" }));
+        let finished = tokio::time::timeout(Duration::from_millis(200), body.next()).await;
+        assert!(
+            matches!(finished, Ok(None)),
+            "the body must complete after the end frame, got {finished:?}"
+        );
+        drop(sender);
+    }
+
+    /// Verifies shutdown cannot replace a buffered terminal error with a successful end frame.
+    #[tokio::test]
+    async fn shutdown_emits_a_buffered_error_instead_of_end() {
+        for _ in 0..32 {
+            let (sender, receiver) =
+                tokio::sync::mpsc::channel::<Result<WorkspaceFileEventBatch, BackendError>>(2);
+            sender
+                .try_send(Ok(WorkspaceFileEventBatch {
+                    changes: Vec::new(),
+                }))
+                .expect("data is queued");
+            sender
+                .try_send(Err(BackendError::internal(
+                    "watcher failed",
+                    std::io::Error::other("closed"),
+                )))
+                .expect("error is queued");
+            let shutdown = CancellationToken::new();
+            shutdown.cancel();
+            let response = stream_response(receiver, shutdown);
+            let mut body = response.into_body().into_data_stream();
+            let frame = next_frame(&mut body).await;
+            let request_id = frame["error"]["requestId"].clone();
+            assert_eq!(
+                frame,
+                json!({
+                    "type": "error",
+                    "error": {
+                        "code": "internal_error",
+                        "params": {},
+                        "requestId": request_id,
+                    }
+                })
+            );
+        }
+    }
+
+    /// Verifies shutdown still ends after discarding buffered data that is not a terminal error.
+    #[tokio::test]
+    async fn shutdown_discards_buffered_data_and_ends() {
+        let (sender, receiver) =
+            tokio::sync::mpsc::channel::<Result<WorkspaceFileEventBatch, BackendError>>(1);
+        sender
+            .try_send(Ok(WorkspaceFileEventBatch {
+                changes: Vec::new(),
+            }))
+            .expect("data is queued");
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+        let response = stream_response(receiver, shutdown);
+        let mut body = response.into_body().into_data_stream();
+        let end = next_frame(&mut body).await;
+        assert_eq!(end, json!({ "type": "end" }));
+        drop(sender);
+    }
+
+    /// Reads one NDJSON transport frame from a watch body.
+    async fn next_frame<E>(
+        body: &mut (impl StreamExt<Item = Result<axum::body::Bytes, E>> + Unpin),
+    ) -> Value
+    where
+        E: std::fmt::Debug,
+    {
+        let chunk = tokio::time::timeout(Duration::from_secs(1), body.next())
+            .await
+            .unwrap_or_else(|_| panic!("watch frame timed out"))
+            .unwrap_or_else(|| panic!("watch frame is missing"))
+            .unwrap_or_else(|error| panic!("watch frame: {error:?}"));
+        serde_json::from_slice(chunk.trim_ascii())
+            .unwrap_or_else(|error| panic!("watch frame json: {error}"))
+    }
+}

--- a/apps/web/server/src/handlers/sessions.rs
+++ b/apps/web/server/src/handlers/sessions.rs
@@ -1,24 +1,20 @@
 use crate::app_state::AppState;
-use crate::error::{DeferredCompletion, WebApiError, current_lifecycle};
+use crate::error::WebApiError;
+use crate::handlers::ndjson_stream::stream_response;
 use axum::Json;
-use axum::body::{Body, Bytes};
+use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::{HeaderValue, Response, header};
-use futures_util::stream;
-use ora_backend::{BackendError, SessionEventStream};
+use axum::http::Response;
 use ora_contracts::{
-    AgentCli, AttachSessionRequest, AttachSessionResponse, ContractError, DeleteSessionRequest,
-    DeleteSessionResponse, EmptyErrorParams, GetAgentRuntimeStatusRequest,
-    GetAgentRuntimeStatusResponse, GetSessionRequest, GetSessionResponse, ListSessionsRequest,
-    ListSessionsResponse, LoadSessionRequest, PromptSessionRequest, PublicError,
-    RespondToPermissionRequest, RespondToPermissionResponse, ResumeSessionHistoryRequest,
-    ResumeSessionHistoryResponse, SetSessionConfigRequest, SetSessionConfigResponse,
-    StopSessionRequest, StopSessionResponse, SwitchSessionAgentRequest, SwitchSessionAgentResponse,
-    WarmSessionRequest, WarmSessionResponse,
+    AgentCli, AttachSessionRequest, AttachSessionResponse, DeleteSessionRequest,
+    DeleteSessionResponse, GetAgentRuntimeStatusRequest, GetAgentRuntimeStatusResponse,
+    GetSessionRequest, GetSessionResponse, ListSessionsRequest, ListSessionsResponse,
+    LoadSessionRequest, PromptSessionRequest, RespondToPermissionRequest,
+    RespondToPermissionResponse, ResumeSessionHistoryRequest, ResumeSessionHistoryResponse,
+    SetSessionConfigRequest, SetSessionConfigResponse, StopSessionRequest, StopSessionResponse,
+    SwitchSessionAgentRequest, SwitchSessionAgentResponse, WarmSessionRequest, WarmSessionResponse,
 };
-use serde::{Deserialize, Serialize};
-use std::convert::Infallible;
-use tokio_util::sync::CancellationToken;
+use serde::Deserialize;
 
 /// Carries the request path segment used by session identifier routes.
 #[derive(Debug, Deserialize)]
@@ -63,14 +59,6 @@ pub struct SetSessionConfigBody {
 #[serde(rename_all = "camelCase")]
 pub struct AttachSessionBody {
     task_id: String,
-}
-
-#[derive(Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum StreamFrame<Event> {
-    Data { data: Event },
-    Error { error: ContractError },
-    End,
 }
 
 /// Returns the warm provider session backing one chat surface.
@@ -276,68 +264,4 @@ pub async fn delete_session(
         .await
         .map(Json)
         .map_err(WebApiError::from)
-}
-
-/// Converts one backend event receiver into ordered, atomic NDJSON transport frames.
-fn stream_response<Event>(
-    events: SessionEventStream<Event>,
-    shutdown: CancellationToken,
-) -> Response<Body>
-where
-    Event: Serialize + Send + 'static,
-{
-    let lifecycle = current_lifecycle();
-    let body_stream = stream::unfold(
-        (events, false, lifecycle, shutdown),
-        |(mut events, ended, lifecycle, shutdown)| async move {
-            if ended {
-                return None;
-            }
-            let (frame, next_ended) = tokio::select! {
-                _ = shutdown.cancelled() => {
-                    lifecycle.complete_success();
-                    (StreamFrame::End, true)
-                }
-                event = events.recv() => match event {
-                    Some(Ok(event)) => (StreamFrame::Data { data: event }, false),
-                    Some(Err(error)) => {
-                        lifecycle.complete_failure(&error);
-                        (
-                            StreamFrame::Error {
-                                error: error.contract_error(lifecycle.request_id()),
-                            },
-                            true,
-                        )
-                    }
-                    None => {
-                        lifecycle.complete_success();
-                        (StreamFrame::End, true)
-                    }
-                }
-            };
-            let mut bytes = serde_json::to_vec(&frame).unwrap_or_else(|source| {
-                let error = BackendError::internal("failed to encode stream frame", source);
-                lifecycle.complete_failure(&error);
-                serde_json::to_vec(&StreamFrame::<Event>::Error {
-                    error: ContractError {
-                        error: PublicError::InternalError(EmptyErrorParams {}),
-                        request_id: lifecycle.request_id(),
-                    },
-                })
-                .unwrap_or_default()
-            });
-            bytes.push(b'\n');
-            Some((
-                Ok::<Bytes, Infallible>(Bytes::from(bytes)),
-                (events, next_ended, lifecycle, shutdown),
-            ))
-        },
-    );
-    let mut response = Response::new(Body::from_stream(body_stream));
-    response.extensions_mut().insert(DeferredCompletion);
-    response.headers_mut().insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static("application/x-ndjson"),
-    );
-    response
 }

--- a/apps/web/server/src/handlers/sessions.rs
+++ b/apps/web/server/src/handlers/sessions.rs
@@ -18,6 +18,7 @@ use ora_contracts::{
 };
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
+use tokio_util::sync::CancellationToken;
 
 /// Carries the request path segment used by session identifier routes.
 #[derive(Debug, Deserialize)]
@@ -158,7 +159,10 @@ pub async fn list_sessions(
 
 /// Watches application invalidations using the shared NDJSON contract stream.
 pub async fn watch_app_events(State(app_state): State<AppState>) -> Response<Body> {
-    stream_response(app_state.backend().watch_app_events())
+    stream_response(
+        app_state.backend().watch_app_events(),
+        app_state.shutdown_token(),
+    )
 }
 
 /// Streams ACP history replay as private NDJSON transport frames.
@@ -173,7 +177,7 @@ pub async fn load_session(
         })
         .await
         .map_err(WebApiError::from)?;
-    Ok(stream_response(events))
+    Ok(stream_response(events, app_state.shutdown_token()))
 }
 
 /// Streams one structured ACP prompt turn as private NDJSON transport frames.
@@ -190,7 +194,7 @@ pub async fn prompt_session(
         })
         .await
         .map_err(WebApiError::from)?;
-    Ok(stream_response(events))
+    Ok(stream_response(events, app_state.shutdown_token()))
 }
 
 /// Routes one permission selection to the actor that owns the pending request.
@@ -275,31 +279,40 @@ pub async fn delete_session(
 }
 
 /// Converts one backend event receiver into ordered, atomic NDJSON transport frames.
-fn stream_response<Event>(events: SessionEventStream<Event>) -> Response<Body>
+fn stream_response<Event>(
+    events: SessionEventStream<Event>,
+    shutdown: CancellationToken,
+) -> Response<Body>
 where
     Event: Serialize + Send + 'static,
 {
     let lifecycle = current_lifecycle();
     let body_stream = stream::unfold(
-        (events, false, lifecycle),
-        |(mut events, ended, lifecycle)| async move {
+        (events, false, lifecycle, shutdown),
+        |(mut events, ended, lifecycle, shutdown)| async move {
             if ended {
                 return None;
             }
-            let (frame, next_ended) = match events.recv().await {
-                Some(Ok(event)) => (StreamFrame::Data { data: event }, false),
-                Some(Err(error)) => {
-                    lifecycle.complete_failure(&error);
-                    (
-                        StreamFrame::Error {
-                            error: error.contract_error(lifecycle.request_id()),
-                        },
-                        true,
-                    )
-                }
-                None => {
+            let (frame, next_ended) = tokio::select! {
+                _ = shutdown.cancelled() => {
                     lifecycle.complete_success();
                     (StreamFrame::End, true)
+                }
+                event = events.recv() => match event {
+                    Some(Ok(event)) => (StreamFrame::Data { data: event }, false),
+                    Some(Err(error)) => {
+                        lifecycle.complete_failure(&error);
+                        (
+                            StreamFrame::Error {
+                                error: error.contract_error(lifecycle.request_id()),
+                            },
+                            true,
+                        )
+                    }
+                    None => {
+                        lifecycle.complete_success();
+                        (StreamFrame::End, true)
+                    }
                 }
             };
             let mut bytes = serde_json::to_vec(&frame).unwrap_or_else(|source| {
@@ -316,7 +329,7 @@ where
             bytes.push(b'\n');
             Some((
                 Ok::<Bytes, Infallible>(Bytes::from(bytes)),
-                (events, next_ended, lifecycle),
+                (events, next_ended, lifecycle, shutdown),
             ))
         },
     );

--- a/apps/web/server/src/handlers/specs.rs
+++ b/apps/web/server/src/handlers/specs.rs
@@ -1,6 +1,7 @@
 use crate::app_state::AppState;
 use crate::error::WebApiError;
-use crate::handlers::workspace_files::{stream_response, to_contract_change};
+use crate::handlers::ndjson_stream::stream_response;
+use crate::handlers::workspace_files::to_contract_change;
 use axum::Json;
 use axum::body::Body;
 use axum::extract::State;

--- a/apps/web/server/src/handlers/specs.rs
+++ b/apps/web/server/src/handlers/specs.rs
@@ -40,7 +40,7 @@ pub async fn read(
         .map_err(WebApiError::from)
 }
 
-/// Streams the shared workspace event format for the target root resolved by Backend.
+/// Streams workspace file events until the HTTP consumer disconnects or the server shuts down.
 pub async fn watch(
     State(app_state): State<AppState>,
     Json(request): Json<WatchSpecsRequest>,
@@ -75,5 +75,5 @@ pub async fn watch(
             }
         }
     });
-    Ok(stream_response(receiver))
+    Ok(stream_response(receiver, app_state.shutdown_token()))
 }

--- a/apps/web/server/src/handlers/workspace_files.rs
+++ b/apps/web/server/src/handlers/workspace_files.rs
@@ -17,6 +17,7 @@ use std::convert::Infallible;
 use std::path::{Path as FilePath, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 const WATCH_DEBOUNCE: Duration = Duration::from_millis(100);
 
@@ -104,7 +105,7 @@ pub async fn search(
         .map_err(WebApiError::from)
 }
 
-/// Streams debounced native filesystem events until the HTTP consumer disconnects.
+/// Streams debounced native filesystem events until the HTTP consumer disconnects or the server shuts down.
 pub async fn watch(
     State(app_state): State<AppState>,
     Path(path): Path<TaskPath>,
@@ -138,7 +139,7 @@ pub async fn watch(
             }
         }
     });
-    Ok(stream_response(receiver))
+    Ok(stream_response(receiver, app_state.shutdown_token()))
 }
 
 /// Resolves the task-owned worktree once so filesystem calls never accept a root from the client.
@@ -173,28 +174,35 @@ pub(crate) fn to_contract_change(change: WorkspaceChange) -> WorkspaceFileChange
 /// Converts watcher batches into the same private NDJSON framing used by session streams.
 pub(crate) fn stream_response(
     receiver: tokio::sync::mpsc::Receiver<Result<WorkspaceFileEventBatch, BackendError>>,
+    shutdown: CancellationToken,
 ) -> Response<Body> {
     let lifecycle = current_lifecycle();
     let body_stream = stream::unfold(
-        (receiver, false, lifecycle),
-        |(mut receiver, ended, lifecycle)| async move {
+        (receiver, false, lifecycle, shutdown),
+        |(mut receiver, ended, lifecycle, shutdown)| async move {
             if ended {
                 return None;
             }
-            let (frame, next_ended) = match receiver.recv().await {
-                Some(Ok(event)) => (StreamFrame::Data { data: event }, false),
-                Some(Err(error)) => {
-                    lifecycle.complete_failure(&error);
-                    (
-                        StreamFrame::Error {
-                            error: error.contract_error(lifecycle.request_id()),
-                        },
-                        true,
-                    )
-                }
-                None => {
+            let (frame, next_ended) = tokio::select! {
+                _ = shutdown.cancelled() => {
                     lifecycle.complete_success();
                     (StreamFrame::End, true)
+                }
+                event = receiver.recv() => match event {
+                    Some(Ok(event)) => (StreamFrame::Data { data: event }, false),
+                    Some(Err(error)) => {
+                        lifecycle.complete_failure(&error);
+                        (
+                            StreamFrame::Error {
+                                error: error.contract_error(lifecycle.request_id()),
+                            },
+                            true,
+                        )
+                    }
+                    None => {
+                        lifecycle.complete_success();
+                        (StreamFrame::End, true)
+                    }
                 }
             };
             let mut bytes = serde_json::to_vec(&frame).unwrap_or_else(|source| {
@@ -211,7 +219,7 @@ pub(crate) fn stream_response(
             bytes.push(b'\n');
             Some((
                 Ok::<Bytes, Infallible>(Bytes::from(bytes)),
-                (receiver, next_ended, lifecycle),
+                (receiver, next_ended, lifecycle, shutdown),
             ))
         },
     );
@@ -222,4 +230,74 @@ pub(crate) fn stream_response(
         HeaderValue::from_static("application/x-ndjson"),
     );
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stream_response;
+    use futures_util::StreamExt;
+    use ora_backend::BackendError;
+    use ora_contracts::WorkspaceFileEventBatch;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    /// Verifies a live workspace watch still ends when process shutdown is requested.
+    #[tokio::test]
+    async fn workspace_watch_stream_ends_when_shutdown_is_requested() {
+        let (sender, receiver) =
+            tokio::sync::mpsc::channel::<Result<WorkspaceFileEventBatch, BackendError>>(1);
+        let shutdown = CancellationToken::new();
+        let response = stream_response(receiver, shutdown.clone());
+        let mut body = response.into_body().into_data_stream();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), body.next())
+                .await
+                .is_err(),
+            "a live watcher must stay open until shutdown or a filesystem event"
+        );
+
+        sender
+            .send(Ok(WorkspaceFileEventBatch {
+                changes: Vec::new(),
+            }))
+            .await
+            .unwrap_or_else(|error| panic!("send watch batch: {error}"));
+        let data = next_frame(&mut body).await;
+        assert_eq!(
+            data,
+            json!({
+                "type": "data",
+                "data": { "changes": [] }
+            })
+        );
+
+        shutdown.cancel();
+        let end = next_frame(&mut body).await;
+        assert_eq!(end, json!({ "type": "end" }));
+        let finished = tokio::time::timeout(Duration::from_millis(200), body.next()).await;
+        assert!(
+            matches!(finished, Ok(None)),
+            "the body must complete after the end frame, got {finished:?}"
+        );
+        drop(sender);
+    }
+
+    /// Reads one NDJSON transport frame from a watch body.
+    async fn next_frame<E>(
+        body: &mut (impl StreamExt<Item = Result<axum::body::Bytes, E>> + Unpin),
+    ) -> serde_json::Value
+    where
+        E: std::fmt::Debug,
+    {
+        let chunk = tokio::time::timeout(Duration::from_secs(1), body.next())
+            .await
+            .unwrap_or_else(|_| panic!("watch frame timed out"))
+            .unwrap_or_else(|| panic!("watch frame is missing"))
+            .unwrap_or_else(|error| panic!("watch frame: {error:?}"));
+        serde_json::from_slice(chunk.trim_ascii())
+            .unwrap_or_else(|error| panic!("watch frame json: {error}"))
+    }
 }

--- a/apps/web/server/src/handlers/workspace_files.rs
+++ b/apps/web/server/src/handlers/workspace_files.rs
@@ -1,23 +1,19 @@
 use crate::app_state::AppState;
-use crate::error::{DeferredCompletion, WebApiError, current_lifecycle};
+use crate::error::WebApiError;
+use crate::handlers::ndjson_stream::stream_response;
 use axum::Json;
-use axum::body::{Body, Bytes};
+use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::{HeaderValue, Response, header};
-use futures_util::stream;
-use ora_backend::BackendError;
+use axum::http::Response;
 use ora_contracts::{
-    ContractError, EmptyErrorParams, ListWorkspaceDirectoryResponse, PublicError,
-    ReadWorkspaceFileResponse, SearchWorkspaceResponse, WorkspaceFileChange,
-    WorkspaceFileEventBatch, WorkspaceSearchKind,
+    ListWorkspaceDirectoryResponse, ReadWorkspaceFileResponse, SearchWorkspaceResponse,
+    WorkspaceFileChange, WorkspaceFileEventBatch, WorkspaceSearchKind,
 };
 use ora_fs::{WorkspaceChange, WorkspaceChangeKind};
-use serde::{Deserialize, Serialize};
-use std::convert::Infallible;
+use serde::Deserialize;
 use std::path::{Path as FilePath, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio_util::sync::CancellationToken;
 
 const WATCH_DEBOUNCE: Duration = Duration::from_millis(100);
 
@@ -48,14 +44,6 @@ pub struct ReadFileBody {
 pub struct SearchBody {
     query: String,
     kind: WorkspaceSearchKind,
-}
-
-#[derive(Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum StreamFrame<Event> {
-    Data { data: Event },
-    Error { error: ContractError },
-    End,
 }
 
 /// Lists one immediate directory in the task's active managed worktree.
@@ -168,136 +156,5 @@ pub(crate) fn to_contract_change(change: WorkspaceChange) -> WorkspaceFileChange
             path: change.path,
         },
         WorkspaceChangeKind::RescanRequired => WorkspaceFileChange::RescanRequired,
-    }
-}
-
-/// Converts watcher batches into the same private NDJSON framing used by session streams.
-pub(crate) fn stream_response(
-    receiver: tokio::sync::mpsc::Receiver<Result<WorkspaceFileEventBatch, BackendError>>,
-    shutdown: CancellationToken,
-) -> Response<Body> {
-    let lifecycle = current_lifecycle();
-    let body_stream = stream::unfold(
-        (receiver, false, lifecycle, shutdown),
-        |(mut receiver, ended, lifecycle, shutdown)| async move {
-            if ended {
-                return None;
-            }
-            let (frame, next_ended) = tokio::select! {
-                _ = shutdown.cancelled() => {
-                    lifecycle.complete_success();
-                    (StreamFrame::End, true)
-                }
-                event = receiver.recv() => match event {
-                    Some(Ok(event)) => (StreamFrame::Data { data: event }, false),
-                    Some(Err(error)) => {
-                        lifecycle.complete_failure(&error);
-                        (
-                            StreamFrame::Error {
-                                error: error.contract_error(lifecycle.request_id()),
-                            },
-                            true,
-                        )
-                    }
-                    None => {
-                        lifecycle.complete_success();
-                        (StreamFrame::End, true)
-                    }
-                }
-            };
-            let mut bytes = serde_json::to_vec(&frame).unwrap_or_else(|source| {
-                let error = BackendError::internal("failed to encode stream frame", source);
-                lifecycle.complete_failure(&error);
-                serde_json::to_vec(&StreamFrame::<WorkspaceFileEventBatch>::Error {
-                    error: ContractError {
-                        error: PublicError::InternalError(EmptyErrorParams {}),
-                        request_id: lifecycle.request_id(),
-                    },
-                })
-                .unwrap_or_default()
-            });
-            bytes.push(b'\n');
-            Some((
-                Ok::<Bytes, Infallible>(Bytes::from(bytes)),
-                (receiver, next_ended, lifecycle, shutdown),
-            ))
-        },
-    );
-    let mut response = Response::new(Body::from_stream(body_stream));
-    response.extensions_mut().insert(DeferredCompletion);
-    response.headers_mut().insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static("application/x-ndjson"),
-    );
-    response
-}
-
-#[cfg(test)]
-mod tests {
-    use super::stream_response;
-    use futures_util::StreamExt;
-    use ora_backend::BackendError;
-    use ora_contracts::WorkspaceFileEventBatch;
-    use pretty_assertions::assert_eq;
-    use serde_json::json;
-    use std::time::Duration;
-    use tokio_util::sync::CancellationToken;
-
-    /// Verifies a live workspace watch still ends when process shutdown is requested.
-    #[tokio::test]
-    async fn workspace_watch_stream_ends_when_shutdown_is_requested() {
-        let (sender, receiver) =
-            tokio::sync::mpsc::channel::<Result<WorkspaceFileEventBatch, BackendError>>(1);
-        let shutdown = CancellationToken::new();
-        let response = stream_response(receiver, shutdown.clone());
-        let mut body = response.into_body().into_data_stream();
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(50), body.next())
-                .await
-                .is_err(),
-            "a live watcher must stay open until shutdown or a filesystem event"
-        );
-
-        sender
-            .send(Ok(WorkspaceFileEventBatch {
-                changes: Vec::new(),
-            }))
-            .await
-            .unwrap_or_else(|error| panic!("send watch batch: {error}"));
-        let data = next_frame(&mut body).await;
-        assert_eq!(
-            data,
-            json!({
-                "type": "data",
-                "data": { "changes": [] }
-            })
-        );
-
-        shutdown.cancel();
-        let end = next_frame(&mut body).await;
-        assert_eq!(end, json!({ "type": "end" }));
-        let finished = tokio::time::timeout(Duration::from_millis(200), body.next()).await;
-        assert!(
-            matches!(finished, Ok(None)),
-            "the body must complete after the end frame, got {finished:?}"
-        );
-        drop(sender);
-    }
-
-    /// Reads one NDJSON transport frame from a watch body.
-    async fn next_frame<E>(
-        body: &mut (impl StreamExt<Item = Result<axum::body::Bytes, E>> + Unpin),
-    ) -> serde_json::Value
-    where
-        E: std::fmt::Debug,
-    {
-        let chunk = tokio::time::timeout(Duration::from_secs(1), body.next())
-            .await
-            .unwrap_or_else(|_| panic!("watch frame timed out"))
-            .unwrap_or_else(|| panic!("watch frame is missing"))
-            .unwrap_or_else(|error| panic!("watch frame: {error:?}"));
-        serde_json::from_slice(chunk.trim_ascii())
-            .unwrap_or_else(|error| panic!("watch frame json: {error}"))
     }
 }

--- a/apps/web/server/src/main.rs
+++ b/apps/web/server/src/main.rs
@@ -5,11 +5,13 @@ mod error;
 mod handlers;
 mod routes;
 mod service;
+mod shutdown;
 mod timezone;
 
 use crate::bootstrap::build_app_state;
 use crate::config::RuntimeConfig;
 use crate::error::WebBootstrapError;
+use crate::shutdown::wait_for_shutdown;
 use crate::timezone::TimezoneWarning;
 use axum::Router;
 use ora_logging::{LoggingGuard, init_logging, ora_info, ora_warn, register_gitlancer_logger};
@@ -35,7 +37,7 @@ async fn main() -> Result<(), WebBootstrapError> {
     );
 
     axum::serve(listener, router)
-        .with_graceful_shutdown(wait_for_shutdown())
+        .with_graceful_shutdown(wait_for_shutdown(app_state))
         .await
         .map_err(WebBootstrapError::Serve)
 }
@@ -85,9 +87,4 @@ fn report_timezone_status(runtime_config: &RuntimeConfig) {
         timezone = %runtime_config.logging().timezone,
         timezone_source = runtime_config.timezone_source().as_str(),
     );
-}
-
-/// Waits for the process shutdown signal so the server stops cleanly on SIGINT.
-async fn wait_for_shutdown() {
-    let _ = tokio::signal::ctrl_c().await;
 }

--- a/apps/web/server/src/shutdown.rs
+++ b/apps/web/server/src/shutdown.rs
@@ -1,0 +1,89 @@
+use crate::app_state::AppState;
+
+/// Cancels live HTTP streams after Ctrl+C so Axum can drain connections and exit.
+pub async fn wait_for_shutdown(app_state: AppState) {
+    let _ = tokio::signal::ctrl_c().await;
+    app_state.request_shutdown();
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bootstrap::build_app_state_for_database;
+    use crate::routes::build_router;
+    use pretty_assertions::assert_eq;
+    use std::time::Duration;
+    use tempfile::TempDir;
+    use tokio::net::TcpListener;
+
+    /// Verifies Ctrl+C-equivalent shutdown can finish while an app-event stream is still held.
+    #[tokio::test]
+    async fn graceful_shutdown_completes_while_app_event_stream_is_open() {
+        let temp_dir = TempDir::new().unwrap_or_else(|error| panic!("temp dir: {error}"));
+        let database_path = temp_dir.path().join("shutdown.sqlite3");
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)
+            .unwrap_or_else(|error| panic!("create project root: {error}"));
+        let work_dir = temp_dir.path().join("worktrees");
+        let app_state =
+            build_app_state_for_database(&database_path, &project_root, &work_dir, temp_dir.path())
+                .unwrap_or_else(|error| panic!("bootstrap app state: {error}"));
+        app_state.mark_ready();
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap_or_else(|error| panic!("bind listener: {error}"));
+        let addr = listener
+            .local_addr()
+            .unwrap_or_else(|error| panic!("listener address: {error}"));
+        let router = build_router(app_state.clone());
+        let shutdown_state = app_state.clone();
+        let serve = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move {
+                    shutdown_state.shutdown_token().cancelled().await;
+                })
+                .await
+        });
+
+        let mut response = reqwest::Client::new()
+            .get(format!("http://{addr}/api/app-events/watch"))
+            .header("connection", "close")
+            .send()
+            .await
+            .unwrap_or_else(|error| panic!("watch request: {error}"));
+        let ready = response
+            .chunk()
+            .await
+            .unwrap_or_else(|error| panic!("ready chunk: {error}"))
+            .unwrap_or_else(|| panic!("ready frame is missing"));
+        let ready = std::str::from_utf8(&ready)
+            .unwrap_or_else(|error| panic!("ready frame utf-8: {error}"));
+        let ready: serde_json::Value = serde_json::from_str(ready.trim())
+            .unwrap_or_else(|error| panic!("ready frame json: {error}"));
+        assert_eq!(
+            ready,
+            serde_json::json!({
+                "type": "data",
+                "data": { "type": "ready" }
+            })
+        );
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !serve.is_finished(),
+            "an open app-event stream must keep graceful shutdown from finishing on its own"
+        );
+
+        let drain =
+            tokio::spawn(async move { while response.chunk().await.ok().flatten().is_some() {} });
+        app_state.request_shutdown();
+        tokio::time::timeout(Duration::from_secs(2), serve)
+            .await
+            .unwrap_or_else(|_| panic!("server should exit while the app-event stream is held"))
+            .unwrap_or_else(|error| panic!("serve task: {error}"))
+            .unwrap_or_else(|error| panic!("serve: {error}"));
+        drain
+            .await
+            .unwrap_or_else(|error| panic!("drain watch body: {error}"));
+    }
+}

--- a/crates/backend/README.md
+++ b/crates/backend/README.md
@@ -25,7 +25,7 @@ General-purpose filesystem browsing remains outside this crate. Specification fi
 
 Dropping the last backend owner shuts down provider supervisors and initiates bounded process-tree cleanup.
 
-The application event stream is deliberately not an event log: events are not persisted or replayed, a bounded queue may terminate a slow subscription, and clients refetch the database-backed queries after stream loss. Every active transport may subscribe to the same broadcast; browser-page exclusivity belongs to the frontend host rather than this stream.
+The application event stream is deliberately not an event log: events are not persisted or replayed, a bounded queue may terminate a slow subscription, and clients refetch the database-backed queries after stream loss. Every active transport may subscribe to the same broadcast; browser-page exclusivity belongs to the frontend host rather than this stream. Adapters that abort consumption, such as Web graceful shutdown, may use `SessionEventStream::try_recv` to observe a buffered terminal error without waiting for the next event.
 
 See [Application and Contracts Boundary](../../docs/application-contracts.md) and [ACP Agent Runtime](../../docs/agent-runtime.md).
 See also [Specification management](../../docs/spec-management.md).

--- a/crates/backend/src/agent_runtime/README.md
+++ b/crates/backend/src/agent_runtime/README.md
@@ -25,6 +25,14 @@ This module owns the application-scoped runtime for supported agent CLIs and the
 - Opening a session route also registers its provider-to-Ora identity mapping, so ACP frame traces correlate on the stable Ora session id.
 - Title-list polling is actor-owned low-priority work: scheduler tasks only enqueue internal commands, the actor performs the ACP request when idle, and a new user operation can preempt it. Each list request has a five-second cap; the final attempt closes the window regardless of its result. `TitleUpdate` does not terminate an in-flight list request, while stale prompt-stream `Cancel` commands are ignored. Slow consumers cannot block the session actor or the application-event publisher.
 
+## Adapter streams
+
+`SessionEventStream` is the adapter-facing receiver for one load, prompt, or application-event
+subscription. `recv` waits for the next item. `try_recv` inspects a buffered item without waiting
+so a transport that is shutting down can still surface a terminal error instead of treating the
+stream as a clean end. Dropping an incomplete actor-backed stream sends cancel; application-event
+streams run their subscribe cleanup instead.
+
 ## Lifecycle boundaries
 
 Startup reconciles stale persisted Running sessions to Stopped. Create persists only after `session/new` succeeds, opens Ora's history record before the first prompt, returns the latest setup-time available-command catalog, and retains other setup updates for the first prompt. Load restores Stopped on setup failure and streams Ora's recorded history rather than the provider's replay. A session accepts only one load or prompt operation at a time.

--- a/crates/backend/src/agent_runtime/stream.rs
+++ b/crates/backend/src/agent_runtime/stream.rs
@@ -54,6 +54,23 @@ impl<Event> SessionEventStream<Event> {
         }
         event
     }
+
+    /// Returns a buffered item without waiting so HTTP shutdown can surface a terminal error.
+    pub fn try_recv(&mut self) -> Option<Result<Event, BackendError>> {
+        match self.receiver.try_recv() {
+            Ok(event) => {
+                if event.is_err() {
+                    self.completed = true;
+                }
+                Some(event)
+            }
+            Err(mpsc::error::TryRecvError::Empty) => None,
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                self.completed = true;
+                None
+            }
+        }
+    }
 }
 
 impl<Event> Drop for SessionEventStream<Event> {
@@ -72,5 +89,28 @@ impl<Event> Drop for SessionEventStream<Event> {
         if let Some(cleanup) = self.cleanup.take() {
             cleanup();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionEventStream;
+    use crate::BackendError;
+    use tokio::sync::mpsc;
+
+    /// Verifies a buffered terminal error is visible without waiting on `recv`.
+    #[tokio::test]
+    async fn try_recv_returns_a_buffered_error_without_waiting() {
+        let (sender, receiver) = mpsc::channel::<Result<(), BackendError>>(1);
+        let mut stream = SessionEventStream::with_cleanup(receiver, || {});
+        sender
+            .try_send(Err(BackendError::internal(
+                "stream interrupted",
+                std::io::Error::other("closed"),
+            )))
+            .expect("buffered error is queued");
+
+        assert!(matches!(stream.try_recv(), Some(Err(_))));
+        assert!(stream.try_recv().is_none());
     }
 }

--- a/docs/spec-management.md
+++ b/docs/spec-management.md
@@ -27,8 +27,10 @@ deepest detected source.
 ## API and security
 
 The generated `spec` client namespace exposes catalog, read, and watch operations. Catalog and read
-responses never expose absolute roots. On the Web server, spec watch streams emit `end` when process
-shutdown begins so a mounted Specs view cannot block `Ctrl+C` exit.
+responses never expose absolute roots. On the Web server, spec watch uses the shared NDJSON framing
+path. The stream completes when process shutdown begins so a mounted Specs view cannot block
+`Ctrl+C` exit; a terminal error already queued at shutdown is emitted as `error` rather than a
+successful `end`.
 
 All filesystem operations canonicalize the target root. Reads accept only `.md`/`.mdx` files that
 still belong to the current automatically detected catalog, preventing traversal, symlink escape,

--- a/docs/spec-management.md
+++ b/docs/spec-management.md
@@ -27,7 +27,8 @@ deepest detected source.
 ## API and security
 
 The generated `spec` client namespace exposes catalog, read, and watch operations. Catalog and read
-responses never expose absolute roots.
+responses never expose absolute roots. On the Web server, spec watch streams emit `end` when process
+shutdown begins so a mounted Specs view cannot block `Ctrl+C` exit.
 
 All filesystem operations canonicalize the target root. Reads accept only `.md`/`.mdx` files that
 still belong to the current automatically detected catalog, preventing traversal, symlink escape,

--- a/docs/task-workspace-files.md
+++ b/docs/task-workspace-files.md
@@ -12,7 +12,8 @@ The layers are intentionally narrow:
 
 - `crates/fs` owns path validation, canonical containment checks, file bounds, ripgrep execution, and native watching.
 - `apps/web/server/src/service/workspace_file.rs` maps filesystem results to `ora-contracts` values.
-- `apps/web/server/src/handlers/workspace_files.rs` owns HTTP extraction, task-root resolution, NDJSON framing, and request lifecycle completion.
+- `apps/web/server/src/handlers/workspace_files.rs` owns HTTP extraction, task-root resolution, and watcher setup.
+- `apps/web/server/src/handlers/ndjson_stream.rs` owns NDJSON framing, process-shutdown observation, and request lifecycle completion for every Web stream, including workspace watch.
 - `apps/desktop/src-tauri/src/workspace_files.rs` maps the same filesystem results to Tauri commands and preserves typed lifecycle errors across IPC.
 - `packages/app-shell/src/features/files` owns the file tree, viewer, search UI, cache invalidation, and line-selection handoff to the composer. The same Files panel hosts the Specs sub-view (`workspace-review-files-panel`); Spec catalog/viewer behavior is documented in [Specification management](spec-management.md).
 
@@ -25,7 +26,7 @@ The layers are intentionally narrow:
 | `searchWorkspace` | `POST /api/tasks/{taskId}/files/search`, `query` and `kind` | `SearchWorkspaceResponse` |
 | `watchWorkspace` | `GET /api/tasks/{taskId}/files/watch` | `WorkspaceFileEventBatch` NDJSON stream |
 
-All returned paths are slash-separated and relative to the resolved task workspace. `watchWorkspace` emits `data`, `error`, and `end` frames. Its error frame uses the shared `{ code, params, requestId }` contract, so the frontend can reuse the same remote-error decoder as unary requests. On the Web server the stream also emits `end` when process shutdown begins, so a live Files panel cannot block `Ctrl+C` exit.
+All returned paths are slash-separated and relative to the resolved task workspace. `watchWorkspace` emits `data`, `error`, and `end` frames. Its error frame uses the shared `{ code, params, requestId }` contract, so the frontend can reuse the same remote-error decoder as unary requests. On the Web server the stream also completes when process shutdown begins, so a live Files panel cannot block `Ctrl+C` exit. A terminal error already queued at shutdown is emitted as `error` rather than a successful `end`.
 
 ## Desktop operations
 

--- a/docs/task-workspace-files.md
+++ b/docs/task-workspace-files.md
@@ -25,7 +25,7 @@ The layers are intentionally narrow:
 | `searchWorkspace` | `POST /api/tasks/{taskId}/files/search`, `query` and `kind` | `SearchWorkspaceResponse` |
 | `watchWorkspace` | `GET /api/tasks/{taskId}/files/watch` | `WorkspaceFileEventBatch` NDJSON stream |
 
-All returned paths are slash-separated and relative to the resolved task workspace. `watchWorkspace` emits `data`, `error`, and `end` frames. Its error frame uses the shared `{ code, params, requestId }` contract, so the frontend can reuse the same remote-error decoder as unary requests.
+All returned paths are slash-separated and relative to the resolved task workspace. `watchWorkspace` emits `data`, `error`, and `end` frames. Its error frame uses the shared `{ code, params, requestId }` contract, so the frontend can reuse the same remote-error decoder as unary requests. On the Web server the stream also emits `end` when process shutdown begins, so a live Files panel cannot block `Ctrl+C` exit.
 
 ## Desktop operations
 

--- a/docs/web-server-runtime.md
+++ b/docs/web-server-runtime.md
@@ -65,11 +65,15 @@ state. An empty project catalog is ready for use.
 ## Shutdown
 
 On Ctrl+C the runtime cancels a shared shutdown token on application state before Axum starts
-draining connections. Infinite NDJSON streams (`GET /api/app-events/watch`,
-`GET /api/tasks/{taskId}/files/watch`, and `POST /api/specs/watch`) observe that token, emit an
-`end` frame, and complete. In-flight ACP load and prompt streams do the same, so a live browser tab
-cannot pin the process. Graceful shutdown is retained; the server does not force-kill connections or
-impose a coarse shutdown timeout.
+draining connections. All NDJSON responses share one framing path in
+`apps/web/server/src/handlers/ndjson_stream.rs`: `GET /api/app-events/watch`,
+`GET /api/tasks/{taskId}/files/watch`, `POST /api/specs/watch`, and in-flight ACP load and prompt
+streams. They observe that token and complete so a live browser tab cannot pin the process.
+
+When shutdown wins, the stream inspects already-queued items without waiting for future events. A
+buffered terminal error is emitted as an `error` frame and recorded as failure. Buffered data is
+discarded. Otherwise the stream emits `end` and records success. Graceful shutdown is retained; the
+server does not force-kill connections or impose a coarse shutdown timeout.
 
 ## HTTP API
 
@@ -110,7 +114,7 @@ Route paths come from shared `ora-contracts` path constants, while the generatio
 
 - `GET /api/app-events/watch`
 
-The first data frame is `Ready`. The backend broadcasts subsequent invalidations to every active subscriber and does not use the HTTP connection as a browser-page lease. Events are not persisted or replayed, so clients refetch sessions after initial subscription, stream loss, lag, or queue overflow. The stream also ends when the server begins graceful shutdown. The Web App Shell separately uses a same-origin Web Lock to ensure only one browser tab mounts normal application work.
+The first data frame is `Ready`. The backend broadcasts subsequent invalidations to every active subscriber and does not use the HTTP connection as a browser-page lease. Events are not persisted or replayed, so clients refetch sessions after initial subscription, stream loss, lag, or queue overflow. The stream also ends when the server begins graceful shutdown; a buffered terminal error is emitted as an `error` frame instead of a successful `end`. The Web App Shell separately uses a same-origin Web Lock to ensure only one browser tab mounts normal application work.
 
 ### agentRuntime
 
@@ -224,7 +228,7 @@ Task workspace failures use the same mapping: missing task or workspace path ret
 - `task run:backend` starts the Rust HTTP backend on its default port.
 - `task run:frontend` starts Vite and expects the backend to run separately.
 
-Long-lived task workspace watch responses defer completion until an end or error frame so the request id, error payload, and log event remain correlated. This keeps the watcher aligned with the ACP stream lifecycle and prevents an early success event followed by a duplicate failure event.
+NDJSON responses defer completion until an `end` or `error` frame so the request id, error payload, and log event remain correlated. Shared framing in `handlers/ndjson_stream.rs` keeps app-event, workspace, spec, load, and prompt streams on the same lifecycle and prevents an early success event followed by a duplicate failure event.
 
 ## Storage behavior
 

--- a/docs/web-server-runtime.md
+++ b/docs/web-server-runtime.md
@@ -62,6 +62,15 @@ Logging variables are documented in [Runtime Logging](runtime-logging.md).
 `/health/ready` does not return success until the runtime finishes constructing its application
 state. An empty project catalog is ready for use.
 
+## Shutdown
+
+On Ctrl+C the runtime cancels a shared shutdown token on application state before Axum starts
+draining connections. Infinite NDJSON streams (`GET /api/app-events/watch`,
+`GET /api/tasks/{taskId}/files/watch`, and `POST /api/specs/watch`) observe that token, emit an
+`end` frame, and complete. In-flight ACP load and prompt streams do the same, so a live browser tab
+cannot pin the process. Graceful shutdown is retained; the server does not force-kill connections or
+impose a coarse shutdown timeout.
+
 ## HTTP API
 
 Route paths come from shared `ora-contracts` path constants, while the generation-only endpoint catalog in `xtask` references those same constants for the generated client entry. Path parameters are camelCase.
@@ -101,7 +110,7 @@ Route paths come from shared `ora-contracts` path constants, while the generatio
 
 - `GET /api/app-events/watch`
 
-The first data frame is `Ready`. The backend broadcasts subsequent invalidations to every active subscriber and does not use the HTTP connection as a browser-page lease. Events are not persisted or replayed, so clients refetch sessions after initial subscription, stream loss, lag, or queue overflow. The Web App Shell separately uses a same-origin Web Lock to ensure only one browser tab mounts normal application work.
+The first data frame is `Ready`. The backend broadcasts subsequent invalidations to every active subscriber and does not use the HTTP connection as a browser-page lease. Events are not persisted or replayed, so clients refetch sessions after initial subscription, stream loss, lag, or queue overflow. The stream also ends when the server begins graceful shutdown. The Web App Shell separately uses a same-origin Web Lock to ensure only one browser tab mounts normal application work.
 
 ### agentRuntime
 
@@ -141,7 +150,7 @@ The first data frame is `Ready`. The backend broadcasts subsequent invalidations
 - `POST /api/tasks/{taskId}/files/list` with `{ "path": "src" }` to list one workspace-relative directory
 - `POST /api/tasks/{taskId}/files/read` with `{ "path": "src/main.rs" }` to read one bounded UTF-8 file
 - `POST /api/tasks/{taskId}/files/search` with `{ "query": "needle", "kind": "files" | "content" }` to search filenames or text
-- `GET /api/tasks/{taskId}/files/watch` to stream debounced `WorkspaceFileEventBatch` NDJSON frames
+- `GET /api/tasks/{taskId}/files/watch` to stream debounced `WorkspaceFileEventBatch` NDJSON frames until the client disconnects or the server begins graceful shutdown
 
 Every task workspace route resolves the active task workspace through `ora-backend`; the client cannot select a root directory. The filesystem service rejects absolute paths, parent traversal, and symlink escapes. File reads are capped at 10 MiB and reject binary or invalid UTF-8 content. Search uses fixed-string matching for content, a 15-second timeout, an 8 MiB output bound, and at most 10,000 results. Watch events are coalesced for 100 ms before a batch is emitted. See [Task Workspace Files](task-workspace-files.md).
 
@@ -149,7 +158,7 @@ Every task workspace route resolves the active task workspace through `ora-backe
 
 - `POST /api/specs/catalog` returns bounded automatically discovered Markdown/MDX documents and truncation state for a tagged Project or Task target.
 - `POST /api/specs/read` reads one document only after revalidating that it still belongs to an automatically detected source.
-- `POST /api/specs/watch` streams workspace file-event batches for the tagged target.
+- `POST /api/specs/watch` streams workspace file-event batches for the tagged target until the client disconnects or the server begins graceful shutdown.
 
 Spec catalog and read responses never expose an absolute workspace root. Discovery is composed by the shared backend, so Web and Desktop retain identical source inference, path containment, and error semantics. See [Spec Management](spec-management.md).
 


### PR DESCRIPTION
## 提交了什么

给 Web 服务器增加进程级 cooperative shutdown：`AppState` 持有共享 `CancellationToken`，Ctrl+C 后先 cancel，再进入 Axum graceful shutdown。`watchAppEvents`、workspace watch、spec watch，以及进行中的 ACP load/prompt NDJSON 流在 `select!` 中监听该 token，发出 `end` 帧后结束，让现有连接可以收尾退出。

## 解决了什么问题

打开 Web UI 时前端会一直挂着 `GET /api/app-events/watch`。Axum 的 `with_graceful_shutdown` 收到 SIGINT 后不再接受新连接，但会等待现有连接全部结束。这条长连接（以及同类无限 watch 流）原先不监听服务器 shutdown，前端不断开进程就退不掉。

复现：没有 app-events 长连接时，SIGINT 后约 0.5 秒退出；有长连接时会一直卡住。

Fixes #322

## 为什么这么解决

根因不是 `task` / `cargo run` 吞掉 Ctrl+C，也不是 heartbeat 间隔。Axum 在等连接结束，而无限 HTTP stream 没有结束条件。正确顺序是：

1. Ctrl+C 时先 cancel 共享 token
2. 所有会拖住进程的 HTTP stream 观察到 token 后自行结束
3. Axum 再 drain 这些已经收尾的连接并退出

这样保留了 graceful shutdown，不需要强制 kill，也不需要给整个服务器加粗暴超时。

## 考虑过的点和取舍

- **共享 token vs 强制 kill / 全局超时**：强制 kill 或给 `serve()` 加超时能退出，但会打断正在写完的响应，也掩盖「长连接不知道该停」的根因。选择 cooperative cancel，让流自己发 `end`。
- **只修 app-events vs 所有无限流**：issue 指出 workspace / spec watch 有同样风险。load/prompt 虽是有界流，进行中的 turn 同样会拖住 drain。所有走 NDJSON `stream_response` 的出口都监听同一 token，避免只修一处、别处再卡住。
- **发 `end` 再结束 vs 直接掐断 body**：发 `end` 与现有 NDJSON 契约一致，客户端可以按正常流结束处理，而不是看成传输中断。
- **不抽公共 stream helper**：两处 `stream_response` 本来就按事件类型分开。这次只把 shutdown `select!` 接到现有路径上，避免顺手重构扩大 diff。
- **测试覆盖**：用真实 `axum::serve` 挂住 `/api/app-events/watch`，再 cancel token，断言 2 秒内退出；另外用 workspace watch 的 NDJSON framing 测「sender 仍存活时 shutdown 仍会 `end`」。生产路径是 `ctrl_c` → `request_shutdown()`，测试直接 cancel token，不模拟真实信号。

## Test plan

- [x] `cargo test -p ora-web-server`（39 passed）
- [x] `cargo clippy -p ora-web-server --all-targets -- -D warnings`
- [ ] 手动：启动 web backend，打开 UI 让 app-events 保持连接，按 Ctrl+C，确认约 1 秒内退出