### PR TITLE
fix(fs): reject Windows reserved device names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,7 @@ version = "0.0.0"
 dependencies = [
  "flate2",
  "ora-domain",
+ "ora-fs",
  "pretty_assertions",
  "serde_yaml",
  "tar",

--- a/crates/fs/README.md
+++ b/crates/fs/README.md
@@ -6,7 +6,7 @@
 
 - `PortableRelativePath` gives wire and configuration paths platform-independent validation and a
   slash-separated identity. It treats both slash styles as separators and rejects parent traversal,
-  rooted paths, Windows drive/UNC prefixes, and NUL bytes on every host.
+  rooted paths, Windows drive/UNC prefixes, reserved device names, and NUL bytes on every host.
 - `CanonicalPathRoot` centralizes canonical root identity, existing-target resolution, absolute
   selection containment, and conversion back to portable relative paths. Workspace and plugin
   callers use the same primitives rather than maintaining local path validators.

--- a/crates/fs/src/path.rs
+++ b/crates/fs/src/path.rs
@@ -28,6 +28,9 @@ impl PortableRelativePath {
                 segment if has_windows_prefix(segment) => {
                     return Err(PortableRelativePathError::WindowsPrefix);
                 }
+                segment if is_windows_reserved_device_name(segment) => {
+                    return Err(PortableRelativePathError::WindowsReservedName);
+                }
                 segment => segments.push(segment),
             }
         }
@@ -69,7 +72,10 @@ impl PortableRelativePath {
                             })?;
                     // Rechecking host components keeps this private constructor aligned with
                     // `parse`, so every construction path preserves the public type invariant.
-                    if segment.contains(['/', '\\']) || has_windows_prefix(segment) {
+                    if segment.contains(['/', '\\'])
+                        || has_windows_prefix(segment)
+                        || is_windows_reserved_device_name(segment)
+                    {
                         return Err(PathContainmentError::NonPortablePath {
                             path: path.to_path_buf(),
                         });
@@ -104,6 +110,8 @@ pub enum PortableRelativePathError {
     Rooted,
     #[error("relative path must not contain a Windows drive or UNC prefix")]
     WindowsPrefix,
+    #[error("relative path must not contain a Windows reserved device name")]
+    WindowsReservedName,
     #[error("relative path must not contain parent traversal")]
     ParentTraversal,
     #[error("relative path must not contain a NUL byte")]
@@ -231,6 +239,26 @@ fn has_windows_prefix(value: &str) -> bool {
         || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
 }
 
+/// Detects device names that Win32 resolves as devices even when they have an extension.
+fn is_windows_reserved_device_name(segment: &str) -> bool {
+    let stem = segment
+        .split_once('.')
+        .map_or(segment, |(stem, _)| stem)
+        .trim_end_matches([' ', '.']);
+
+    if ["CON", "PRN", "AUX", "NUL"]
+        .iter()
+        .any(|reserved| stem.eq_ignore_ascii_case(reserved))
+    {
+        return true;
+    }
+
+    let bytes = stem.as_bytes();
+    bytes.len() == 4
+        && (bytes[..3].eq_ignore_ascii_case(b"COM") || bytes[..3].eq_ignore_ascii_case(b"LPT"))
+        && matches!(bytes[3], b'1'..=b'9')
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -283,6 +311,53 @@ mod tests {
 
         for (input, expected) in cases {
             assert_eq!(PortableRelativePath::parse(input), Err(expected), "{input}");
+        }
+    }
+
+    /// Verifies Windows reserved device names are unsafe in every portable path component.
+    #[test]
+    fn rejects_windows_reserved_device_names() {
+        let cases = [
+            "CON",
+            "con.txt",
+            "folder/PrN.md",
+            "AUX.tar.gz",
+            "NUL.",
+            "COM1",
+            "com9.log",
+            "folder\\LPT1\\notes.txt",
+            "lpt9.md",
+        ];
+
+        for input in cases {
+            assert_eq!(
+                PortableRelativePath::parse(input),
+                Err(PortableRelativePathError::WindowsReservedName),
+                "{input}"
+            );
+        }
+    }
+
+    /// Verifies names outside the reserved device set remain portable ordinary paths.
+    #[test]
+    fn accepts_names_near_windows_reserved_device_names() {
+        let cases = [
+            ("CONSOLE.txt", "CONSOLE.txt"),
+            ("COM0", "COM0"),
+            ("COM10.txt", "COM10.txt"),
+            ("LPT0", "LPT0"),
+            ("LPT10.md", "LPT10.md"),
+            ("NULLED/SKILL.md", "NULLED/SKILL.md"),
+            ("folder.CON/notes.txt", "folder.CON/notes.txt"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                PortableRelativePath::parse(input)
+                    .unwrap_or_else(|error| panic!("parse {input:?}: {error}"))
+                    .as_str(),
+                expected
+            );
         }
     }
 

--- a/crates/skill-package/Cargo.toml
+++ b/crates/skill-package/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 flate2 = { workspace = true }
 ora-domain = { workspace = true }
+ora-fs = { workspace = true }
 serde_yaml = { workspace = true }
 tar = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/skill-package/README.md
+++ b/crates/skill-package/README.md
@@ -26,7 +26,8 @@ destination directory.
 ## Key invariants
 
 - Every relative path stored in a `RelativePath` is a safe, validated, `\`-normalized UTF-8 path
-  with no empty, `.`, or `..` segments.
+  with no empty, `.`, or `..` segments or Windows reserved device names. Portable filename safety
+  is inherited from `ora-fs`; this crate adds package-specific depth and length limits.
 - Resource-limit and path-safety failures reject the whole source; a malformed manifest only
   invalidates that one candidate and is surfaced as a `ManifestError`.
 - Archive entries are never followed as links and never written before their paths pass

--- a/crates/skill-package/src/path.rs
+++ b/crates/skill-package/src/path.rs
@@ -18,7 +18,8 @@ pub const MAX_DEPTH: usize = 32;
 pub enum PathValidationError {
     /// The path is not valid UTF-8 or contains disallowed control characters.
     EncodingInvalid,
-    /// The path is absolute, a drive/UNC path, or contains empty, `.`, or `..` segments.
+    /// The path is absolute, a drive/UNC path, contains empty, `.`, or `..` segments, or names a
+    /// Windows reserved device.
     Unsafe,
     /// One segment exceeds the byte or UTF-16 code-unit limit.
     SegmentTooLong,
@@ -30,9 +31,10 @@ pub enum PathValidationError {
 
 /// A validated skill-relative path stored with forward-slash separators.
 ///
-/// Parsing rejects every unsafe shape (zip-slip, absolute, drive/UNC, traversal, control
-/// characters, non-UTF-8) and enforces segment, total-length, and depth limits. Instances are
-/// safe to use as key material and to reconstruct under a destination root via [`RelativePath::to_path`].
+/// Parsing rejects every unsafe shape (zip-slip, absolute, drive/UNC, traversal, Windows reserved
+/// device names, control characters, non-UTF-8) and enforces segment, total-length, and depth
+/// limits. Instances are safe to use as key material and to reconstruct under a destination root
+/// via [`RelativePath::to_path`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RelativePath {
     path: String,
@@ -52,6 +54,10 @@ impl RelativePath {
 
         let normalized = raw.replace('\\', "/");
         validate_shape(&normalized)?;
+        // Reusing the shared portable parser keeps platform-specific filename safety consistent
+        // with every other filesystem-facing caller while this type adds package-specific limits.
+        ora_fs::PortableRelativePath::parse(&normalized)
+            .map_err(|_| PathValidationError::Unsafe)?;
         let segments = normalized.split('/').collect::<Vec<_>>();
 
         let depth = segments.len() - 1;
@@ -243,6 +249,31 @@ mod tests {
                 RelativePath::parse(raw),
                 Err(PathValidationError::Unsafe),
                 "expected {raw:?} to be rejected"
+            );
+        }
+    }
+
+    /// Verifies skill paths inherit portable Windows device-name safety before materialization.
+    #[test]
+    fn rejects_windows_reserved_device_names() {
+        for raw in ["CON", "folder/aux.txt", "folder\\COM1\\notes.txt"] {
+            assert_eq!(
+                RelativePath::parse(raw),
+                Err(PathValidationError::Unsafe),
+                "expected {raw:?} to be rejected"
+            );
+        }
+    }
+
+    /// Verifies the shared portable rule does not reject nearby legal skill path names.
+    #[test]
+    fn accepts_names_near_windows_reserved_device_names() {
+        for raw in ["CONSOLE.txt", "COM10.txt", "folder/LPT0/notes.txt"] {
+            assert_eq!(
+                RelativePath::parse(raw)
+                    .unwrap_or_else(|error| panic!("parse {raw:?}: {error:?}"))
+                    .as_str(),
+                raw
             );
         }
     }


### PR DESCRIPTION
Centralize portable device-name validation in ora-fs and apply it to skill package paths before filesystem access.

Cover case-insensitive names, extensions, nested components, and nearby valid names.

Fixes #226