### PR TITLE
feat(xtask): add DT declaration checker and pilot it on ora-fs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,32 @@ Ora is an IDE for AI Agent. In the crates folder where the rust code lives:
 - `crates/contracts`, `crates/domain`, and `crates/pty`, including their descendant modules, are intentional exceptions. Their type definitions and code-level documentation are the primary documentation because they do not own architectural orchestration that benefits from separate README files.
 - When adding a crate or directory-based module, add its README in the same change. When changing a module's responsibilities, boundaries, core flows, or interactions, update the corresponding README in the same change.
 - READMEs document stable facts that should remain true across internal refactors: responsibilities, non-responsibilities, public boundaries, key invariants, lifecycle, important failure semantics, and module interactions. Put local implementation rationale, algorithm details, data-structure choices, specialized branches, performance trade-offs, and temporary implementation constraints in English code comments instead.
+- A README that owns tests must also contain a `## Feature points` section; see "Developer test (DT) declarations".
+
+## Developer test (DT) declarations
+
+Every Rust test function under `crates/` carries a one-line structured declaration as the first line of its doc comment. `task lint:dt` (optionally scoped: `task lint:dt -- crates/fs`) rejects any test that lacks or misspells it. The declaration itself cannot be omitted; the only escape hatch is the reserved word `todo` in either field.
+
+```rust
+/// DT[<feature>][<kind>] <statement>
+#[test]
+fn …() { … }
+```
+
+- `<feature>` is a kebab-case feature point declared in the owning module README under `## Feature points`. The owning README is the nearest `README.md` walking up from the test file; crate-level `tests/` files resolve to the crate root README. Prefix with a `src/`-relative module path (`parse::commit-readback`) only when the test must attach to another module's catalog in the same crate; never qualify with the module the file already lives in.
+- `<kind>` is exactly one of `happy` (nominal path), `edge` (boundary of valid input: empty, max, repeat, ordering, exhaustive combinations), `error` (rejection, failure handling, compensation, no dirty state), `concurrency` (interleaving, cancellation, timeouts, locks, leases). Do not encode provenance such as "regression" here; put it in the statement if it matters.
+- `todo` may replace `<feature>`, `<kind>`, or both when no existing entry fits and reworking the catalog does not belong in the current change. It passes the check, is counted as governance debt, and must never be a default. Never add `todo` to a README catalog.
+- `<statement>` is one English sentence in present tense: under what condition, what outcome. Describe the behavior, not the test ("A stale lease is reclaimed…", not "Verifies that…"). Do not repeat the feature point, the kind, or the function name.
+
+Rules:
+
+- One declaration per test function, on the first `///` line, before any `#[…]` attribute. Additional `///` lines may follow and are ignored by tooling.
+- Helpers, fixtures, and non-test functions must not carry a DT line.
+- Every test attaches to exactly one feature point and one kind. If a test spans several feature points, pick the primary one; if that happens often, split the test.
+- Before using a new feature point, add it to the owning README's `## Feature points` section as ``- `id`: description``. Read the existing entries first and reuse one when the meaning overlaps. Name behavior areas with noun phrases (`branch-listing`), not test actions, and do not prefix with the module name.
+- Every crate that has tests must have a crate root `README.md` with a `## Feature points` section, including `crates/contracts`, `crates/domain`, and `crates/pty`; their exemption from module-level READMEs is unchanged.
+- Do not generate test functions with `macro_rules!`; the checker treats a DT line inside a macro body as one declaration shared by every expansion.
+- Renaming or removing a feature point is a single change that updates the README and every declaration referring to it.
 
 ## Tests
 
@@ -59,6 +85,7 @@ authoritative list of available tasks.
 - Frontend tests: `task test:frontend`
 - Rust workspace lint: `task lint:crates`
 - Rust workspace tests: `task test:crates`
+- DT declaration check (standalone, scoped by path): `task lint:dt -- crates/fs`
 - All lint tasks: `task lint`
 - All lint and test tasks (long-running): `task test`
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,6 +118,11 @@ tasks:
       - cargo fmt --all -- --check
       - cargo clippy --workspace -- -D warnings
 
+  lint:dt:
+    desc: Check DT declarations and feature point catalogs (optionally scoped, e.g. `task lint:dt -- crates/fs`)
+    cmds:
+      - cargo xtask check-dt {{.CLI_ARGS}}
+
   test:
     desc: Run all frontend and Rust workspace checks (may take a long time)
     silent: true

--- a/crates/fs/README.md
+++ b/crates/fs/README.md
@@ -16,3 +16,14 @@
 - The `spec` module discovers Markdown/MDX through the same injected bundled ripgrep, supports explicit ignored sources, and resolves platform-selected directories without allowing workspace escape.
 
 The adapters are documented in [Task Workspace Files](../../docs/task-workspace-files.md) and [Specification management](../../docs/spec-management.md). Tests can inject a `ProcessSpawner` rather than starting ripgrep.
+
+## Feature points
+
+Stable identifiers that DT declarations in this crate attach to. Tests under `src/spec/` use the
+catalog in `src/spec/README.md` instead.
+
+- `directory-listing`: Workspace-relative directory listings that hide Git internals and order directories before files.
+- `file-read`: Bounded UTF-8 file reads that return content, size, and a metadata-derived version token.
+- `path-containment`: Rejecting traversal and workspace escapes before any host filesystem access.
+- `content-search`: ripgrep argument construction and JSON match parsing for workspace search.
+- `change-watching`: Normalizing native watcher events into workspace-relative change batches.

--- a/crates/fs/src/search.rs
+++ b/crates/fs/src/search.rs
@@ -285,7 +285,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
-    /// Verifies protocol bookkeeping is ignored while line matches retain their location.
+    /// DT[content-search][happy] Ripgrep JSON begin/end bookkeeping is dropped while match lines keep their path, line, and column.
     #[test]
     fn parses_ripgrep_json_matches() {
         let workspace =
@@ -312,7 +312,7 @@ mod tests {
         );
     }
 
-    /// Verifies the plain-text UI search cannot interpret punctuation as regex syntax.
+    /// DT[content-search][edge] Content queries run with --fixed-strings so punctuation such as brackets is matched literally, never as regex.
     #[test]
     fn uses_fixed_strings_for_content_search() {
         let arguments = search_arguments("[main]", SearchKind::Content);

--- a/crates/fs/src/spec/README.md
+++ b/crates/fs/src/spec/README.md
@@ -6,3 +6,11 @@ discovery, and supports scans of built-in source directories with ignore rules d
 
 The module never decides project ownership or source classification. Canonical containment checks
 reject traversal and symbolic-link escapes before paths cross the adapter boundary.
+
+## Feature points
+
+Stable identifiers that DT declarations in this module attach to.
+
+- `markdown-discovery`: Bounded Markdown/MDX discovery through the injected ripgrep; global discovery honors Git ignore while explicit sources bypass it.
+- `spec-read`: Reading specification files only when they are contained Markdown, rejecting other files and symbolic-link escapes.
+- `index-truncation`: Surfacing result-count and byte-boundary truncation of a Markdown index to callers.

--- a/crates/fs/src/spec/mod.rs
+++ b/crates/fs/src/spec/mod.rs
@@ -237,7 +237,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
-    /// Verifies discovery and explicit enumeration share fixed generated-directory exclusions.
+    /// DT[markdown-discovery][happy] Discovery and explicit enumeration share the Markdown globs and generated-directory exclusions, and only explicit sources add --no-ignore.
     #[test]
     fn builds_bounded_markdown_arguments() {
         let discovery = markdown_arguments(&[], IgnorePolicy::Honor);
@@ -254,7 +254,7 @@ mod tests {
         assert_eq!(explicit.last(), Some(&"docs/specs".to_string()));
     }
 
-    /// Verifies global discovery honors Git ignore while explicit sources bypass it.
+    /// DT[markdown-discovery][happy] Global discovery honors Git ignore while explicit sources return the ignored Markdown.
     #[tokio::test]
     async fn discovers_case_insensitive_markdown_and_explicit_ignored_sources() {
         let workspace = TempDir::new().expect("create temporary workspace");
@@ -292,7 +292,7 @@ mod tests {
         );
     }
 
-    /// Verifies Spec reads reject non-Markdown files and symbolic-link escapes.
+    /// DT[spec-read][error] Non-Markdown files and symbolic-link escapes are rejected while contained Markdown reads succeed.
     #[test]
     fn reads_only_contained_markdown() {
         let workspace = TempDir::new().expect("create temporary workspace");
@@ -327,7 +327,7 @@ mod tests {
         }
     }
 
-    /// Verifies result and byte-boundary truncation remain visible to catalog callers.
+    /// DT[index-truncation][edge] Result-count and byte-boundary truncation are both surfaced as a truncated index.
     #[test]
     fn reports_markdown_index_truncation() {
         let workspace = TempDir::new().expect("create temporary workspace");

--- a/crates/fs/src/watch.rs
+++ b/crates/fs/src/watch.rs
@@ -141,7 +141,7 @@ mod tests {
     use std::time::Duration;
     use tempfile::TempDir;
 
-    /// Verifies native callbacks are normalized to workspace-relative paths.
+    /// DT[change-watching][happy] A native write event surfaces as a workspace-relative change path.
     #[test]
     fn observes_workspace_file_changes() {
         let workspace =

--- a/crates/fs/src/workspace.rs
+++ b/crates/fs/src/workspace.rs
@@ -265,7 +265,7 @@ mod tests {
     use std::path::Path;
     use tempfile::TempDir;
 
-    /// Verifies listings stay relative, hide Git internals, and sort directories before files.
+    /// DT[directory-listing][happy] Listings are workspace-relative, hide .git, and place directories before files.
     #[test]
     fn lists_workspace_directory() {
         let workspace =
@@ -301,7 +301,7 @@ mod tests {
         );
     }
 
-    /// Verifies UTF-8 reads include a metadata-derived version token.
+    /// DT[file-read][happy] A UTF-8 file read returns its content, byte size, and a metadata-derived version token.
     #[test]
     fn reads_workspace_file() {
         let workspace =
@@ -320,7 +320,7 @@ mod tests {
         assert!(file.version.ends_with(":13"));
     }
 
-    /// Verifies parent traversal is rejected before touching the host filesystem.
+    /// DT[path-containment][error] A parent-traversal path is rejected as not relative before the host filesystem is touched.
     #[test]
     fn rejects_parent_traversal() {
         let workspace =

--- a/xtask/src/dt/README.md
+++ b/xtask/src/dt/README.md
@@ -1,0 +1,68 @@
+# DT declaration checker
+
+`cargo xtask check-dt [--deny-todo] [PATH...]` validates developer test (DT) declarations under
+`crates/` (or the given paths) against the feature point catalogs in module READMEs. It is the
+enforcement half of the Rust test asset governance design; the writing rules live in the repository
+`AGENTS.md` under "Developer test (DT) declarations".
+
+## Responsibilities
+
+- Find every test function (`#[test]`, `#[tokio::test]`, or any attribute whose path ends in `test`)
+  in the scoped `.rs` files and require exactly one well-formed `/// DT[<feature>][<kind>] <statement>`
+  line as the first line of its header block.
+- Resolve each feature reference to a README: the nearest `README.md` from the file's directory up to
+  the crate root, or `<crate>/src/<segments>/README.md` for a `seg::seg::id` qualifier.
+- Parse the `## Feature points` section of every resolved or in-scope README and reject unknown ids,
+  malformed entries, duplicates, and the reserved word `todo` as an entry.
+- Print `path:line:1: DTnnn message` diagnostics sorted by path and line, a `note:` line counting
+  `todo` placeholders, and exit non-zero when any rule fired.
+
+## Non-responsibilities
+
+- No Rust parsing: the scanner is line based (see "Blind spots").
+- No aggregation, statistics, or gap reports; those consume the same parser but are separate tooling.
+- No incremental mode. Scope is an explicit path list; the default is the whole `crates/` tree.
+
+## Rules
+
+| Code  | Trigger                                                                                                    |
+| ----- | ---------------------------------------------------------------------------------------------------------- |
+| DT001 | Test function without a declaration                                                                        |
+| DT002 | `DT[` line that does not match the grammar                                                                 |
+| DT003 | Kind outside `happy`, `edge`, `error`, `concurrency`, `todo`                                               |
+| DT004 | Feature id not declared in the resolved catalog                                                            |
+| DT005 | Owning README missing, or resolved README has no `## Feature points` section (once per file for the owner) |
+| DT006 | More than one declaration on a test, or a declaration on a non-test function or non-function item          |
+| DT007 | Declaration not on the first header line, or separated from its function by a blank line                   |
+| DT008 | Qualifier that names the file's own module (redundant) or a module without a README                        |
+| DT009 | Malformed catalog entry, duplicate id, empty description, or `todo` used as an id                          |
+| DT010 | Any `todo` placeholder while `--deny-todo` is set                                                          |
+
+`todo` in either field is otherwise valid; it is counted and reported, never rejected.
+
+## Module layout
+
+- `declaration.rs`: grammar of one declaration line.
+- `scan.rs`: header-block scanner that pairs declarations with the item they precede.
+- `catalog.rs`: `## Feature points` parser.
+- `resolve.rs`: scope walking, crate root and owning README resolution.
+- `check.rs`: rule evaluation over scanned files and catalogs.
+- `mod.rs`: argument parsing and report rendering.
+
+## Blind spots
+
+- `#[test]` or `/// DT[` inside string literals or block comments is treated as real.
+- A DT line inside a `macro_rules!` body is one declaration shared by every expansion.
+
+Both are accepted because the repository does not use these patterns and the failure is loud.
+
+## Feature points
+
+Stable identifiers that DT declarations in this module attach to.
+
+- `declaration-grammar`: Parsing one `DT[<feature>][<kind>] <statement>` line, including qualifiers and `todo`.
+- `header-scanning`: Pairing doc lines and attributes with the function or item they precede.
+- `catalog-parsing`: Reading `## Feature points` entries from a README and reporting format problems.
+- `ownership-resolution`: Choosing the crate root and owning README for a file, and collecting scope files.
+- `rule-evaluation`: Turning scanned headers and catalogs into DT001–DT010 diagnostics.
+- `command-line`: Argument parsing for `check-dt`.

--- a/xtask/src/dt/catalog.rs
+++ b/xtask/src/dt/catalog.rs
@@ -1,0 +1,113 @@
+//! Parsing of the `## Feature points` section of a module README.
+//!
+//! The section is the single source of feature point ids for the module and
+//! doubles as the module's "should be covered" list, so its format is strict:
+//! every top-level bullet must be `` - `id`: description ``.
+
+use super::declaration::{TODO, is_feature_id};
+use std::collections::BTreeMap;
+
+/// Exact heading that opens the catalog section.
+pub(crate) const SECTION_HEADING: &str = "## Feature points";
+
+/// Parsed catalog of one README.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct Catalog {
+    /// Whether the README contains the section at all.
+    pub(crate) has_section: bool,
+    /// Feature id to its one-line description.
+    pub(crate) entries: BTreeMap<String, String>,
+    /// Format problems, each with the 1-based README line.
+    pub(crate) problems: Vec<CatalogProblem>,
+}
+
+/// One malformed line inside the section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CatalogProblem {
+    pub(crate) line: usize,
+    pub(crate) message: String,
+}
+
+/// Parses a README's catalog section. Lines outside the section are ignored.
+pub(crate) fn parse_catalog(markdown: &str) -> Catalog {
+    let mut catalog = Catalog::default();
+    let mut in_section = false;
+    let mut in_fence = false;
+
+    for (index, line) in markdown.lines().enumerate() {
+        let line_number = index + 1;
+        let trimmed_end = line.trim_end();
+
+        // Fenced code blocks may contain anything, including fake bullets and headings.
+        if trimmed_end.starts_with("```") || trimmed_end.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+
+        if trimmed_end == SECTION_HEADING {
+            in_section = true;
+            catalog.has_section = true;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        // Any heading of level one or two closes the section; `###` is allowed for grouping.
+        if trimmed_end.starts_with("# ") || trimmed_end.starts_with("## ") {
+            in_section = false;
+            continue;
+        }
+        let Some(item) = line.strip_prefix("- ") else {
+            // Prose, blank lines, sub-headings, and indented continuation lines are not entries.
+            continue;
+        };
+        match parse_entry(item) {
+            Ok((id, description)) => {
+                if id == TODO {
+                    catalog.problems.push(CatalogProblem {
+                        line: line_number,
+                        message: format!(
+                            "`{TODO}` is a reserved word and cannot be a feature point"
+                        ),
+                    });
+                } else if catalog.entries.contains_key(id) {
+                    catalog.problems.push(CatalogProblem {
+                        line: line_number,
+                        message: format!("duplicate feature point `{id}`"),
+                    });
+                } else {
+                    catalog
+                        .entries
+                        .insert(id.to_string(), description.to_string());
+                }
+            }
+            Err(message) => catalog.problems.push(CatalogProblem {
+                line: line_number,
+                message: message.to_string(),
+            }),
+        }
+    }
+    catalog
+}
+
+/// Parses `` `id`: description `` (the text after `- `).
+fn parse_entry(item: &str) -> Result<(&str, &str), &'static str> {
+    let rest = item
+        .strip_prefix('`')
+        .ok_or("feature point entries must start with a backticked id: - `id`: description")?;
+    let (id, rest) = rest.split_once('`').ok_or("unterminated backticked id")?;
+    if !is_feature_id(id) {
+        return Err("feature id must be kebab-case: [a-z0-9]+(-[a-z0-9]+)*");
+    }
+    let rest = rest
+        .strip_prefix(':')
+        .ok_or("expected `:` directly after the backticked id")?;
+    let description = rest.trim();
+    if !rest.starts_with(' ') || description.is_empty() {
+        return Err("expected a non-empty description after `: `");
+    }
+    Ok((id, description))
+}

--- a/xtask/src/dt/check.rs
+++ b/xtask/src/dt/check.rs
@@ -1,0 +1,371 @@
+//! Rule evaluation: turns scanned headers and README catalogs into diagnostics.
+
+use super::catalog::{Catalog, SECTION_HEADING, parse_catalog};
+use super::declaration::{Declaration, FeatureRef, Kind, ParseError, parse_declaration};
+use super::resolve::{ScopedFiles, qualified_readme, resolve_ownership};
+use super::scan::{Header, HeaderTarget, scan_headers};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Stable rule identifiers; the numeric suffix is what appears in output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Code {
+    /// Test function without a declaration.
+    Dt001,
+    /// Declaration attempt that does not match the grammar.
+    Dt002,
+    /// Unknown kind.
+    Dt003,
+    /// Feature point not declared in the resolved catalog.
+    Dt004,
+    /// Owning README missing or without a `## Feature points` section.
+    Dt005,
+    /// Multiple declarations, or a declaration on a non-test item.
+    Dt006,
+    /// Declaration is not the first header line, or is detached from its function.
+    Dt007,
+    /// Redundant or unresolvable module qualifier.
+    Dt008,
+    /// Malformed catalog section.
+    Dt009,
+    /// `todo` used while `--deny-todo` is active.
+    Dt010,
+}
+
+impl fmt::Display for Code {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let text = match self {
+            Self::Dt001 => "DT001",
+            Self::Dt002 => "DT002",
+            Self::Dt003 => "DT003",
+            Self::Dt004 => "DT004",
+            Self::Dt005 => "DT005",
+            Self::Dt006 => "DT006",
+            Self::Dt007 => "DT007",
+            Self::Dt008 => "DT008",
+            Self::Dt009 => "DT009",
+            Self::Dt010 => "DT010",
+        };
+        formatter.write_str(text)
+    }
+}
+
+/// One reported violation, anchored to a file line.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Diagnostic {
+    pub(crate) path: PathBuf,
+    pub(crate) line: usize,
+    pub(crate) code: Code,
+    pub(crate) message: String,
+}
+
+/// Knobs that change which rules fire.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CheckOptions {
+    pub(crate) deny_todo: bool,
+}
+
+/// Aggregate result of one run.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CheckReport {
+    pub(crate) diagnostics: Vec<Diagnostic>,
+    pub(crate) tests_checked: usize,
+    pub(crate) files_with_tests: usize,
+    /// Declarations that use `todo` in at least one field.
+    pub(crate) todo_declarations: usize,
+    pub(crate) todo_features: usize,
+    pub(crate) todo_kinds: usize,
+}
+
+/// Runs every rule over the scoped files.
+pub(crate) fn check(files: &ScopedFiles, options: CheckOptions) -> Result<CheckReport, String> {
+    let mut checker = Checker {
+        options,
+        report: CheckReport::default(),
+        catalogs: BTreeMap::new(),
+        referenced_readmes: BTreeSet::new(),
+    };
+    for rust_file in &files.rust_files {
+        checker.check_rust_file(rust_file)?;
+    }
+    // Catalog format is checked for READMEs inside the scope and for every README a
+    // declaration resolved against, so an out-of-scope but referenced catalog cannot rot.
+    let mut readmes: BTreeSet<PathBuf> = files.readmes.iter().cloned().collect();
+    readmes.extend(checker.referenced_readmes.iter().cloned());
+    for readme in readmes {
+        let catalog = checker.catalog(&readme)?.clone();
+        for problem in catalog.problems {
+            checker.report.diagnostics.push(Diagnostic {
+                path: readme.clone(),
+                line: problem.line,
+                code: Code::Dt009,
+                message: problem.message,
+            });
+        }
+    }
+    checker.report.diagnostics.sort();
+    checker.report.diagnostics.dedup();
+    Ok(checker.report)
+}
+
+/// Mutable state shared across files during one run.
+struct Checker {
+    options: CheckOptions,
+    report: CheckReport,
+    catalogs: BTreeMap<PathBuf, Catalog>,
+    referenced_readmes: BTreeSet<PathBuf>,
+}
+
+impl Checker {
+    /// Loads and caches a README catalog; a missing file yields an empty catalog.
+    fn catalog(&mut self, readme: &Path) -> Result<&Catalog, String> {
+        if !self.catalogs.contains_key(readme) {
+            let markdown = fs::read_to_string(readme)
+                .map_err(|error| format!("failed to read {}: {error}", readme.display()))?;
+            self.catalogs
+                .insert(readme.to_path_buf(), parse_catalog(&markdown));
+        }
+        Ok(&self.catalogs[readme])
+    }
+
+    fn push(&mut self, path: &Path, line: usize, code: Code, message: String) {
+        self.report.diagnostics.push(Diagnostic {
+            path: path.to_path_buf(),
+            line,
+            code,
+            message,
+        });
+    }
+
+    /// Applies the per-function rules to one Rust file.
+    fn check_rust_file(&mut self, rust_file: &Path) -> Result<(), String> {
+        let source = fs::read_to_string(rust_file)
+            .map_err(|error| format!("failed to read {}: {error}", rust_file.display()))?;
+        let headers = scan_headers(&source);
+        let ownership = resolve_ownership(rust_file)?;
+        // DT005 is a per-file condition; reporting it on every test would only add noise.
+        let mut reported_missing_catalog = false;
+        let mut has_tests = false;
+
+        for header in headers {
+            match &header.target {
+                HeaderTarget::Function {
+                    name,
+                    is_test: true,
+                } => {
+                    has_tests = true;
+                    self.report.tests_checked += 1;
+                    let Some(declaration) = self.declaration_of(rust_file, &header, name) else {
+                        continue;
+                    };
+                    self.check_feature(
+                        rust_file,
+                        header.line,
+                        &declaration,
+                        &ownership.crate_root,
+                        ownership.owning_readme.as_deref(),
+                        &mut reported_missing_catalog,
+                    )?;
+                    if declaration.kind == Kind::Todo {
+                        self.report.todo_kinds += 1;
+                    }
+                    let uses_todo =
+                        declaration.kind == Kind::Todo || declaration.feature == FeatureRef::Todo;
+                    if uses_todo {
+                        self.report.todo_declarations += 1;
+                    }
+                    if uses_todo && self.options.deny_todo {
+                        self.push(
+                            rust_file,
+                            header.line,
+                            Code::Dt010,
+                            format!("test `{name}` uses the reserved word `todo` while --deny-todo is active"),
+                        );
+                    }
+                }
+                HeaderTarget::Function {
+                    name,
+                    is_test: false,
+                } => {
+                    for declaration in &header.declarations {
+                        self.push(
+                            rust_file,
+                            declaration.line,
+                            Code::Dt006,
+                            format!("declaration on non-test function `{name}`; only test functions carry DT lines"),
+                        );
+                    }
+                }
+                HeaderTarget::OtherItem => {
+                    for declaration in &header.declarations {
+                        self.push(
+                            rust_file,
+                            declaration.line,
+                            Code::Dt006,
+                            "declaration attached to a non-function item".to_string(),
+                        );
+                    }
+                }
+                HeaderTarget::Detached => {
+                    for declaration in &header.declarations {
+                        self.push(
+                            rust_file,
+                            declaration.line,
+                            Code::Dt007,
+                            "declaration is separated from its function; only doc lines and attributes may follow it".to_string(),
+                        );
+                    }
+                }
+            }
+        }
+        if has_tests {
+            self.report.files_with_tests += 1;
+        }
+        Ok(())
+    }
+
+    /// Extracts the single valid declaration of a test function, reporting structural problems.
+    fn declaration_of(
+        &mut self,
+        rust_file: &Path,
+        header: &Header,
+        name: &str,
+    ) -> Option<Declaration> {
+        let Some(first) = header.declarations.first() else {
+            self.push(
+                rust_file,
+                header.line,
+                Code::Dt001,
+                format!("test `{name}` has no `/// DT[<feature>][<kind>] <statement>` declaration"),
+            );
+            return None;
+        };
+        for extra in header.declarations.iter().skip(1) {
+            self.push(
+                rust_file,
+                extra.line,
+                Code::Dt006,
+                format!("test `{name}` has more than one declaration"),
+            );
+        }
+        if !first.is_first_header_line {
+            self.push(
+                rust_file,
+                first.line,
+                Code::Dt007,
+                format!("declaration of `{name}` must be the first doc line, before any attribute"),
+            );
+        }
+        match parse_declaration(&first.doc) {
+            Ok(declaration) => Some(declaration),
+            Err(error @ ParseError::Malformed(_)) => {
+                self.push(rust_file, first.line, Code::Dt002, error.to_string());
+                None
+            }
+            Err(error @ ParseError::UnknownKind(_)) => {
+                self.push(rust_file, first.line, Code::Dt003, error.to_string());
+                None
+            }
+        }
+    }
+
+    /// Resolves the feature reference against the right catalog and reports DT004/DT005/DT008.
+    fn check_feature(
+        &mut self,
+        rust_file: &Path,
+        line: usize,
+        declaration: &Declaration,
+        crate_root: &Path,
+        owning_readme: Option<&Path>,
+        reported_missing_catalog: &mut bool,
+    ) -> Result<(), String> {
+        let (readme, id) = match &declaration.feature {
+            FeatureRef::Todo => {
+                self.report.todo_features += 1;
+                return Ok(());
+            }
+            FeatureRef::Local(id) => {
+                let Some(readme) = owning_readme else {
+                    if !*reported_missing_catalog {
+                        *reported_missing_catalog = true;
+                        self.push(
+                            rust_file,
+                            line,
+                            Code::Dt005,
+                            format!(
+                                "no README.md between this file and the crate root {}; a crate with tests needs a root README with `{SECTION_HEADING}`",
+                                crate_root.display()
+                            ),
+                        );
+                    }
+                    return Ok(());
+                };
+                (readme.to_path_buf(), id.clone())
+            }
+            FeatureRef::Qualified { segments, id } => {
+                let target = qualified_readme(crate_root, segments);
+                if owning_readme == Some(target.as_path()) {
+                    self.push(
+                        rust_file,
+                        line,
+                        Code::Dt008,
+                        format!("qualifier `{}` is redundant: it names the module this file already belongs to", declaration.feature),
+                    );
+                    return Ok(());
+                }
+                if !target.is_file() {
+                    self.push(
+                        rust_file,
+                        line,
+                        Code::Dt008,
+                        format!(
+                            "qualifier `{}` does not resolve: {} does not exist",
+                            declaration.feature,
+                            target.display()
+                        ),
+                    );
+                    return Ok(());
+                }
+                (target, id.clone())
+            }
+        };
+
+        self.referenced_readmes.insert(readme.clone());
+        // Copy the two facts out of the cache so the report can be mutated afterwards.
+        let (has_section, has_entry) = {
+            let catalog = self.catalog(&readme)?;
+            (catalog.has_section, catalog.entries.contains_key(&id))
+        };
+        if !has_section {
+            // A qualified target without a section is always reported; the owning README
+            // only once per file.
+            let is_owning = owning_readme == Some(readme.as_path());
+            if !is_owning || !*reported_missing_catalog {
+                if is_owning {
+                    *reported_missing_catalog = true;
+                }
+                self.push(
+                    rust_file,
+                    line,
+                    Code::Dt005,
+                    format!("{} has no `{SECTION_HEADING}` section", readme.display()),
+                );
+            }
+            return Ok(());
+        }
+        if !has_entry {
+            self.push(
+                rust_file,
+                line,
+                Code::Dt004,
+                format!(
+                    "feature point `{id}` is not declared in {} ({SECTION_HEADING})",
+                    readme.display()
+                ),
+            );
+        }
+        Ok(())
+    }
+}

--- a/xtask/src/dt/declaration.rs
+++ b/xtask/src/dt/declaration.rs
@@ -1,0 +1,199 @@
+//! Parsing of a single `/// DT[<feature>][<kind>] <statement>` line.
+//!
+//! The grammar is deliberately line-local so that a declaration can be
+//! recognised without any Rust syntax analysis. Only the text after `///`
+//! is inspected here; deciding which function a line belongs to is the
+//! scanner's job.
+
+use std::fmt;
+
+/// Reserved word that may replace the feature or the kind when a test cannot be
+/// classified yet. It never appears in a README catalog.
+pub(crate) const TODO: &str = "todo";
+
+/// Prefix that marks a doc line as a DT declaration attempt.
+const PREFIX: &str = "DT[";
+
+/// Coverage region a test verifies. Closed set; `Todo` is the governance placeholder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Kind {
+    Happy,
+    Edge,
+    Error,
+    Concurrency,
+    Todo,
+}
+
+impl Kind {
+    /// Maps the textual kind to the enum; unknown words are rejected by the caller.
+    fn parse(text: &str) -> Option<Self> {
+        match text {
+            "happy" => Some(Self::Happy),
+            "edge" => Some(Self::Edge),
+            "error" => Some(Self::Error),
+            "concurrency" => Some(Self::Concurrency),
+            TODO => Some(Self::Todo),
+            _ => None,
+        }
+    }
+}
+
+/// Feature point reference as written in the declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FeatureRef {
+    /// Reserved placeholder; resolves against no catalog.
+    Todo,
+    /// Kebab-case id resolved against the owning README of the test file.
+    Local(String),
+    /// Id resolved against `src/<segments...>/README.md` of the same crate.
+    Qualified { segments: Vec<String>, id: String },
+}
+
+impl fmt::Display for FeatureRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Todo => formatter.write_str(TODO),
+            Self::Local(id) => formatter.write_str(id),
+            Self::Qualified { segments, id } => {
+                for segment in segments {
+                    write!(formatter, "{segment}::")?;
+                }
+                formatter.write_str(id)
+            }
+        }
+    }
+}
+
+/// A syntactically valid declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Declaration {
+    pub(crate) feature: FeatureRef,
+    pub(crate) kind: Kind,
+    pub(crate) statement: String,
+}
+
+/// Why a `DT[` line failed to parse. Each variant maps to one human message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ParseError {
+    Malformed(&'static str),
+    UnknownKind(String),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed(reason) => write!(
+                formatter,
+                "malformed declaration ({reason}); expected `/// DT[<feature>][<kind>] <statement>`"
+            ),
+            Self::UnknownKind(kind) => write!(
+                formatter,
+                "unknown kind `{kind}`; expected one of happy, edge, error, concurrency, todo"
+            ),
+        }
+    }
+}
+
+/// Returns the doc text of a `///` line, or `None` when the line is not an outer doc comment.
+pub(crate) fn doc_text(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    // `////` is a plain comment in Rust, not a doc comment.
+    if trimmed.starts_with("////") {
+        return None;
+    }
+    trimmed.strip_prefix("///")
+}
+
+/// Whether a doc line is a declaration attempt, i.e. it must parse or be reported.
+pub(crate) fn is_declaration_attempt(doc: &str) -> bool {
+    doc.trim_start().starts_with(PREFIX)
+}
+
+/// Parses the doc text (the part after `///`) of a declaration attempt.
+pub(crate) fn parse_declaration(doc: &str) -> Result<Declaration, ParseError> {
+    let rest = doc
+        .trim_start()
+        .strip_prefix(PREFIX)
+        .ok_or(ParseError::Malformed("missing `DT[` prefix"))?;
+    let (feature_text, rest) = rest
+        .split_once(']')
+        .ok_or(ParseError::Malformed("unterminated feature field"))?;
+    let rest = rest.strip_prefix('[').ok_or(ParseError::Malformed(
+        "kind field must directly follow the feature field",
+    ))?;
+    let (kind_text, rest) = rest
+        .split_once(']')
+        .ok_or(ParseError::Malformed("unterminated kind field"))?;
+    let statement = rest.strip_prefix(' ').ok_or(ParseError::Malformed(
+        "statement must be separated by one space",
+    ))?;
+
+    let feature = parse_feature(feature_text)?;
+    let kind =
+        Kind::parse(kind_text).ok_or_else(|| ParseError::UnknownKind(kind_text.to_string()))?;
+    if statement.is_empty() || statement.starts_with(char::is_whitespace) {
+        return Err(ParseError::Malformed(
+            "statement must not be empty or start with whitespace",
+        ));
+    }
+    if statement.ends_with(char::is_whitespace) {
+        return Err(ParseError::Malformed(
+            "statement must not end with whitespace",
+        ));
+    }
+
+    Ok(Declaration {
+        feature,
+        kind,
+        statement: statement.to_string(),
+    })
+}
+
+/// Parses `todo`, `id`, or `seg::seg::id`.
+fn parse_feature(text: &str) -> Result<FeatureRef, ParseError> {
+    if text == TODO {
+        return Ok(FeatureRef::Todo);
+    }
+    let mut parts: Vec<&str> = text.split("::").collect();
+    let id = parts
+        .pop()
+        .filter(|id| is_feature_id(id))
+        .ok_or(ParseError::Malformed(
+            "feature id must be kebab-case: [a-z0-9]+(-[a-z0-9]+)*",
+        ))?;
+    if id == TODO {
+        return Err(ParseError::Malformed("`todo` cannot be module-qualified"));
+    }
+    if parts.iter().any(|segment| !is_module_segment(segment)) {
+        return Err(ParseError::Malformed(
+            "module qualifier segments must be Rust identifiers separated by `::`",
+        ));
+    }
+    if parts.is_empty() {
+        return Ok(FeatureRef::Local(id.to_string()));
+    }
+    Ok(FeatureRef::Qualified {
+        segments: parts.iter().map(ToString::to_string).collect(),
+        id: id.to_string(),
+    })
+}
+
+/// Checks the kebab-case id grammar shared by declarations and README catalogs.
+pub(crate) fn is_feature_id(text: &str) -> bool {
+    !text.is_empty()
+        && text.split('-').all(|word| {
+            !word.is_empty()
+                && word
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        })
+}
+
+/// Checks a Rust module path segment: `[A-Za-z_][A-Za-z0-9_]*`.
+fn is_module_segment(text: &str) -> bool {
+    let mut bytes = text.bytes();
+    bytes
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic() || first == b'_')
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}

--- a/xtask/src/dt/mod.rs
+++ b/xtask/src/dt/mod.rs
@@ -1,0 +1,126 @@
+//! `cargo xtask check-dt`: validates developer test (DT) declarations and the
+//! `## Feature points` catalogs they resolve against. See `README.md` in this
+//! directory for the rules and the design document they come from.
+
+mod catalog;
+mod check;
+mod declaration;
+mod resolve;
+mod scan;
+
+#[cfg(test)]
+mod tests;
+
+use check::{CheckOptions, CheckReport, check};
+use resolve::collect_scope;
+use std::path::{Path, PathBuf};
+
+/// Default scope when no path is given.
+const DEFAULT_SCOPE: &str = "crates";
+
+/// Parsed command line of `check-dt`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckDtArgs {
+    /// Scope paths relative to the workspace root (or absolute); empty means `crates/`.
+    pub paths: Vec<PathBuf>,
+    /// Treat `todo` placeholders as violations.
+    pub deny_todo: bool,
+}
+
+impl CheckDtArgs {
+    /// Parses `[--deny-todo] [PATH...]`.
+    pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Self, String> {
+        let mut args = Self {
+            paths: Vec::new(),
+            deny_todo: false,
+        };
+        for argument in arguments {
+            match argument.as_str() {
+                "--deny-todo" => args.deny_todo = true,
+                flag if flag.starts_with('-') => {
+                    return Err(format!(
+                        "unknown option `{flag}`; usage: cargo xtask check-dt [--deny-todo] [PATH...]"
+                    ));
+                }
+                path => args.paths.push(PathBuf::from(path)),
+            }
+        }
+        Ok(args)
+    }
+}
+
+/// Runs the check, prints diagnostics to stderr, and fails when any rule fired.
+pub fn run_check_dt(workspace_root: &Path, args: &CheckDtArgs) -> Result<(), String> {
+    let scope: Vec<PathBuf> = if args.paths.is_empty() {
+        vec![workspace_root.join(DEFAULT_SCOPE)]
+    } else {
+        args.paths
+            .iter()
+            .map(|path| {
+                if path.is_absolute() {
+                    path.clone()
+                } else {
+                    workspace_root.join(path)
+                }
+            })
+            .collect()
+    };
+    let files = collect_scope(&scope)?;
+    let report = check(
+        &files,
+        CheckOptions {
+            deny_todo: args.deny_todo,
+        },
+    )?;
+    eprint!("{}", render_report(workspace_root, &report));
+    if report.diagnostics.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} DT violation(s) across {} file(s)",
+            report.diagnostics.len(),
+            distinct_files(&report)
+        ))
+    }
+}
+
+/// Formats diagnostics as `path:line:1: CODE message`, followed by the summary lines.
+fn render_report(workspace_root: &Path, report: &CheckReport) -> String {
+    let mut output = String::new();
+    for diagnostic in &report.diagnostics {
+        let path = diagnostic
+            .path
+            .strip_prefix(workspace_root)
+            .unwrap_or(&diagnostic.path);
+        output.push_str(&format!(
+            "{}:{}:1: {} {}\n",
+            path.display(),
+            diagnostic.line,
+            diagnostic.code,
+            diagnostic.message
+        ));
+    }
+    output.push_str(&format!(
+        "note: {} declaration(s) use `todo` (feature: {}, kind: {})\n",
+        report.todo_declarations, report.todo_features, report.todo_kinds
+    ));
+    if report.diagnostics.is_empty() {
+        output.push_str(&format!(
+            "ok: checked {} test function(s) in {} file(s)\n",
+            report.tests_checked, report.files_with_tests
+        ));
+    }
+    output
+}
+
+/// Number of distinct files that carry at least one diagnostic.
+fn distinct_files(report: &CheckReport) -> usize {
+    let mut paths: Vec<&Path> = report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.path.as_path())
+        .collect();
+    paths.sort();
+    paths.dedup();
+    paths.len()
+}

--- a/xtask/src/dt/resolve.rs
+++ b/xtask/src/dt/resolve.rs
@@ -1,0 +1,104 @@
+//! Filesystem resolution: which files are in scope and which README owns a test file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Directory names that are never scanned.
+const SKIPPED_DIRECTORIES: &[&str] = &["target", "node_modules", ".git"];
+
+/// Files discovered under the requested scope, split by role.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ScopedFiles {
+    pub(crate) rust_files: Vec<PathBuf>,
+    pub(crate) readmes: Vec<PathBuf>,
+}
+
+/// Collects `.rs` files and `README.md` files under each scope path (file or directory).
+pub(crate) fn collect_scope(paths: &[PathBuf]) -> Result<ScopedFiles, String> {
+    let mut files = ScopedFiles::default();
+    for path in paths {
+        if path.is_file() {
+            classify(path, &mut files);
+        } else if path.is_dir() {
+            walk(path, &mut files)?;
+        } else {
+            return Err(format!("scope path does not exist: {}", path.display()));
+        }
+    }
+    files.rust_files.sort();
+    files.readmes.sort();
+    Ok(files)
+}
+
+/// Recursively visits a directory, skipping build and dependency folders.
+fn walk(directory: &Path, files: &mut ScopedFiles) -> Result<(), String> {
+    let entries = fs::read_dir(directory)
+        .map_err(|error| format!("failed to read {}: {error}", directory.display()))?;
+    for entry in entries {
+        let path = entry
+            .map_err(|error| format!("failed to read entry in {}: {error}", directory.display()))?
+            .path();
+        if path.is_dir() {
+            let skip = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| SKIPPED_DIRECTORIES.contains(&name));
+            if !skip {
+                walk(&path, files)?;
+            }
+        } else {
+            classify(&path, files);
+        }
+    }
+    Ok(())
+}
+
+/// Buckets a file by role; anything else is ignored.
+fn classify(path: &Path, files: &mut ScopedFiles) {
+    if path.extension().is_some_and(|extension| extension == "rs") {
+        files.rust_files.push(path.to_path_buf());
+    } else if path.file_name().is_some_and(|name| name == "README.md") {
+        files.readmes.push(path.to_path_buf());
+    }
+}
+
+/// Where a test file's declarations resolve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Ownership {
+    /// Directory containing the crate's `Cargo.toml`.
+    pub(crate) crate_root: PathBuf,
+    /// Nearest `README.md` from the file's directory up to the crate root, if any.
+    pub(crate) owning_readme: Option<PathBuf>,
+}
+
+/// Resolves the crate root and owning README for a Rust file.
+///
+/// The crate root is the nearest ancestor with a `Cargo.toml`; the owning README is the
+/// first `README.md` met while walking from the file's directory up to that root.
+pub(crate) fn resolve_ownership(rust_file: &Path) -> Result<Ownership, String> {
+    let mut owning_readme = None;
+    let mut directory = rust_file.parent();
+    while let Some(current) = directory {
+        let readme = current.join("README.md");
+        if owning_readme.is_none() && readme.is_file() {
+            owning_readme = Some(readme);
+        }
+        if current.join("Cargo.toml").is_file() {
+            return Ok(Ownership {
+                crate_root: current.to_path_buf(),
+                owning_readme,
+            });
+        }
+        directory = current.parent();
+    }
+    Err(format!("no Cargo.toml found above {}", rust_file.display()))
+}
+
+/// README that a `seg::seg::id` qualifier points at: `<crate>/src/<segments>/README.md`.
+pub(crate) fn qualified_readme(crate_root: &Path, segments: &[String]) -> PathBuf {
+    let mut path = crate_root.join("src");
+    for segment in segments {
+        path.push(segment);
+    }
+    path.join("README.md")
+}

--- a/xtask/src/dt/scan.rs
+++ b/xtask/src/dt/scan.rs
@@ -1,0 +1,191 @@
+//! Line-level scanner that finds function headers in Rust source text.
+//!
+//! The scanner does not parse Rust. It tracks the contiguous run of doc
+//! comments, plain comments, and attributes that precedes an item ("header
+//! block") and reports, for every block, which item terminated it. This is
+//! enough for the declaration rules because the DT grammar is line-oriented
+//! by design; see the module README for the accepted blind spots.
+
+use super::declaration::{doc_text, is_declaration_attempt};
+
+/// A `/// DT[` line inside a header block, kept verbatim for later parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeclarationLine {
+    /// 1-based line number in the file.
+    pub(crate) line: usize,
+    /// Doc text after `///`.
+    pub(crate) doc: String,
+    /// Whether this line is the very first line of its header block.
+    pub(crate) is_first_header_line: bool,
+}
+
+/// What ended a header block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HeaderTarget {
+    /// A function definition; `is_test` is true when a `*test` attribute is present.
+    Function { name: String, is_test: bool },
+    /// Any other item line (struct, mod, impl, statement, ...).
+    OtherItem,
+    /// A blank line or end of file, i.e. the header is attached to nothing.
+    Detached,
+}
+
+/// A header block together with the item that terminated it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Header {
+    /// 1-based line of the terminating item (or of the last header line when detached).
+    pub(crate) line: usize,
+    pub(crate) declarations: Vec<DeclarationLine>,
+    pub(crate) target: HeaderTarget,
+}
+
+/// Scans a Rust source file and returns every header block that is worth checking:
+/// blocks that terminate at a function, or blocks that carry a declaration attempt.
+pub(crate) fn scan_headers(source: &str) -> Vec<Header> {
+    let mut headers = Vec::new();
+    let mut current = HeaderAccumulator::default();
+    // Depth of unbalanced `[` inside a multi-line attribute; zero when not inside one.
+    let mut attribute_depth = 0usize;
+
+    for (index, raw_line) in source.lines().enumerate() {
+        let line_number = index + 1;
+        let trimmed = raw_line.trim();
+
+        if attribute_depth > 0 {
+            attribute_depth = next_attribute_depth(attribute_depth, trimmed);
+            current.saw_line();
+            continue;
+        }
+
+        if let Some(doc) = doc_text(raw_line) {
+            current.push_doc(line_number, doc);
+            continue;
+        }
+        if trimmed.starts_with("//") {
+            // Plain comments are transparent inside a header block.
+            current.saw_line();
+            continue;
+        }
+        if trimmed.starts_with("#[") {
+            if is_test_attribute(trimmed) {
+                current.mark_test();
+            }
+            current.saw_line();
+            attribute_depth = next_attribute_depth(0, trimmed);
+            continue;
+        }
+        if trimmed.starts_with("#![") {
+            // Inner attributes never belong to a function header, but they may
+            // span lines and must be skipped as a unit.
+            current.saw_line();
+            attribute_depth = next_attribute_depth(0, trimmed);
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            current.finish(&mut headers, line_number, HeaderTarget::Detached);
+            continue;
+        }
+        let target = match function_name(trimmed) {
+            Some(name) => HeaderTarget::Function {
+                name,
+                is_test: current.is_test,
+            },
+            None => HeaderTarget::OtherItem,
+        };
+        current.finish(&mut headers, line_number, target);
+    }
+    let last_line = source.lines().count();
+    current.finish(&mut headers, last_line, HeaderTarget::Detached);
+    headers
+}
+
+/// Mutable state for the header block being accumulated.
+#[derive(Debug, Default)]
+struct HeaderAccumulator {
+    lines_seen: usize,
+    is_test: bool,
+    declarations: Vec<DeclarationLine>,
+}
+
+impl HeaderAccumulator {
+    /// Records a doc line, remembering declaration attempts with their position in the block.
+    fn push_doc(&mut self, line: usize, doc: &str) {
+        if is_declaration_attempt(doc) {
+            self.declarations.push(DeclarationLine {
+                line,
+                doc: doc.to_string(),
+                is_first_header_line: self.lines_seen == 0,
+            });
+        }
+        self.lines_seen += 1;
+    }
+
+    fn saw_line(&mut self) {
+        self.lines_seen += 1;
+    }
+
+    fn mark_test(&mut self) {
+        self.is_test = true;
+    }
+
+    /// Emits the block when it matters and resets for the next one.
+    fn finish(&mut self, headers: &mut Vec<Header>, line: usize, target: HeaderTarget) {
+        let is_function = matches!(target, HeaderTarget::Function { .. });
+        if is_function || !self.declarations.is_empty() {
+            headers.push(Header {
+                line,
+                declarations: std::mem::take(&mut self.declarations),
+                target,
+            });
+        }
+        *self = Self::default();
+    }
+}
+
+/// Updates the bracket depth after consuming one attribute line.
+fn next_attribute_depth(depth: usize, line: &str) -> usize {
+    line.bytes().fold(depth, |depth, byte| match byte {
+        b'[' => depth + 1,
+        b']' => depth.saturating_sub(1),
+        _ => depth,
+    })
+}
+
+/// Whether an attribute line names a test macro: its path's last segment is `test`.
+fn is_test_attribute(line: &str) -> bool {
+    let Some(inner) = line.strip_prefix("#[") else {
+        return false;
+    };
+    let path_end = inner
+        .find(|character: char| character == ']' || character == '(' || character.is_whitespace())
+        .unwrap_or(inner.len());
+    inner[..path_end].rsplit("::").next() == Some("test")
+}
+
+/// Extracts the function name when the line starts a function definition.
+fn function_name(line: &str) -> Option<String> {
+    let mut rest = line;
+    loop {
+        rest = rest.trim_start();
+        if let Some(after) = rest.strip_prefix("fn") {
+            let after = after.strip_prefix(char::is_whitespace)?;
+            let name: String = after
+                .chars()
+                .take_while(|character| character.is_alphanumeric() || *character == '_')
+                .collect();
+            return (!name.is_empty()).then_some(name);
+        }
+        // Visibility and qualifiers that may precede `fn`.
+        rest = if let Some(after) = rest.strip_prefix("pub(") {
+            after.split_once(')')?.1
+        } else {
+            let (word, after) = rest.split_once(char::is_whitespace)?;
+            match word {
+                "pub" | "async" | "unsafe" | "const" | "extern" | "default" => after,
+                _ if word.starts_with("extern") || word.starts_with('"') => after,
+                _ => return None,
+            }
+        };
+    }
+}

--- a/xtask/src/dt/tests.rs
+++ b/xtask/src/dt/tests.rs
@@ -1,0 +1,635 @@
+use super::CheckDtArgs;
+use super::catalog::{Catalog, CatalogProblem, parse_catalog};
+use super::check::{CheckOptions, Code, Diagnostic, check};
+use super::declaration::{Declaration, FeatureRef, Kind, ParseError, parse_declaration};
+use super::resolve::{Ownership, ScopedFiles, collect_scope, resolve_ownership};
+use super::scan::{DeclarationLine, Header, HeaderTarget, scan_headers};
+use pretty_assertions::assert_eq;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// DT[declaration-grammar][happy] A local feature, a known kind, and a statement parse into the declaration triple.
+#[test]
+fn parses_local_declaration() {
+    assert_eq!(
+        parse_declaration("DT[branch-listing][happy] Local refs are listed with display labels."),
+        Ok(Declaration {
+            feature: FeatureRef::Local("branch-listing".to_string()),
+            kind: Kind::Happy,
+            statement: "Local refs are listed with display labels.".to_string(),
+        })
+    );
+}
+
+/// DT[declaration-grammar][happy] A `seg::seg::id` feature parses into its module segments and id.
+#[test]
+fn parses_qualified_declaration() {
+    assert_eq!(
+        parse_declaration(" DT[parse::commit::readback-id][edge] Empty summaries survive."),
+        Ok(Declaration {
+            feature: FeatureRef::Qualified {
+                segments: vec!["parse".to_string(), "commit".to_string()],
+                id: "readback-id".to_string(),
+            },
+            kind: Kind::Edge,
+            statement: "Empty summaries survive.".to_string(),
+        })
+    );
+}
+
+/// DT[declaration-grammar][edge] The reserved word `todo` is accepted in either field and both at once.
+#[test]
+fn accepts_todo_in_both_fields() {
+    assert_eq!(
+        parse_declaration("DT[todo][todo] Not yet classified.")
+            .map(|declaration| (declaration.feature, declaration.kind)),
+        Ok((FeatureRef::Todo, Kind::Todo))
+    );
+    assert_eq!(
+        parse_declaration("DT[todo][error] Rejects garbage.")
+            .map(|declaration| declaration.feature),
+        Ok(FeatureRef::Todo)
+    );
+}
+
+/// DT[declaration-grammar][error] Grammar violations report which part is malformed instead of guessing.
+#[test]
+fn rejects_malformed_declarations() {
+    let cases = [
+        (
+            "DT[branch-listing][happy]",
+            "statement must be separated by one space",
+        ),
+        (
+            "DT[branch-listing][happy]  two spaces",
+            "statement must not be empty or start with whitespace",
+        ),
+        (
+            "DT[branch-listing][happy] trailing ",
+            "statement must not end with whitespace",
+        ),
+        (
+            "DT[branch-listing] [happy] gap",
+            "kind field must directly follow the feature field",
+        ),
+        (
+            "DT[Branch-Listing][happy] upper",
+            "feature id must be kebab-case: [a-z0-9]+(-[a-z0-9]+)*",
+        ),
+        (
+            "DT[branch--listing][happy] double dash",
+            "feature id must be kebab-case: [a-z0-9]+(-[a-z0-9]+)*",
+        ),
+        (
+            "DT[bad-seg::x-y][happy] qualified",
+            "module qualifier segments must be Rust identifiers separated by `::`",
+        ),
+        (
+            "DT[parse::todo][happy] qualified todo",
+            "`todo` cannot be module-qualified",
+        ),
+        ("DT[branch-listing][happy", "unterminated kind field"),
+    ];
+    let actual: Vec<Result<Declaration, ParseError>> = cases
+        .iter()
+        .map(|(doc, _)| parse_declaration(doc))
+        .collect();
+    let expected: Vec<Result<Declaration, ParseError>> = cases
+        .iter()
+        .map(|(_, reason)| Err(ParseError::Malformed(reason)))
+        .collect();
+    assert_eq!(actual, expected);
+}
+
+/// DT[declaration-grammar][error] An unknown kind is reported separately from grammar errors so the message can list the enum.
+#[test]
+fn rejects_unknown_kind() {
+    assert_eq!(
+        parse_declaration("DT[branch-listing][regression] Fixed once."),
+        Err(ParseError::UnknownKind("regression".to_string()))
+    );
+}
+
+/// DT[header-scanning][happy] Doc lines, plain comments, and attributes before `fn` form one header whose target knows the test attribute.
+#[test]
+fn scans_test_function_headers() {
+    let source = "\
+|mod tests {
+|    /// DT[a-b][happy] First.
+|    // a plain comment is transparent
+|    #[tokio::test(flavor = \"multi_thread\",
+|        worker_threads = 4)]
+|    async fn first() {}
+|
+|    #[test]
+|    fn missing_declaration() {}
+|
+|    /// Helper docs.
+|    fn helper() {}
+|}
+";
+    assert_eq!(
+        scan_headers(&fixture(source)),
+        vec![
+            Header {
+                line: 6,
+                declarations: vec![DeclarationLine {
+                    line: 2,
+                    doc: " DT[a-b][happy] First.".to_string(),
+                    is_first_header_line: true,
+                }],
+                target: HeaderTarget::Function {
+                    name: "first".to_string(),
+                    is_test: true,
+                },
+            },
+            Header {
+                line: 9,
+                declarations: vec![],
+                target: HeaderTarget::Function {
+                    name: "missing_declaration".to_string(),
+                    is_test: true,
+                },
+            },
+            Header {
+                line: 12,
+                declarations: vec![],
+                target: HeaderTarget::Function {
+                    name: "helper".to_string(),
+                    is_test: false,
+                },
+            },
+        ]
+    );
+}
+
+/// DT[header-scanning][edge] A declaration that is not the first header line, one that is detached by a blank line, and one on a struct are each classified distinctly.
+#[test]
+fn classifies_misplaced_declarations() {
+    let source = "\
+|/// Some intro.
+|/// DT[a-b][happy] Late.
+|#[test]
+|fn late() {}
+|
+|/// DT[a-b][happy] Detached.
+|
+|#[test]
+|fn detached() {}
+|
+|/// DT[a-b][happy] On a struct.
+|struct Fixture;
+";
+    assert_eq!(
+        scan_headers(&fixture(source)),
+        vec![
+            Header {
+                line: 4,
+                declarations: vec![DeclarationLine {
+                    line: 2,
+                    doc: " DT[a-b][happy] Late.".to_string(),
+                    is_first_header_line: false,
+                }],
+                target: HeaderTarget::Function {
+                    name: "late".to_string(),
+                    is_test: true,
+                },
+            },
+            Header {
+                line: 7,
+                declarations: vec![DeclarationLine {
+                    line: 6,
+                    doc: " DT[a-b][happy] Detached.".to_string(),
+                    is_first_header_line: true,
+                }],
+                target: HeaderTarget::Detached,
+            },
+            Header {
+                line: 9,
+                declarations: vec![],
+                target: HeaderTarget::Function {
+                    name: "detached".to_string(),
+                    is_test: true,
+                },
+            },
+            Header {
+                line: 12,
+                declarations: vec![DeclarationLine {
+                    line: 11,
+                    doc: " DT[a-b][happy] On a struct.".to_string(),
+                    is_first_header_line: true,
+                }],
+                target: HeaderTarget::OtherItem,
+            },
+        ]
+    );
+}
+
+/// DT[catalog-parsing][happy] Entries are collected from the section while prose, sub-headings, and fenced code are ignored.
+#[test]
+fn parses_catalog_section() {
+    let markdown = "\
+|# Module
+|
+|## Guarantees
+|
+|- `not-an-entry`: outside the section
+|
+|## Feature points
+|
+|Stable identifiers.
+|
+|### Reads
+|
+|- `file-read`: Bounded UTF-8 reads.
+|  Continuation line is ignored.
+|- `dir-listing`: Sorted listings.
+|
+|```markdown
+|- `fenced`: never parsed
+|```
+|
+|## Next section
+|
+|- `after`: also outside
+";
+    assert_eq!(
+        parse_catalog(&fixture(markdown)),
+        Catalog {
+            has_section: true,
+            entries: [
+                ("dir-listing".to_string(), "Sorted listings.".to_string()),
+                ("file-read".to_string(), "Bounded UTF-8 reads.".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            problems: vec![],
+        }
+    );
+}
+
+/// DT[catalog-parsing][error] Malformed entries, duplicates, and the reserved word are reported with their line numbers.
+#[test]
+fn reports_catalog_problems() {
+    let markdown = "\
+|## Feature points
+|
+|- `file-read`: Reads.
+|- `file-read`: Again.
+|- `todo`: Reserved.
+|- plain bullet
+|- `Bad_Id`: description
+|- `no-desc`:
+|- `no-colon` description
+";
+    let catalog = parse_catalog(&fixture(markdown));
+    assert_eq!(
+        catalog.entries.keys().collect::<Vec<_>>(),
+        vec!["file-read"]
+    );
+    assert_eq!(
+        catalog.problems,
+        vec![
+            CatalogProblem {
+                line: 4,
+                message: "duplicate feature point `file-read`".to_string()
+            },
+            CatalogProblem {
+                line: 5,
+                message: "`todo` is a reserved word and cannot be a feature point".to_string()
+            },
+            CatalogProblem {
+                line: 6,
+                message:
+                    "feature point entries must start with a backticked id: - `id`: description"
+                        .to_string()
+            },
+            CatalogProblem {
+                line: 7,
+                message: "feature id must be kebab-case: [a-z0-9]+(-[a-z0-9]+)*".to_string()
+            },
+            CatalogProblem {
+                line: 8,
+                message: "expected a non-empty description after `: `".to_string()
+            },
+            CatalogProblem {
+                line: 9,
+                message: "expected `:` directly after the backticked id".to_string()
+            },
+        ]
+    );
+}
+
+/// DT[catalog-parsing][edge] A README without the section yields an empty catalog flagged as sectionless rather than an error.
+#[test]
+fn distinguishes_missing_section() {
+    assert_eq!(
+        parse_catalog("# Only prose\n\n- `x`: y\n"),
+        Catalog::default()
+    );
+}
+
+/// DT[ownership-resolution][happy] The nearest README between the file and the crate root owns the file; deeper files skip READMEs above them only when a closer one exists.
+#[test]
+fn resolves_nearest_readme_within_crate() {
+    let workspace = FixtureCrate::new();
+    workspace.write("README.md", "");
+    workspace.write("src/spec/README.md", "");
+    let nested = workspace.write("src/spec/inner/leaf.rs", "");
+    let root_level = workspace.write("src/lib.rs", "");
+    let integration = workspace.write("tests/api.rs", "");
+
+    assert_eq!(
+        (
+            resolve_ownership(&nested),
+            resolve_ownership(&root_level),
+            resolve_ownership(&integration)
+        ),
+        (
+            Ok(Ownership {
+                crate_root: workspace.root(),
+                owning_readme: Some(workspace.path("src/spec/README.md"))
+            }),
+            Ok(Ownership {
+                crate_root: workspace.root(),
+                owning_readme: Some(workspace.path("README.md"))
+            }),
+            Ok(Ownership {
+                crate_root: workspace.root(),
+                owning_readme: Some(workspace.path("README.md"))
+            }),
+        )
+    );
+}
+
+/// DT[ownership-resolution][edge] A crate without any README resolves to its root with no owning README instead of climbing past `Cargo.toml`.
+#[test]
+fn stops_at_crate_root_without_readme() {
+    let workspace = FixtureCrate::new();
+    fs::write(workspace.temp.path().join("README.md"), "").expect("write parent README");
+    let file = workspace.write("src/lib.rs", "");
+    assert_eq!(
+        resolve_ownership(&file),
+        Ok(Ownership {
+            crate_root: workspace.root(),
+            owning_readme: None
+        })
+    );
+}
+
+/// DT[ownership-resolution][happy] Scope collection buckets Rust files and READMEs and skips build directories.
+#[test]
+fn collects_scope_files() {
+    let workspace = FixtureCrate::new();
+    workspace.write("README.md", "");
+    workspace.write("src/a.rs", "");
+    workspace.write("target/debug/generated.rs", "");
+    workspace.write("src/notes.txt", "");
+    assert_eq!(
+        collect_scope(&[workspace.root()]),
+        Ok(ScopedFiles {
+            rust_files: vec![workspace.path("src/a.rs")],
+            readmes: vec![workspace.path("README.md")],
+        })
+    );
+}
+
+/// DT[rule-evaluation][happy] A crate whose tests all reference catalogued features passes with counts and no diagnostics.
+#[test]
+fn accepts_conforming_crate() {
+    let workspace = FixtureCrate::new();
+    workspace.write("README.md", "## Feature points\n\n- `root-thing`: Root.\n");
+    workspace.write(
+        "src/spec/README.md",
+        "## Feature points\n\n- `spec-read`: Reads specs.\n",
+    );
+    workspace.write(
+        "src/spec/mod.rs",
+        "/// DT[spec-read][happy] Reads.\n#[test]\nfn reads() {}\n\n/// DT[spec-read][todo] Unsure.\n#[test]\nfn unsure() {}\n",
+    );
+    workspace.write(
+        "tests/api.rs",
+        "/// DT[root-thing][error] Fails.\n#[test]\nfn fails() {}\n\n/// DT[spec::spec-read][edge] Qualified.\n#[test]\nfn qualified() {}\n",
+    );
+
+    let report = check(&workspace.scope(), CheckOptions::default()).expect("check runs");
+    assert_eq!(
+        (
+            report.diagnostics,
+            report.tests_checked,
+            report.files_with_tests,
+            report.todo_declarations,
+            report.todo_features,
+            report.todo_kinds
+        ),
+        (vec![], 4, 2, 1, 0, 1)
+    );
+}
+
+/// DT[rule-evaluation][error] Each rule fires on its own trigger and diagnostics are sorted by path and line.
+#[test]
+fn reports_each_rule() {
+    let workspace = FixtureCrate::new();
+    workspace.write(
+        "README.md",
+        "## Feature points\n\n- `root-thing`: Root.\n- `root-thing`: Dup.\n",
+    );
+    workspace.write("src/spec/README.md", "# No section\n");
+    workspace.write(
+        "src/lib.rs",
+        &fixture(
+            "\
+|#[test]
+|fn no_declaration() {}
+|
+|/// DT[unknown-thing][happy] Unknown feature.
+|#[test]
+|fn unknown_feature() {}
+|
+|/// DT[root-thing][weird] Bad kind.
+|#[test]
+|fn bad_kind() {}
+|
+|/// DT[root-thing][happy]
+|#[test]
+|fn malformed() {}
+|
+|/// DT[root-thing][happy] One.
+|/// DT[root-thing][edge] Two.
+|#[test]
+|fn doubled() {}
+|
+|/// Intro first.
+|/// DT[root-thing][happy] Late.
+|#[test]
+|fn late() {}
+|
+|/// DT[root-thing][happy] Helper.
+|fn helper() {}
+|
+|/// DT[spec::spec-read][happy] Target lacks section.
+|#[test]
+|fn sectionless_target() {}
+|
+|/// DT[missing::thing][happy] Target missing.
+|#[test]
+|fn missing_target() {}
+",
+        ),
+    );
+    workspace.write(
+        "src/spec/mod.rs",
+        "/// DT[spec::spec-read][happy] Redundant qualifier.\n#[test]\nfn redundant() {}\n\n/// DT[spec-read][happy] Sectionless owner.\n#[test]\nfn owner_lacks_section() {}\n",
+    );
+
+    let report = check(&workspace.scope(), CheckOptions::default()).expect("check runs");
+    let codes: Vec<(PathBuf, usize, Code)> = report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.path.clone(), diagnostic.line, diagnostic.code))
+        .collect();
+    assert_eq!(
+        codes,
+        vec![
+            (workspace.path("README.md"), 4, Code::Dt009),
+            (workspace.path("src/lib.rs"), 2, Code::Dt001),
+            (workspace.path("src/lib.rs"), 6, Code::Dt004),
+            (workspace.path("src/lib.rs"), 8, Code::Dt003),
+            (workspace.path("src/lib.rs"), 12, Code::Dt002),
+            (workspace.path("src/lib.rs"), 17, Code::Dt006),
+            (workspace.path("src/lib.rs"), 22, Code::Dt007),
+            (workspace.path("src/lib.rs"), 26, Code::Dt006),
+            (workspace.path("src/lib.rs"), 31, Code::Dt005),
+            (workspace.path("src/lib.rs"), 35, Code::Dt008),
+            (workspace.path("src/spec/mod.rs"), 3, Code::Dt008),
+            (workspace.path("src/spec/mod.rs"), 7, Code::Dt005),
+        ]
+    );
+}
+
+/// DT[rule-evaluation][error] With `deny_todo`, every declaration using the reserved word becomes a DT010 violation.
+#[test]
+fn denies_todo_when_requested() {
+    let workspace = FixtureCrate::new();
+    workspace.write("README.md", "## Feature points\n\n- `root-thing`: Root.\n");
+    workspace.write(
+        "src/lib.rs",
+        "/// DT[todo][happy] A.\n#[test]\nfn a() {}\n\n/// DT[root-thing][todo] B.\n#[test]\nfn b() {}\n\n/// DT[root-thing][happy] C.\n#[test]\nfn c() {}\n",
+    );
+
+    let report = check(&workspace.scope(), CheckOptions { deny_todo: true }).expect("check runs");
+    assert_eq!(
+        report.diagnostics,
+        vec![
+            Diagnostic {
+                path: workspace.path("src/lib.rs"),
+                line: 3,
+                code: Code::Dt010,
+                message: "test `a` uses the reserved word `todo` while --deny-todo is active"
+                    .to_string(),
+            },
+            Diagnostic {
+                path: workspace.path("src/lib.rs"),
+                line: 7,
+                code: Code::Dt010,
+                message: "test `b` uses the reserved word `todo` while --deny-todo is active"
+                    .to_string(),
+            },
+        ]
+    );
+}
+
+/// DT[rule-evaluation][error] A crate with tests but no README at all is reported once per file as DT005.
+#[test]
+fn reports_missing_crate_readme_once_per_file() {
+    let workspace = FixtureCrate::new();
+    workspace.write(
+        "src/lib.rs",
+        "/// DT[x-y][happy] A.\n#[test]\nfn a() {}\n\n/// DT[x-y][happy] B.\n#[test]\nfn b() {}\n",
+    );
+    let report = check(&workspace.scope(), CheckOptions::default()).expect("check runs");
+    assert_eq!(
+        report
+            .diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.line, diagnostic.code))
+            .collect::<Vec<_>>(),
+        vec![(3, Code::Dt005)]
+    );
+}
+
+/// DT[command-line][happy] Positional paths and the `--deny-todo` flag parse in any order.
+#[test]
+fn parses_arguments() {
+    assert_eq!(
+        CheckDtArgs::parse([
+            "crates/fs".to_string(),
+            "--deny-todo".to_string(),
+            "xtask".to_string()
+        ]),
+        Ok(CheckDtArgs {
+            paths: vec![PathBuf::from("crates/fs"), PathBuf::from("xtask")],
+            deny_todo: true,
+        })
+    );
+}
+
+/// DT[command-line][error] An unknown flag is rejected with the usage line.
+#[test]
+fn rejects_unknown_flags() {
+    assert_eq!(
+        CheckDtArgs::parse(["--strict".to_string()]),
+        Err(
+            "unknown option `--strict`; usage: cargo xtask check-dt [--deny-todo] [PATH...]"
+                .to_string()
+        )
+    );
+}
+
+/// Temporary crate layout with a `Cargo.toml` at its root.
+struct FixtureCrate {
+    temp: TempDir,
+}
+
+impl FixtureCrate {
+    fn new() -> Self {
+        let temp = TempDir::new().expect("create temp dir");
+        let root = temp.path().join("crate");
+        fs::create_dir_all(&root).expect("create crate root");
+        fs::write(root.join("Cargo.toml"), "[package]\nname = \"fixture\"\n")
+            .expect("write Cargo.toml");
+        Self { temp }
+    }
+
+    fn root(&self) -> PathBuf {
+        self.temp.path().join("crate")
+    }
+
+    fn path(&self, relative: &str) -> PathBuf {
+        self.root().join(relative)
+    }
+
+    /// Writes a file inside the crate, creating parent directories, and returns its path.
+    fn write(&self, relative: &str, content: &str) -> PathBuf {
+        let path = self.path(relative);
+        fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        fs::write(&path, content).expect("write fixture");
+        path
+    }
+
+    fn scope(&self) -> ScopedFiles {
+        collect_scope(&[self.root()]).expect("collect scope")
+    }
+}
+
+/// Strips the `|` margin used so fixture text is not mistaken for real declarations by `check-dt`.
+fn fixture(text: &str) -> String {
+    let mut output: String = text
+        .lines()
+        .map(|line| line.strip_prefix('|').unwrap_or(line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    output.push('\n');
+    output
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,4 +1,6 @@
+mod dt;
 mod export_contracts;
 mod frontend;
 
+pub use dt::{CheckDtArgs, run_check_dt};
 pub use export_contracts::run_export_contracts;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,7 @@
 use std::process::ExitCode;
 
+const USAGE: &str = "usage: cargo xtask <export-contracts | check-dt [--deny-todo] [PATH...]>";
+
 /// Runs the requested xtask command from the workspace root.
 fn main() -> ExitCode {
     match run() {
@@ -15,21 +17,25 @@ fn main() -> ExitCode {
 fn run() -> Result<(), String> {
     let mut arguments = std::env::args().skip(1);
     let Some(command) = arguments.next() else {
-        return Err("usage: cargo xtask export-contracts".to_string());
+        return Err(USAGE.to_string());
     };
-
-    if command != "export-contracts" {
-        return Err(format!("unknown xtask command `{command}`"));
-    }
-
-    if let Some(unexpected) = arguments.next() {
-        return Err(format!("unexpected argument `{unexpected}`"));
-    }
 
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .ok_or_else(|| "failed to determine workspace root".to_string())?;
 
-    xtask::run_export_contracts(workspace_root)
-        .map_err(|error| format!("failed to export contracts: {error}"))
+    match command.as_str() {
+        "export-contracts" => {
+            if let Some(unexpected) = arguments.next() {
+                return Err(format!("unexpected argument `{unexpected}`"));
+            }
+            xtask::run_export_contracts(workspace_root)
+                .map_err(|error| format!("failed to export contracts: {error}"))
+        }
+        "check-dt" => {
+            let args = xtask::CheckDtArgs::parse(arguments)?;
+            xtask::run_check_dt(workspace_root, &args)
+        }
+        other => Err(format!("unknown xtask command `{other}`\n{USAGE}")),
+    }
 }


### PR DESCRIPTION
Refs #379 (keep the issue open after merge; remaining crates and CI wiring follow separately).

## What

- DT declaration format `/// DT[<feature>][<kind>] <statement>` and the module README `## Feature points` catalog it resolves against.
- `cargo xtask check-dt [--deny-todo] [PATH...]` (new `xtask/src/dt/` module): line-based checker with rules DT001–DT010, `todo` placeholder counting, path-scoped runs. Exposed as `task lint:dt`; not yet wired into `lint:backend`/CI.
- `AGENTS.md`: "Developer test (DT) declarations" writing rules.
- Pilot: `crates/fs` READMEs gain feature point catalogs and all 10 tests carry declarations.

## Verification

- `task lint:dt -- crates/fs xtask/src/dt` → ok (29 tests, 5 files)
- `task lint:dt` (whole `crates/`) detects 594 tests / 98 files, matching the requirement snapshot
- `cargo test -p xtask` (30 passed), `task lint:backend` passes