### PR TITLE
fix(desktop): bypass execution policy when extracting sidecar archives on Windows

### DIFF
--- a/scripts/setup-binary.mjs
+++ b/scripts/setup-binary.mjs
@@ -120,6 +120,8 @@ async function installBinary({
     if (process.platform === "win32" && archiveExtension === "zip") {
       await execFileAsync("powershell", [
         "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
         "-Command",
         `Expand-Archive -LiteralPath '${archivePath}' -DestinationPath '${extractDirectory}' -Force`,
       ]);


### PR DESCRIPTION
Follow-up on the runtime sidecar bundling: the Windows postinstall used \powershell Expand-Archive\, which fails under a \Restricted\ execution policy when Windows PowerShell 5.1 picks up the PowerShell 7 script-module copy of \Microsoft.PowerShell.Archive\ from \c:\program files\powershell\7\Modules\ (which shadows the system32 binary module). Added \-ExecutionPolicy Bypass\ to the invocation.

Branch carries the full 122-commit feature stack relative to main; the minimal isolated change is d0dae74.