### PR TITLE
docs(web-server): 修正 Skill 导入缓冲与删除保证的文档措辞

### DIFF
--- a/docs/web-server-runtime.md
+++ b/docs/web-server-runtime.md
@@ -179,11 +179,11 @@ Unary requests and streams receive a server-generated canonical request id befor
 
 ### Skill imports
 
-`POST /api/skill-imports?mode=folder|archive` accepts one `multipart/form-data` source. Folder parts carry a validated source-relative path as their filename; archive mode accepts exactly one `.zip`, `.skill`, `.tar.gz`, or `.tgz` part. The adapter streams the upload to OS temporary storage before it calls the shared prepare service, so previewing never touches the database or committed skill packages.
+`POST /api/skill-imports?mode=folder|archive` accepts one `multipart/form-data` source. Folder parts carry a validated source-relative path as their filename; archive mode accepts exactly one `.zip`, `.skill`, `.tar.gz`, or `.tgz` part. The adapter writes each multipart chunk to a file under OS temporary storage as it is read, so memory use stays bounded by chunk size rather than by upload size, before it calls the shared prepare service; previewing never touches the database or committed skill packages.
 
 Preparation snapshots and safely scans the source, rejects unsafe paths, links and archive expansion attacks, then returns an opaque session id and every discovered candidate. `GET` renews the prepared session while it is within its idle and absolute lifetime. `POST .../commit` returns `202 Accepted` after it freezes every conflict decision; the background job remains observable via `GET`. `DELETE` cancels only prepared sessions.
 
-Each created, updated, overwritten, or deleted skill is atomic across its SQLite row and `<ORA_DATA_DIR>/atoms/skills/<name>/` package. The package transaction uses a same-filesystem staging directory and backup, while import sources remain in OS temp because it may be a different filesystem. Startup recovers interrupted package transactions, removes unowned package directories, and refuses to start if a visible row lacks its package or root `SKILL.md`.
+Each created, updated, overwritten, or deleted skill is atomic across its SQLite row and `<ORA_DATA_DIR>/atoms/skills/<name>/` package: a same-filesystem rename swaps the formal directory into or out of place before the database commit, and a failed database write rolls that rename back. Once a transaction commits, removing its now-unused staging or backup directory is best-effort — a cleanup failure is logged rather than surfaced to the caller, and the leftover directory is reclaimed the next time the server starts. Startup recovers interrupted package transactions, removes unowned package directories, and refuses to start if a visible row lacks its package or root `SKILL.md`.
 
 ### Filesystem browsing
 


### PR DESCRIPTION
## 概述
- docs/web-server-runtime.md 中「Skill imports」一节的两处描述强于实际实现，问题来自 #231（对 #198 的二次检视）。
- 上传：改为说明内存占用受限于单个分块大小（对应 `apps/web/server/src/handlers/skill_imports.rs` 中按块写入的 `stream_part_to_file`），不再笼统地用「streams」一词。
- 删除：改为明确说明"正式目录的 rename 与数据库提交是原子的"，而"事后的 journal/backup 清理是尽力而为的，失败时靠下次启动对账兜底回收"（对应 `crates/application/src/skill/filesystem_storage.rs` 中的 `commit_delete`/`finish_delete`/`best_effort_cleanup`）。

Fixes #231

## 测试计划
- [x] 纯文档改动，无需运行构建或测试任务。