### PR TITLE
fix(skill): document and test the import lock boundary from #234

### DIFF
--- a/crates/application/src/skill/README.md
+++ b/crates/application/src/skill/README.md
@@ -24,5 +24,21 @@ on-disk packages.
 - Domain validation (`ora-domain::Skill`) enforces the ASCII slug name rules and the 4096-byte
   description limit shared by create, update, and import.
 
+## Atomicity and recovery model
+
+Atomicity across the two stores is provided by the journal and startup recovery, not by a database
+transaction that spans both. Every mutation stages its package, writes a `Prepared` journal marker,
+promotes the formal directory, marks the journal `Swapped`, writes the database row, and only then
+clears the journal and its compensation artifacts. A failed database write compensates by rolling
+the directory back from the backup.
+
+Consequently no SQLite transaction is ever held open across a filesystem promote: the row write is
+a single statement that runs after the rename returns. This bounds write-lock hold time to that one
+statement, so a slow or network-backed skills root cannot starve unrelated catalog writers into the
+pool's busy timeout. The cost is that a crash between the promote and the row write leaves a
+recoverable inconsistency on disk rather than an impossible one, which is why every mutation must
+write its journal marker before touching the formal tree and why startup blocks on
+reconciliation before serving requests.
+
 See the [ora-application overview](../../README.md) and the
 [skill_import module](../skill_import/README.md).

--- a/crates/application/src/skill_import/README.md
+++ b/crates/application/src/skill_import/README.md
@@ -36,5 +36,9 @@ filesystem port (see the `skill` module), and does not decide HTTP or IPC semant
   preparation.
 - Once a commit is accepted it is uncancellable; retrying with the same decisions replays the
   stored results, and retrying with different decisions returns `already_committed`.
+- Each candidate promotes its package directory before writing its database row, so no SQLite
+  transaction stays open across the rename and a slow skills root cannot block unrelated writers.
+  See the [skill module's atomicity and recovery model](../skill/README.md) for the journal and
+  startup reconciliation that make this ordering crash-safe.
 
 See the [ora-application overview](../../README.md).

--- a/crates/backend/src/skill.rs
+++ b/crates/backend/src/skill.rs
@@ -135,3 +135,223 @@ impl SkillApi {
         self.import.cancel(request)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ora_application::{
+        AgentDefinitionRepository, CreateHandle, DeleteHandle, SkillRepository, SkillStorage,
+        SkillStorageError, SwapHandle, TransactionJournal,
+    };
+    use ora_db::{
+        DatabaseBootstrapper, DatabaseLocation, SqliteAgentDefinitionRepository,
+        default_migration_catalog,
+    };
+    use ora_domain::{AgentDefinition, AgentDefinitionId, AuditFields, Namespace};
+    use ora_logging::with_trace_logging;
+    use ora_skill_package::path::RelativePath;
+    use pretty_assertions::assert_eq;
+    use std::path::Path;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use tempfile::TempDir;
+
+    /// Delegates every storage operation but parks `commit_create` on a barrier.
+    ///
+    /// The park lets a test hold the package promote open for as long as it wants, which is the
+    /// slow-storage case the promote ordering has to tolerate.
+    struct PausingSkillStorage {
+        inner: FilesystemSkillStorage,
+        promote: Arc<Barrier>,
+    }
+
+    impl SkillStorage for PausingSkillStorage {
+        fn commit_create(
+            &self,
+            name: &str,
+            staging: &Path,
+        ) -> Result<CreateHandle, SkillStorageError> {
+            let handle = self.inner.commit_create(name, staging)?;
+            // Enter the promote window, then hold it until the observing thread releases it.
+            self.promote.wait();
+            self.promote.wait();
+            Ok(handle)
+        }
+
+        fn create_staging(&self) -> Result<std::path::PathBuf, SkillStorageError> {
+            self.inner.create_staging()
+        }
+
+        fn stage_existing(&self, name: &str, staging: &Path) -> Result<(), SkillStorageError> {
+            self.inner.stage_existing(name, staging)
+        }
+
+        fn write_file(
+            &self,
+            staging: &Path,
+            relative: &RelativePath,
+            bytes: &[u8],
+        ) -> Result<(), SkillStorageError> {
+            self.inner.write_file(staging, relative, bytes)
+        }
+
+        fn copy_file(
+            &self,
+            staging: &Path,
+            relative: &RelativePath,
+            source: &Path,
+        ) -> Result<(), SkillStorageError> {
+            self.inner.copy_file(staging, relative, source)
+        }
+
+        fn write_manifest(&self, staging: &Path, content: &[u8]) -> Result<(), SkillStorageError> {
+            self.inner.write_manifest(staging, content)
+        }
+
+        fn rollback_create(&self, handle: &CreateHandle) -> Result<(), SkillStorageError> {
+            self.inner.rollback_create(handle)
+        }
+
+        fn finish_create(&self, handle: &CreateHandle) -> Result<(), SkillStorageError> {
+            self.inner.finish_create(handle)
+        }
+
+        fn commit_swap(
+            &self,
+            name: &str,
+            from_name: &str,
+            staging: &Path,
+        ) -> Result<SwapHandle, SkillStorageError> {
+            self.inner.commit_swap(name, from_name, staging)
+        }
+
+        fn rollback_swap(&self, handle: &SwapHandle) -> Result<(), SkillStorageError> {
+            self.inner.rollback_swap(handle)
+        }
+
+        fn finish_swap(&self, handle: &SwapHandle) -> Result<(), SkillStorageError> {
+            self.inner.finish_swap(handle)
+        }
+
+        fn commit_delete(&self, name: &str) -> Result<DeleteHandle, SkillStorageError> {
+            self.inner.commit_delete(name)
+        }
+
+        fn rollback_delete(&self, handle: &DeleteHandle) -> Result<(), SkillStorageError> {
+            self.inner.rollback_delete(handle)
+        }
+
+        fn finish_delete(&self, handle: &DeleteHandle) -> Result<(), SkillStorageError> {
+            self.inner.finish_delete(handle)
+        }
+
+        fn formal_exists(&self, name: &str) -> bool {
+            self.inner.formal_exists(name)
+        }
+
+        fn read_manifest(&self, name: &str) -> Result<Option<Vec<u8>>, SkillStorageError> {
+            self.inner.read_manifest(name)
+        }
+
+        fn list_formal_names(&self) -> Result<Vec<String>, SkillStorageError> {
+            self.inner.list_formal_names()
+        }
+
+        fn remove_temp(&self, path: &Path) -> Result<(), SkillStorageError> {
+            self.inner.remove_temp(path)
+        }
+
+        fn restore_backup(&self, backup: &Path, name: &str) -> Result<(), SkillStorageError> {
+            self.inner.restore_backup(backup, name)
+        }
+
+        fn remove_dir(&self, path: &Path) -> Result<(), SkillStorageError> {
+            self.inner.remove_dir(path)
+        }
+
+        fn list_journals(&self) -> Result<Vec<TransactionJournal>, SkillStorageError> {
+            self.inner.list_journals()
+        }
+
+        fn remove_journal(&self, journal: &TransactionJournal) -> Result<(), SkillStorageError> {
+            self.inner.remove_journal(journal)
+        }
+    }
+
+    /// Verifies a stalled package promote never blocks unrelated catalog writers.
+    ///
+    /// Skill creation and import promote the package directory before writing their row, so the
+    /// SQLite write lock is never held across the rename. A promote parked indefinitely must
+    /// therefore leave concurrent writers free instead of starving them into the 5 second busy
+    /// timeout that the pool configures.
+    #[test]
+    fn stalled_package_promote_leaves_concurrent_catalog_writes_unblocked() {
+        with_trace_logging(|| {
+            let temp_dir = TempDir::new().unwrap();
+            let pool = DatabaseBootstrapper::system()
+                .bootstrap_repository_pool(
+                    &DatabaseLocation::path(temp_dir.path().join("ora.sqlite3")),
+                    &default_migration_catalog().unwrap(),
+                )
+                .unwrap();
+            let skill_repository = SqliteSkillRepository::new(pool.clone());
+            let agent_repository = SqliteAgentDefinitionRepository::new(pool);
+            let promote = Arc::new(Barrier::new(2));
+            let handler = CreateSkillHandler::new(
+                skill_repository.clone(),
+                PausingSkillStorage {
+                    inner: FilesystemSkillStorage::new(
+                        temp_dir.path().join("atoms").join("skills"),
+                    ),
+                    promote: promote.clone(),
+                },
+                UuidSkillIdGenerator::new(),
+                SystemClock,
+            );
+            let created_agent = AgentDefinition::new(
+                AgentDefinitionId::new("agent-1"),
+                Namespace::local(),
+                "opencode",
+                "Assists",
+                "",
+                AuditFields::new(1, 1, false),
+            )
+            .unwrap();
+
+            thread::scope(|scope| {
+                scope.spawn(|| {
+                    handler
+                        .handle(CreateSkillRequest {
+                            name: "review".to_string(),
+                            description: "Reviews changes".to_string(),
+                            content: None,
+                        })
+                        .unwrap();
+                });
+                scope.spawn(|| {
+                    promote.wait();
+                    // Runs strictly inside the parked promote: a lock held across the rename
+                    // would fail this write with SQLITE_BUSY instead.
+                    agent_repository
+                        .create_agent_definition(created_agent.clone())
+                        .unwrap();
+                    promote.wait();
+                });
+            });
+
+            assert_eq!(
+                agent_repository.list_agent_definitions().unwrap(),
+                vec![created_agent]
+            );
+            assert_eq!(
+                skill_repository
+                    .list_skills()
+                    .unwrap()
+                    .into_iter()
+                    .map(|skill| skill.name)
+                    .collect::<Vec<_>>(),
+                vec!["review".to_string()]
+            );
+        });
+    }
+}

--- a/crates/db/src/repository/skill.rs
+++ b/crates/db/src/repository/skill.rs
@@ -21,7 +21,18 @@ impl SkillRepository for SqliteSkillRepository {
     fn create_skill(&self, skill: Skill) -> Result<Skill, RepositoryError> {
         self.pool
             .with_connection(|connection| {
-                insert_skill_row(connection, &skill)?;
+                connection.execute(
+                    "INSERT INTO skills (id, namespace, name, description, created_at, updated_at, is_deleted) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    params![
+                        skill.id.to_string(),
+                        skill.namespace.as_ref(),
+                        &skill.name,
+                        &skill.description,
+                        skill.audit_fields.created_at,
+                        skill.audit_fields.updated_at,
+                        bool_to_sqlite(skill.audit_fields.is_deleted),
+                    ],
+                )?;
                 Ok(skill)
             })
             .map_err(skill_repository_error_from_database)
@@ -91,30 +102,6 @@ impl SkillRepository for SqliteSkillRepository {
             ).map(|rows| rows > 0).map_err(Into::into)
         }).map_err(skill_repository_error_from_database)
     }
-}
-
-/// Inserts one skill row on the given connection, shared by the repository and the import unit of work.
-///
-/// Centralizing the statement keeps the per-statement create path and the transactional import path
-/// writing identical columns, so the two insertion routes cannot drift apart.
-pub(crate) fn insert_skill_row(
-    connection: &rusqlite::Connection,
-    skill: &Skill,
-) -> Result<(), rusqlite::Error> {
-    connection.execute(
-        "INSERT INTO skills (id, namespace, name, description, created_at, updated_at, is_deleted) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-        params![
-            skill.id.to_string(),
-            skill.namespace.as_ref(),
-            &skill.name,
-            &skill.description,
-            skill.audit_fields.created_at,
-            skill.audit_fields.updated_at,
-            bool_to_sqlite(skill.audit_fields.is_deleted),
-        ],
-    )?;
-
-    Ok(())
 }
 
 /// Reconstructs a domain skill from a selected SQLite row.


### PR DESCRIPTION
## Summary

Closes #234.

The SQLite write-lock-held-across-`rename` design flagged in #234 (originally in `SqliteSkillImportUnitOfWork`, `crates/db/src/repository/skill_import.rs`) no longer exists in this form — it was superseded by #258's journal-based `commit_create`/`commit_swap` ordering, which promotes the package directory first and only then writes the database row as a single, separately-committed statement. So the write lock is never held across `stat`/`rename` today.

That resolution was incidental (#258 didn't reference this issue) and left two of #234's acceptance items unmet: no concurrency test, and no written record of the new atomicity/recovery model. This PR closes those gaps without changing behavior:

- Add `stalled_package_promote_leaves_concurrent_catalog_writes_unblocked` (`crates/backend/src/skill.rs`): stalls a package promote on a barrier via a decorator around `FilesystemSkillStorage`, and asserts an unrelated catalog write on the same SQLite pool still succeeds while the promote is parked. This would fail with `SQLITE_BUSY` if the lock were ever reintroduced across the rename.
- Document the atomicity/recovery model — journal + startup reconciliation instead of a transaction spanning both stores — in `crates/application/src/skill/README.md` and cross-link it from `crates/application/src/skill_import/README.md`.
- Remove the `insert_skill_row` helper in `crates/db/src/repository/skill.rs`: its doc comment claimed it was "shared by the repository and the import unit of work," but that unit of work was deleted in #258 and the helper had exactly one remaining call site.

## Test plan

- [x] `cargo test -p ora-backend -p ora-db`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`