### PR TITLE
feat(plugin): run agent plugins as first-class ACP providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,6 +2908,8 @@ dependencies = [
  "ora-fs",
  "ora-history",
  "ora-logging",
+ "ora-plugin-manager",
+ "ora-plugin-runtime",
  "ora-process",
  "ora-scheduler",
  "ora-skill-package",

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -5,6 +5,7 @@ use crate::stream_forwarding::{forward_contract_stream, forward_workspace_watch}
 use crate::workspace_files::{WorkspaceFileApi, workspace_file_backend_error};
 use ora_backend::{Backend, BackendError, RequestLifecycle, UuidRequestIdGenerator};
 use ora_contracts::*;
+use ora_plugin_manager::PluginContribution;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -743,6 +744,14 @@ backend_command!(
     "Reports the live detection status of every application-scoped CLI runtime through the shared Backend."
 );
 
+backend_command!(
+    list_agent_models,
+    ListAgentModelsRequest,
+    ListAgentModelsResponse,
+    list_agent_models,
+    "Lists the models one agent advertises outside any session through the shared Backend."
+);
+
 // =============================================================================
 // skill
 // =============================================================================
@@ -879,22 +888,20 @@ pub async fn list_installed_plugins(
         .plugin_manager
         .installed_plugins()
         .iter()
-        .map(|plugin| InstalledPlugin {
-            id: plugin.id.clone(),
-            package_name: plugin.package_name.clone(),
-            display_name: plugin.display_name.clone(),
-            version: plugin.version.to_string(),
-            kind: plugin.kind.as_str().to_string(),
-            main: plugin.main.to_string_lossy().to_string(),
-            agents: plugin
-                .agents
-                .iter()
-                .map(|agent| InstalledPluginAgent {
-                    id: agent.id.clone(),
+        .map(|plugin| {
+            let PluginContribution::Agent(agent) = &plugin.contributes;
+            InstalledPlugin {
+                id: plugin.id.clone(),
+                package_name: plugin.package_name.clone(),
+                display_name: plugin.display_name.clone(),
+                version: plugin.version.to_string(),
+                kind: plugin.contributes.kind().to_string(),
+                main: plugin.main.to_string_lossy().to_string(),
+                agent: InstalledPluginAgent {
                     display_name: agent.display_name.clone(),
                     contract_version: agent.contract_version,
-                })
-                .collect(),
+                },
+            }
         })
         .collect();
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,12 +11,12 @@ mod workspace_files;
 use crate::config::DesktopConfigStore;
 use crate::error::DesktopBootstrapError;
 use crate::state::{BundledBinaryPaths, DesktopRuntimeGuard, DesktopState};
-use ora_backend::{Backend, BackendPaths};
+use ora_backend::{AgentPluginPackage, Backend, BackendPaths};
 use ora_logging::{
     FileLoggingConfig, LogLevel, LogOutput, LoggingConfig, RotationPolicy, init_logging, ora_error,
     ora_info, ora_warn, register_gitlancer_logger,
 };
-use ora_plugin_manager::PluginManager;
+use ora_plugin_manager::{PluginContribution, PluginManager};
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
@@ -93,6 +93,7 @@ pub fn run() {
             // agentRuntime
             // =============================================================================
             commands::get_agent_runtime_status,
+            commands::list_agent_models,
             // =============================================================================
             // skill
             // =============================================================================
@@ -221,17 +222,6 @@ fn bootstrap_desktop(
         }
     };
     let ripgrep_path = binary_paths.ripgrep_path().to_path_buf();
-    let backend = Backend::open(BackendPaths {
-        database_path: app_data_directory.join("ora.sqlite3"),
-        worktree_root: config_snapshot.worktree_root().to_path_buf(),
-        home_directory,
-        relative_path_base: desktop_relative_path_base(&app_data_directory),
-        sessions_root: app_data_directory.join("sessions"),
-        skills_root: app_data_directory.join("atoms").join("skills"),
-        ripgrep_path: ripgrep_path.clone(),
-        timezone: resolved_timezone.timezone,
-    })?;
-    let workspace_files = Arc::new(workspace_files::WorkspaceFileApi::new(ripgrep_path));
     let plugin_manager = PluginManager::discover(&app_data_directory);
     for issue in plugin_manager.discovery_issues() {
         ora_warn!(
@@ -243,6 +233,21 @@ fn bootstrap_desktop(
         );
     }
 
+    let agent_plugins = agent_plugin_packages(&plugin_manager, binary_paths.deno_path());
+    let backend = Backend::open(
+        BackendPaths {
+            database_path: app_data_directory.join("ora.sqlite3"),
+            worktree_root: config_snapshot.worktree_root().to_path_buf(),
+            home_directory,
+            relative_path_base: desktop_relative_path_base(&app_data_directory),
+            sessions_root: app_data_directory.join("sessions"),
+            skills_root: app_data_directory.join("atoms").join("skills"),
+            ripgrep_path: ripgrep_path.clone(),
+            timezone: resolved_timezone.timezone,
+        },
+        agent_plugins,
+    )?;
+    let workspace_files = Arc::new(workspace_files::WorkspaceFileApi::new(ripgrep_path));
     Ok((
         DesktopState {
             backend,
@@ -255,6 +260,29 @@ fn bootstrap_desktop(
         },
         DesktopRuntimeGuard { _logging: logging },
     ))
+}
+
+/// Selects the installed plugins that contribute an agent the runtime should supervise.
+///
+/// Every discovered plugin is already validated, so the entrypoint is resolved against the package
+/// root here rather than re-checked; a package that contributes no agent simply has nothing to
+/// supervise.
+fn agent_plugin_packages(
+    plugin_manager: &PluginManager,
+    deno_path: &std::path::Path,
+) -> Vec<AgentPluginPackage> {
+    plugin_manager
+        .installed_plugins()
+        .iter()
+        .map(|plugin| {
+            let PluginContribution::Agent(_) = &plugin.contributes;
+            AgentPluginPackage {
+                id: plugin.id.clone(),
+                deno_path: deno_path.to_path_buf(),
+                entrypoint: plugin.package_root.join(&plugin.main),
+            }
+        })
+        .collect()
 }
 
 /// Resolves the configured Desktop data root or falls back to Tauri's application data directory.

--- a/apps/desktop/web/tauri-transport.ts
+++ b/apps/desktop/web/tauri-transport.ts
@@ -88,6 +88,7 @@ const tauriCommands = {
   // agentRuntime
   // =============================================================================
   getAgentRuntimeStatus: "get_agent_runtime_status",
+  listAgentModels: "list_agent_models",
 
   // =============================================================================
   // skill

--- a/crates/acp/README.md
+++ b/crates/acp/README.md
@@ -1,12 +1,15 @@
 # ora-acp
 
-`ora-acp` is Ora's provider-neutral ACP v1 transport over newline-delimited JSON-RPC stdio. It turns an asynchronous reader and writer into a typed request client plus one ordered inbound stream for each session's updates, permission requests, and terminating responses.
+`ora-acp` is Ora's provider-neutral ACP v1 peer. It turns one connection into a typed request client plus one ordered inbound stream for each session's updates, permission requests, and terminating responses.
+
+The peer is transport-neutral: it consumes and produces whole JSON-RPC messages and never inspects framing. `AcpTransport` is the seam. `NdjsonTransport` serves agents reached over a child process's stdio pipes, while a transport whose messages are already parsed — such as plugin IPC — avoids serializing values that were never bytes.
 
 ACP wire values come from the official `agent-client-protocol-schema` crate. `ora-acp` owns transport behavior and Ora-specific routing metadata, not a fork of the protocol schema.
 
 ## Responsibilities
 
-- `AcpPeer` owns the reader task and exposes an `AcpClient` for serialized writes.
+- `AcpTransport` owns framing and write ordering: `send` delivers whole messages in call order, and the `AcpMessages` stream handed to `AcpPeer::spawn` yields exactly one message per frame.
+- `AcpPeer` owns the routing task and exposes an `AcpClient` for writes.
 - `AcpClient` correlates direct requests by `RequestId`, decodes typed responses, sends notifications, and answers agent-originated requests.
 - Session trace registrations translate provider session identifiers into the Ora-owned identifiers used by the `session_id` log field.
 - Session requests return a pending handle whose response is emitted into the same inbound stream as that session's updates and permission requests. The reader preserves their wire order, so a terminating response cannot overtake an earlier update.
@@ -15,10 +18,10 @@ ACP wire values come from the official `agent-client-protocol-schema` crate. `or
 
 ## Boundaries and failure semantics
 
-- Frames are newline-delimited JSON with an 8 MiB maximum. An oversized or malformed frame is fatal to the connection.
+- Framing limits belong to the transport. `NdjsonTransport` uses newline-delimited JSON with an 8 MiB maximum; an oversized or malformed frame ends the inbound stream with that failure, which is fatal to the connection.
 - Unmatched responses, stdio loss, and invalid response envelopes fail pending operations instead of being silently ignored. The exception is a response for a cancelled direct request or deliberately abandoned session request, which is recognized by its bounded tombstone.
 - Recognized permission requests are emitted as `PermissionRequest`. Unknown agent-originated methods receive a correlated method-not-found response without terminating the connection.
 - The connection-to-router inbound channel is intentionally unbounded and preserves the reader's order. Per-session bounds and overflow policy belong to the backend runtime, where one noisy session can be isolated from others.
-- Writes share one mutex so concurrent JSON-RPC frames cannot interleave.
+- Write serialization is the transport's guarantee. `NdjsonTransport` holds one mutex so concurrent JSON-RPC frames cannot interleave bytes.
 
 This crate does not spawn provider processes, supervise reconnects, route updates to Ora sessions, or enforce session lifecycle policy. Those responsibilities belong to `ora-backend`. See [ACP Agent Runtime](../../docs/agent-runtime.md).

--- a/crates/acp/src/client.rs
+++ b/crates/acp/src/client.rs
@@ -1,0 +1,258 @@
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol_schema::v1::RequestId;
+use agent_client_protocol_schema::v1::SessionId;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::json;
+use tokio::sync::oneshot;
+
+use crate::error::AcpError;
+use crate::events::SessionResponse;
+use crate::frame::send_traced;
+use crate::pending::{PendingRequest, PendingRequests, lock_pending};
+use crate::trace::{SessionTraceRegistration, SessionTraceRegistry};
+use crate::transport::AcpTransport;
+
+/// Retires a direct request when its waiting future is cancelled or times out.
+///
+/// Direct responses bypass the ordered session-event stream, but they still need a bounded
+/// tombstone after cancellation so a late provider response is ignored rather than treated as an
+/// unknown correlation id. Keeping this guard inside `request` makes every caller cancellation
+/// safe without exposing correlation bookkeeping in the public API.
+struct DirectRequestRegistration {
+    request_id: RequestId,
+    pending: Arc<Mutex<PendingRequests>>,
+    unregister_on_drop: bool,
+}
+
+impl DirectRequestRegistration {
+    /// Stops Drop cleanup after the reader has already consumed the correlation entry.
+    fn complete(&mut self) {
+        self.unregister_on_drop = false;
+    }
+
+    /// Removes a request that failed before a valid response could be produced.
+    fn remove(&mut self) {
+        lock_pending(&self.pending).remove_active(&self.request_id);
+        self.unregister_on_drop = false;
+    }
+}
+
+impl Drop for DirectRequestRegistration {
+    fn drop(&mut self) {
+        if self.unregister_on_drop {
+            lock_pending(&self.pending).abandon(&self.request_id);
+        }
+    }
+}
+
+/// Completes a typed session request after its ordered response event is received.
+///
+/// Dropping an unsettled handle retires its id so a late response can be discarded without
+/// masking a genuinely unknown correlation id.
+pub struct PendingSessionRequest<Response> {
+    request_id: RequestId,
+    session_id: SessionId,
+    pending: Arc<Mutex<PendingRequests>>,
+    unregister_on_drop: bool,
+    response: PhantomData<Response>,
+}
+
+impl<Response> PendingSessionRequest<Response>
+where
+    Response: DeserializeOwned,
+{
+    /// Returns whether this handle owns the terminating response.
+    pub fn matches_response(&self, response: &SessionResponse) -> bool {
+        response.request_id == self.request_id && response.session_id == self.session_id
+    }
+
+    /// Validates response ownership before decoding the typed result.
+    pub fn finish(mut self, response: SessionResponse) -> Result<Response, AcpError> {
+        if !self.matches_response(&response) {
+            // The handle is consumed here; unregister so correlation cannot leak forever.
+            // Callers that need to keep waiting must filter with `matches_response` first.
+            lock_pending(&self.pending).abandon(&self.request_id);
+            self.unregister_on_drop = false;
+            return Err(AcpError::InvalidResponse(format!(
+                "response {response_id} for session {response_session_id} does not match request {request_id} for session {request_session_id}",
+                response_id = response.request_id,
+                response_session_id = response.session_id,
+                request_id = self.request_id,
+                request_session_id = self.session_id,
+            )));
+        }
+        // The reader already removed this id when the response entered the inbound stream.
+        self.unregister_on_drop = false;
+        match response.response {
+            Ok(result) => serde_json::from_value(result)
+                .map_err(|error| AcpError::InvalidResponse(error.to_string())),
+            Err(error) => Err(AcpError::RequestFailed(error.message)),
+        }
+    }
+
+    /// Retires the request so its late response can be discarded without masking unknown ids.
+    pub fn abandon(mut self) {
+        lock_pending(&self.pending).abandon(&self.request_id);
+        self.unregister_on_drop = false;
+    }
+}
+
+impl<Response> Drop for PendingSessionRequest<Response> {
+    fn drop(&mut self) {
+        if self.unregister_on_drop {
+            lock_pending(&self.pending).abandon(&self.request_id);
+        }
+    }
+}
+
+/// Sends correlated ACP requests and protocol responses over one connection transport.
+pub struct AcpClient<Transport> {
+    pub(crate) transport: Arc<Transport>,
+    pub(crate) pending: Arc<Mutex<PendingRequests>>,
+    pub(crate) next_request_id: Arc<AtomicI64>,
+    pub(crate) trace_sessions: SessionTraceRegistry,
+}
+
+impl<Transport> Clone for AcpClient<Transport> {
+    fn clone(&self) -> Self {
+        Self {
+            transport: self.transport.clone(),
+            pending: self.pending.clone(),
+            next_request_id: self.next_request_id.clone(),
+            trace_sessions: self.trace_sessions.clone(),
+        }
+    }
+}
+
+impl<Transport> AcpClient<Transport>
+where
+    Transport: AcpTransport,
+{
+    /// Associates provider traffic with the Ora session identifier used by application logs.
+    pub fn register_session_trace(
+        &self,
+        agent_session_id: &str,
+        ora_session_id: &str,
+    ) -> SessionTraceRegistration {
+        self.trace_sessions
+            .register(agent_session_id, ora_session_id)
+    }
+
+    /// Sends a typed request and waits for the independently-read correlated response.
+    pub async fn request<Request, Response>(
+        &self,
+        method: &str,
+        params: &Request,
+    ) -> Result<Response, AcpError>
+    where
+        Request: Serialize,
+        Response: DeserializeOwned,
+    {
+        let request_id = RequestId::Number(self.next_request_id.fetch_add(1, Ordering::Relaxed));
+        let (response_sender, response_receiver) = oneshot::channel();
+        lock_pending(&self.pending)
+            .insert(request_id.clone(), PendingRequest::Direct(response_sender));
+        let mut registration = DirectRequestRegistration {
+            request_id: request_id.clone(),
+            pending: Arc::clone(&self.pending),
+            unregister_on_drop: true,
+        };
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        });
+        if let Err(error) = self.send(frame).await {
+            registration.remove();
+            return Err(error);
+        }
+        let response = response_receiver
+            .await
+            .map_err(|_| AcpError::StreamClosed)?;
+        // The reader removes direct requests before delivering their response through the
+        // oneshot, so Drop must not turn a successfully correlated request into a tombstone.
+        registration.complete();
+        match response {
+            Ok(result) => serde_json::from_value(result)
+                .map_err(|error| AcpError::InvalidResponse(error.to_string())),
+            Err(error) => Err(AcpError::RequestFailed(error.message)),
+        }
+    }
+
+    /// Starts a session request whose response must remain ordered with session events.
+    pub async fn start_session_request<Request, Response>(
+        &self,
+        session_id: SessionId,
+        method: &str,
+        params: &Request,
+    ) -> Result<PendingSessionRequest<Response>, AcpError>
+    where
+        Request: Serialize,
+        Response: DeserializeOwned,
+    {
+        let request_id = RequestId::Number(self.next_request_id.fetch_add(1, Ordering::Relaxed));
+        lock_pending(&self.pending).insert(
+            request_id.clone(),
+            PendingRequest::Session {
+                session_id: session_id.clone(),
+            },
+        );
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        });
+        if let Err(error) = self.send(frame).await {
+            lock_pending(&self.pending).remove_active(&request_id);
+            return Err(error);
+        }
+        Ok(PendingSessionRequest {
+            request_id,
+            session_id,
+            pending: self.pending.clone(),
+            unregister_on_drop: true,
+            response: PhantomData,
+        })
+    }
+
+    /// Sends a notification that intentionally has no JSON-RPC response.
+    pub async fn notify<Params>(&self, method: &str, params: &Params) -> Result<(), AcpError>
+    where
+        Params: Serialize,
+    {
+        self.send(json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }))
+        .await
+    }
+
+    /// Responds to an agent-originated permission request with a typed result payload.
+    pub async fn respond<ResultBody>(
+        &self,
+        request_id: &RequestId,
+        result: &ResultBody,
+    ) -> Result<(), AcpError>
+    where
+        ResultBody: Serialize,
+    {
+        self.send(json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": result,
+        }))
+        .await
+    }
+
+    /// Hands one complete message to the transport, which owns framing and write ordering.
+    async fn send(&self, value: serde_json::Value) -> Result<(), AcpError> {
+        send_traced(&self.transport, &self.trace_sessions, value).await
+    }
+}

--- a/crates/acp/src/error.rs
+++ b/crates/acp/src/error.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+/// Reports framing, correlation, serialization, and transport failures.
+#[derive(Debug, Error)]
+pub enum AcpError {
+    #[error("ACP stream ended before the pending operation completed")]
+    StreamClosed,
+    #[error("ACP transport I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("ACP frame is invalid: {0}")]
+    InvalidFrame(String),
+    #[error("ACP frame exceeds 8 MiB")]
+    FrameTooLarge,
+    #[error("ACP returned an operation error: {0}")]
+    RequestFailed(String),
+    #[error("ACP response payload is invalid: {0}")]
+    InvalidResponse(String),
+}

--- a/crates/acp/src/events.rs
+++ b/crates/acp/src/events.rs
@@ -1,0 +1,38 @@
+use agent_client_protocol_schema::v1::RequestId;
+use agent_client_protocol_schema::v1::RequestPermissionRequest;
+use agent_client_protocol_schema::v1::SessionId;
+use agent_client_protocol_schema::v1::SessionNotification;
+
+use crate::error::AcpError;
+use crate::pending::PendingResponse;
+
+/// Carries one permission request together with its JSON-RPC correlation id.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PermissionRequest {
+    pub request_id: RequestId,
+    pub request: RequestPermissionRequest,
+}
+
+/// Carries a response that terminates one ordered session request.
+#[derive(Debug)]
+pub struct SessionResponse {
+    pub(crate) request_id: RequestId,
+    pub(crate) session_id: SessionId,
+    pub(crate) response: PendingResponse,
+}
+
+impl SessionResponse {
+    /// Identifies the provider session that owns this response.
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
+    }
+}
+
+/// Preserves wire order for all events that participate in a session turn.
+#[derive(Debug)]
+pub enum AcpInboundEvent {
+    SessionUpdate(SessionNotification),
+    PermissionRequest(PermissionRequest),
+    SessionResponse(SessionResponse),
+    Fatal(AcpError),
+}

--- a/crates/acp/src/frame.rs
+++ b/crates/acp/src/frame.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+
+use ora_logging::ora_trace;
+use serde_json::Value;
+
+use crate::error::AcpError;
+use crate::transport::AcpTransport;
+
+#[cfg(debug_assertions)]
+use {
+    crate::pending::{PendingRequests, lock_pending},
+    agent_client_protocol_schema::v1::RequestId,
+    std::sync::Mutex,
+};
+
+use crate::trace::SessionTraceRegistry;
+
+/// Sends one whole message through the connection transport after recording its trace summary.
+pub(crate) async fn send_traced<Transport>(
+    transport: &Arc<Transport>,
+    trace_sessions: &SessionTraceRegistry,
+    value: Value,
+) -> Result<(), AcpError>
+where
+    Transport: AcpTransport,
+{
+    #[cfg(debug_assertions)]
+    {
+        let (msg, jsonrpc_method, session_id) =
+            trace_frame_summary(&value, "send", trace_sessions, /*pending*/ None);
+        ora_trace!(
+            direction = "send",
+            jsonrpc_method = %jsonrpc_method,
+            session_id = %session_id,
+            frame = %value,
+            "{}", msg,
+        );
+    }
+    #[cfg(not(debug_assertions))]
+    let _ = trace_sessions;
+    transport.send(value).await
+}
+
+/// Extracts summary fields from a JSON-RPC frame for trace-level correlation without re-parsing.
+#[cfg(debug_assertions)]
+pub(crate) fn trace_frame_summary(
+    value: &Value,
+    direction: &str,
+    trace_sessions: &SessionTraceRegistry,
+    pending: Option<&Mutex<PendingRequests>>,
+) -> (String, String, String) {
+    let jsonrpc_method = value.get("method").and_then(|v| v.as_str()).unwrap_or("");
+    let agent_session_id = value
+        .get("params")
+        .and_then(|p| p.get("sessionId"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            let request_id = value
+                .get("id")
+                .cloned()
+                .and_then(|id| serde_json::from_value::<RequestId>(id).ok())?;
+            pending
+                .map(lock_pending)?
+                .session_id(&request_id)
+                .map(ToString::to_string)
+        })
+        .unwrap_or_default();
+    let session_id = trace_sessions.resolve(&agent_session_id);
+    let is_response = value.get("result").is_some();
+    let is_error = value.get("error").is_some();
+
+    let message = if !jsonrpc_method.is_empty() {
+        format!("{direction} {jsonrpc_method}")
+    } else if is_response {
+        format!("{direction} response")
+    } else if is_error {
+        format!("{direction} error response")
+    } else {
+        format!("{direction} frame")
+    };
+
+    (message, jsonrpc_method.to_string(), session_id)
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::trace_frame_summary;
+    use crate::pending::{PendingRequest, PendingRequests};
+    use crate::trace::SessionTraceRegistry;
+    use agent_client_protocol_schema::v1::RequestId;
+    use agent_client_protocol_schema::v1::SessionId;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    /// Verifies ACP trace fields expose the registered Ora session identity.
+    #[test]
+    fn traces_the_registered_ora_session_id() {
+        let trace_sessions = SessionTraceRegistry::default();
+        let _registration = trace_sessions.register("agent-session-1", "ora-session-1");
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": { "sessionId": "agent-session-1" },
+        });
+
+        assert_eq!(
+            trace_frame_summary(&frame, "recv", &trace_sessions, /*pending*/ None),
+            (
+                "recv session/update".to_string(),
+                "session/update".to_string(),
+                "ora-session-1".to_string(),
+            )
+        );
+    }
+
+    /// Verifies response frames inherit identity from their pending session request.
+    #[test]
+    fn traces_the_ora_session_id_on_correlated_responses() {
+        let trace_sessions = SessionTraceRegistry::default();
+        let _registration = trace_sessions.register("agent-session-1", "ora-session-1");
+        let request_id = RequestId::Number(7);
+        let mut pending = PendingRequests::default();
+        pending.insert(
+            request_id.clone(),
+            PendingRequest::Session {
+                session_id: SessionId::new("agent-session-1"),
+            },
+        );
+        let pending = Mutex::new(pending);
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": { "stopReason": "end_turn" },
+        });
+
+        assert_eq!(
+            trace_frame_summary(&frame, "recv", &trace_sessions, Some(&pending)),
+            (
+                "recv response".to_string(),
+                String::new(),
+                "ora-session-1".to_string(),
+            )
+        );
+    }
+}

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -1,11 +1,25 @@
-//! Minimal ACP v1 stdio peer used by Ora's provider-neutral agent runtime.
+//! Minimal ACP v1 peer used by Ora's provider-neutral agent runtime.
+//!
+//! The peer is transport-neutral: it consumes and produces whole JSON-RPC messages and leaves
+//! framing to an [`AcpTransport`]. `NdjsonTransport` serves agents spoken to over a child
+//! process's stdio pipes, while an already-parsed transport (such as plugin IPC) avoids
+//! re-serializing messages that were never bytes to begin with.
 
+mod client;
+mod error;
+mod events;
+mod frame;
 mod peer;
 mod pending;
 mod trace;
+mod transport;
 
-pub use peer::{
-    AcpClient, AcpError, AcpInboundEvent, AcpPeer, PendingSessionRequest, PermissionRequest,
-    SessionResponse,
-};
+#[cfg(test)]
+mod tests;
+
+pub use client::{AcpClient, PendingSessionRequest};
+pub use error::AcpError;
+pub use events::{AcpInboundEvent, PermissionRequest, SessionResponse};
+pub use peer::AcpPeer;
 pub use trace::SessionTraceRegistration;
+pub use transport::{AcpMessages, AcpTransport, NdjsonTransport};

--- a/crates/acp/src/peer.rs
+++ b/crates/acp/src/peer.rs
@@ -1,347 +1,51 @@
-use super::pending::{
-    PendingRequest, PendingRequests, PendingResponse, ResponseRequest, lock_pending,
-};
-use super::trace::{SessionTraceRegistration, SessionTraceRegistry};
+use std::sync::atomic::AtomicI64;
+use std::sync::{Arc, Mutex};
+
 use agent_client_protocol_schema::v1::CLIENT_METHOD_NAMES;
 use agent_client_protocol_schema::v1::RequestId;
-use agent_client_protocol_schema::v1::RequestPermissionRequest;
-use agent_client_protocol_schema::v1::SessionId;
-use agent_client_protocol_schema::v1::SessionNotification;
-use futures_util::StreamExt;
 use ora_logging::ora_trace;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
-use std::marker::PhantomData;
-use std::sync::atomic::{AtomicI64, Ordering};
-use std::sync::{Arc, Mutex};
-use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use tokio::sync::{Mutex as AsyncMutex, mpsc, oneshot};
-use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
+use tokio::sync::mpsc;
 
-const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+use crate::client::AcpClient;
+use crate::error::AcpError;
+use crate::events::{AcpInboundEvent, PermissionRequest, SessionResponse};
+use crate::frame::send_traced;
+use crate::pending::{PendingRequest, PendingRequests, ResponseRequest, lock_pending};
+use crate::trace::SessionTraceRegistry;
+use crate::transport::{AcpMessages, AcpTransport};
 
-/// Reports framing, correlation, serialization, and process-pipe failures.
-#[derive(Debug, Error)]
-pub enum AcpError {
-    #[error("ACP stream ended before the pending operation completed")]
-    StreamClosed,
-    #[error("ACP transport I/O failed: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("ACP frame is invalid: {0}")]
-    InvalidFrame(String),
-    #[error("ACP frame exceeds 8 MiB")]
-    FrameTooLarge,
-    #[error("ACP returned an operation error: {0}")]
-    RequestFailed(String),
-    #[error("ACP response payload is invalid: {0}")]
-    InvalidResponse(String),
-}
-
-/// Carries one permission request together with its JSON-RPC correlation id.
-#[derive(Debug, Clone, PartialEq)]
-pub struct PermissionRequest {
-    pub request_id: RequestId,
-    pub request: RequestPermissionRequest,
-}
-
-/// Carries a response that terminates one ordered session request.
-#[derive(Debug)]
-pub struct SessionResponse {
-    request_id: RequestId,
-    session_id: SessionId,
-    response: PendingResponse,
-}
-
-/// Retires a direct request when its waiting future is cancelled or times out.
-///
-/// Direct responses bypass the ordered session-event stream, but they still need a bounded
-/// tombstone after cancellation so a late provider response is ignored rather than treated as an
-/// unknown correlation id. Keeping this guard inside `request` makes every caller cancellation
-/// safe without exposing correlation bookkeeping in the public API.
-struct DirectRequestRegistration {
-    request_id: RequestId,
-    pending: Arc<Mutex<PendingRequests>>,
-    unregister_on_drop: bool,
-}
-
-impl DirectRequestRegistration {
-    /// Stops Drop cleanup after the reader has already consumed the correlation entry.
-    fn complete(&mut self) {
-        self.unregister_on_drop = false;
-    }
-
-    /// Removes a request that failed before a valid response could be produced.
-    fn remove(&mut self) {
-        lock_pending(&self.pending).remove_active(&self.request_id);
-        self.unregister_on_drop = false;
-    }
-}
-
-impl Drop for DirectRequestRegistration {
-    fn drop(&mut self) {
-        if self.unregister_on_drop {
-            lock_pending(&self.pending).abandon(&self.request_id);
-        }
-    }
-}
-
-impl SessionResponse {
-    /// Identifies the provider session that owns this response.
-    pub fn session_id(&self) -> &SessionId {
-        &self.session_id
-    }
-}
-
-/// Completes a typed session request after its ordered response event is received.
-///
-/// Dropping an unsettled handle retires its id so a late response can be discarded without
-/// masking a genuinely unknown correlation id.
-pub struct PendingSessionRequest<Response> {
-    request_id: RequestId,
-    session_id: SessionId,
-    pending: Arc<Mutex<PendingRequests>>,
-    unregister_on_drop: bool,
-    response: PhantomData<Response>,
-}
-
-impl<Response> PendingSessionRequest<Response>
-where
-    Response: DeserializeOwned,
-{
-    /// Returns whether this handle owns the terminating response.
-    pub fn matches_response(&self, response: &SessionResponse) -> bool {
-        response.request_id == self.request_id && response.session_id == self.session_id
-    }
-
-    /// Validates response ownership before decoding the typed result.
-    pub fn finish(mut self, response: SessionResponse) -> Result<Response, AcpError> {
-        if !self.matches_response(&response) {
-            // The handle is consumed here; unregister so correlation cannot leak forever.
-            // Callers that need to keep waiting must filter with `matches_response` first.
-            lock_pending(&self.pending).abandon(&self.request_id);
-            self.unregister_on_drop = false;
-            return Err(AcpError::InvalidResponse(format!(
-                "response {response_id} for session {response_session_id} does not match request {request_id} for session {request_session_id}",
-                response_id = response.request_id,
-                response_session_id = response.session_id,
-                request_id = self.request_id,
-                request_session_id = self.session_id,
-            )));
-        }
-        // The reader already removed this id when the response entered the inbound stream.
-        self.unregister_on_drop = false;
-        match response.response {
-            Ok(result) => serde_json::from_value(result)
-                .map_err(|error| AcpError::InvalidResponse(error.to_string())),
-            Err(error) => Err(AcpError::RequestFailed(error.message)),
-        }
-    }
-
-    /// Retires the request so its late response can be discarded without masking unknown ids.
-    pub fn abandon(mut self) {
-        lock_pending(&self.pending).abandon(&self.request_id);
-        self.unregister_on_drop = false;
-    }
-}
-
-impl<Response> Drop for PendingSessionRequest<Response> {
-    fn drop(&mut self) {
-        if self.unregister_on_drop {
-            lock_pending(&self.pending).abandon(&self.request_id);
-        }
-    }
-}
-
-/// Preserves wire order for all events that participate in a session turn.
-#[derive(Debug)]
-pub enum AcpInboundEvent {
-    SessionUpdate(SessionNotification),
-    PermissionRequest(PermissionRequest),
-    SessionResponse(SessionResponse),
-    Fatal(AcpError),
-}
-
-/// Sends correlated ACP requests and protocol responses over one serialized writer.
-pub struct AcpClient<Writer> {
-    writer: Arc<AsyncMutex<Writer>>,
-    pending: Arc<Mutex<PendingRequests>>,
-    next_request_id: Arc<AtomicI64>,
-    trace_sessions: SessionTraceRegistry,
-}
-
-impl<Writer> Clone for AcpClient<Writer> {
-    fn clone(&self) -> Self {
-        Self {
-            writer: self.writer.clone(),
-            pending: self.pending.clone(),
-            next_request_id: self.next_request_id.clone(),
-            trace_sessions: self.trace_sessions.clone(),
-        }
-    }
-}
-
-impl<Writer> AcpClient<Writer>
-where
-    Writer: AsyncWrite + Unpin + Send + 'static,
-{
-    /// Associates provider traffic with the Ora session identifier used by application logs.
-    pub fn register_session_trace(
-        &self,
-        agent_session_id: &str,
-        ora_session_id: &str,
-    ) -> SessionTraceRegistration {
-        self.trace_sessions
-            .register(agent_session_id, ora_session_id)
-    }
-
-    /// Sends a typed request and waits for the independently-read correlated response.
-    pub async fn request<Request, Response>(
-        &self,
-        method: &str,
-        params: &Request,
-    ) -> Result<Response, AcpError>
-    where
-        Request: Serialize,
-        Response: DeserializeOwned,
-    {
-        let request_id = RequestId::Number(self.next_request_id.fetch_add(1, Ordering::Relaxed));
-        let (response_sender, response_receiver) = oneshot::channel();
-        lock_pending(&self.pending)
-            .insert(request_id.clone(), PendingRequest::Direct(response_sender));
-        let mut registration = DirectRequestRegistration {
-            request_id: request_id.clone(),
-            pending: Arc::clone(&self.pending),
-            unregister_on_drop: true,
-        };
-        let frame = json!({
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "method": method,
-            "params": params,
-        });
-        if let Err(error) = self.write_frame(&frame).await {
-            registration.remove();
-            return Err(error);
-        }
-        let response = response_receiver
-            .await
-            .map_err(|_| AcpError::StreamClosed)?;
-        // The reader removes direct requests before delivering their response through the
-        // oneshot, so Drop must not turn a successfully correlated request into a tombstone.
-        registration.complete();
-        match response {
-            Ok(result) => serde_json::from_value(result)
-                .map_err(|error| AcpError::InvalidResponse(error.to_string())),
-            Err(error) => Err(AcpError::RequestFailed(error.message)),
-        }
-    }
-
-    /// Starts a session request whose response must remain ordered with session events.
-    pub async fn start_session_request<Request, Response>(
-        &self,
-        session_id: SessionId,
-        method: &str,
-        params: &Request,
-    ) -> Result<PendingSessionRequest<Response>, AcpError>
-    where
-        Request: Serialize,
-        Response: DeserializeOwned,
-    {
-        let request_id = RequestId::Number(self.next_request_id.fetch_add(1, Ordering::Relaxed));
-        lock_pending(&self.pending).insert(
-            request_id.clone(),
-            PendingRequest::Session {
-                session_id: session_id.clone(),
-            },
-        );
-        let frame = json!({
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "method": method,
-            "params": params,
-        });
-        if let Err(error) = self.write_frame(&frame).await {
-            lock_pending(&self.pending).remove_active(&request_id);
-            return Err(error);
-        }
-        Ok(PendingSessionRequest {
-            request_id,
-            session_id,
-            pending: self.pending.clone(),
-            unregister_on_drop: true,
-            response: PhantomData,
-        })
-    }
-
-    /// Sends a notification that intentionally has no JSON-RPC response.
-    pub async fn notify<Params>(&self, method: &str, params: &Params) -> Result<(), AcpError>
-    where
-        Params: Serialize,
-    {
-        self.write_frame(&json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-        }))
-        .await
-    }
-
-    /// Responds to an agent-originated permission request with a typed result payload.
-    pub async fn respond<ResultBody>(
-        &self,
-        request_id: &RequestId,
-        result: &ResultBody,
-    ) -> Result<(), AcpError>
-    where
-        ResultBody: Serialize,
-    {
-        self.write_frame(&json!({
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "result": result,
-        }))
-        .await
-    }
-
-    /// Serializes one complete NDJSON frame so concurrent control writes cannot interleave.
-    async fn write_frame(&self, value: &Value) -> Result<(), AcpError> {
-        write_frame(&self.writer, &self.trace_sessions, value).await
-    }
-}
+#[cfg(debug_assertions)]
+use crate::frame::trace_frame_summary;
 
 /// Owns the ordered inbound receiver for one ACP connection.
-pub struct AcpPeer<Writer> {
-    pub client: AcpClient<Writer>,
+pub struct AcpPeer<Transport> {
+    pub client: AcpClient<Transport>,
     inbound: mpsc::UnboundedReceiver<AcpInboundEvent>,
 }
 
-impl<Writer> AcpPeer<Writer>
+impl<Transport> AcpPeer<Transport>
 where
-    Writer: AsyncWrite + Unpin + Send + 'static,
+    Transport: AcpTransport,
 {
-    /// Starts the reader task and delegates session-event flow control to the connection owner.
-    pub fn spawn<Reader>(reader: Reader, writer: Writer) -> Self
-    where
-        Reader: AsyncRead + Unpin + Send + 'static,
-    {
+    /// Starts the routing task and delegates session-event flow control to the connection owner.
+    pub fn spawn(messages: AcpMessages, transport: Transport) -> Self {
         let pending = Arc::new(Mutex::new(PendingRequests::default()));
-        let writer = Arc::new(AsyncMutex::new(writer));
+        let transport = Arc::new(transport);
         let trace_sessions = SessionTraceRegistry::default();
         // The application router applies bounded queues per provider session. Bounding this
         // connection-wide handoff would let one noisy session terminate every other session.
         let (inbound_sender, inbound) = mpsc::unbounded_channel();
-        tokio::spawn(read_frames(
-            reader,
-            writer.clone(),
+        tokio::spawn(route_messages(
+            messages,
+            transport.clone(),
             pending.clone(),
             trace_sessions.clone(),
             inbound_sender,
         ));
         Self {
             client: AcpClient {
-                writer,
+                transport,
                 pending,
                 next_request_id: Arc::new(AtomicI64::new(1)),
                 trace_sessions,
@@ -356,42 +60,31 @@ where
     }
 
     /// Splits the peer into its writer client and ordered inbound receiver.
-    pub fn into_parts(self) -> (AcpClient<Writer>, mpsc::UnboundedReceiver<AcpInboundEvent>) {
+    pub fn into_parts(
+        self,
+    ) -> (
+        AcpClient<Transport>,
+        mpsc::UnboundedReceiver<AcpInboundEvent>,
+    ) {
         (self.client, self.inbound)
     }
 }
 
-/// Parses agent frames and routes responses, updates, and requests without blocking on consumers.
-async fn read_frames<Reader, Writer>(
-    reader: Reader,
-    writer: Arc<AsyncMutex<Writer>>,
+/// Routes decoded messages into responses, updates, and requests without blocking on consumers.
+async fn route_messages<Transport>(
+    mut messages: AcpMessages,
+    transport: Arc<Transport>,
     pending: Arc<Mutex<PendingRequests>>,
     trace_sessions: SessionTraceRegistry,
     inbound: mpsc::UnboundedSender<AcpInboundEvent>,
 ) where
-    Reader: AsyncRead + Unpin,
-    Writer: AsyncWrite + Unpin,
+    Transport: AcpTransport,
 {
-    let mut lines = FramedRead::new(reader, LinesCodec::new_with_max_length(MAX_FRAME_BYTES));
-    while let Some(line) = lines.next().await {
-        let value = match line {
-            Ok(line) => match serde_json::from_str::<Value>(&line) {
-                Ok(value) => value,
-                Err(error) => {
-                    let _ = inbound.send(AcpInboundEvent::Fatal(AcpError::InvalidFrame(
-                        error.to_string(),
-                    )));
-                    lock_pending(&pending).clear();
-                    return;
-                }
-            },
-            Err(LinesCodecError::MaxLineLengthExceeded) => {
-                let _ = inbound.send(AcpInboundEvent::Fatal(AcpError::FrameTooLarge));
-                lock_pending(&pending).clear();
-                return;
-            }
-            Err(LinesCodecError::Io(error)) => {
-                let _ = inbound.send(AcpInboundEvent::Fatal(AcpError::Io(error)));
+    while let Some(message) = messages.recv().await {
+        let value = match message {
+            Ok(value) => value,
+            Err(error) => {
+                let _ = inbound.send(AcpInboundEvent::Fatal(error));
                 lock_pending(&pending).clear();
                 return;
             }
@@ -408,7 +101,9 @@ async fn read_frames<Reader, Writer>(
                 "{}", msg,
             );
         }
-        if let Err(error) = route_frame(value, &writer, &pending, &trace_sessions, &inbound).await {
+        if let Err(error) =
+            route_frame(value, &transport, &pending, &trace_sessions, &inbound).await
+        {
             let _ = inbound.send(AcpInboundEvent::Fatal(error));
             lock_pending(&pending).clear();
             return;
@@ -420,15 +115,15 @@ async fn read_frames<Reader, Writer>(
 }
 
 /// Routes one validated JSON-RPC object and makes ambiguous shapes fatal.
-async fn route_frame<Writer>(
+async fn route_frame<Transport>(
     value: Value,
-    writer: &AsyncMutex<Writer>,
+    transport: &Arc<Transport>,
     pending: &Mutex<PendingRequests>,
     trace_sessions: &SessionTraceRegistry,
     inbound: &mpsc::UnboundedSender<AcpInboundEvent>,
 ) -> Result<(), AcpError>
 where
-    Writer: AsyncWrite + Unpin,
+    Transport: AcpTransport,
 {
     let object = value.as_object().ok_or_else(|| {
         AcpError::InvalidFrame("batch and non-object frames are unsupported".to_string())
@@ -469,7 +164,7 @@ where
                     "message": format!("method not found: {method}"),
                 },
             });
-            write_frame(writer, trace_sessions, &response).await
+            send_traced(transport, trace_sessions, response).await
         }
         (Some(method), None) if method == CLIENT_METHOD_NAMES.session_update => {
             let notification =
@@ -517,631 +212,5 @@ where
         (None, None) => Err(AcpError::InvalidFrame(
             "frame has neither method nor id".to_string(),
         )),
-    }
-}
-
-/// Extracts summary fields from a JSON-RPC frame for trace-level correlation without re-parsing.
-#[cfg(debug_assertions)]
-fn trace_frame_summary(
-    value: &Value,
-    direction: &str,
-    trace_sessions: &SessionTraceRegistry,
-    pending: Option<&Mutex<PendingRequests>>,
-) -> (String, String, String) {
-    let jsonrpc_method = value.get("method").and_then(|v| v.as_str()).unwrap_or("");
-    let agent_session_id = value
-        .get("params")
-        .and_then(|p| p.get("sessionId"))
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
-        .or_else(|| {
-            let request_id = value
-                .get("id")
-                .cloned()
-                .and_then(|id| serde_json::from_value::<RequestId>(id).ok())?;
-            pending
-                .map(lock_pending)?
-                .session_id(&request_id)
-                .map(ToString::to_string)
-        })
-        .unwrap_or_default();
-    let session_id = trace_sessions.resolve(&agent_session_id);
-    let is_response = value.get("result").is_some();
-    let is_error = value.get("error").is_some();
-
-    let message = if !jsonrpc_method.is_empty() {
-        format!("{direction} {jsonrpc_method}")
-    } else if is_response {
-        format!("{direction} response")
-    } else if is_error {
-        format!("{direction} error response")
-    } else {
-        format!("{direction} frame")
-    };
-
-    (message, jsonrpc_method.to_string(), session_id)
-}
-
-/// Writes a reader-originated protocol response through the connection's serialized sink.
-async fn write_frame<Writer>(
-    writer: &AsyncMutex<Writer>,
-    trace_sessions: &SessionTraceRegistry,
-    value: &Value,
-) -> Result<(), AcpError>
-where
-    Writer: AsyncWrite + Unpin,
-{
-    #[cfg(debug_assertions)]
-    {
-        let (msg, jsonrpc_method, session_id) =
-            trace_frame_summary(value, "send", trace_sessions, /*pending*/ None);
-        ora_trace!(
-            direction = "send",
-            jsonrpc_method = %jsonrpc_method,
-            session_id = %session_id,
-            frame = %value,
-            "{}", msg,
-        );
-    }
-    let mut bytes =
-        serde_json::to_vec(value).map_err(|error| AcpError::InvalidFrame(error.to_string()))?;
-    if bytes.len() > MAX_FRAME_BYTES {
-        return Err(AcpError::FrameTooLarge);
-    }
-    bytes.push(b'\n');
-    let mut writer = writer.lock().await;
-    writer.write_all(&bytes).await?;
-    writer.flush().await?;
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        AcpError, AcpInboundEvent, AcpPeer, PendingRequest, PendingRequests, trace_frame_summary,
-    };
-    use crate::trace::SessionTraceRegistry;
-    use agent_client_protocol_schema::v1::RequestId;
-    use agent_client_protocol_schema::v1::SessionId;
-    use agent_client_protocol_schema::v1::SessionNotification;
-    use agent_client_protocol_schema::v1::{SessionInfoUpdate, SessionUpdate};
-    use pretty_assertions::assert_eq;
-    use serde_json::{Value, json};
-    use std::sync::Mutex;
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, duplex, split};
-
-    /// Verifies ACP trace fields expose the registered Ora session identity.
-    #[test]
-    fn traces_the_registered_ora_session_id() {
-        let trace_sessions = SessionTraceRegistry::default();
-        let _registration = trace_sessions.register("agent-session-1", "ora-session-1");
-        let frame = json!({
-            "jsonrpc": "2.0",
-            "method": "session/update",
-            "params": { "sessionId": "agent-session-1" },
-        });
-
-        assert_eq!(
-            trace_frame_summary(&frame, "recv", &trace_sessions, /*pending*/ None),
-            (
-                "recv session/update".to_string(),
-                "session/update".to_string(),
-                "ora-session-1".to_string(),
-            )
-        );
-    }
-
-    /// Verifies response frames inherit identity from their pending session request.
-    #[test]
-    fn traces_the_ora_session_id_on_correlated_responses() {
-        let trace_sessions = SessionTraceRegistry::default();
-        let _registration = trace_sessions.register("agent-session-1", "ora-session-1");
-        let request_id = RequestId::Number(7);
-        let mut pending = PendingRequests::default();
-        pending.insert(
-            request_id.clone(),
-            PendingRequest::Session {
-                session_id: SessionId::new("agent-session-1"),
-            },
-        );
-        let pending = Mutex::new(pending);
-        let frame = json!({
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "result": { "stopReason": "end_turn" },
-        });
-
-        assert_eq!(
-            trace_frame_summary(&frame, "recv", &trace_sessions, Some(&pending)),
-            (
-                "recv response".to_string(),
-                String::new(),
-                "ora-session-1".to_string(),
-            )
-        );
-    }
-
-    /// Verifies connection-wide handoff cannot make one burst terminate unrelated sessions.
-    #[tokio::test]
-    async fn hands_off_more_than_one_session_queue_of_updates() {
-        let (ora_stream, mut agent_stream) = duplex(16 * 1024);
-        let (ora_reader, ora_writer) = split(ora_stream);
-        let mut peer = AcpPeer::spawn(ora_reader, ora_writer);
-        let expected = (0..300)
-            .map(|index| {
-                SessionNotification::new(
-                    format!("session-{}", index % 2),
-                    SessionUpdate::SessionInfoUpdate(
-                        SessionInfoUpdate::new().title(format!("Update {index}")),
-                    ),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        for notification in &expected {
-            let frame = json!({
-                "jsonrpc": "2.0",
-                "method": "session/update",
-                "params": notification,
-            });
-            agent_stream
-                .write_all(format!("{frame}\n").as_bytes())
-                .await
-                .expect("write session update");
-        }
-
-        let mut received = Vec::with_capacity(expected.len());
-        for _ in 0..expected.len() {
-            match peer.next_event().await.expect("receive session event") {
-                AcpInboundEvent::SessionUpdate(update) => received.push(update),
-                AcpInboundEvent::PermissionRequest(_)
-                | AcpInboundEvent::SessionResponse(_)
-                | AcpInboundEvent::Fatal(_) => panic!("expected session update"),
-            }
-        }
-        assert_eq!(received, expected);
-    }
-
-    /// Verifies tail updates and their terminating response preserve transport order.
-    #[tokio::test]
-    async fn orders_session_updates_before_the_session_response() {
-        let (ora_stream, agent_stream) = duplex(16 * 1024);
-        let (ora_reader, ora_writer) = split(ora_stream);
-        let (agent_reader, mut agent_writer) = split(agent_stream);
-        let mut agent_reader = BufReader::new(agent_reader);
-        let mut peer = AcpPeer::spawn(ora_reader, ora_writer);
-        let session_id = SessionId::new("session-1");
-        let pending = peer
-            .client
-            .start_session_request::<_, Value>(
-                session_id.clone(),
-                "session/prompt",
-                &json!({ "sessionId": session_id }),
-            )
-            .await
-            .expect("start session request");
-        let mut outbound = String::new();
-        agent_reader
-            .read_line(&mut outbound)
-            .await
-            .expect("read session request");
-        let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse session request");
-        let request_id = outbound["id"].clone();
-        let expected = ["First", "Second"].map(|title| {
-            SessionNotification::new(
-                "session-1",
-                SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title(title)),
-            )
-        });
-        for update in &expected {
-            agent_writer
-                .write_all(
-                    format!(
-                        "{}\n",
-                        json!({
-                            "jsonrpc": "2.0",
-                            "method": "session/update",
-                            "params": update,
-                        })
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .expect("write session update");
-        }
-        agent_writer
-            .write_all(
-                format!(
-                    "{}\n",
-                    json!({
-                        "jsonrpc": "2.0",
-                        "id": request_id,
-                        "result": { "stopReason": "end_turn" },
-                    })
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("write session response");
-
-        for expected_update in expected {
-            match peer.next_event().await.expect("receive update event") {
-                AcpInboundEvent::SessionUpdate(update) => assert_eq!(update, expected_update),
-                AcpInboundEvent::PermissionRequest(_)
-                | AcpInboundEvent::SessionResponse(_)
-                | AcpInboundEvent::Fatal(_) => panic!("expected session update"),
-            }
-        }
-        let response = match peer.next_event().await.expect("receive response event") {
-            AcpInboundEvent::SessionResponse(response) => response,
-            AcpInboundEvent::SessionUpdate(_)
-            | AcpInboundEvent::PermissionRequest(_)
-            | AcpInboundEvent::Fatal(_) => panic!("expected session response"),
-        };
-        assert_eq!(
-            pending.finish(response).expect("finish session request"),
-            json!({ "stopReason": "end_turn" })
-        );
-    }
-
-    /// Verifies abandoning a session request discards its late response without a fatal.
-    #[tokio::test]
-    async fn discards_a_late_response_after_the_session_request_is_abandoned() {
-        let (ora_stream, agent_stream) = duplex(16 * 1024);
-        let (ora_reader, ora_writer) = split(ora_stream);
-        let (agent_reader, mut agent_writer) = split(agent_stream);
-        let mut agent_reader = BufReader::new(agent_reader);
-        let mut peer = AcpPeer::spawn(ora_reader, ora_writer);
-        let session_id = SessionId::new("session-1");
-        let pending = peer
-            .client
-            .start_session_request::<_, Value>(
-                session_id.clone(),
-                "session/prompt",
-                &json!({ "sessionId": session_id }),
-            )
-            .await
-            .expect("start session request");
-        let mut outbound = String::new();
-        agent_reader
-            .read_line(&mut outbound)
-            .await
-            .expect("read session request");
-        let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse session request");
-        pending.abandon();
-        agent_writer
-            .write_all(
-                format!(
-                    "{}\n",
-                    json!({
-                        "jsonrpc": "2.0",
-                        "id": outbound["id"],
-                        "result": { "stopReason": "end_turn" },
-                    })
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("write abandoned session response");
-        agent_writer
-            .write_all(
-                format!(
-                    "{}\n",
-                    json!({
-                        "jsonrpc": "2.0",
-                        "method": "session/update",
-                        "params": SessionNotification::new(
-                            "session-1",
-                            SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title("Alive")),
-                        ),
-                    })
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("write follow-up update");
-
-        match peer.next_event().await.expect("receive follow-up update") {
-            AcpInboundEvent::SessionUpdate(update) => assert_eq!(
-                update,
-                SessionNotification::new(
-                    "session-1",
-                    SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title("Alive")),
-                )
-            ),
-            AcpInboundEvent::PermissionRequest(_)
-            | AcpInboundEvent::SessionResponse(_)
-            | AcpInboundEvent::Fatal(_) => {
-                panic!("expected session update after abandoned response")
-            }
-        }
-    }
-
-    /// Verifies dropping an unsettled handle unregisters the request like an explicit abandon.
-    #[tokio::test]
-    async fn dropping_a_pending_session_request_unregisters_it() {
-        let (ora_stream, agent_stream) = duplex(16 * 1024);
-        let (ora_reader, ora_writer) = split(ora_stream);
-        let (agent_reader, mut agent_writer) = split(agent_stream);
-        let mut agent_reader = BufReader::new(agent_reader);
-        let mut peer = AcpPeer::spawn(ora_reader, ora_writer);
-        let session_id = SessionId::new("session-1");
-        let pending = peer
-            .client
-            .start_session_request::<_, Value>(
-                session_id.clone(),
-                "session/prompt",
-                &json!({ "sessionId": session_id }),
-            )
-            .await
-            .expect("start session request");
-        let mut outbound = String::new();
-        agent_reader
-            .read_line(&mut outbound)
-            .await
-            .expect("read session request");
-        let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse session request");
-        drop(pending);
-        agent_writer
-            .write_all(
-                format!(
-                    "{}\n",
-                    json!({
-                        "jsonrpc": "2.0",
-                        "id": outbound["id"],
-                        "result": { "stopReason": "cancelled" },
-                    })
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("write dropped session response");
-        agent_writer
-            .write_all(
-                format!(
-                    "{}\n",
-                    json!({
-                        "jsonrpc": "2.0",
-                        "method": "session/update",
-                        "params": SessionNotification::new(
-                            "session-1",
-                            SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title("Still open")),
-                        ),
-                    })
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("write follow-up update");
-
-        match peer.next_event().await.expect("receive follow-up update") {
-            AcpInboundEvent::SessionUpdate(update) => assert_eq!(
-                update,
-                SessionNotification::new(
-                    "session-1",
-                    SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title("Still open")),
-                )
-            ),
-            AcpInboundEvent::PermissionRequest(_)
-            | AcpInboundEvent::SessionResponse(_)
-            | AcpInboundEvent::Fatal(_) => panic!("expected session update after dropped request"),
-        }
-    }
-
-    /// Verifies cancelling a direct request retires its id and keeps later traffic readable.
-    #[tokio::test]
-    async fn dropping_a_direct_request_future_unregisters_it() {
-        let (ora_stream, agent_stream) = duplex(16 * 1024);
-        let (ora_reader, ora_writer) = split(ora_stream);
-        let (agent_reader, mut agent_writer) = split(agent_stream);
-        let mut agent_reader = BufReader::new(agent_reader);
-        let mut peer = AcpPeer::spawn(ora_reader, ora_writer);
-        let client = peer.client.clone();
-        let request = tokio::spawn(async move {
-            client
-                .request::<_, Value>("session/list", &json!({ "cwd": "/workspace" }))
-                .await
-        });
-
-        let mut outbound = String::new();
-        agent_reader
-            .read_line(&mut outbound)
-            .await
-            .expect("read direct request");
-        let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse direct request");
-        request.abort();
-        let _ = request.await;
-
-        agent_writer
-            .write_all(
-                format!(
-                    "{}\n",
-                    json!({
-                        "jsonrpc": "2.0",
-                        "id": outbound["id"],
-                        "result": { "sessions": [] },
-                    })
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("write abandoned direct response");
-        agent_writer
-            .write_all(
-                format!(
-                    "{}\n",
-                    json!({
-                        "jsonrpc": "2.0",
-                        "method": "session/update",
-                        "params": SessionNotification::new(
-                            "session-1",
-                            SessionUpdate::SessionInfoUpdate(
-                                SessionInfoUpdate::new().title("Still connected"),
-                            ),
-                        ),
-                    })
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("write follow-up update");
-
-        match peer.next_event().await.expect("receive follow-up update") {
-            AcpInboundEvent::SessionUpdate(update) => assert_eq!(
-                update,
-                SessionNotification::new(
-                    "session-1",
-                    SessionUpdate::SessionInfoUpdate(
-                        SessionInfoUpdate::new().title("Still connected"),
-                    ),
-                )
-            ),
-            AcpInboundEvent::PermissionRequest(_)
-            | AcpInboundEvent::SessionResponse(_)
-            | AcpInboundEvent::Fatal(_) => {
-                panic!("expected update after abandoned direct response")
-            }
-        }
-    }
-
-    /// Verifies a response id that was never pending remains a fatal correlation failure.
-    #[tokio::test]
-    async fn rejects_a_response_with_an_unknown_id() {
-        let (ora_stream, agent_stream) = duplex(16 * 1024);
-        let (ora_reader, ora_writer) = split(ora_stream);
-        let (agent_reader, mut agent_writer) = split(agent_stream);
-        let mut agent_reader = BufReader::new(agent_reader);
-        let mut peer = AcpPeer::spawn(ora_reader, ora_writer);
-        let session_id = SessionId::new("session-1");
-        let _pending = peer
-            .client
-            .start_session_request::<_, Value>(
-                session_id.clone(),
-                "session/prompt",
-                &json!({ "sessionId": session_id }),
-            )
-            .await
-            .expect("start session request");
-        let mut outbound = String::new();
-        agent_reader
-            .read_line(&mut outbound)
-            .await
-            .expect("read session request");
-        agent_writer
-            .write_all(
-                format!(
-                    "{}\n",
-                    json!({
-                        "jsonrpc": "2.0",
-                        "id": 999,
-                        "result": { "stopReason": "end_turn" },
-                    })
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("write unmatched response");
-
-        match peer.next_event().await.expect("receive fatal event") {
-            AcpInboundEvent::Fatal(AcpError::InvalidFrame(message)) => {
-                assert_eq!(message, "unmatched response id 999");
-            }
-            AcpInboundEvent::SessionUpdate(_)
-            | AcpInboundEvent::PermissionRequest(_)
-            | AcpInboundEvent::SessionResponse(_)
-            | AcpInboundEvent::Fatal(_) => panic!("expected unmatched response failure"),
-        }
-    }
-
-    /// Verifies extension requests receive method-not-found without closing request correlation.
-    #[tokio::test]
-    async fn rejects_unknown_agent_request_and_continues_reading() {
-        let (ora_stream, agent_stream) = duplex(16 * 1024);
-        let (ora_reader, ora_writer) = split(ora_stream);
-        let (agent_reader, mut agent_writer) = split(agent_stream);
-        let mut agent_reader = BufReader::new(agent_reader);
-        let peer = AcpPeer::spawn(ora_reader, ora_writer);
-        let client = peer.client.clone();
-        let request = tokio::spawn(async move {
-            client
-                .request::<_, Value>("initialize", &json!({ "protocolVersion": 1 }))
-                .await
-        });
-
-        let mut outbound = String::new();
-        agent_reader
-            .read_line(&mut outbound)
-            .await
-            .expect("read Ora request");
-        let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse Ora request");
-        let request_id = outbound["id"].clone();
-        agent_writer
-            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"ext/future\",\"params\":{}}\n")
-            .await
-            .expect("write extension request");
-
-        let mut rejection = String::new();
-        agent_reader
-            .read_line(&mut rejection)
-            .await
-            .expect("read method-not-found response");
-        assert_eq!(
-            serde_json::from_str::<Value>(rejection.trim()).expect("parse rejection"),
-            json!({
-                "jsonrpc": "2.0",
-                "id": 99,
-                "error": {
-                    "code": -32601,
-                    "message": "method not found: ext/future",
-                },
-            })
-        );
-
-        let response = json!({
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "result": { "accepted": true },
-        });
-        agent_writer
-            .write_all(format!("{response}\n").as_bytes())
-            .await
-            .expect("write correlated response");
-        assert_eq!(
-            request
-                .await
-                .expect("join request")
-                .expect("complete request"),
-            json!({ "accepted": true })
-        );
-    }
-
-    /// Verifies EOF wakes correlated requests instead of leaving them to an outer timeout.
-    #[tokio::test]
-    async fn closes_pending_requests_when_agent_stdout_ends() {
-        let (ora_stream, agent_stream) = duplex(16 * 1024);
-        let (ora_reader, ora_writer) = split(ora_stream);
-        let (agent_reader, mut agent_writer) = split(agent_stream);
-        let mut agent_reader = BufReader::new(agent_reader);
-        let peer = AcpPeer::spawn(ora_reader, ora_writer);
-        let client = peer.client.clone();
-        let request = tokio::spawn(async move {
-            client
-                .request::<_, Value>("initialize", &json!({ "protocolVersion": 1 }))
-                .await
-        });
-        let mut outbound = String::new();
-        agent_reader
-            .read_line(&mut outbound)
-            .await
-            .expect("read Ora request");
-
-        agent_writer.shutdown().await.expect("close agent writer");
-        drop(agent_reader);
-        drop(agent_writer);
-
-        assert!(matches!(
-            request.await.expect("join request"),
-            Err(AcpError::StreamClosed)
-        ));
     }
 }

--- a/crates/acp/src/tests.rs
+++ b/crates/acp/src/tests.rs
@@ -1,0 +1,605 @@
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol_schema::v1::SessionId;
+use agent_client_protocol_schema::v1::SessionNotification;
+use agent_client_protocol_schema::v1::{SessionInfoUpdate, SessionUpdate};
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tokio::io::{
+    AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream, ReadHalf, WriteHalf, duplex, split,
+};
+use tokio::sync::mpsc;
+
+use crate::error::AcpError;
+use crate::events::AcpInboundEvent;
+use crate::peer::AcpPeer;
+use crate::transport::{AcpMessages, AcpTransport, NdjsonTransport};
+
+type NdjsonPeer = AcpPeer<NdjsonTransport<WriteHalf<DuplexStream>>>;
+
+/// Starts an NDJSON peer over one duplex connection, matching the stdio agent path.
+fn spawn_ndjson_peer(
+    reader: ReadHalf<DuplexStream>,
+    writer: WriteHalf<DuplexStream>,
+) -> NdjsonPeer {
+    let (transport, messages) = NdjsonTransport::spawn(reader, writer);
+    AcpPeer::spawn(messages, transport)
+}
+
+/// Carries ACP messages as already-parsed values, standing in for the plugin IPC transport.
+struct MemoryTransport {
+    sent: Arc<Mutex<Vec<Value>>>,
+}
+
+impl AcpTransport for MemoryTransport {
+    async fn send(&self, message: Value) -> Result<(), AcpError> {
+        self.sent
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(message);
+        Ok(())
+    }
+}
+
+/// Projects inbound events onto comparable data so two transports can be asserted equal.
+#[derive(Debug, PartialEq)]
+enum ObservedEvent {
+    Update(SessionNotification),
+    Permission(String),
+    Response { session_id: String, result: Value },
+    Fatal(String),
+}
+
+impl From<AcpInboundEvent> for ObservedEvent {
+    fn from(event: AcpInboundEvent) -> Self {
+        match event {
+            AcpInboundEvent::SessionUpdate(update) => Self::Update(update),
+            AcpInboundEvent::PermissionRequest(permission) => {
+                Self::Permission(permission.request_id.to_string())
+            }
+            AcpInboundEvent::SessionResponse(response) => Self::Response {
+                session_id: response.session_id().to_string(),
+                result: response.response.clone().unwrap_or(Value::Null),
+            },
+            AcpInboundEvent::Fatal(error) => Self::Fatal(error.to_string()),
+        }
+    }
+}
+
+/// Builds one session update notification with a stable title.
+fn update_frame(session_id: &str, title: &str) -> Value {
+    let session_id = session_id.to_string();
+    json!({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": SessionNotification::new(
+            session_id,
+            SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title(title)),
+        ),
+    })
+}
+
+/// Verifies connection-wide handoff cannot make one burst terminate unrelated sessions.
+#[tokio::test]
+async fn hands_off_more_than_one_session_queue_of_updates() {
+    let (ora_stream, mut agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let mut peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let expected = (0..300)
+        .map(|index| {
+            SessionNotification::new(
+                format!("session-{}", index % 2),
+                SessionUpdate::SessionInfoUpdate(
+                    SessionInfoUpdate::new().title(format!("Update {index}")),
+                ),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for notification in &expected {
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": notification,
+        });
+        agent_stream
+            .write_all(format!("{frame}\n").as_bytes())
+            .await
+            .expect("write session update");
+    }
+
+    let mut received = Vec::with_capacity(expected.len());
+    for _ in 0..expected.len() {
+        match peer.next_event().await.expect("receive session event") {
+            AcpInboundEvent::SessionUpdate(update) => received.push(update),
+            AcpInboundEvent::PermissionRequest(_)
+            | AcpInboundEvent::SessionResponse(_)
+            | AcpInboundEvent::Fatal(_) => panic!("expected session update"),
+        }
+    }
+    assert_eq!(received, expected);
+}
+
+/// Verifies a byte-stream and an already-parsed transport produce identical inbound events.
+#[tokio::test]
+async fn produces_identical_events_over_both_transports() {
+    let session_id = SessionId::new("session-1");
+    let inbound_frames = |request_id: Value| {
+        vec![
+            update_frame("session-1", "First"),
+            update_frame("session-1", "Second"),
+            json!({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": { "stopReason": "end_turn" },
+            }),
+        ]
+    };
+
+    let (ora_stream, agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let (agent_reader, mut agent_writer) = split(agent_stream);
+    let mut agent_reader = BufReader::new(agent_reader);
+    let mut ndjson_peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let _ndjson_request = ndjson_peer
+        .client
+        .start_session_request::<_, Value>(
+            session_id.clone(),
+            "session/prompt",
+            &json!({ "sessionId": session_id }),
+        )
+        .await
+        .expect("start session request");
+    let mut outbound = String::new();
+    agent_reader
+        .read_line(&mut outbound)
+        .await
+        .expect("read session request");
+    let ndjson_outbound: Value =
+        serde_json::from_str(outbound.trim()).expect("parse session request");
+    for frame in inbound_frames(ndjson_outbound["id"].clone()) {
+        agent_writer
+            .write_all(format!("{frame}\n").as_bytes())
+            .await
+            .expect("write inbound frame");
+    }
+
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let (memory_sender, memory_messages) = mpsc::unbounded_channel();
+    let mut memory_peer = AcpPeer::spawn(
+        memory_messages as AcpMessages,
+        MemoryTransport { sent: sent.clone() },
+    );
+    let _memory_request = memory_peer
+        .client
+        .start_session_request::<_, Value>(
+            session_id.clone(),
+            "session/prompt",
+            &json!({ "sessionId": session_id }),
+        )
+        .await
+        .expect("start session request");
+    let memory_outbound = sent
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .first()
+        .cloned()
+        .expect("record session request");
+    for frame in inbound_frames(memory_outbound["id"].clone()) {
+        memory_sender.send(Ok(frame)).expect("queue inbound frame");
+    }
+
+    let mut ndjson_events = Vec::new();
+    let mut memory_events = Vec::new();
+    for _ in 0..3 {
+        ndjson_events.push(ObservedEvent::from(
+            ndjson_peer.next_event().await.expect("ndjson event"),
+        ));
+        memory_events.push(ObservedEvent::from(
+            memory_peer.next_event().await.expect("memory event"),
+        ));
+    }
+
+    assert_eq!(ndjson_outbound, memory_outbound);
+    assert_eq!(ndjson_events, memory_events);
+}
+
+/// Verifies tail updates and their terminating response preserve transport order.
+#[tokio::test]
+async fn orders_session_updates_before_the_session_response() {
+    let (ora_stream, agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let (agent_reader, mut agent_writer) = split(agent_stream);
+    let mut agent_reader = BufReader::new(agent_reader);
+    let mut peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let session_id = SessionId::new("session-1");
+    let pending = peer
+        .client
+        .start_session_request::<_, Value>(
+            session_id.clone(),
+            "session/prompt",
+            &json!({ "sessionId": session_id }),
+        )
+        .await
+        .expect("start session request");
+    let mut outbound = String::new();
+    agent_reader
+        .read_line(&mut outbound)
+        .await
+        .expect("read session request");
+    let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse session request");
+    let request_id = outbound["id"].clone();
+    let expected = ["First", "Second"].map(|title| {
+        SessionNotification::new(
+            "session-1",
+            SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title(title)),
+        )
+    });
+    for update in &expected {
+        agent_writer
+            .write_all(
+                format!(
+                    "{}\n",
+                    json!({
+                        "jsonrpc": "2.0",
+                        "method": "session/update",
+                        "params": update,
+                    })
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("write session update");
+    }
+    agent_writer
+        .write_all(
+            format!(
+                "{}\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": { "stopReason": "end_turn" },
+                })
+            )
+            .as_bytes(),
+        )
+        .await
+        .expect("write session response");
+
+    for expected_update in expected {
+        match peer.next_event().await.expect("receive update event") {
+            AcpInboundEvent::SessionUpdate(update) => assert_eq!(update, expected_update),
+            AcpInboundEvent::PermissionRequest(_)
+            | AcpInboundEvent::SessionResponse(_)
+            | AcpInboundEvent::Fatal(_) => panic!("expected session update"),
+        }
+    }
+    let response = match peer.next_event().await.expect("receive response event") {
+        AcpInboundEvent::SessionResponse(response) => response,
+        AcpInboundEvent::SessionUpdate(_)
+        | AcpInboundEvent::PermissionRequest(_)
+        | AcpInboundEvent::Fatal(_) => panic!("expected session response"),
+    };
+    assert_eq!(
+        pending.finish(response).expect("finish session request"),
+        json!({ "stopReason": "end_turn" })
+    );
+}
+
+/// Verifies abandoning a session request discards its late response without a fatal.
+#[tokio::test]
+async fn discards_a_late_response_after_the_session_request_is_abandoned() {
+    let (ora_stream, agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let (agent_reader, mut agent_writer) = split(agent_stream);
+    let mut agent_reader = BufReader::new(agent_reader);
+    let mut peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let session_id = SessionId::new("session-1");
+    let pending = peer
+        .client
+        .start_session_request::<_, Value>(
+            session_id.clone(),
+            "session/prompt",
+            &json!({ "sessionId": session_id }),
+        )
+        .await
+        .expect("start session request");
+    let mut outbound = String::new();
+    agent_reader
+        .read_line(&mut outbound)
+        .await
+        .expect("read session request");
+    let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse session request");
+    pending.abandon();
+    agent_writer
+        .write_all(
+            format!(
+                "{}\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": outbound["id"],
+                    "result": { "stopReason": "end_turn" },
+                })
+            )
+            .as_bytes(),
+        )
+        .await
+        .expect("write abandoned session response");
+    agent_writer
+        .write_all(format!("{}\n", update_frame("session-1", "Alive")).as_bytes())
+        .await
+        .expect("write follow-up update");
+
+    match peer.next_event().await.expect("receive follow-up update") {
+        AcpInboundEvent::SessionUpdate(update) => assert_eq!(
+            update,
+            SessionNotification::new(
+                "session-1",
+                SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title("Alive")),
+            )
+        ),
+        AcpInboundEvent::PermissionRequest(_)
+        | AcpInboundEvent::SessionResponse(_)
+        | AcpInboundEvent::Fatal(_) => {
+            panic!("expected session update after abandoned response")
+        }
+    }
+}
+
+/// Verifies dropping an unsettled handle unregisters the request like an explicit abandon.
+#[tokio::test]
+async fn dropping_a_pending_session_request_unregisters_it() {
+    let (ora_stream, agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let (agent_reader, mut agent_writer) = split(agent_stream);
+    let mut agent_reader = BufReader::new(agent_reader);
+    let mut peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let session_id = SessionId::new("session-1");
+    let pending = peer
+        .client
+        .start_session_request::<_, Value>(
+            session_id.clone(),
+            "session/prompt",
+            &json!({ "sessionId": session_id }),
+        )
+        .await
+        .expect("start session request");
+    let mut outbound = String::new();
+    agent_reader
+        .read_line(&mut outbound)
+        .await
+        .expect("read session request");
+    let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse session request");
+    drop(pending);
+    agent_writer
+        .write_all(
+            format!(
+                "{}\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": outbound["id"],
+                    "result": { "stopReason": "cancelled" },
+                })
+            )
+            .as_bytes(),
+        )
+        .await
+        .expect("write dropped session response");
+    agent_writer
+        .write_all(format!("{}\n", update_frame("session-1", "Still open")).as_bytes())
+        .await
+        .expect("write follow-up update");
+
+    match peer.next_event().await.expect("receive follow-up update") {
+        AcpInboundEvent::SessionUpdate(update) => assert_eq!(
+            update,
+            SessionNotification::new(
+                "session-1",
+                SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title("Still open")),
+            )
+        ),
+        AcpInboundEvent::PermissionRequest(_)
+        | AcpInboundEvent::SessionResponse(_)
+        | AcpInboundEvent::Fatal(_) => panic!("expected session update after dropped request"),
+    }
+}
+
+/// Verifies cancelling a direct request retires its id and keeps later traffic readable.
+#[tokio::test]
+async fn dropping_a_direct_request_future_unregisters_it() {
+    let (ora_stream, agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let (agent_reader, mut agent_writer) = split(agent_stream);
+    let mut agent_reader = BufReader::new(agent_reader);
+    let mut peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let client = peer.client.clone();
+    let request = tokio::spawn(async move {
+        client
+            .request::<_, Value>("session/list", &json!({ "cwd": "/workspace" }))
+            .await
+    });
+
+    let mut outbound = String::new();
+    agent_reader
+        .read_line(&mut outbound)
+        .await
+        .expect("read direct request");
+    let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse direct request");
+    request.abort();
+    let _ = request.await;
+
+    agent_writer
+        .write_all(
+            format!(
+                "{}\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": outbound["id"],
+                    "result": { "sessions": [] },
+                })
+            )
+            .as_bytes(),
+        )
+        .await
+        .expect("write abandoned direct response");
+    agent_writer
+        .write_all(format!("{}\n", update_frame("session-1", "Still connected")).as_bytes())
+        .await
+        .expect("write follow-up update");
+
+    match peer.next_event().await.expect("receive follow-up update") {
+        AcpInboundEvent::SessionUpdate(update) => assert_eq!(
+            update,
+            SessionNotification::new(
+                "session-1",
+                SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title("Still connected")),
+            )
+        ),
+        AcpInboundEvent::PermissionRequest(_)
+        | AcpInboundEvent::SessionResponse(_)
+        | AcpInboundEvent::Fatal(_) => {
+            panic!("expected update after abandoned direct response")
+        }
+    }
+}
+
+/// Verifies a response id that was never pending remains a fatal correlation failure.
+#[tokio::test]
+async fn rejects_a_response_with_an_unknown_id() {
+    let (ora_stream, agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let (agent_reader, mut agent_writer) = split(agent_stream);
+    let mut agent_reader = BufReader::new(agent_reader);
+    let mut peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let session_id = SessionId::new("session-1");
+    let _pending = peer
+        .client
+        .start_session_request::<_, Value>(
+            session_id.clone(),
+            "session/prompt",
+            &json!({ "sessionId": session_id }),
+        )
+        .await
+        .expect("start session request");
+    let mut outbound = String::new();
+    agent_reader
+        .read_line(&mut outbound)
+        .await
+        .expect("read session request");
+    agent_writer
+        .write_all(
+            format!(
+                "{}\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 999,
+                    "result": { "stopReason": "end_turn" },
+                })
+            )
+            .as_bytes(),
+        )
+        .await
+        .expect("write unmatched response");
+
+    match peer.next_event().await.expect("receive fatal event") {
+        AcpInboundEvent::Fatal(AcpError::InvalidFrame(message)) => {
+            assert_eq!(message, "unmatched response id 999");
+        }
+        AcpInboundEvent::SessionUpdate(_)
+        | AcpInboundEvent::PermissionRequest(_)
+        | AcpInboundEvent::SessionResponse(_)
+        | AcpInboundEvent::Fatal(_) => panic!("expected unmatched response failure"),
+    }
+}
+
+/// Verifies extension requests receive method-not-found without closing request correlation.
+#[tokio::test]
+async fn rejects_unknown_agent_request_and_continues_reading() {
+    let (ora_stream, agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let (agent_reader, mut agent_writer) = split(agent_stream);
+    let mut agent_reader = BufReader::new(agent_reader);
+    let peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let client = peer.client.clone();
+    let request = tokio::spawn(async move {
+        client
+            .request::<_, Value>("initialize", &json!({ "protocolVersion": 1 }))
+            .await
+    });
+
+    let mut outbound = String::new();
+    agent_reader
+        .read_line(&mut outbound)
+        .await
+        .expect("read Ora request");
+    let outbound: Value = serde_json::from_str(outbound.trim()).expect("parse Ora request");
+    let request_id = outbound["id"].clone();
+    agent_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"ext/future\",\"params\":{}}\n")
+        .await
+        .expect("write extension request");
+
+    let mut rejection = String::new();
+    agent_reader
+        .read_line(&mut rejection)
+        .await
+        .expect("read method-not-found response");
+    assert_eq!(
+        serde_json::from_str::<Value>(rejection.trim()).expect("parse rejection"),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 99,
+            "error": {
+                "code": -32601,
+                "message": "method not found: ext/future",
+            },
+        })
+    );
+
+    let response = json!({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": { "accepted": true },
+    });
+    agent_writer
+        .write_all(format!("{response}\n").as_bytes())
+        .await
+        .expect("write correlated response");
+    assert_eq!(
+        request
+            .await
+            .expect("join request")
+            .expect("complete request"),
+        json!({ "accepted": true })
+    );
+}
+
+/// Verifies EOF wakes correlated requests instead of leaving them to an outer timeout.
+#[tokio::test]
+async fn closes_pending_requests_when_agent_stdout_ends() {
+    let (ora_stream, agent_stream) = duplex(16 * 1024);
+    let (ora_reader, ora_writer) = split(ora_stream);
+    let (agent_reader, mut agent_writer) = split(agent_stream);
+    let mut agent_reader = BufReader::new(agent_reader);
+    let peer = spawn_ndjson_peer(ora_reader, ora_writer);
+    let client = peer.client.clone();
+    let request = tokio::spawn(async move {
+        client
+            .request::<_, Value>("initialize", &json!({ "protocolVersion": 1 }))
+            .await
+    });
+    let mut outbound = String::new();
+    agent_reader
+        .read_line(&mut outbound)
+        .await
+        .expect("read Ora request");
+
+    agent_writer.shutdown().await.expect("close agent writer");
+    drop(agent_reader);
+    drop(agent_writer);
+
+    assert!(matches!(
+        request.await.expect("join request"),
+        Err(AcpError::StreamClosed)
+    ));
+}

--- a/crates/acp/src/transport.rs
+++ b/crates/acp/src/transport.rs
@@ -1,0 +1,96 @@
+use std::future::Future;
+
+use futures_util::StreamExt;
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
+use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
+
+use crate::error::AcpError;
+
+pub(crate) const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+/// Yields whole inbound ACP messages, or the framing failure that ended the connection.
+///
+/// The stream is unbounded because it is connection-wide: bounding it would let one busy session
+/// stall every other session sharing the same agent process.
+pub type AcpMessages = mpsc::UnboundedReceiver<Result<Value, AcpError>>;
+
+/// Carries whole ACP JSON-RPC messages for one connection.
+///
+/// Implementations own framing and ordering: `send` must deliver complete messages in call order,
+/// and the receiver handed to `AcpPeer::spawn` must yield exactly one message per frame. The peer
+/// never inspects transport-level framing, so a transport may be a byte stream (NDJSON over stdio)
+/// or an already-parsed channel (plugin IPC).
+pub trait AcpTransport: Send + Sync + 'static {
+    fn send(&self, message: Value) -> impl Future<Output = Result<(), AcpError>> + Send;
+}
+
+/// Carries ACP messages as newline-delimited JSON over one child process's stdio pipes.
+pub struct NdjsonTransport<Writer> {
+    writer: AsyncMutex<Writer>,
+}
+
+impl<Writer> NdjsonTransport<Writer>
+where
+    Writer: AsyncWrite + Unpin + Send + 'static,
+{
+    /// Starts line decoding on `reader` and pairs the sink half with its inbound message stream.
+    pub fn spawn<Reader>(reader: Reader, writer: Writer) -> (Self, AcpMessages)
+    where
+        Reader: AsyncRead + Unpin + Send + 'static,
+    {
+        let (sender, messages) = mpsc::unbounded_channel();
+        tokio::spawn(decode_lines(reader, sender));
+        (
+            Self {
+                writer: AsyncMutex::new(writer),
+            },
+            messages,
+        )
+    }
+}
+
+impl<Writer> AcpTransport for NdjsonTransport<Writer>
+where
+    Writer: AsyncWrite + Unpin + Send + 'static,
+{
+    /// Serializes one complete NDJSON line so concurrent writers cannot interleave bytes.
+    async fn send(&self, message: Value) -> Result<(), AcpError> {
+        let mut bytes = serde_json::to_vec(&message)
+            .map_err(|error| AcpError::InvalidFrame(error.to_string()))?;
+        if bytes.len() > MAX_FRAME_BYTES {
+            return Err(AcpError::FrameTooLarge);
+        }
+        bytes.push(b'\n');
+        let mut writer = self.writer.lock().await;
+        writer.write_all(&bytes).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+}
+
+/// Decodes one byte stream into whole JSON values until EOF or the first framing failure.
+///
+/// A framing failure is terminal: the reader cannot know where the next message begins, so it
+/// forwards the failure once and stops rather than resynchronizing on arbitrary bytes.
+async fn decode_lines<Reader>(
+    reader: Reader,
+    sender: mpsc::UnboundedSender<Result<Value, AcpError>>,
+) where
+    Reader: AsyncRead + Unpin,
+{
+    let mut lines = FramedRead::new(reader, LinesCodec::new_with_max_length(MAX_FRAME_BYTES));
+    while let Some(line) = lines.next().await {
+        let message = match line {
+            Ok(line) => serde_json::from_str::<Value>(&line)
+                .map_err(|error| AcpError::InvalidFrame(error.to_string())),
+            Err(LinesCodecError::MaxLineLengthExceeded) => Err(AcpError::FrameTooLarge),
+            Err(LinesCodecError::Io(error)) => Err(AcpError::Io(error)),
+        };
+        let terminal = message.is_err();
+        if sender.send(message).is_err() || terminal {
+            return;
+        }
+    }
+}

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -21,6 +21,8 @@ ora-domain = { workspace = true }
 ora-fs = { workspace = true }
 ora-history = { workspace = true }
 ora-logging = { workspace = true }
+ora-plugin-manager = { workspace = true }
+ora-plugin-runtime = { workspace = true }
 ora-process = { workspace = true }
 ora-scheduler = { workspace = true }
 ora-skill-package = { workspace = true }

--- a/crates/backend/src/agent_runtime/README.md
+++ b/crates/backend/src/agent_runtime/README.md
@@ -1,14 +1,18 @@
 # ACP Agent Runtime
 
-This module owns the application-scoped runtime for supported agent CLIs and the serialized lifecycle actor for each persisted Ora session.
+This module owns the application-scoped runtime for every agent Ora can reach and the serialized lifecycle actor for each persisted Ora session.
+
+An agent comes from one of two sources: a built-in CLI Ora launches itself and speaks NDJSON ACP to over stdio, or an installed [agent plugin](plugin_agent/README.md) that owns its agent process and relays ACP frames. The two differ only in how a connection is started and torn down. Once a connection is ready, every caller sees the same `RuntimeConnection` and cannot tell which source produced it.
 
 ## Runtime model
 
-- `AgentRuntimeManager` owns one independently supervised ACP child connection per supported CLI and routes sessions to the supervisor selected by their current `agent_cli` binding. Switching replaces that binding while preserving the Ora session and its recorded history.
+- `AgentRuntimeManager` owns one independently supervised ACP connection per agent and routes sessions to the supervisor selected by their current `agent_cli` binding. Switching replaces that binding while preserving the Ora session and its recorded history.
+- Supervisors are keyed by the agent's persisted namespaced identity rather than by a closed enum, so a plugin-provided agent is reachable through the same lookup as a built-in CLI. A plugin that would shadow an identity already supervised is ignored rather than allowed to replace it. A lookup miss is a normal runtime state — a session can outlive the plugin that provided its agent — and is reported as an unavailable runtime.
 - Each session has one actor that serializes load, prompt, permission, cancellation, stop, deletion, and user-title adoption commands.
-- Sessions targeting the same CLI share its process and connection; sessions targeting different CLIs or different actors can progress concurrently.
+- Sessions targeting the same agent share its process and connection; sessions targeting different agents or different actors can progress concurrently.
 - Prompts preserve the public ACP `ContentBlock` sequence, so one turn can contain text, images, audio, and linked or embedded resources instead of being reduced to plain text.
 - Model discovery runs each CLI's bounded command independently and returns only successful groups.
+- Agents that advertise models before any session exists publish them once per connection generation, so a reconnect is what refreshes the list. Built-in CLIs advertise none: their models arrive as ACP session config options after a session exists.
 - CLI executables are located with the same semantics on every platform: each directory on the process `PATH` is searched first, then the CLI's fixed per-user install directory (`~/.{cli}/bin`) as a fallback. PATH wins so the resolved binary matches what `which` reports in the user's terminal; the fallback keeps official install-script setups working when a desktop-launched GUI process inherits a minimal PATH. Known limitation: PATH entries added only by shell rc files (nvm, bun) may be invisible to a GUI-launched process; the not-found error enumerates every searched location to keep that diagnosable.
 - Session cwd for project-root tasks and warm project-root chats is resolved against the bootstrap path base, not live process cwd.
 - A newly attached session has a non-persisted title-acquisition window. It accepts valid ACP `session_info_update` titles from attach onward and, after the first eligible prompt (`EndTurn`, `MaxTokens`, or `MaxTurnRequests`), schedules bounded `session/list` fallbacks at three and ten seconds when the CLI advertises that capability. A user-driven rename locks that window so a later agent title cannot overwrite the chosen name. Restored sessions start with acquisition disabled.
@@ -18,7 +22,7 @@ This module owns the application-scoped runtime for supported agent CLIs and the
 - The central connection router receives one unbounded, ordered connection-wide event stream, then forwards updates, permission requests, and terminating responses into a bounded per-session FIFO of 256 items.
 - While `session/new` is waiting to reveal its provider session id, the router temporarily buffers otherwise-unrouted setup updates. Registration drains matching updates into the new session route; unmatched setup updates are discarded when the last concurrent setup finishes. Permission requests and responses are never treated as setup updates and are cancelled or discarded when no route exists.
 - An active actor grants every permission request it receives immediately, preferring the offered option that also remembers the choice for later calls in the same turn. Ora runs with no human-in-the-loop review of tool calls; the `RespondToPermission` command remains for a request that arrives outside an active prompt, where it fails with "not pending" since nothing was left unanswered.
-- Session overflow, prompt timeout, or cancellation stops only the affected session. Connection framing, correlation, or stdio failure invalidates the connection generation and stops only sessions registered on that CLI.
+- Session overflow, prompt timeout, or cancellation stops only the affected session. Connection framing, correlation, or transport failure invalidates the connection generation and stops only sessions registered on that agent. The blast radius of a plugin process dying is therefore identical to that of a CLI process dying: one agent.
 - Connection loss and queue overflow use an independent control channel, so a terminal failure cannot be hidden behind the bounded event FIFO. An active actor drains already accepted events before applying that control and polls its command channel after a bounded event burst.
 - A load or prompt completes only after consuming its matching response fence. This keeps updates that precede the response in the same operation and prevents tail events from leaking into the next prompt.
 - Routes are generation-bound. Updates from old connections or unloaded sessions are discarded as stale.

--- a/crates/backend/src/agent_runtime/actor.rs
+++ b/crates/backend/src/agent_runtime/actor.rs
@@ -1,3 +1,4 @@
+use super::connection::AgentAcpClient;
 use super::events::{
     drain_idle_events, drain_queued_prompt_events, settle_abandoned_session_response,
     settle_cancelled_prompt,
@@ -19,9 +20,7 @@ use agent_client_protocol_schema::v1::{
 };
 use agent_client_protocol_schema::v1::{PromptRequest, PromptResponse, StopReason};
 use agent_client_protocol_schema::v1::{RequestPermissionOutcome, RequestPermissionResponse};
-use ora_acp::AcpClient;
 use ora_logging::{ora_debug, ora_warn};
-use tokio::process::ChildStdin;
 use tokio::time::{Instant, timeout};
 
 /// How far replaying Ora's record got before it stopped.
@@ -764,7 +763,7 @@ impl RuntimeActor {
     /// Cancels the provider turn and settles every outstanding permission request.
     async fn cancel(
         &self,
-        client: &AcpClient<ChildStdin>,
+        client: &AgentAcpClient,
         permissions: &HashMap<String, (agent_client_protocol_schema::v1::RequestId, Vec<String>)>,
     ) {
         ora_debug!(session_id = %self.session.id, pending_permissions = permissions.len(), "cancelling prompt");
@@ -902,6 +901,7 @@ impl Drop for RuntimeActor {
 
 #[cfg(test)]
 mod tests {
+    use super::super::connection::AgentSource;
     use super::*;
     use crate::agent_runtime::connection::ConnectionSupervisor;
     use crate::agent_runtime::title_acquisition::TitleAcquisition;
@@ -925,7 +925,7 @@ mod tests {
         .expect("create repository pool");
         let scheduler = Scheduler::new(chrono_tz::UTC);
         let connection = ConnectionSupervisor::start(
-            AgentCli::Codex,
+            AgentSource::Cli(AgentCli::Codex),
             pool.clone(),
             temporary.path().to_path_buf(),
             SystemClock,

--- a/crates/backend/src/agent_runtime/connection.rs
+++ b/crates/backend/src/agent_runtime/connection.rs
@@ -1,3 +1,7 @@
+use super::plugin_agent::{
+    self, AgentTransport, LaunchedPluginAgent, PluginAcpTransport, PluginAgentError,
+    PluginAgentModel, PluginAgentSpec,
+};
 use super::routing::{RouteRegistry, SessionChannel, SessionEvent};
 use super::{
     CANCELLATION_GRACE, CONTRACT_QUEUE_CAPACITY, INITIALIZE_TIMEOUT, map_acp_error,
@@ -12,31 +16,69 @@ use agent_client_protocol_schema::v1::{
     InitializeResponse, SessionConfigOptionsCapabilities,
 };
 use agent_client_protocol_schema::v1::{RequestPermissionOutcome, RequestPermissionResponse};
-use ora_acp::{AcpClient, AcpInboundEvent, AcpPeer};
+use ora_acp::{AcpClient, AcpInboundEvent, AcpMessages, AcpPeer, NdjsonTransport};
 use ora_application::{Clock, SessionRepository};
 use ora_contracts::PublicError;
 use ora_db::{RepositoryPool, SqliteSessionRepository};
 use ora_domain::{AgentCli, SessionStatus};
 use ora_logging::{ora_error, ora_info, ora_warn};
+use ora_plugin_runtime::PluginRuntime;
 use ora_process::{
     ManagedProcess, ProcessSpawner, ProcessSpec, TokioManagedProcess, TokioProcessSpawner,
 };
+use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
-use tokio::process::ChildStdin;
 use tokio::sync::{mpsc, watch};
 use tokio::time::timeout;
 
 const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(250);
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
 
+/// Names the ACP transport every supervised agent connection speaks over.
+///
+/// `RuntimeConnection` is published through a `watch` channel, so the transport cannot stay
+/// generic; naming it once keeps the rest of the runtime unaware of which transport is in use.
+pub(super) type AgentAcpClient = AcpClient<AgentTransport>;
+
+/// Selects how one supervised agent is started and who owns the process behind it.
+///
+/// The two variants differ only in startup and teardown. Once a connection is ready, every caller
+/// above this module sees the same `RuntimeConnection` regardless of which variant produced it,
+/// which is what lets plugin-provided and built-in agents coexist without branching elsewhere.
+#[derive(Debug, Clone)]
+pub(super) enum AgentSource {
+    /// A CLI Ora launches itself and speaks NDJSON ACP to over its stdio pipes.
+    Cli(AgentCli),
+    /// A plugin package that owns its agent process and relays ACP frames to the host.
+    Plugin(PluginAgentSpec),
+}
+
+impl AgentSource {
+    /// Returns the persisted, namespaced identity of the agent this source provides.
+    fn identifier(&self) -> &str {
+        match self {
+            Self::Cli(agent_cli) => agent_cli.database_value(),
+            Self::Plugin(spec) => &spec.plugin_id,
+        }
+    }
+
+    /// Returns the short name used for supervisor thread names and operator-facing messages.
+    fn label(&self) -> &str {
+        match self {
+            Self::Cli(agent_cli) => agent_cli.executable_name(),
+            Self::Plugin(spec) => &spec.plugin_id,
+        }
+    }
+}
+
 /// Exposes one initialized ACP connection without transferring child-process ownership.
 #[derive(Clone)]
 pub(super) struct RuntimeConnection {
-    pub client: AcpClient<ChildStdin>,
+    pub client: AgentAcpClient,
     pub generation: u64,
     pub load_session_supported: bool,
     /// Whether the agent advertises the bounded fallback used for first-title acquisition.
@@ -48,6 +90,11 @@ pub(super) struct RuntimeConnection {
     /// it so unused provider history does not accumulate; agents without it fall
     /// back to `session/close`, which only detaches.
     pub delete_session_supported: bool,
+    /// Models this agent advertises outside any session, empty when it cannot advertise any.
+    ///
+    /// The list is read once per connection generation rather than on demand: it changes only
+    /// when the provider restarts, and a reconnect already refreshes it.
+    pub models: Arc<[PluginAgentModel]>,
 }
 
 #[derive(Clone)]
@@ -67,7 +114,7 @@ pub(super) enum ConnectionStatus {
 
 /// Keeps one supervisor generation's fixed dependencies together as the retry loop evolves.
 struct SupervisorContext {
-    agent_cli: AgentCli,
+    source: AgentSource,
     pool: RepositoryPool,
     home_directory: PathBuf,
     clock: SystemClock,
@@ -80,64 +127,71 @@ struct SupervisorContext {
 /// Gives session actors access to the current connection and central event router.
 #[derive(Clone)]
 pub(super) struct ConnectionSupervisor {
-    agent_cli: AgentCli,
+    label: Arc<str>,
     state: watch::Receiver<ConnectionState>,
     active_generation: Arc<AtomicU64>,
     routes: Arc<RouteRegistry>,
     shutdown: mpsc::UnboundedSender<()>,
 }
 
-/// Owns one independently supervised connection for every supported CLI.
+/// Owns one independently supervised connection for every agent Ora can reach.
+///
+/// Agents are keyed by their persisted namespaced identity rather than by a closed enum, so a
+/// plugin-provided agent is reachable through exactly the same lookup as a built-in CLI.
 #[derive(Clone)]
 pub(super) struct ConnectionSupervisors {
-    opencode: ConnectionSupervisor,
-    nga: ConnectionSupervisor,
-    code_agent_cli: ConnectionSupervisor,
-    claude: ConnectionSupervisor,
-    codex: ConnectionSupervisor,
+    supervisors: Arc<HashMap<String, ConnectionSupervisor>>,
 }
 
 impl ConnectionSupervisors {
-    /// Starts every CLI eagerly so availability is independent across providers.
-    pub fn start(pool: RepositoryPool, home_directory: PathBuf, clock: SystemClock) -> Self {
+    /// Starts every built-in CLI and every installed agent plugin eagerly.
+    ///
+    /// Availability stays independent per agent: one provider that is missing or crash-looping
+    /// never delays or degrades the others, which is why each gets its own supervisor.
+    pub fn start(
+        agent_plugins: Vec<PluginAgentSpec>,
+        pool: RepositoryPool,
+        home_directory: PathBuf,
+        clock: SystemClock,
+    ) -> Self {
+        let sources = AgentCli::ALL
+            .into_iter()
+            .map(AgentSource::Cli)
+            .chain(agent_plugins.into_iter().map(AgentSource::Plugin));
+        let mut supervisors = HashMap::new();
+        for source in sources {
+            let identifier = source.identifier().to_string();
+            // A plugin that shadows a built-in identity would silently replace it. Refusing keeps
+            // the agent the user already had instead of handing it to an unvetted package.
+            if supervisors.contains_key(&identifier) {
+                ora_warn!(
+                    agent = %identifier,
+                    "ignoring an agent whose identity is already supervised"
+                );
+                continue;
+            }
+            supervisors.insert(
+                identifier,
+                ConnectionSupervisor::start(source, pool.clone(), home_directory.clone(), clock),
+            );
+        }
         Self {
-            opencode: ConnectionSupervisor::start(
-                AgentCli::OpenCode,
-                pool.clone(),
-                home_directory.clone(),
-                clock,
-            ),
-            nga: ConnectionSupervisor::start(
-                AgentCli::Nga,
-                pool.clone(),
-                home_directory.clone(),
-                clock,
-            ),
-            code_agent_cli: ConnectionSupervisor::start(
-                AgentCli::CodeAgentCli,
-                pool.clone(),
-                home_directory.clone(),
-                clock,
-            ),
-            claude: ConnectionSupervisor::start(
-                AgentCli::Claude,
-                pool.clone(),
-                home_directory.clone(),
-                clock,
-            ),
-            codex: ConnectionSupervisor::start(AgentCli::Codex, pool, home_directory, clock),
+            supervisors: Arc::new(supervisors),
         }
     }
 
-    /// Selects the sole application-scoped connection for one persisted CLI identity.
-    pub fn for_agent(&self, agent_cli: AgentCli) -> ConnectionSupervisor {
-        match agent_cli {
-            AgentCli::OpenCode => self.opencode.clone(),
-            AgentCli::Nga => self.nga.clone(),
-            AgentCli::CodeAgentCli => self.code_agent_cli.clone(),
-            AgentCli::Claude => self.claude.clone(),
-            AgentCli::Codex => self.codex.clone(),
-        }
+    /// Selects the sole application-scoped connection for one persisted agent identity.
+    ///
+    /// A miss is a normal runtime state rather than data corruption: a session can outlive the
+    /// plugin that provided its agent, and the caller reports that as an unavailable runtime.
+    pub fn for_agent(&self, agent_cli: AgentCli) -> Result<ConnectionSupervisor, BackendError> {
+        let identifier = agent_cli.database_value();
+        self.supervisors.get(identifier).cloned().ok_or_else(|| {
+            runtime_internal(
+                "agent_runtime_unavailable",
+                format!("{identifier} is not installed"),
+            )
+        })
     }
 }
 
@@ -147,9 +201,9 @@ impl ConnectionSupervisor {
         self.routes.begin_session_setup()
     }
 
-    /// Starts one application-scoped CLI supervisor independently of the caller's runtime.
+    /// Starts one application-scoped agent supervisor independently of the caller's runtime.
     pub(super) fn start(
-        agent_cli: AgentCli,
+        source: AgentSource,
         pool: RepositoryPool,
         home_directory: PathBuf,
         clock: SystemClock,
@@ -158,10 +212,12 @@ impl ConnectionSupervisor {
         let (shutdown, shutdown_receiver) = mpsc::unbounded_channel();
         let active_generation = Arc::new(AtomicU64::new(0));
         let routes = Arc::new(RouteRegistry::default());
+        let label: Arc<str> = Arc::from(source.label());
+        let identifier = source.identifier().to_string();
         if let Err(error) = spawn_runtime_thread(
-            agent_cli,
+            &label,
             run_supervisor(SupervisorContext {
-                agent_cli,
+                source,
                 pool,
                 home_directory,
                 clock,
@@ -172,13 +228,13 @@ impl ConnectionSupervisor {
             }),
         ) {
             ora_warn!(
-                agent_cli = agent_cli.database_value(),
+                agent = %identifier,
                 error = %error,
-                "agent CLI supervisor thread could not start"
+                "agent supervisor thread could not start"
             );
         }
         Self {
-            agent_cli,
+            label,
             state,
             active_generation,
             routes,
@@ -199,13 +255,10 @@ impl ConnectionSupervisor {
     pub fn current(&self) -> Result<RuntimeConnection, BackendError> {
         match self.state.borrow().clone() {
             ConnectionState::Ready(connection) => Ok(connection),
-            ConnectionState::Starting | ConnectionState::Unavailable => {
-                let executable_name = self.agent_cli.executable_name();
-                Err(runtime_internal(
-                    "agent_runtime_unavailable",
-                    format!("{executable_name} runtime is unavailable"),
-                ))
-            }
+            ConnectionState::Starting | ConnectionState::Unavailable => Err(runtime_internal(
+                "agent_runtime_unavailable",
+                format!("{label} runtime is unavailable", label = self.label),
+            )),
         }
     }
 
@@ -219,10 +272,7 @@ impl ConnectionSupervisor {
         if self.active_generation.load(Ordering::Acquire) != connection.generation {
             return Err(runtime_internal(
                 "agent_runtime_unavailable",
-                format!(
-                    "{executable_name} runtime is recovering",
-                    executable_name = self.agent_cli.executable_name()
-                ),
+                format!("{label} runtime is recovering", label = self.label),
             ));
         }
         let (events_sender, events) = mpsc::channel(CONTRACT_QUEUE_CAPACITY);
@@ -240,10 +290,7 @@ impl ConnectionSupervisor {
             drop(registration);
             return Err(runtime_internal(
                 "agent_runtime_unavailable",
-                format!(
-                    "{executable_name} runtime is recovering",
-                    executable_name = self.agent_cli.executable_name()
-                ),
+                format!("{label} runtime is recovering", label = self.label),
             ));
         }
         Ok(SessionChannel {
@@ -258,18 +305,13 @@ impl ConnectionSupervisor {
 }
 
 /// Runs the supervisor on a dedicated runtime because Desktop bootstrap is synchronous.
-fn spawn_runtime_thread<Supervisor>(
-    agent_cli: AgentCli,
-    supervisor: Supervisor,
-) -> std::io::Result<()>
+fn spawn_runtime_thread<Supervisor>(label: &str, supervisor: Supervisor) -> std::io::Result<()>
 where
     Supervisor: Future<Output = ()> + Send + 'static,
 {
+    let thread_label = label.to_string();
     std::thread::Builder::new()
-        .name(format!(
-            "ora-{executable_name}-supervisor",
-            executable_name = agent_cli.executable_name()
-        ))
+        .name(format!("ora-{thread_label}-supervisor"))
         .spawn(move || {
             let runtime = match tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -278,9 +320,9 @@ where
                 Ok(runtime) => runtime,
                 Err(error) => {
                     ora_error!(
-                        agent_cli = agent_cli.database_value(),
+                        agent = %thread_label,
                         error = %error,
-                        "agent CLI supervisor runtime could not start"
+                        "agent supervisor runtime could not start"
                     );
                     return;
                 }
@@ -298,9 +340,71 @@ impl Drop for ConnectionSupervisor {
     }
 }
 
+/// Owns whatever process backs one connection generation for that generation's whole lifetime.
+///
+/// A built-in CLI is Ora's own child. A plugin instead owns the agent it fronts, so the host holds
+/// the plugin runtime: dropping it sends `ora/shutdown` and reaps the plugin's process tree, which
+/// is the host's standing guarantee regardless of how well the plugin cleans up after itself.
+enum AgentProcess {
+    // Boxed because a managed child process is far larger than a plugin handle, and every
+    // connection would otherwise carry the bigger variant's footprint.
+    Cli(Box<TokioManagedProcess>),
+    Plugin(PluginRuntime),
+}
+
+impl AgentProcess {
+    /// Reaps a failed generation before its replacement so two generations cannot overlap.
+    async fn terminate_and_reap(&self, plugin_id: &str) {
+        match self {
+            Self::Cli(child) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+            }
+            Self::Plugin(runtime) => {
+                // Stopping the agent is the plugin's chance to reap the CLI it owns; ending the
+                // plugin itself cannot wait for the last transport clone to be dropped, or a
+                // surviving session actor would keep a failed plugin running.
+                plugin_agent::stop_agent(runtime, plugin_id).await;
+                runtime.shutdown();
+            }
+        }
+    }
+
+    /// Bounds application shutdown even when the operating system does not promptly reap a child.
+    async fn stop_with_grace(&self, plugin_id: &str) {
+        let _ = timeout(CANCELLATION_GRACE, self.terminate_and_reap(plugin_id)).await;
+    }
+}
+
+/// Separates a startup failure worth retrying from one that can never succeed.
+///
+/// Almost every failure is retryable: a CLI can be installed later, a crashed provider can come
+/// back. A provider that does not implement the contract this host requires is different — it will
+/// fail identically forever, so retrying only produces a warning every backoff interval and never
+/// a working agent.
+enum StartFailure {
+    Retryable(BackendError),
+    Terminal(BackendError),
+}
+
+impl From<BackendError> for StartFailure {
+    fn from(error: BackendError) -> Self {
+        Self::Retryable(error)
+    }
+}
+
+/// Holds everything one agent source produces before the ACP handshake runs.
+struct StartedAgent {
+    process: AgentProcess,
+    transport: AgentTransport,
+    messages: AcpMessages,
+    models: Vec<PluginAgentModel>,
+}
+
 struct SharedProcess {
-    child: TokioManagedProcess,
-    client: AcpClient<ChildStdin>,
+    process: AgentProcess,
+    client: AgentAcpClient,
+    models: Arc<[PluginAgentModel]>,
     inbound: mpsc::UnboundedReceiver<AcpInboundEvent>,
     load_session_supported: bool,
     list_session_supported: bool,
@@ -311,7 +415,7 @@ struct SharedProcess {
 /// Supervises one process generation at a time and retries only after it is fully reaped.
 async fn run_supervisor(context: SupervisorContext) {
     let SupervisorContext {
-        agent_cli,
+        source,
         pool,
         home_directory,
         clock,
@@ -320,17 +424,19 @@ async fn run_supervisor(context: SupervisorContext) {
         routes,
         mut shutdown,
     } = context;
+    let identifier = source.identifier();
     let mut retry_delay = INITIAL_RETRY_DELAY;
     let mut generation = 0_u64;
     loop {
         let _ = state.send(ConnectionState::Starting);
-        match spawn_initialized_process(agent_cli, &home_directory).await {
+        match spawn_initialized_process(&source, &home_directory).await {
             Ok(mut process) => {
                 generation += 1;
                 retry_delay = INITIAL_RETRY_DELAY;
                 active_generation.store(generation, Ordering::Release);
                 let connection = RuntimeConnection {
                     client: process.client.clone(),
+                    models: process.models.clone(),
                     generation,
                     load_session_supported: process.load_session_supported,
                     list_session_supported: process.list_session_supported,
@@ -338,42 +444,47 @@ async fn run_supervisor(context: SupervisorContext) {
                     delete_session_supported: process.delete_session_supported,
                 };
                 let _ = state.send(ConnectionState::Ready(connection));
-                ora_info!(
-                    agent_cli = agent_cli.database_value(),
-                    generation,
-                    process_id = process.child.id(),
-                    "agent CLI runtime is ready"
-                );
+                ora_info!(agent = identifier, generation, "agent runtime is ready");
                 let shutting_down =
                     run_process_generation(&mut process, &routes, &mut shutdown).await;
                 active_generation.store(0, Ordering::Release);
                 let _ = state.send(ConnectionState::Unavailable);
                 let error =
-                    runtime_internal("agent_runtime_unavailable", "agent CLI connection was lost");
+                    runtime_internal("agent_runtime_unavailable", "agent connection was lost");
                 routes.fail_generation(generation, error);
-                mark_running_sessions_stopped(&pool, clock, agent_cli);
+                mark_running_sessions_stopped(&pool, clock, identifier);
                 if shutting_down {
-                    stop_process_with_grace(&process.child).await;
+                    process.process.stop_with_grace(identifier).await;
                     return;
                 }
-                terminate_and_reap(&process.child).await;
+                process.process.terminate_and_reap(identifier).await;
                 ora_warn!(
-                    agent_cli = agent_cli.database_value(),
+                    agent = identifier,
                     generation,
-                    "agent CLI connection failed; scheduling restart"
+                    "agent connection failed; scheduling restart"
                 );
             }
-            Err(error) => {
+            Err(StartFailure::Terminal(error)) => {
                 let _ = state.send(ConnectionState::Unavailable);
-                // A CLI that is simply not installed is an expected local configuration, and the
-                // supervisor keeps retrying it for the whole process lifetime. Logging it would
-                // flood the runtime log with one line per retry while `ConnectionState::Unavailable`
-                // already carries that fact to the UI, so only genuine startup failures are logged.
+                ora_warn!(
+                    agent = identifier,
+                    error = %error,
+                    "agent cannot serve this host; giving up on it for this process"
+                );
+                return;
+            }
+            Err(StartFailure::Retryable(error)) => {
+                let _ = state.send(ConnectionState::Unavailable);
+                // An agent that is simply not installed is an expected local configuration, and
+                // the supervisor keeps retrying it for the whole process lifetime. Logging it
+                // would flood the runtime log with one line per retry while
+                // `ConnectionState::Unavailable` already carries that fact to the UI, so only
+                // genuine startup failures are logged.
                 if !matches!(error.public_error(), PublicError::AgentCliNotFound(_)) {
                     ora_warn!(
-                        agent_cli = agent_cli.database_value(),
+                        agent = identifier,
                         error = %error,
-                        "agent CLI startup failed; scheduling retry"
+                        "agent startup failed; scheduling retry"
                     );
                 }
             }
@@ -420,7 +531,7 @@ async fn run_process_generation(
                     Some(AcpInboundEvent::Fatal(error)) => {
                         ora_warn!(
                             error = %error,
-                            "agent CLI ACP connection failed"
+                            "agent ACP connection failed"
                         );
                         return false;
                     }
@@ -432,41 +543,25 @@ async fn run_process_generation(
     }
 }
 
-/// Starts one CLI in the neutral home directory and completes the ACP handshake.
+/// Starts one agent in the neutral home directory and completes the ACP handshake.
+///
+/// Both sources converge here on purpose: whichever way the agent was started, the connection is
+/// only reported ready once ACP `initialize` has returned its capabilities, so no caller can send
+/// a session request to a transport that is not yet carrying a live agent.
 async fn spawn_initialized_process(
-    agent_cli: AgentCli,
+    source: &AgentSource,
     home_directory: &Path,
-) -> Result<SharedProcess, BackendError> {
-    let executable = resolve_agent_cli_path(
-        agent_cli,
-        std::env::var_os("PATH").as_deref(),
-        home_directory,
-    )?;
-    let mut child = TokioProcessSpawner::new()
-        .spawn(
-            ProcessSpec::new(executable)
-                .args(agent_cli.launch_arguments())
-                .cwd(home_directory),
-        )
-        .map_err(|source| BackendError::internal("failed to start agent CLI", source))?;
-    let Some(stdin) = child.take_stdin() else {
-        terminate_and_reap(&child).await;
-        return Err(runtime_internal(
-            "agent_start_failed",
-            "agent CLI stdin is unavailable",
-        ));
+) -> Result<SharedProcess, StartFailure> {
+    let StartedAgent {
+        process,
+        transport,
+        messages,
+        models,
+    } = match source {
+        AgentSource::Cli(agent_cli) => spawn_cli_connection(*agent_cli, home_directory).await?,
+        AgentSource::Plugin(spec) => spawn_plugin_connection(spec, home_directory).await?,
     };
-    let Some(stdout) = child.take_stdout() else {
-        terminate_and_reap(&child).await;
-        return Err(runtime_internal(
-            "agent_start_failed",
-            "agent CLI stdout is unavailable",
-        ));
-    };
-    if let Some(stderr) = child.take_stderr() {
-        tokio::spawn(super::drain_stderr(stderr));
-    }
-    let peer = AcpPeer::spawn(stdout, stdin);
+    let peer = AcpPeer::spawn(messages, transport);
     // Config options are only sent by agents that see the client advertise them,
     // so the model selector depends on this declaration. Boolean options stay
     // undeclared because Ora renders only select-style options today; claiming
@@ -488,21 +583,22 @@ async fn spawn_initialized_process(
     {
         Ok(Ok(response)) => response,
         Ok(Err(error)) => {
-            terminate_and_reap(&child).await;
-            return Err(map_acp_error(error));
+            process.terminate_and_reap(source.identifier()).await;
+            return Err(StartFailure::Retryable(map_acp_error(error)));
         }
         Err(_) => {
-            terminate_and_reap(&child).await;
-            return Err(runtime_internal(
+            process.terminate_and_reap(source.identifier()).await;
+            return Err(StartFailure::Retryable(runtime_internal(
                 "agent_initialize_timeout",
-                "agent CLI initialization timed out",
-            ));
+                "agent initialization timed out",
+            )));
         }
     };
     let (client, inbound) = peer.into_parts();
     Ok(SharedProcess {
-        child,
+        process,
         client,
+        models: models.into(),
         inbound,
         load_session_supported: response.agent_capabilities.load_session,
         list_session_supported: response
@@ -523,14 +619,97 @@ async fn spawn_initialized_process(
     })
 }
 
-/// Persists one CLI's connection loss without stopping sessions owned by healthy CLIs.
-fn mark_running_sessions_stopped(pool: &RepositoryPool, clock: SystemClock, agent_cli: AgentCli) {
+/// Launches one built-in CLI and wires NDJSON ACP over its stdio pipes.
+async fn spawn_cli_connection(
+    agent_cli: AgentCli,
+    home_directory: &Path,
+) -> Result<StartedAgent, StartFailure> {
+    let executable = resolve_agent_cli_path(
+        agent_cli,
+        std::env::var_os("PATH").as_deref(),
+        home_directory,
+    )?;
+    let mut child = TokioProcessSpawner::new()
+        .spawn(
+            ProcessSpec::new(executable)
+                .args(agent_cli.launch_arguments())
+                .cwd(home_directory),
+        )
+        .map_err(|source| BackendError::internal("failed to start agent CLI", source))?;
+    let stdio = child.take_stdin().zip(child.take_stdout());
+    let Some((stdin, stdout)) = stdio else {
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+        return Err(StartFailure::Retryable(runtime_internal(
+            "agent_start_failed",
+            "agent CLI stdio is unavailable",
+        )));
+    };
+    if let Some(stderr) = child.take_stderr() {
+        tokio::spawn(super::drain_stderr(stderr));
+    }
+    let (transport, messages) = NdjsonTransport::spawn(stdout, stdin);
+    Ok(StartedAgent {
+        process: AgentProcess::Cli(Box::new(child)),
+        transport: AgentTransport::Stdio(transport),
+        messages,
+        // A built-in CLI has no pre-session model list; its models arrive as ACP session config
+        // options once a session exists.
+        models: Vec::new(),
+    })
+}
+
+/// Launches one agent plugin and wires ACP over its notification channel.
+async fn spawn_plugin_connection(
+    spec: &PluginAgentSpec,
+    home_directory: &Path,
+) -> Result<StartedAgent, StartFailure> {
+    let LaunchedPluginAgent { runtime, messages } =
+        plugin_agent::launch(spec, home_directory, env!("CARGO_PKG_VERSION"))
+            .await
+            .map_err(plugin_start_error)?;
+    let models = plugin_agent::list_models(&runtime)
+        .await
+        .map_err(plugin_start_error)?;
+    let transport = AgentTransport::Plugin(PluginAcpTransport::new(runtime.clone()));
+    Ok(StartedAgent {
+        process: AgentProcess::Plugin(runtime),
+        transport,
+        messages,
+        models,
+    })
+}
+
+/// Maps a plugin startup failure onto the same public shape a missing CLI already produces.
+///
+/// A plugin whose agent is not installed must be indistinguishable from a CLI that is not
+/// installed, because the supervisor treats that case as an expected local configuration and
+/// retries it without logging.
+fn plugin_start_error(error: PluginAgentError) -> StartFailure {
+    match error {
+        PluginAgentError::AgentNotInstalled => StartFailure::Retryable(runtime_internal(
+            "agent_cli_not_found",
+            "the agent behind this plugin is not installed",
+        )),
+        PluginAgentError::ContractIncomplete(detail) => {
+            StartFailure::Terminal(runtime_internal("agent_start_failed", detail))
+        }
+        PluginAgentError::Failed(detail) => {
+            StartFailure::Retryable(runtime_internal("agent_start_failed", detail))
+        }
+    }
+}
+
+/// Persists one agent's connection loss without stopping sessions owned by healthy agents.
+fn mark_running_sessions_stopped(pool: &RepositoryPool, clock: SystemClock, identifier: &str) {
     let repository = SqliteSessionRepository::new(pool.clone());
     let Ok(sessions) = repository.list_sessions() else {
         return;
     };
     for session in sessions {
-        if session.agent_cli == agent_cli && session.status == SessionStatus::Running {
+        if session.agent_cli.database_value() == identifier
+            && session.status == SessionStatus::Running
+        {
             let _ = repository.update_session_status(
                 &session.id,
                 SessionStatus::Stopped,
@@ -540,25 +719,10 @@ fn mark_running_sessions_stopped(pool: &RepositoryPool, clock: SystemClock, agen
     }
 }
 
-/// Reaps a failed process before replacement so two generations of one CLI cannot overlap.
-async fn terminate_and_reap(child: &TokioManagedProcess) {
-    let _ = child.kill().await;
-    let _ = child.wait().await;
-}
-
-/// Bounds application shutdown even when the operating system does not promptly reap the child.
-async fn stop_process_with_grace(child: &TokioManagedProcess) {
-    let _ = timeout(CANCELLATION_GRACE, async {
-        let _ = child.kill().await;
-        let _ = child.wait().await;
-    })
-    .await;
-}
-
 #[cfg(test)]
 mod tests {
-    use super::spawn_runtime_thread;
-    use ora_domain::AgentCli;
+    use super::{PluginAgentError, StartFailure, plugin_start_error, spawn_runtime_thread};
+    use ora_contracts::PublicError;
     use pretty_assertions::assert_eq;
     use std::time::Duration;
 
@@ -567,11 +731,42 @@ mod tests {
     fn starts_a_dedicated_runtime_thread() {
         let (sender, receiver) = std::sync::mpsc::channel();
 
-        spawn_runtime_thread(AgentCli::OpenCode, async move {
+        spawn_runtime_thread("opencode", async move {
             sender.send("ready").expect("send runtime signal");
         })
         .expect("start runtime thread");
 
         assert_eq!(receiver.recv_timeout(Duration::from_secs(1)), Ok("ready"));
+    }
+
+    /// Verifies a missing agent stays retryable and reports the same cause as a missing CLI.
+    #[test]
+    fn treats_a_missing_plugin_agent_like_a_missing_cli() {
+        let failure = plugin_start_error(PluginAgentError::AgentNotInstalled);
+
+        let StartFailure::Retryable(error) = failure else {
+            panic!("a missing agent must stay retryable");
+        };
+        assert!(matches!(
+            error.public_error(),
+            PublicError::AgentCliNotFound(_)
+        ));
+    }
+
+    /// Verifies a plugin that cannot serve the contract is abandoned instead of retried forever.
+    #[test]
+    fn gives_up_on_a_plugin_that_cannot_serve_the_contract() {
+        let failure =
+            plugin_start_error(PluginAgentError::ContractIncomplete("missing".to_string()));
+
+        assert!(matches!(failure, StartFailure::Terminal(_)));
+    }
+
+    /// Verifies an ordinary startup failure is retried, because the agent may recover.
+    #[test]
+    fn retries_an_ordinary_plugin_startup_failure() {
+        let failure = plugin_start_error(PluginAgentError::Failed("spawn refused".to_string()));
+
+        assert!(matches!(failure, StartFailure::Retryable(_)));
     }
 }

--- a/crates/backend/src/agent_runtime/events.rs
+++ b/crates/backend/src/agent_runtime/events.rs
@@ -1,11 +1,10 @@
 use super::RuntimeActor;
 use super::RuntimeCommand;
+use super::connection::AgentAcpClient;
 use super::routing::{SessionChannel, SessionEvent};
 use crate::BackendError;
 use agent_client_protocol_schema::v1::{RequestPermissionOutcome, RequestPermissionResponse};
-use ora_acp::AcpClient;
 use ora_contracts::PromptSessionEvent;
-use tokio::process::ChildStdin;
 use tokio::sync::mpsc;
 
 /// Drains an idle session's event FIFO while preserving title updates for the actor.
@@ -13,7 +12,7 @@ use tokio::sync::mpsc;
 /// Idle traffic must not leak into the next prompt, but dropping `SessionInfoUpdate` here would
 /// lose a push title that arrived after attach and before the first eligible prompt.
 pub(super) async fn drain_idle_events(
-    client: &AcpClient<ChildStdin>,
+    client: &AgentAcpClient,
     events: &mut mpsc::Receiver<SessionEvent>,
     title_updates: &mpsc::WeakUnboundedSender<RuntimeCommand>,
 ) {
@@ -36,7 +35,7 @@ pub(super) async fn drain_idle_events(
 }
 
 /// Settles one unexpected idle event without allowing it to leak into a later operation.
-pub(super) async fn settle_idle_event(client: &AcpClient<ChildStdin>, event: SessionEvent) {
+pub(super) async fn settle_idle_event(client: &AgentAcpClient, event: SessionEvent) {
     match event {
         SessionEvent::Permission(permission) => {
             let _ = client
@@ -54,7 +53,7 @@ pub(super) async fn settle_idle_event(client: &AcpClient<ChildStdin>, event: Ses
 pub(super) async fn settle_cancelled_prompt<Response>(
     actor: &mut RuntimeActor,
     channel: &mut SessionChannel,
-    client: &AcpClient<ChildStdin>,
+    client: &AgentAcpClient,
     pending: ora_acp::PendingSessionRequest<Response>,
     events: &mpsc::Sender<Result<PromptSessionEvent, BackendError>>,
 ) -> Option<Result<Response, ora_acp::AcpError>>
@@ -94,7 +93,7 @@ where
 pub(super) async fn drain_queued_prompt_events(
     actor: &mut RuntimeActor,
     channel: &mut SessionChannel,
-    client: &AcpClient<ChildStdin>,
+    client: &AgentAcpClient,
     events: &mpsc::Sender<Result<PromptSessionEvent, BackendError>>,
 ) {
     // Only drain the snapshot that was accepted before isolation was requested. Events
@@ -130,7 +129,7 @@ pub(super) async fn drain_queued_prompt_events(
 pub(super) async fn settle_abandoned_session_response<Response>(
     actor: &mut RuntimeActor,
     channel: &mut SessionChannel,
-    client: &AcpClient<ChildStdin>,
+    client: &AgentAcpClient,
     pending: ora_acp::PendingSessionRequest<Response>,
 ) -> Option<Result<Response, ora_acp::AcpError>>
 where

--- a/crates/backend/src/agent_runtime/mod.rs
+++ b/crates/backend/src/agent_runtime/mod.rs
@@ -4,6 +4,7 @@ mod connection;
 mod events;
 mod handoff;
 mod history;
+mod plugin_agent;
 mod replay;
 mod routing;
 mod scheduling;
@@ -23,6 +24,7 @@ pub use stream::SessionEventStream;
 use support::*;
 use title_acquisition::TitleAcquisition;
 
+use crate::bootstrap::AgentPluginPackage;
 use crate::clock::SystemClock;
 use crate::task::{resolve_project_cwd, resolve_task_cwd};
 use crate::{BackendError, ErrorClassification};
@@ -50,6 +52,7 @@ use ora_domain::{
 use ora_history::{HistoryIntegrity, binding_needs_handoff, read_session_history};
 use ora_logging::{ora_debug, ora_warn};
 use ora_scheduler::Scheduler;
+use plugin_agent::PluginAgentSpec;
 use routing::{SessionChannel, SessionEvent};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -196,19 +199,42 @@ struct OpenedRecorder {
     failure: Option<String>,
 }
 
+/// Groups the fixed dependencies the agent runtime is constructed from.
+pub(crate) struct AgentRuntimeSetup {
+    /// Agent plugins that join the built-in CLIs as providers, already discovered and validated.
+    pub agent_plugins: Vec<AgentPluginPackage>,
+    pub pool: RepositoryPool,
+    pub home_directory: PathBuf,
+    pub relative_path_base: PathBuf,
+    pub sessions_root: PathBuf,
+    pub clock: SystemClock,
+    pub scheduler: Scheduler,
+    pub app_events: AppEventPublisher,
+}
+
 impl AgentRuntimeManager {
     /// Builds the manager, reconciles stale rows, and immediately starts the shared supervisor.
-    pub(crate) fn new(
-        pool: RepositoryPool,
-        home_directory: PathBuf,
-        relative_path_base: PathBuf,
-        sessions_root: PathBuf,
-        clock: SystemClock,
-        scheduler: Scheduler,
-        app_events: AppEventPublisher,
-    ) -> Result<Self, BackendError> {
+    pub(crate) fn new(setup: AgentRuntimeSetup) -> Result<Self, BackendError> {
+        let AgentRuntimeSetup {
+            agent_plugins,
+            pool,
+            home_directory,
+            relative_path_base,
+            sessions_root,
+            clock,
+            scheduler,
+            app_events,
+        } = setup;
         reconcile_running_sessions(&pool, clock)?;
-        let connections = ConnectionSupervisors::start(pool.clone(), home_directory.clone(), clock);
+        let connections = ConnectionSupervisors::start(
+            agent_plugins
+                .into_iter()
+                .map(PluginAgentSpec::from)
+                .collect(),
+            pool.clone(),
+            home_directory.clone(),
+            clock,
+        );
         Ok(Self {
             inner: Arc::new(ManagerInner {
                 pool,
@@ -261,6 +287,33 @@ impl AgentRuntimeManager {
         })
     }
 
+    /// Reports the models one agent advertises before any session exists.
+    ///
+    /// The list is whatever the agent published when its current connection came up. An agent
+    /// that has no pre-session model list returns an empty one rather than an error, because
+    /// "this agent does not advertise models" is a normal answer for built-in CLIs.
+    pub(crate) fn agent_models(
+        &self,
+        request: ora_contracts::ListAgentModelsRequest,
+    ) -> Result<ora_contracts::ListAgentModelsResponse, BackendError> {
+        let supervisor = self
+            .inner
+            .connections
+            .for_agent(domain_agent_cli(request.agent_cli))?;
+        let connection = supervisor.current()?;
+        Ok(ora_contracts::ListAgentModelsResponse {
+            models: connection
+                .models
+                .iter()
+                .map(|model| ora_contracts::AgentModel {
+                    id: model.id.clone(),
+                    display_name: model.display_name.clone(),
+                    default: model.default,
+                })
+                .collect(),
+        })
+    }
+
     /// Reports the live ACP handshake status of every application-scoped CLI runtime.
     pub(crate) fn agent_runtime_status(&self) -> ora_contracts::GetAgentRuntimeStatusResponse {
         ora_contracts::GetAgentRuntimeStatusResponse {
@@ -268,10 +321,19 @@ impl AgentRuntimeManager {
                 .into_iter()
                 .map(|agent_cli| ora_contracts::AgentCliRuntimeStatus {
                     agent_cli: contract_agent_cli(agent_cli),
-                    status: match self.inner.connections.for_agent(agent_cli).status() {
-                        ConnectionStatus::Ready => ora_contracts::AgentCliStatus::Ready,
-                        ConnectionStatus::Starting => ora_contracts::AgentCliStatus::Starting,
-                        ConnectionStatus::Unavailable => ora_contracts::AgentCliStatus::Unavailable,
+                    // An agent with no supervisor is one this installation cannot reach at
+                    // all, which the UI shows the same way as one that failed to start.
+                    status: match self
+                        .inner
+                        .connections
+                        .for_agent(agent_cli)
+                        .map(|supervisor| supervisor.status())
+                    {
+                        Ok(ConnectionStatus::Ready) => ora_contracts::AgentCliStatus::Ready,
+                        Ok(ConnectionStatus::Starting) => ora_contracts::AgentCliStatus::Starting,
+                        Ok(ConnectionStatus::Unavailable) | Err(_) => {
+                            ora_contracts::AgentCliStatus::Unavailable
+                        }
                     },
                 })
                 .collect(),
@@ -372,7 +434,7 @@ impl AgentRuntimeManager {
 
         let response = async {
             let _lifecycle = self.inner.lifecycle.lock().await;
-            let supervisor = self.inner.connections.for_agent(agent_cli);
+            let supervisor = self.inner.connections.for_agent(agent_cli)?;
             let channel =
                 supervisor.open_session_channel(&agent_session_id, session_id.as_ref())?;
             let now = self.inner.clock.now_timestamp_millis();
@@ -486,7 +548,7 @@ impl AgentRuntimeManager {
 
         let response = async {
             let _lifecycle = self.inner.lifecycle.lock().await;
-            let supervisor = self.inner.connections.for_agent(target);
+            let supervisor = self.inner.connections.for_agent(target)?;
             let channel =
                 supervisor.open_session_channel(&agent_session_id, session.id.as_ref())?;
             let (session, recorder) = self
@@ -898,7 +960,7 @@ impl AgentRuntimeManager {
             return Ok(handle);
         }
         let cwd = self.task_cwd(&session.task_id)?;
-        let connection = self.inner.connections.for_agent(session.agent_cli);
+        let connection = self.inner.connections.for_agent(session.agent_cli)?;
         let mut opened = self.open_recorder(&session)?;
         let session = match opened.failure.take() {
             Some(reason) => self.settle_record(session, RecordOutcome::JustFailed { reason }),

--- a/crates/backend/src/agent_runtime/plugin_agent/README.md
+++ b/crates/backend/src/agent_runtime/plugin_agent/README.md
@@ -1,0 +1,68 @@
+# plugin_agent
+
+`plugin_agent` turns one installed agent plugin into something the connection supervisor can treat
+exactly like a built-in CLI. It launches the plugin process, verifies the plugin declared the whole
+agent contract, brings the agent up, and exposes the plugin's notification channel as an ACP
+message stream and sink.
+
+This module is the only place in the agent runtime that knows a plugin exists. Everything above it
+sees a `RuntimeConnection` and cannot tell which kind of provider produced it.
+
+## Responsibilities
+
+- Launch one plugin process per agent with the Deno permissions an agent plugin requires.
+- Reject, at handshake time, any plugin whose registration does not cover `agent/start`,
+  `agent/stop`, `agent/listModels`, and the emitted `agent/acp`.
+- Call `agent/start` and confirm the plugin will speak a protocol version this host understands.
+- Read the plugin's pre-session model list through `agent/listModels`.
+- Relay ACP messages in both directions as `agent/acp` notifications.
+- Ask the plugin to stop its agent before the host reaps the plugin's process tree.
+
+## Non-responsibilities
+
+- Discovering, validating, installing, or enabling plugin packages. The caller supplies an
+  already-resolved `PluginAgentSpec`.
+- Interpreting ACP. The host is a pipe for `agent/acp` payloads and never parses, validates, or
+  rewrites them, which is what lets a plugin support ACP methods this host has never heard of.
+- Supervising the agent's process. A plugin spawns and owns its agent CLI itself.
+- Retry, backoff, and connection state. Those belong to the connection supervisor, which treats a
+  dead plugin exactly as it treats a dead CLI.
+
+## Boundaries and failure semantics
+
+The contract check runs the moment the handshake completes — before any session exists and before a
+user is waiting on a prompt — so a plugin that does not implement the contract surfaces as an
+unavailable agent rather than as a failure in the middle of someone's turn. That failure is
+terminal: the supervisor abandons the agent for the rest of the process instead of retrying, because
+the same plugin will fail identically every time and retrying only produces a warning per backoff
+interval.
+
+`agent/start` failures split in two. `-32001` means the agent CLI is absent from this machine; that
+is an expected local configuration, so it maps onto the same public error a missing built-in CLI
+produces and is retried without logging. Every other code is a genuine startup failure.
+
+ACP travels as notifications rather than plugin method calls. ACP frames already carry their own
+ids, cancellation, and ordering, so a second correlation layer would mean two timeouts and two
+cancellation paths per frame, and the runtime's control-call timeout would sever prompts that
+legitimately run for minutes.
+
+A single unusable inbound frame — one that is not an object, or a notification method this runtime
+does not consume — is dropped with a warning rather than failing the connection: one bad payload
+must not end every live session on that agent. Frames that arrive before `agent/start` returns are
+discarded, because they belong to no connection.
+
+Teardown is `agent/stop`, then an explicit plugin shutdown that sends `ora/shutdown` and kills the
+process tree once the shutdown timeout expires. `agent/stop` has its own short deadline, well inside
+the host's cancellation grace, and the plugin is ended whether or not it answered — teardown must
+never be the reason shutdown stalls. Ending the plugin explicitly also matters because plugin
+handles are cloned into the ACP transport that live sessions hold: waiting for the last clone to
+drop would let one surviving session actor keep a failed plugin running. Plugin cleanup is best
+effort; final reclamation of the process tree is always the host's.
+
+## Sandboxing
+
+Agent plugins currently receive `--allow-run` plus read, env, and network access, because they spawn
+and own the agent CLI. An agent plugin is therefore roughly as privileged as the host itself. This
+is a deliberate, documented gap rather than an oversight: capability narrowing is deferred until the
+agent contract is proven, and closing it later changes only how the agent is started, never the
+`agent/acp` pipe.

--- a/crates/backend/src/agent_runtime/plugin_agent/control.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/control.rs
@@ -1,0 +1,193 @@
+use std::path::Path;
+use std::time::Duration;
+
+use ora_logging::ora_warn;
+use ora_plugin_runtime::{PluginRegistration, PluginRuntime, PluginRuntimeError};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use thiserror::Error;
+use tokio::time::timeout;
+
+/// The method a plugin must serve to bring its agent up.
+pub(super) const AGENT_START_METHOD: &str = "agent/start";
+/// The method a plugin must serve to bring its agent down while staying alive itself.
+pub(super) const AGENT_STOP_METHOD: &str = "agent/stop";
+/// The method a plugin must serve to list selectable models outside any session.
+pub(super) const AGENT_LIST_MODELS_METHOD: &str = "agent/listModels";
+/// The notification method that carries ACP frames in both directions.
+pub(crate) const AGENT_ACP_METHOD: &str = "agent/acp";
+
+/// How long a plugin has to confirm it stopped its agent.
+///
+/// This is far shorter than the general control-call timeout, and shorter than the host's own
+/// cancellation grace, because teardown must never be the reason shutdown stalls: the plugin
+/// process is ended immediately afterwards whether or not it answered.
+const AGENT_STOP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The error code a plugin returns when the agent it fronts is not installed on this machine.
+///
+/// This is an expected local configuration rather than a fault, so the supervisor retries it
+/// silently; every other code is a genuine startup failure worth logging.
+const AGENT_NOT_INSTALLED_CODE: i64 = -32001;
+
+/// Reports why one agent plugin could not be brought up or queried.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub(crate) enum PluginAgentError {
+    #[error("agent plugin contract is incomplete: {0}")]
+    ContractIncomplete(String),
+    #[error("the plugin's agent is not installed")]
+    AgentNotInstalled,
+    #[error("agent plugin failed: {0}")]
+    Failed(String),
+}
+
+impl From<PluginRuntimeError> for PluginAgentError {
+    fn from(error: PluginRuntimeError) -> Self {
+        match error {
+            PluginRuntimeError::Remote {
+                code: AGENT_NOT_INSTALLED_CODE,
+                ..
+            } => Self::AgentNotInstalled,
+            other => Self::Failed(other.to_string()),
+        }
+    }
+}
+
+/// Parameters handed to a plugin when the host asks it to bring its agent up.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentStartParams<'a> {
+    cwd: &'a Path,
+    host_version: &'a str,
+}
+
+/// The plugin's confirmation that its agent is ready to receive ACP frames.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct AgentStartResult {
+    protocol: AgentProtocol,
+    acp_version: u32,
+}
+
+/// The wire protocol a plugin speaks on the ACP channel.
+///
+/// Only ACP exists today; the field is on the wire so a future translating plugin can declare a
+/// different protocol without changing the notification channel's shape.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum AgentProtocol {
+    Acp,
+}
+
+/// The ACP major version this host speaks over the plugin channel.
+const SUPPORTED_ACP_VERSION: u32 = 1;
+
+/// Describes one model an agent plugin offers before any session exists.
+///
+/// This is deliberately separate from ACP session config options, which only exist after
+/// `session/new`: the agent and model pickers must render before any session is created.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PluginAgentModel {
+    pub id: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub default: bool,
+}
+
+/// Carries the model list one plugin advertises.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct ListModelsResult {
+    models: Vec<PluginAgentModel>,
+}
+
+/// Rejects a plugin whose registration does not cover the whole agent contract.
+///
+/// This runs the moment the handshake completes, before any session exists and before a user is
+/// waiting on a prompt, so a contract mismatch surfaces as an unavailable agent instead of a
+/// failure in the middle of someone's turn.
+pub(super) fn verify_agent_contract(
+    registration: &PluginRegistration,
+) -> Result<(), PluginAgentError> {
+    let missing_methods = [
+        AGENT_START_METHOD,
+        AGENT_STOP_METHOD,
+        AGENT_LIST_MODELS_METHOD,
+    ]
+    .into_iter()
+    .filter(|method| !registration.methods.contains(*method))
+    .collect::<Vec<_>>();
+    if !missing_methods.is_empty() {
+        return Err(PluginAgentError::ContractIncomplete(format!(
+            "missing methods {}",
+            missing_methods.join(", ")
+        )));
+    }
+    if !registration.emits.contains(AGENT_ACP_METHOD) {
+        return Err(PluginAgentError::ContractIncomplete(format!(
+            "missing emitted method {AGENT_ACP_METHOD}"
+        )));
+    }
+    Ok(())
+}
+
+/// Brings one plugin's agent up and confirms it will speak a protocol this host understands.
+pub(super) async fn start_agent(
+    runtime: &PluginRuntime,
+    cwd: &Path,
+    host_version: &str,
+) -> Result<(), PluginAgentError> {
+    let params = serde_json::to_value(AgentStartParams { cwd, host_version })
+        .map_err(|error| PluginAgentError::Failed(error.to_string()))?;
+    let result = runtime.invoke(AGENT_START_METHOD, params).await?;
+    let result: AgentStartResult = serde_json::from_value(result).map_err(|error| {
+        PluginAgentError::Failed(format!("invalid {AGENT_START_METHOD} result: {error}"))
+    })?;
+    if result.acp_version != SUPPORTED_ACP_VERSION {
+        return Err(PluginAgentError::ContractIncomplete(format!(
+            "unsupported ACP version {}; expected {SUPPORTED_ACP_VERSION}",
+            result.acp_version
+        )));
+    }
+    let AgentProtocol::Acp = result.protocol;
+    Ok(())
+}
+
+/// Asks one plugin to terminate the agent it owns while leaving the plugin process alive.
+///
+/// Failures are logged rather than propagated: plugin cleanup is best effort, and the host always
+/// reaps the process tree afterwards regardless of what the plugin did. Dropping the plugin
+/// runtime is what ends the plugin itself, so stopping the agent first is the plugin's one chance
+/// to reap the CLI it owns.
+pub(crate) async fn stop_agent(runtime: &PluginRuntime, plugin_id: &str) {
+    match timeout(
+        AGENT_STOP_TIMEOUT,
+        runtime.invoke(AGENT_STOP_METHOD, json!({})),
+    )
+    .await
+    {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => ora_warn!(
+            plugin_id = %plugin_id,
+            error = %error,
+            "agent plugin did not confirm shutdown"
+        ),
+        Err(_) => ora_warn!(
+            plugin_id = %plugin_id,
+            "agent plugin did not answer shutdown before its deadline"
+        ),
+    }
+}
+
+/// Reads the models one plugin offers for the agent and model pickers.
+pub(crate) async fn list_models(
+    runtime: &PluginRuntime,
+) -> Result<Vec<PluginAgentModel>, PluginAgentError> {
+    let result = runtime.invoke(AGENT_LIST_MODELS_METHOD, json!({})).await?;
+    let result: ListModelsResult = serde_json::from_value(result).map_err(|error| {
+        PluginAgentError::Failed(format!(
+            "invalid {AGENT_LIST_MODELS_METHOD} result: {error}"
+        ))
+    })?;
+    Ok(result.models)
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/inbound.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/inbound.rs
@@ -1,0 +1,65 @@
+use ora_acp::AcpMessages;
+use ora_logging::ora_warn;
+use ora_plugin_runtime::PluginNotification;
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use super::control::AGENT_ACP_METHOD;
+
+/// Discards notifications that arrived before the agent was started.
+///
+/// Frames delivered before `agent/start` returned have no connection to be routed to. Draining
+/// them here — rather than letting the channel buffer replay them into a connection that did not
+/// exist when they were produced — keeps the stream that reaches the ACP peer aligned with one
+/// live agent generation.
+pub(super) fn discard_frames_before_start(
+    notifications: &mut mpsc::UnboundedReceiver<PluginNotification>,
+    plugin_id: &str,
+) {
+    let mut discarded = 0_usize;
+    while notifications.try_recv().is_ok() {
+        discarded += 1;
+    }
+    if discarded != 0 {
+        ora_warn!(
+            plugin_id = %plugin_id,
+            discarded,
+            "agent plugin sent frames before its agent was started"
+        );
+    }
+}
+
+/// Forwards `agent/acp` payloads into the message stream one ACP peer reads.
+///
+/// A single malformed or unrecognized notification is dropped with a warning instead of failing
+/// the connection: the host is a pipe for these payloads, and letting one bad frame tear down
+/// every session on the agent would trade a recoverable defect for an outage.
+pub(super) fn spawn_frame_forwarding(
+    mut notifications: mpsc::UnboundedReceiver<PluginNotification>,
+    plugin_id: String,
+) -> AcpMessages {
+    let (sender, messages) = mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        while let Some(notification) = notifications.recv().await {
+            if notification.method != AGENT_ACP_METHOD {
+                ora_warn!(
+                    plugin_id = %plugin_id,
+                    method = %notification.method,
+                    "agent plugin sent a notification the agent runtime does not consume"
+                );
+                continue;
+            }
+            if !matches!(notification.params, Value::Object(_)) {
+                ora_warn!(
+                    plugin_id = %plugin_id,
+                    "agent plugin sent an ACP frame that is not a JSON object"
+                );
+                continue;
+            }
+            if sender.send(Ok(notification.params)).is_err() {
+                return;
+            }
+        }
+    });
+    messages
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/mod.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mod.rs
@@ -1,0 +1,90 @@
+mod control;
+mod inbound;
+mod transport;
+
+#[cfg(test)]
+mod tests;
+
+pub(crate) use control::{PluginAgentError, PluginAgentModel, list_models, stop_agent};
+pub(crate) use transport::{AgentTransport, PluginAcpTransport};
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use ora_acp::AcpMessages;
+use ora_plugin_runtime::{PluginRuntime, PluginRuntimeConfig};
+use ora_process::TokioProcessSpawner;
+
+use crate::bootstrap::AgentPluginPackage;
+
+/// How long a plugin has to publish its capability registration before it is considered dead.
+const PLUGIN_READY_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long one control method may run. ACP traffic is a notification and is not bounded by this.
+const PLUGIN_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long a plugin has to exit after `ora/shutdown` before its process tree is killed.
+const PLUGIN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// The Deno permissions granted to an agent plugin.
+///
+/// An agent plugin spawns and owns the agent CLI itself, so it needs `--allow-run` and everything
+/// that CLI needs to work. That makes an agent plugin roughly as privileged as the host. This is a
+/// deliberate, documented gap: capability narrowing for agent plugins is deferred until the agent
+/// contract itself is proven, and closing it later changes only how the agent is started, never
+/// the `agent/acp` pipe.
+const AGENT_PLUGIN_PERMISSIONS: [&str; 4] =
+    ["--allow-run", "--allow-read", "--allow-env", "--allow-net"];
+
+/// Describes one installed agent plugin the connection supervisor can launch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginAgentSpec {
+    /// The plugin package id, which is also this agent's identity throughout the host.
+    pub plugin_id: String,
+    pub deno_path: PathBuf,
+    pub entrypoint: PathBuf,
+}
+
+impl From<AgentPluginPackage> for PluginAgentSpec {
+    fn from(package: AgentPluginPackage) -> Self {
+        Self {
+            plugin_id: package.id,
+            deno_path: package.deno_path,
+            entrypoint: package.entrypoint,
+        }
+    }
+}
+
+/// Holds one running agent plugin together with the ACP stream it feeds.
+pub(crate) struct LaunchedPluginAgent {
+    pub runtime: PluginRuntime,
+    pub messages: AcpMessages,
+}
+
+/// Starts one agent plugin and brings up the agent behind it.
+///
+/// On return the plugin has registered a complete agent contract and confirmed its agent is ready
+/// to receive ACP frames, so the caller can immediately begin the ACP handshake.
+pub(crate) async fn launch(
+    spec: &PluginAgentSpec,
+    home_directory: &Path,
+    host_version: &str,
+) -> Result<LaunchedPluginAgent, PluginAgentError> {
+    let config = PluginRuntimeConfig {
+        plugin_id: spec.plugin_id.clone(),
+        deno_path: spec.deno_path.clone(),
+        entrypoint: spec.entrypoint.clone(),
+        permissions: AGENT_PLUGIN_PERMISSIONS.map(str::to_string).to_vec(),
+        ready_timeout: PLUGIN_READY_TIMEOUT,
+        call_timeout: PLUGIN_CALL_TIMEOUT,
+        shutdown_timeout: PLUGIN_SHUTDOWN_TIMEOUT,
+    };
+    let (runtime, mut notifications) =
+        PluginRuntime::launch(&TokioProcessSpawner::new(), config).await?;
+    control::verify_agent_contract(&runtime.registration().await)?;
+    control::start_agent(&runtime, home_directory, host_version).await?;
+    inbound::discard_frames_before_start(&mut notifications, &spec.plugin_id);
+
+    Ok(LaunchedPluginAgent {
+        runtime,
+        messages: inbound::spawn_frame_forwarding(notifications, spec.plugin_id.clone()),
+    })
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/tests.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/tests.rs
@@ -1,0 +1,127 @@
+use std::collections::HashSet;
+
+use ora_plugin_runtime::{PluginNotification, PluginRegistration};
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+use super::control::{PluginAgentError, verify_agent_contract};
+use super::inbound::{discard_frames_before_start, spawn_frame_forwarding};
+
+/// Builds a registration that satisfies the whole agent contract.
+fn complete_registration() -> PluginRegistration {
+    PluginRegistration {
+        methods: HashSet::from([
+            "agent/start".to_string(),
+            "agent/stop".to_string(),
+            "agent/listModels".to_string(),
+        ]),
+        emits: HashSet::from(["agent/acp".to_string()]),
+    }
+}
+
+/// A plugin that declares the whole contract is accepted without further checks.
+#[test]
+fn accepts_a_complete_agent_contract() {
+    assert_eq!(verify_agent_contract(&complete_registration()), Ok(()));
+}
+
+/// Every missing control method is named at once so one restart surfaces the whole gap.
+#[test]
+fn rejects_a_registration_missing_control_methods() {
+    let mut registration = complete_registration();
+    registration.methods.remove("agent/stop");
+    registration.methods.remove("agent/listModels");
+
+    let error = verify_agent_contract(&registration).unwrap_err();
+
+    let PluginAgentError::ContractIncomplete(detail) = error else {
+        panic!("expected an incomplete contract");
+    };
+    assert_eq!(
+        detail.strip_prefix("missing methods ").map(|methods| {
+            let mut methods = methods.split(", ").collect::<Vec<_>>();
+            methods.sort_unstable();
+            methods
+        }),
+        Some(vec!["agent/listModels", "agent/stop"])
+    );
+}
+
+/// A plugin that cannot emit ACP frames can never serve a session, so it fails at handshake.
+#[test]
+fn rejects_a_registration_that_cannot_emit_acp() {
+    let mut registration = complete_registration();
+    registration.emits.clear();
+
+    assert_eq!(
+        verify_agent_contract(&registration),
+        Err(PluginAgentError::ContractIncomplete(
+            "missing emitted method agent/acp".to_string()
+        ))
+    );
+}
+
+/// Frames that arrived before the agent started belong to no connection and are dropped.
+#[tokio::test]
+async fn discards_frames_that_arrived_before_the_agent_started() {
+    let (sender, mut notifications) = mpsc::unbounded_channel();
+    for index in 0..3 {
+        sender
+            .send(PluginNotification {
+                method: "agent/acp".to_string(),
+                params: json!({ "id": index }),
+            })
+            .expect("queue early frame");
+    }
+
+    discard_frames_before_start(&mut notifications, "example.agent");
+    sender
+        .send(PluginNotification {
+            method: "agent/acp".to_string(),
+            params: json!({ "id": 99 }),
+        })
+        .expect("queue live frame");
+    let mut messages = spawn_frame_forwarding(notifications, "example.agent".to_string());
+
+    assert_eq!(
+        messages
+            .recv()
+            .await
+            .expect("receive frame")
+            .expect("frame is not a failure"),
+        json!({ "id": 99 })
+    );
+}
+
+/// Unusable single frames are dropped so one bad payload cannot end every live session.
+#[tokio::test]
+async fn drops_unusable_frames_without_failing_the_connection() {
+    let (sender, notifications) = mpsc::unbounded_channel();
+    for notification in [
+        PluginNotification {
+            method: "agent/modelsChanged".to_string(),
+            params: json!({}),
+        },
+        PluginNotification {
+            method: "agent/acp".to_string(),
+            params: json!("not an object"),
+        },
+        PluginNotification {
+            method: "agent/acp".to_string(),
+            params: json!({ "jsonrpc": "2.0", "method": "session/update" }),
+        },
+    ] {
+        sender.send(notification).expect("queue notification");
+    }
+    let mut messages = spawn_frame_forwarding(notifications, "example.agent".to_string());
+
+    assert_eq!(
+        messages
+            .recv()
+            .await
+            .expect("receive frame")
+            .expect("frame is not a failure"),
+        json!({ "jsonrpc": "2.0", "method": "session/update" })
+    );
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/transport.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/transport.rs
@@ -1,0 +1,55 @@
+use std::io;
+
+use ora_acp::{AcpError, AcpTransport, NdjsonTransport};
+use ora_plugin_runtime::PluginRuntime;
+use serde_json::Value;
+use tokio::process::ChildStdin;
+
+use super::control::AGENT_ACP_METHOD;
+
+/// Relays whole ACP messages to one agent plugin as `agent/acp` notifications.
+///
+/// The host never inspects the payload. A notification is used rather than a plugin method call
+/// because ACP already carries its own ids, cancellation, and ordering; layering the runtime's
+/// request correlation on top would mean two timeouts and two cancellation paths for one frame,
+/// and would bound multi-minute prompts by a control-call timeout.
+pub(crate) struct PluginAcpTransport {
+    runtime: PluginRuntime,
+}
+
+impl PluginAcpTransport {
+    pub(crate) fn new(runtime: PluginRuntime) -> Self {
+        Self { runtime }
+    }
+}
+
+impl AcpTransport for PluginAcpTransport {
+    async fn send(&self, message: Value) -> Result<(), AcpError> {
+        self.runtime
+            .notify(AGENT_ACP_METHOD, message)
+            .await
+            .map_err(|error| AcpError::Io(io::Error::other(error.to_string())))
+    }
+}
+
+/// Selects the transport that carries one connection's ACP traffic.
+///
+/// `RuntimeConnection` is published through a `watch` channel, so the transport cannot remain a
+/// generic parameter of the connection type. An enum keeps dispatch static and every match
+/// exhaustive, which a trait object would give up.
+///
+/// The `Stdio` variant exists only while Ora still launches agent CLIs itself; once every builtin
+/// CLI ships as a plugin, plugins are the sole transport and this enum collapses.
+pub(crate) enum AgentTransport {
+    Stdio(NdjsonTransport<ChildStdin>),
+    Plugin(PluginAcpTransport),
+}
+
+impl AcpTransport for AgentTransport {
+    async fn send(&self, message: Value) -> Result<(), AcpError> {
+        match self {
+            Self::Stdio(transport) => transport.send(message).await,
+            Self::Plugin(transport) => transport.send(message).await,
+        }
+    }
+}

--- a/crates/backend/src/agent_runtime/routing.rs
+++ b/crates/backend/src/agent_runtime/routing.rs
@@ -226,7 +226,7 @@ mod tests {
     use agent_client_protocol_schema::v1::SessionNotification;
     use agent_client_protocol_schema::v1::{SessionInfoUpdate, SessionUpdate};
     use agent_client_protocol_schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
-    use ora_acp::{AcpInboundEvent, AcpPeer, PermissionRequest};
+    use ora_acp::{AcpInboundEvent, AcpPeer, NdjsonTransport, PermissionRequest};
     use pretty_assertions::assert_eq;
     use serde_json::{Value, json};
     use std::sync::Arc;
@@ -270,7 +270,8 @@ mod tests {
         let (ora_reader, ora_writer) = split(ora_stream);
         let (agent_reader, mut agent_writer) = split(agent_stream);
         let mut agent_reader = BufReader::new(agent_reader);
-        let mut peer = AcpPeer::spawn(ora_reader, ora_writer);
+        let (transport, messages) = NdjsonTransport::spawn(ora_reader, ora_writer);
+        let mut peer = AcpPeer::spawn(messages, transport);
         let session_id = SessionId::new("session-1");
         let _pending = peer
             .client
@@ -444,7 +445,8 @@ mod tests {
         let (ora_reader, ora_writer) = split(ora_stream);
         let (agent_reader, mut agent_writer) = split(agent_stream);
         let mut agent_reader = BufReader::new(agent_reader);
-        let mut peer = AcpPeer::spawn(ora_reader, ora_writer);
+        let (transport, messages) = NdjsonTransport::spawn(ora_reader, ora_writer);
+        let mut peer = AcpPeer::spawn(messages, transport);
         let session_id = SessionId::new("session-1");
         let _pending = peer
             .client

--- a/crates/backend/src/agent_runtime/support.rs
+++ b/crates/backend/src/agent_runtime/support.rs
@@ -1,9 +1,9 @@
+use super::connection::AgentAcpClient;
 use crate::{BackendError, ErrorClassification};
 use agent_client_protocol_schema::v1::{
     PermissionOption, PermissionOptionId, PermissionOptionKind, RequestPermissionOutcome,
     RequestPermissionResponse, SelectedPermissionOutcome,
 };
-use ora_acp::AcpClient;
 use ora_contracts::{
     AgentCli as ContractAgentCli, RespondToPermissionRequest, RespondToPermissionResponse,
     Session as ContractSession, SessionHistoryState as ContractSessionHistoryState,
@@ -12,11 +12,10 @@ use ora_contracts::{
 use ora_contracts::{EmptyErrorParams, PublicError};
 use ora_domain::{AgentCli, HistoryState, Session, SessionStatus};
 use std::collections::HashMap;
-use tokio::process::ChildStdin;
 
 /// Responds to a pending permission after validating the public request ownership.
 pub(super) async fn respond_permission(
-    client: &AcpClient<ChildStdin>,
+    client: &AgentAcpClient,
     request: RespondToPermissionRequest,
     permissions: &mut HashMap<String, (agent_client_protocol_schema::v1::RequestId, Vec<String>)>,
 ) -> Result<RespondToPermissionResponse, BackendError> {

--- a/crates/backend/src/agent_runtime/warm.rs
+++ b/crates/backend/src/agent_runtime/warm.rs
@@ -168,7 +168,7 @@ impl WarmSessions {
         let gate = self.gate(&key);
         let _guard = gate.lock().await;
 
-        let supervisor = self.connections.for_agent(key.agent_cli);
+        let supervisor = self.connections.for_agent(key.agent_cli)?;
         let connection = supervisor.current()?;
         let now = self.clock.now_timestamp_millis();
         let (decision, released) =
@@ -314,7 +314,7 @@ impl WarmSessions {
             Reservation::NeedsRebuild => {}
         }
 
-        let connection = self.connections.for_agent(agent_cli).current()?;
+        let connection = self.connections.for_agent(agent_cli)?.current()?;
         let created = self.create(agent_cli, session_id, cwd).await?;
         let config_options = self
             .replay(
@@ -385,7 +385,7 @@ impl WarmSessions {
         let gate = self.gate(&key);
         let _guard = gate.lock().await;
 
-        let connection = self.connections.for_agent(key.agent_cli).current()?;
+        let connection = self.connections.for_agent(key.agent_cli)?.current()?;
         let now = self.clock.now_timestamp_millis();
         let (decision, released) =
             lock_pool(&self.pool).lookup_and_reserve(&key, cwd, connection.generation, now, || {
@@ -473,7 +473,11 @@ impl WarmSessions {
     async fn refresh_generations(&self) {
         let mut pool = lock_pool(&self.pool);
         for agent_cli in AgentCli::ALL {
-            if let Ok(connection) = self.connections.for_agent(agent_cli).current() {
+            if let Ok(connection) = self
+                .connections
+                .for_agent(agent_cli)
+                .and_then(|supervisor| supervisor.current())
+            {
                 pool.invalidate_generation(agent_cli, connection.generation);
             }
         }
@@ -512,7 +516,7 @@ impl WarmSessions {
         ora_session_id: &SessionId,
         cwd: &Path,
     ) -> Result<CreatedProvider, BackendError> {
-        let supervisor = self.connections.for_agent(agent_cli);
+        let supervisor = self.connections.for_agent(agent_cli)?;
         let connection = supervisor.current()?;
         let _setup = supervisor.begin_session_setup();
         let response = timeout(
@@ -589,7 +593,11 @@ impl WarmSessions {
         let Some(released) = released else {
             return;
         };
-        let Ok(connection) = self.connections.for_agent(released.agent_cli).current() else {
+        let Ok(connection) = self
+            .connections
+            .for_agent(released.agent_cli)
+            .and_then(|supervisor| supervisor.current())
+        else {
             return;
         };
         if connection.generation != released.generation {
@@ -639,7 +647,7 @@ pub(super) async fn request_config_option(
     config_id: &SessionConfigId,
     value: &SessionConfigOptionValue,
 ) -> Result<Vec<SessionConfigOption>, BackendError> {
-    let connection = connections.for_agent(agent_cli).current()?;
+    let connection = connections.for_agent(agent_cli)?.current()?;
     let response = timeout(
         SESSION_SETUP_TIMEOUT,
         connection

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -1,5 +1,7 @@
 use crate::agent::AgentApi;
-use crate::agent_runtime::{AgentRuntimeManager, SessionEventStream, SessionLocator};
+use crate::agent_runtime::{
+    AgentRuntimeManager, AgentRuntimeSetup, SessionEventStream, SessionLocator,
+};
 use crate::app_event::AppEventHub;
 use crate::clock::SystemClock;
 use crate::error::{BackendError, ErrorClassification};
@@ -23,6 +25,20 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use thiserror::Error;
+
+/// Describes one installed agent plugin the runtime should supervise.
+///
+/// Discovery and validation belong to the caller, which owns the plugin catalogue; the backend
+/// receives an already-resolved package so it never rediscovers or re-validates plugins itself.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentPluginPackage {
+    /// Plugin package id, which is also this agent's persisted identity.
+    pub id: String,
+    /// Deno executable used to run this plugin's process.
+    pub deno_path: PathBuf,
+    /// Absolute path to the plugin's JavaScript entrypoint.
+    pub entrypoint: PathBuf,
+}
 
 /// Names the persistent paths required to construct the shared backend.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -89,7 +105,13 @@ pub struct Backend {
 
 impl Backend {
     /// Opens persistent storage and constructs every shared CRUD API.
-    pub fn open(paths: BackendPaths) -> Result<Self, BackendBootstrapError> {
+    ///
+    /// `agent_plugins` joins the built-in CLIs as agent providers; supplying an empty list keeps
+    /// the runtime to built-in agents only.
+    pub fn open(
+        paths: BackendPaths,
+        agent_plugins: Vec<AgentPluginPackage>,
+    ) -> Result<Self, BackendBootstrapError> {
         ensure_directory(
             paths
                 .database_path
@@ -112,15 +134,16 @@ impl Backend {
         let sessions_root = paths.sessions_root;
         let relative_path_base = paths.relative_path_base;
         let agent_runtime = Arc::new(
-            AgentRuntimeManager::new(
-                pool.clone(),
-                paths.home_directory,
-                relative_path_base.clone(),
-                sessions_root.clone(),
+            AgentRuntimeManager::new(AgentRuntimeSetup {
+                agent_plugins,
+                pool: pool.clone(),
+                home_directory: paths.home_directory,
+                relative_path_base: relative_path_base.clone(),
+                sessions_root: sessions_root.clone(),
                 clock,
                 scheduler,
-                app_events.publisher(),
-            )
+                app_events: app_events.publisher(),
+            })
             .map_err(BackendBootstrapError::AgentRuntime)?,
         );
         // Crash recovery: fail orphaned node runs and running runs left by a previous process
@@ -665,6 +688,14 @@ impl Backend {
         Ok(self.agent_runtime.agent_runtime_status())
     }
 
+    /// Lists the models one agent advertises outside any session.
+    pub fn list_agent_models(
+        &self,
+        request: ListAgentModelsRequest,
+    ) -> Result<ListAgentModelsResponse, BackendError> {
+        self.agent_runtime.agent_models(request)
+    }
+
     /// Resolves one Ora session id to its private agent session identifier and worktree cwd.
     ///
     /// Backend-only: the returned `agent_session_id` is never exposed to the frontend. The
@@ -1054,16 +1085,19 @@ mod tests {
         let temporary = TempDir::new().expect("create temporary backend directory");
         let database_path = temporary.path().join("data").join("ora.sqlite3");
         let worktree_root = temporary.path().join("worktrees");
-        let backend = Backend::open(BackendPaths {
-            database_path: database_path.clone(),
-            worktree_root: worktree_root.clone(),
-            home_directory: temporary.path().to_path_buf(),
-            relative_path_base: temporary.path().to_path_buf(),
-            sessions_root: temporary.path().join("sessions"),
-            skills_root: temporary.path().join("atoms").join("skills"),
-            ripgrep_path: std::path::PathBuf::from("rg"),
-            timezone: chrono_tz::UTC,
-        })
+        let backend = Backend::open(
+            BackendPaths {
+                database_path: database_path.clone(),
+                worktree_root: worktree_root.clone(),
+                home_directory: temporary.path().to_path_buf(),
+                relative_path_base: temporary.path().to_path_buf(),
+                sessions_root: temporary.path().join("sessions"),
+                skills_root: temporary.path().join("atoms").join("skills"),
+                ripgrep_path: std::path::PathBuf::from("rg"),
+                timezone: chrono_tz::UTC,
+            },
+            Vec::new(),
+        )
         .expect("open shared backend");
 
         assert!(database_path.is_file());
@@ -1173,16 +1207,19 @@ mod tests {
     fn update_preserves_other_package_files() {
         let temporary = TempDir::new().expect("create temporary backend directory");
         let skills_root = temporary.path().join("atoms").join("skills");
-        let backend = Backend::open(BackendPaths {
-            database_path: temporary.path().join("ora.sqlite3"),
-            worktree_root: temporary.path().join("worktrees"),
-            home_directory: temporary.path().to_path_buf(),
-            relative_path_base: temporary.path().to_path_buf(),
-            sessions_root: temporary.path().join("sessions"),
-            skills_root: skills_root.clone(),
-            ripgrep_path: std::path::PathBuf::from("rg"),
-            timezone: chrono_tz::UTC,
-        })
+        let backend = Backend::open(
+            BackendPaths {
+                database_path: temporary.path().join("ora.sqlite3"),
+                worktree_root: temporary.path().join("worktrees"),
+                home_directory: temporary.path().to_path_buf(),
+                relative_path_base: temporary.path().to_path_buf(),
+                sessions_root: temporary.path().join("sessions"),
+                skills_root: skills_root.clone(),
+                ripgrep_path: std::path::PathBuf::from("rg"),
+                timezone: chrono_tz::UTC,
+            },
+            Vec::new(),
+        )
         .expect("open shared backend");
 
         let skill = backend
@@ -1221,16 +1258,19 @@ mod tests {
         let repository_root = temporary.path().join("repository");
         initialize_repository(&repository_root);
         let original_worktree_root = temporary.path().join("original-worktrees");
-        let backend = Backend::open(BackendPaths {
-            database_path: temporary.path().join("ora.sqlite3"),
-            worktree_root: original_worktree_root.clone(),
-            home_directory: temporary.path().to_path_buf(),
-            relative_path_base: temporary.path().to_path_buf(),
-            sessions_root: temporary.path().join("sessions"),
-            skills_root: temporary.path().join("atoms").join("skills"),
-            ripgrep_path: std::path::PathBuf::from("rg"),
-            timezone: chrono_tz::UTC,
-        })
+        let backend = Backend::open(
+            BackendPaths {
+                database_path: temporary.path().join("ora.sqlite3"),
+                worktree_root: original_worktree_root.clone(),
+                home_directory: temporary.path().to_path_buf(),
+                relative_path_base: temporary.path().to_path_buf(),
+                sessions_root: temporary.path().join("sessions"),
+                skills_root: temporary.path().join("atoms").join("skills"),
+                ripgrep_path: std::path::PathBuf::from("rg"),
+                timezone: chrono_tz::UTC,
+            },
+            Vec::new(),
+        )
         .expect("open shared backend");
         let project = backend
             .create_project(CreateProjectRequest {

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -23,7 +23,7 @@ mod workflow_run_prerequisites;
 
 pub use agent_runtime::{SessionEventStream, SessionLocator};
 pub use app_event::AppEventHub;
-pub use bootstrap::{Backend, BackendBootstrapError, BackendPaths};
+pub use bootstrap::{AgentPluginPackage, Backend, BackendBootstrapError, BackendPaths};
 pub use error::{BackendError, ErrorClassification};
 pub use request_lifecycle::{RequestIdGenerator, RequestLifecycle, UuidRequestIdGenerator};
 pub use skill_reconciliation::SkillStorageReconciliationError;

--- a/crates/backend/src/task_diff.rs
+++ b/crates/backend/src/task_diff.rs
@@ -386,16 +386,19 @@ mod tests {
 
     /// Opens one isolated backend whose worktrees stay inside the test fixture.
     fn open_backend(temporary: &TempDir) -> Backend {
-        Backend::open(BackendPaths {
-            database_path: temporary.path().join("ora.sqlite3"),
-            worktree_root: temporary.path().join("worktrees"),
-            home_directory: temporary.path().to_path_buf(),
-            relative_path_base: temporary.path().to_path_buf(),
-            sessions_root: temporary.path().join("sessions"),
-            skills_root: temporary.path().join("atoms").join("skills"),
-            ripgrep_path: std::path::PathBuf::from("rg"),
-            timezone: chrono_tz::UTC,
-        })
+        Backend::open(
+            BackendPaths {
+                database_path: temporary.path().join("ora.sqlite3"),
+                worktree_root: temporary.path().join("worktrees"),
+                home_directory: temporary.path().to_path_buf(),
+                relative_path_base: temporary.path().to_path_buf(),
+                sessions_root: temporary.path().join("sessions"),
+                skills_root: temporary.path().join("atoms").join("skills"),
+                ripgrep_path: std::path::PathBuf::from("rg"),
+                timezone: chrono_tz::UTC,
+            },
+            Vec::new(),
+        )
         .expect("open shared backend")
     }
 

--- a/crates/contracts/src/plugin.rs
+++ b/crates/contracts/src/plugin.rs
@@ -1,12 +1,13 @@
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-/// Describes one agent contribution from an installed plugin package.
+/// Describes the single agent contributed by an installed agent plugin package.
+///
+/// The agent carries no id: one package provides exactly one agent, identified by the package.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "plugin.ts")]
 pub struct InstalledPluginAgent {
-    pub id: String,
     pub display_name: String,
     pub contract_version: u32,
 }
@@ -22,7 +23,7 @@ pub struct InstalledPlugin {
     pub version: String,
     pub kind: String,
     pub main: String,
-    pub agents: Vec<InstalledPluginAgent>,
+    pub agent: InstalledPluginAgent,
 }
 
 /// Requests the immutable startup snapshot of installed plugin packages.
@@ -67,11 +68,10 @@ mod tests {
             version: "0.1.0".to_string(),
             kind: "agent".to_string(),
             main: "dist/index.js".to_string(),
-            agents: vec![InstalledPluginAgent {
-                id: "claude-code".to_string(),
+            agent: InstalledPluginAgent {
                 display_name: "Claude Code".to_string(),
                 contract_version: 1,
-            }],
+            },
         };
 
         assert_eq!(
@@ -91,11 +91,10 @@ mod tests {
                     "version": "0.1.0",
                     "kind": "agent",
                     "main": "dist/index.js",
-                    "agents": [{
-                        "id": "claude-code",
+                    "agent": {
                         "displayName": "Claude Code",
                         "contractVersion": 1
-                    }]
+                    }
                 }]
             })
         );

--- a/crates/contracts/src/session.rs
+++ b/crates/contracts/src/session.rs
@@ -36,6 +36,37 @@ pub struct AgentCliRuntimeStatus {
     pub status: AgentCliStatus,
 }
 
+/// Describes one model an agent offers before any session exists.
+///
+/// This is separate from the session config options an agent sends after `session/new`: the agent
+/// and model pickers must render before any session has been created. Agents that expose models
+/// only through session config options contribute nothing here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "session.ts")]
+pub struct AgentModel {
+    pub id: String,
+    pub display_name: String,
+    /// Whether the agent would select this model when the user expresses no preference.
+    pub default: bool,
+}
+
+/// Requests the pre-session model list of one application-scoped agent runtime.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "session.ts")]
+pub struct ListAgentModelsRequest {
+    pub agent_cli: AgentCli,
+}
+
+/// Returns the models one agent advertises outside any session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "session.ts")]
+pub struct ListAgentModelsResponse {
+    pub models: Vec<AgentModel>,
+}
+
 /// Requests the live detection status of every application-scoped CLI runtime.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -412,6 +443,9 @@ pub(crate) fn export(config: &ts_rs::Config) -> Result<(), ts_rs::ExportError> {
     AgentCli::export(config)?;
     AgentCliStatus::export(config)?;
     AgentCliRuntimeStatus::export(config)?;
+    AgentModel::export(config)?;
+    ListAgentModelsRequest::export(config)?;
+    ListAgentModelsResponse::export(config)?;
     GetAgentRuntimeStatusRequest::export(config)?;
     GetAgentRuntimeStatusResponse::export(config)?;
     SessionStatus::export(config)?;

--- a/crates/plugin-manager/README.md
+++ b/crates/plugin-manager/README.md
@@ -8,6 +8,8 @@
 - Read and validate each child package's `package.json`.
 - Resolve `ora.main` as an existing regular file whose canonical target remains inside its package,
   then retain its normalized portable relative path.
+- Pair `ora.kind` with the contribution that kind must declare, so a validated plugin always
+  carries exactly the contribution its kind promises.
 - Return a deterministic, immutable snapshot of valid installed plugins.
 - Isolate malformed or unsupported packages as structured discovery issues.
 
@@ -21,6 +23,11 @@
 ## Public interface
 
 Call `PluginManager::discover(data_dir)` once during application bootstrap. Consumers read the resulting snapshot through `installed_plugins()` and report any non-fatal problems from `discovery_issues()`.
+
+One agent-kind package contributes exactly one agent, declared under `ora.contributes.agent`. The
+agent has no identifier of its own: the package's `ora.id` is that agent's identity everywhere in
+the host, which is why `PluginContribution::Agent` carries only a display name and contract version.
+A package whose `ora.kind` is `agent` but which declares no agent fails validation.
 
 Discovery never follows symlinked package directories, never recurses below one package directory,
 and never reads more than 1 MiB from one manifest. Entrypoint containment rejects the current target

--- a/crates/plugin-manager/src/lib.rs
+++ b/crates/plugin-manager/src/lib.rs
@@ -10,7 +10,7 @@ mod tests;
 
 pub use issue::{PluginDiscoveryIssue, PluginDiscoveryIssueKind};
 pub use validation::{
-    InstalledPlugin, InstalledPluginAgent, PluginEngines, PluginKind, PluginPackageType,
+    InstalledPlugin, InstalledPluginAgent, PluginContribution, PluginEngines, PluginPackageType,
 };
 
 use std::path::Path;

--- a/crates/plugin-manager/src/manifest.rs
+++ b/crates/plugin-manager/src/manifest.rs
@@ -34,16 +34,21 @@ pub(crate) struct EngineManifest {
 }
 
 /// Mirrors contributions declared by one plugin package.
+///
+/// Every contribution is optional here because the required set depends on `ora.kind`; semantic
+/// validation resolves which one this package had to declare.
 #[derive(Debug, Deserialize)]
 pub(crate) struct ContributionManifest {
-    pub agents: Vec<AgentManifest>,
+    pub agent: Option<AgentManifest>,
 }
 
-/// Mirrors one contributed agent declaration.
+/// Mirrors the single agent an agent-kind package contributes.
+///
+/// The agent carries no id of its own: one package provides exactly one agent, whose identity is
+/// the package's `ora.id`.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AgentManifest {
-    pub id: String,
     pub display_name: String,
     pub contract_version: u32,
 }

--- a/crates/plugin-manager/src/tests.rs
+++ b/crates/plugin-manager/src/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    MAX_MANIFEST_BYTES, PluginDiscoveryIssueKind, PluginKind, PluginManager, PluginPackageType,
+    InstalledPluginAgent, MAX_MANIFEST_BYTES, PluginContribution, PluginDiscoveryIssueKind,
+    PluginManager, PluginPackageType,
 };
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
@@ -29,16 +30,18 @@ fn discovers_complete_manifest() {
     assert_eq!(plugin.manifest_version, 1);
     assert_eq!(plugin.id, "ora.claude-code");
     assert_eq!(plugin.display_name, "Claude Code");
-    assert_eq!(plugin.kind, PluginKind::Agent);
-    assert_eq!(plugin.kind.as_str(), "agent");
+    assert_eq!(plugin.contributes.kind(), "agent");
     assert_eq!(plugin.main, Path::new("dist/index.js"));
     assert_eq!(plugin.engines.ora, ">=0.1.0 <0.2.0");
     assert_eq!(plugin.engines.plugin_api, 1);
     assert_eq!(plugin.engines.bun, ">=1.0.0 <2.0.0");
-    assert_eq!(plugin.agents.len(), 1);
-    assert_eq!(plugin.agents[0].id, "claude-code");
-    assert_eq!(plugin.agents[0].display_name, "Claude Code");
-    assert_eq!(plugin.agents[0].contract_version, 1);
+    assert_eq!(
+        plugin.contributes,
+        PluginContribution::Agent(InstalledPluginAgent {
+            display_name: "Claude Code".to_string(),
+            contract_version: 1,
+        })
+    );
 }
 
 /// Verifies a missing plugin root represents an empty installation.
@@ -58,7 +61,6 @@ fn sorts_plugins_by_identifier_and_accepts_extended_metadata() {
     let temp_dir = TempDir::new().unwrap();
     let mut zeta = valid_manifest("ora.zeta", "工具箱", "1.2.3-alpha.1+build.7");
     zeta["description"] = json!("ignored npm metadata");
-    zeta["ora"]["contributes"]["agents"] = json!([]);
     write_manifest(temp_dir.path(), "created-first", zeta);
     write_manifest(
         temp_dir.path(),
@@ -81,7 +83,6 @@ fn sorts_plugins_by_identifier_and_accepts_extended_metadata() {
         manager.installed_plugins()[1].version.to_string(),
         "1.2.3-alpha.1+build.7"
     );
-    assert_eq!(manager.installed_plugins()[1].agents, &[]);
 }
 
 /// Verifies malformed packages are isolated while valid siblings remain visible.
@@ -226,9 +227,9 @@ fn rejects_unsupported_manifest_contract_values() {
             "ora.engines.pluginApi",
         ),
         (
-            vec!["ora", "contributes", "agents", "0", "contractVersion"],
+            vec!["ora", "contributes", "agent", "contractVersion"],
             json!(2),
-            "ora.contributes.agents[].contractVersion",
+            "ora.contributes.agent.contractVersion",
         ),
     ];
 
@@ -260,12 +261,8 @@ fn rejects_empty_required_strings() {
         (vec!["ora", "engines", "ora"], "ora.engines.ora"),
         (vec!["ora", "engines", "bun"], "ora.engines.bun"),
         (
-            vec!["ora", "contributes", "agents", "0", "id"],
-            "ora.contributes.agents[].id",
-        ),
-        (
-            vec!["ora", "contributes", "agents", "0", "displayName"],
-            "ora.contributes.agents[].displayName",
+            vec!["ora", "contributes", "agent", "displayName"],
+            "ora.contributes.agent.displayName",
         ),
     ];
 
@@ -384,21 +381,27 @@ fn rejects_entrypoint_symlink_escape() {
     assert_eq!(manager.discovery_issues()[0].field_path(), Some("ora.main"));
 }
 
-/// Verifies duplicate contribution and plugin identifiers are diagnosed deterministically.
+/// Verifies an agent package that declares no agent is rejected with a stable field path.
 #[test]
-fn rejects_duplicate_agent_and_plugin_ids() {
+fn rejects_agent_package_without_an_agent_contribution() {
     let temp_dir = TempDir::new().unwrap();
-    let duplicate_agent = json!({
-        "id": "claude-code",
-        "displayName": "Claude Code Copy",
-        "contractVersion": 1
-    });
-    let mut manifest = valid_manifest("ora.agents", "Agents", "1.0.0");
-    manifest["ora"]["contributes"]["agents"]
-        .as_array_mut()
-        .unwrap()
-        .push(duplicate_agent);
-    write_manifest(temp_dir.path(), "00-duplicate-agent", manifest);
+    let mut manifest = valid_manifest("ora.agentless", "Agentless", "1.0.0");
+    manifest["ora"]["contributes"] = json!({});
+    write_manifest(temp_dir.path(), "agentless", manifest);
+
+    let manager = PluginManager::discover(temp_dir.path());
+
+    assert_eq!(manager.installed_plugins(), &[]);
+    assert_eq!(
+        manager.discovery_issues()[0].field_path(),
+        Some("ora.contributes.agent")
+    );
+}
+
+/// Verifies duplicate plugin identifiers are diagnosed deterministically.
+#[test]
+fn rejects_duplicate_plugin_ids() {
+    let temp_dir = TempDir::new().unwrap();
     write_manifest(
         temp_dir.path(),
         "01-first-plugin",
@@ -420,10 +423,7 @@ fn rejects_duplicate_agent_and_plugin_ids() {
             .iter()
             .map(|issue| issue.kind())
             .collect::<Vec<_>>(),
-        vec![
-            PluginDiscoveryIssueKind::InvalidManifest,
-            PluginDiscoveryIssueKind::DuplicatePluginId,
-        ]
+        vec![PluginDiscoveryIssueKind::DuplicatePluginId]
     );
 }
 
@@ -495,11 +495,10 @@ fn valid_manifest(id: &str, display_name: &str, version: &str) -> Value {
                 "bun": ">=1.0.0 <2.0.0"
             },
             "contributes": {
-                "agents": [{
-                    "id": "claude-code",
+                "agent": {
                     "displayName": "Claude Code",
                     "contractVersion": 1
-                }]
+                }
             }
         }
     })

--- a/crates/plugin-manager/src/validation.rs
+++ b/crates/plugin-manager/src/validation.rs
@@ -1,7 +1,6 @@
 use crate::manifest::{AgentManifest, PackageManifest};
 use ora_utils::path::{CanonicalPathRoot, PortableRelativePath};
 use semver::Version;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -15,17 +14,21 @@ pub enum PluginPackageType {
     Module,
 }
 
-/// Identifies the supported contribution family of an installed plugin.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PluginKind {
-    Agent,
+/// Holds the validated contribution of one installed plugin.
+///
+/// `ora.kind` selects the variant, and each variant carries everything that kind must declare.
+/// Keeping the kind and its contribution in one value is what makes an agent package without an
+/// agent declaration unrepresentable rather than a case every consumer has to re-check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginContribution {
+    Agent(InstalledPluginAgent),
 }
 
-impl PluginKind {
-    /// Returns the package manifest spelling used on the frontend wire contract.
-    pub fn as_str(self) -> &'static str {
+impl PluginContribution {
+    /// Returns the `ora.kind` spelling used on the frontend wire contract.
+    pub fn kind(&self) -> &'static str {
         match self {
-            Self::Agent => "agent",
+            Self::Agent(_) => "agent",
         }
     }
 }
@@ -38,10 +41,12 @@ pub struct PluginEngines {
     pub bun: String,
 }
 
-/// Holds one validated agent contribution.
+/// Holds the single validated agent contributed by one agent-kind package.
+///
+/// The agent has no identifier of its own: one package provides exactly one agent, so the
+/// package's `ora.id` is that agent's identity everywhere in the host.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstalledPluginAgent {
-    pub id: String,
     pub display_name: String,
     pub contract_version: u32,
 }
@@ -56,10 +61,9 @@ pub struct InstalledPlugin {
     pub manifest_version: u32,
     pub id: String,
     pub display_name: String,
-    pub kind: PluginKind,
     pub main: PathBuf,
     pub engines: PluginEngines,
-    pub agents: Vec<InstalledPluginAgent>,
+    pub contributes: PluginContribution,
 }
 
 /// Reports a semantic manifest constraint after structural deserialization succeeds.
@@ -103,15 +107,7 @@ pub(crate) fn validate(
     }
     require_non_empty("ora.id", &manifest.ora.id)?;
     require_non_empty("ora.displayName", &manifest.ora.display_name)?;
-    let kind = match manifest.ora.kind.as_str() {
-        "agent" => PluginKind::Agent,
-        value => {
-            return Err(invalid(
-                "ora.kind",
-                format!("unsupported plugin kind `{value}`; expected `agent`"),
-            ));
-        }
-    };
+    let contributes = validate_contribution(&manifest.ora.kind, manifest.ora.contributes.agent)?;
     let main = validate_main_path(package_root, &manifest.ora.main)?;
     require_non_empty("ora.engines.ora", &manifest.ora.engines.ora)?;
     if manifest.ora.engines.plugin_api != SUPPORTED_PLUGIN_API_VERSION {
@@ -125,8 +121,6 @@ pub(crate) fn validate(
     }
     require_non_empty("ora.engines.bun", &manifest.ora.engines.bun)?;
 
-    let agents = validate_agents(manifest.ora.contributes.agents)?;
-
     Ok(InstalledPlugin {
         package_root: package_root.to_path_buf(),
         package_name: manifest.name,
@@ -135,14 +129,13 @@ pub(crate) fn validate(
         manifest_version: manifest.ora.manifest_version,
         id: manifest.ora.id,
         display_name: manifest.ora.display_name,
-        kind,
         main,
         engines: PluginEngines {
             ora: manifest.ora.engines.ora,
             plugin_api: manifest.ora.engines.plugin_api,
             bun: manifest.ora.engines.bun,
         },
-        agents,
+        contributes,
     })
 }
 
@@ -194,40 +187,39 @@ fn validate_main_path(
     Ok(main.to_path_buf())
 }
 
-/// Validates agent contract versions and uniqueness inside one package.
-fn validate_agents(
-    agents: Vec<AgentManifest>,
-) -> Result<Vec<InstalledPluginAgent>, ManifestValidationError> {
-    let mut seen_ids = HashSet::new();
-    let mut installed = Vec::with_capacity(agents.len());
-
-    for agent in agents {
-        require_non_empty("ora.contributes.agents[].id", &agent.id)?;
-        require_non_empty("ora.contributes.agents[].displayName", &agent.display_name)?;
-        if agent.contract_version != SUPPORTED_AGENT_CONTRACT_VERSION {
-            return Err(invalid(
-                "ora.contributes.agents[].contractVersion",
-                format!(
-                    "unsupported agent contract version {}; expected {SUPPORTED_AGENT_CONTRACT_VERSION}",
-                    agent.contract_version
-                ),
-            ));
+/// Pairs the declared kind with the contribution that kind is required to carry.
+fn validate_contribution(
+    kind: &str,
+    agent: Option<AgentManifest>,
+) -> Result<PluginContribution, ManifestValidationError> {
+    match kind {
+        "agent" => {
+            let agent = agent.ok_or_else(|| {
+                invalid(
+                    "ora.contributes.agent",
+                    "an agent plugin must contribute one agent",
+                )
+            })?;
+            require_non_empty("ora.contributes.agent.displayName", &agent.display_name)?;
+            if agent.contract_version != SUPPORTED_AGENT_CONTRACT_VERSION {
+                return Err(invalid(
+                    "ora.contributes.agent.contractVersion",
+                    format!(
+                        "unsupported agent contract version {}; expected {SUPPORTED_AGENT_CONTRACT_VERSION}",
+                        agent.contract_version
+                    ),
+                ));
+            }
+            Ok(PluginContribution::Agent(InstalledPluginAgent {
+                display_name: agent.display_name,
+                contract_version: agent.contract_version,
+            }))
         }
-        if !seen_ids.insert(agent.id.clone()) {
-            return Err(invalid(
-                "ora.contributes.agents[].id",
-                format!("duplicate agent id `{}`", agent.id),
-            ));
-        }
-
-        installed.push(InstalledPluginAgent {
-            id: agent.id,
-            display_name: agent.display_name,
-            contract_version: agent.contract_version,
-        });
+        value => Err(invalid(
+            "ora.kind",
+            format!("unsupported plugin kind `{value}`; expected `agent`"),
+        )),
     }
-
-    Ok(installed)
 }
 
 /// Rejects required strings that contain only whitespace while preserving valid values verbatim.

--- a/crates/plugin-runtime/README.md
+++ b/crates/plugin-runtime/README.md
@@ -2,14 +2,55 @@
 
 `ora-plugin-runtime` owns the lifecycle and stdio protocol for sandboxed Ora plugin
 processes. It launches a configured JavaScript entrypoint with Deno, waits for the
-plugin's immutable method registration, correlates concurrent JSON-RPC calls, drains
-plugin logs from stderr, and shuts down the complete child process tree.
+plugin's immutable capability registration, correlates concurrent JSON-RPC calls,
+carries notifications in both directions, drains plugin logs from stderr, and shuts
+down the complete child process tree.
 
 The crate does not discover, install, select, or configure plugins. Callers supply a
-plugin identifier, an entrypoint, a Deno executable, and the exact method to invoke.
-Application-level code remains responsible for mapping Ora capabilities to those
-plugin methods.
+plugin identifier, an entrypoint, a Deno executable, the permission flags the plugin
+was granted, and the exact method to invoke. Application-level code remains
+responsible for mapping Ora capabilities to those plugin methods.
+
+## Protocol
 
 Stdout is reserved for framed protocol messages. Each frame contains a four-byte
 big-endian length, a one-byte frame type, and a UTF-8 JSON payload. Protocol failures
 invalidate the process because the host can no longer safely correlate responses.
+
+A plugin declares both traffic directions once, in its `ora/register` notification:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "ora/register",
+  "params": { "methods": ["agent/start"], "emits": ["agent/acp"] },
+}
+```
+
+- `methods` lists what the host may `invoke`. Invoking anything else fails locally
+  without reaching the plugin.
+- `emits` lists what the plugin may send on its own initiative. Notifications outside
+  the whitelist, and any plugin message carrying a JSON-RPC id, invalidate the
+  connection: a plugin whose behaviour exceeds its declaration cannot be trusted to
+  correlate correctly.
+
+Both fields are fixed for the life of the process; a second registration is a protocol
+error.
+
+## Traffic shapes
+
+| Direction     | Shape                     | Correlation        | Bounded by     |
+| ------------- | ------------------------- | ------------------ | -------------- |
+| Host → plugin | `invoke` request/response | runtime request id | `call_timeout` |
+| Host → plugin | `notify` notification     | none               | nothing        |
+| Plugin → host | whitelisted notification  | none               | nothing        |
+
+`call_timeout` deliberately covers `invoke` only. Notifications carry payloads whose
+own protocol owns correlation and cancellation — ACP traffic streams for minutes, which
+a control-call timeout would sever. Plugin-originated notifications arrive on the
+unbounded receiver returned by `launch`; connection-wide backpressure would let one
+noisy stream stall unrelated traffic, so bounded queues belong to each consumer.
+
+Reverse request/response — a plugin calling into the host — is intentionally absent.
+No current plugin contract needs it, and the pending-request table stays single-purpose
+until one does.

--- a/crates/plugin-runtime/src/lib.rs
+++ b/crates/plugin-runtime/src/lib.rs
@@ -1,24 +1,30 @@
-mod codec;
+//! Owns the lifecycle and bidirectional stdio protocol of one sandboxed Ora plugin process.
 
-use std::collections::{HashMap, HashSet};
+mod codec;
+mod protocol;
+mod state;
+mod tasks;
+
+#[cfg(test)]
+mod tests;
+
+pub use protocol::{PluginNotification, PluginRegistration};
+
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use ora_logging::{ora_error, ora_info, ora_warn};
+use ora_logging::ora_info;
 use ora_process::{ManagedProcess, ProcessSpawner, ProcessSpec};
 use serde_json::{Value, json};
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::sync::{Mutex, RwLock, mpsc, oneshot, watch};
 use tokio::time::timeout;
 
-use crate::codec::{read_frame, write_frame};
-
-const JSON_RPC_VERSION: &str = "2.0";
-const REGISTER_METHOD: &str = "ora/register";
-const SHUTDOWN_METHOD: &str = "ora/shutdown";
+use crate::protocol::{JSON_RPC_VERSION, SHUTDOWN_METHOD};
+use crate::state::{RuntimeInner, RuntimeStatus, SupervisorCommand};
 
 /// Describes one eagerly started Deno plugin process and its lifecycle timeouts.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,6 +32,8 @@ pub struct PluginRuntimeConfig {
     pub plugin_id: String,
     pub deno_path: PathBuf,
     pub entrypoint: PathBuf,
+    /// Extra Deno permission flags placed before the entrypoint, such as `--allow-run`.
+    pub permissions: Vec<String>,
     pub ready_timeout: Duration,
     pub call_timeout: Duration,
     pub shutdown_timeout: Duration,
@@ -54,27 +62,7 @@ pub enum PluginRuntimeError {
     Remote { code: i64, message: String },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum RuntimeStatus {
-    Starting,
-    Ready,
-    Failed(String),
-    ShuttingDown,
-}
-
-type PendingResult = Result<Value, PluginRuntimeError>;
-
-struct RuntimeInner {
-    plugin_id: String,
-    methods: RwLock<HashSet<String>>,
-    status_tx: watch::Sender<RuntimeStatus>,
-    writer_tx: mpsc::Sender<Value>,
-    supervisor_tx: mpsc::UnboundedSender<SupervisorCommand>,
-    pending: Mutex<HashMap<u64, oneshot::Sender<PendingResult>>>,
-    next_request_id: AtomicU64,
-    call_timeout: Duration,
-}
-
+/// Ends the plugin process once the last clone of its public handle is dropped.
 struct RuntimeLease {
     writer_tx: mpsc::Sender<Value>,
     supervisor_tx: mpsc::UnboundedSender<SupervisorCommand>,
@@ -98,11 +86,15 @@ pub struct PluginRuntime {
 }
 
 impl PluginRuntime {
-    /// Launches one plugin and waits until it publishes its immutable method registration.
+    /// Launches one plugin and waits until it publishes its immutable capability registration.
+    ///
+    /// The returned receiver carries every whitelisted plugin-originated notification. It is
+    /// unbounded on purpose: connection-wide backpressure would let one noisy stream stall
+    /// unrelated traffic on the same process, so bounded queues belong to each consumer instead.
     pub async fn launch<P>(
         spawner: &P,
         config: PluginRuntimeConfig,
-    ) -> Result<Self, PluginRuntimeError>
+    ) -> Result<(Self, mpsc::UnboundedReceiver<PluginNotification>), PluginRuntimeError>
     where
         P: ProcessSpawner,
         P::Process: Send + 'static,
@@ -114,6 +106,7 @@ impl PluginRuntime {
         let spec = ProcessSpec::new(config.deno_path.as_os_str())
             .arg("run")
             .arg("--no-prompt")
+            .args(config.permissions.iter().map(String::as_str))
             .arg(config.entrypoint.as_os_str());
         let mut process = spawner
             .spawn(spec)
@@ -131,13 +124,15 @@ impl PluginRuntime {
         let (writer_tx, writer_rx) = mpsc::channel(64);
         let (writer_close_tx, writer_close_rx) = oneshot::channel();
         let (supervisor_tx, supervisor_rx) = mpsc::unbounded_channel();
+        let (inbound_tx, inbound_rx) = mpsc::unbounded_channel();
         let (status_tx, mut status_rx) = watch::channel(RuntimeStatus::Starting);
         let inner = Arc::new(RuntimeInner {
             plugin_id: config.plugin_id.clone(),
-            methods: RwLock::new(HashSet::new()),
+            registration: RwLock::new(PluginRegistration::default()),
             status_tx,
             writer_tx: writer_tx.clone(),
             supervisor_tx: supervisor_tx.clone(),
+            inbound: inbound_tx,
             pending: Mutex::new(HashMap::new()),
             next_request_id: AtomicU64::new(1),
             call_timeout: config.call_timeout,
@@ -150,15 +145,15 @@ impl PluginRuntime {
             }),
         };
 
-        tokio::spawn(run_writer(
+        tokio::spawn(tasks::run_writer(
             stdin,
             writer_rx,
             writer_close_rx,
             Arc::clone(&inner),
         ));
-        tokio::spawn(run_reader(stdout, Arc::clone(&inner)));
-        tokio::spawn(run_stderr(stderr, config.plugin_id.clone()));
-        tokio::spawn(run_supervisor(
+        tokio::spawn(tasks::run_reader(stdout, Arc::clone(&inner)));
+        tokio::spawn(tasks::run_stderr(stderr, config.plugin_id.clone()));
+        tokio::spawn(tasks::run_supervisor(
             process,
             supervisor_rx,
             Arc::clone(&inner),
@@ -199,28 +194,25 @@ impl PluginRuntime {
             message = "plugin runtime ready",
             plugin_id = %config.plugin_id,
         );
-        Ok(runtime)
+        Ok((runtime, inbound_rx))
+    }
+
+    /// Returns the capability declaration published by the plugin, fixed once the plugin is ready.
+    pub async fn registration(&self) -> PluginRegistration {
+        self.inner.registration.read().await.clone()
     }
 
     /// Invokes one registered method and returns its JSON result.
     pub async fn invoke(&self, method: &str, params: Value) -> Result<Value, PluginRuntimeError> {
-        match self.inner.status_tx.borrow().clone() {
-            RuntimeStatus::Ready => {}
-            RuntimeStatus::Starting => {
-                return Err(PluginRuntimeError::Unavailable(
-                    "plugin is still starting".to_string(),
-                ));
-            }
-            RuntimeStatus::Failed(reason) => {
-                return Err(PluginRuntimeError::Unavailable(reason));
-            }
-            RuntimeStatus::ShuttingDown => {
-                return Err(PluginRuntimeError::Unavailable(
-                    "plugin is shutting down".to_string(),
-                ));
-            }
-        }
-        if !self.inner.methods.read().await.contains(method) {
+        self.ensure_ready()?;
+        if !self
+            .inner
+            .registration
+            .read()
+            .await
+            .methods
+            .contains(method)
+        {
             return Err(PluginRuntimeError::MethodNotRegistered(method.to_string()));
         }
 
@@ -254,344 +246,54 @@ impl PluginRuntime {
         }
     }
 
+    /// Sends one host-originated notification the plugin never answers.
+    ///
+    /// Notifications occupy no correlation slot and are therefore outside `call_timeout`, which
+    /// exists to bound short control calls. Payloads that stream for minutes, such as ACP
+    /// traffic, depend on that distinction.
+    pub async fn notify(&self, method: &str, params: Value) -> Result<(), PluginRuntimeError> {
+        self.ensure_ready()?;
+        let notification = json!({
+            "jsonrpc": JSON_RPC_VERSION,
+            "method": method,
+            "params": params,
+        });
+        self.inner
+            .writer_tx
+            .send(notification)
+            .await
+            .map_err(|_| PluginRuntimeError::RequestChannelClosed)
+    }
+
+    /// Rejects traffic whenever the connection is not serving, carrying why it stopped serving.
+    fn ensure_ready(&self) -> Result<(), PluginRuntimeError> {
+        match self.inner.status_tx.borrow().clone() {
+            RuntimeStatus::Ready => Ok(()),
+            RuntimeStatus::Starting => Err(PluginRuntimeError::Unavailable(
+                "plugin is still starting".to_string(),
+            )),
+            RuntimeStatus::Failed(reason) => Err(PluginRuntimeError::Unavailable(reason)),
+            RuntimeStatus::ShuttingDown => Err(PluginRuntimeError::Unavailable(
+                "plugin is shutting down".to_string(),
+            )),
+        }
+    }
+
+    /// Ends the plugin process without waiting for the last handle clone to be dropped.
+    ///
+    /// Handles are cloned into long-lived callers, so drop alone cannot bound teardown: one
+    /// surviving clone would keep a failed plugin running. Callers that own a plugin's lifetime
+    /// therefore end it explicitly, and the supervisor still kills the process tree if the plugin
+    /// does not exit within its shutdown timeout.
+    pub fn shutdown(&self) {
+        self.request_shutdown();
+    }
+
     fn request_shutdown(&self) {
         let _ = self.inner.writer_tx.try_send(json!({
             "jsonrpc": JSON_RPC_VERSION,
             "method": SHUTDOWN_METHOD,
         }));
         let _ = self.inner.supervisor_tx.send(SupervisorCommand::Shutdown);
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum SupervisorCommand {
-    Shutdown,
-    ProtocolFailure,
-}
-
-/// Serializes all outbound frames through one task so concurrent callers cannot interleave bytes.
-async fn run_writer<W>(
-    mut stdin: W,
-    mut messages: mpsc::Receiver<Value>,
-    mut close: oneshot::Receiver<()>,
-    inner: Arc<RuntimeInner>,
-) where
-    W: tokio::io::AsyncWrite + Unpin,
-{
-    loop {
-        let message = tokio::select! {
-            message = messages.recv() => match message {
-                Some(message) => message,
-                None => return,
-            },
-            _ = &mut close => return,
-        };
-        let payload = match serde_json::to_vec(&message) {
-            Ok(payload) => payload,
-            Err(error) => {
-                fail_runtime(&inner, format!("failed to encode plugin request: {error}")).await;
-                return;
-            }
-        };
-        if let Err(error) = write_frame(&mut stdin, &payload).await {
-            fail_runtime(&inner, format!("failed to write plugin frame: {error}")).await;
-            return;
-        }
-    }
-}
-
-/// Reads plugin registration and responses from the stdout protocol stream.
-async fn run_reader<R>(mut stdout: R, inner: Arc<RuntimeInner>)
-where
-    R: AsyncRead + Unpin,
-{
-    loop {
-        let payload = match read_frame(&mut stdout).await {
-            Ok(Some(payload)) => payload,
-            Ok(None) => {
-                fail_runtime(&inner, "plugin stdout closed".to_string()).await;
-                return;
-            }
-            Err(error) => {
-                fail_runtime(&inner, format!("invalid plugin frame: {error}")).await;
-                return;
-            }
-        };
-        let message: Value = match serde_json::from_slice(&payload) {
-            Ok(message) => message,
-            Err(error) => {
-                fail_runtime(&inner, format!("invalid plugin JSON: {error}")).await;
-                return;
-            }
-        };
-        if let Err(reason) = handle_message(&inner, message).await {
-            fail_runtime(&inner, reason).await;
-            return;
-        }
-    }
-}
-
-/// Applies one validated registration or response message to runtime state.
-async fn handle_message(inner: &RuntimeInner, message: Value) -> Result<(), String> {
-    let object = message
-        .as_object()
-        .ok_or_else(|| "plugin message must be a JSON object".to_string())?;
-    if object.get("jsonrpc").and_then(Value::as_str) != Some(JSON_RPC_VERSION) {
-        return Err("plugin message has an invalid JSON-RPC version".to_string());
-    }
-
-    if object.get("method").and_then(Value::as_str) == Some(REGISTER_METHOD) {
-        if object.contains_key("id") {
-            return Err("plugin registration must be a notification".to_string());
-        }
-        if !matches!(*inner.status_tx.borrow(), RuntimeStatus::Starting) {
-            return Err("plugin registered methods more than once".to_string());
-        }
-        let methods = object
-            .get("params")
-            .and_then(|params| params.get("methods"))
-            .and_then(Value::as_array)
-            .ok_or_else(|| "plugin registration is missing a methods array".to_string())?;
-        let mut registered = HashSet::with_capacity(methods.len());
-        for method in methods {
-            let method = method
-                .as_str()
-                .filter(|method| !method.is_empty())
-                .ok_or_else(|| "plugin registration contains an invalid method".to_string())?;
-            if !registered.insert(method.to_string()) {
-                return Err(format!("plugin registered duplicate method {method}"));
-            }
-        }
-        *inner.methods.write().await = registered;
-        inner.status_tx.send_replace(RuntimeStatus::Ready);
-        return Ok(());
-    }
-
-    if object.contains_key("method") {
-        return Err("plugin sent an unsupported notification or request".to_string());
-    }
-
-    let request_id = object
-        .get("id")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| "plugin response has an invalid request ID".to_string())?;
-    let result = match (object.get("result"), object.get("error")) {
-        (Some(result), None) => Ok(result.clone()),
-        (None, Some(error)) => {
-            let code = error
-                .get("code")
-                .and_then(Value::as_i64)
-                .ok_or_else(|| "plugin error response has an invalid code".to_string())?;
-            let message = error
-                .get("message")
-                .and_then(Value::as_str)
-                .ok_or_else(|| "plugin error response has an invalid message".to_string())?;
-            Err(PluginRuntimeError::Remote {
-                code,
-                message: message.to_string(),
-            })
-        }
-        _ => return Err("plugin response must contain exactly one result or error".to_string()),
-    };
-    let sender = inner
-        .pending
-        .lock()
-        .await
-        .remove(&request_id)
-        .ok_or_else(|| format!("plugin responded with unknown request ID {request_id}"))?;
-    let _ = sender.send(result);
-    Ok(())
-}
-
-/// Drains plugin stderr continuously so logging cannot block the child process.
-async fn run_stderr<R>(mut stderr: R, plugin_id: String)
-where
-    R: AsyncRead + Unpin,
-{
-    let mut buffer = [0_u8; 8 * 1024];
-    loop {
-        match stderr.read(&mut buffer).await {
-            Ok(0) => return,
-            Ok(length) => {
-                let message = String::from_utf8_lossy(&buffer[..length]);
-                ora_info!(
-                    message = "plugin stderr",
-                    plugin_id = %plugin_id,
-                    output = %message.trim_end(),
-                );
-            }
-            Err(error) => {
-                ora_warn!(
-                    message = "failed to read plugin stderr",
-                    plugin_id = %plugin_id,
-                    error = %error,
-                );
-                return;
-            }
-        }
-    }
-}
-
-/// Supervises process exit and guarantees a bounded graceful shutdown.
-async fn run_supervisor<P>(
-    process: P,
-    mut commands: mpsc::UnboundedReceiver<SupervisorCommand>,
-    inner: Arc<RuntimeInner>,
-    shutdown_timeout: Duration,
-    writer_close: oneshot::Sender<()>,
-) where
-    P: ManagedProcess + Send + 'static,
-{
-    tokio::select! {
-        status = process.wait() => {
-            let reason = match status {
-                Ok(status) => format!("plugin process exited with {status}"),
-                Err(error) => format!("failed to wait for plugin process: {error}"),
-            };
-            fail_pending(&inner, PluginRuntimeError::Unavailable(reason.clone())).await;
-            if !matches!(*inner.status_tx.borrow(), RuntimeStatus::ShuttingDown) {
-                inner.status_tx.send_replace(RuntimeStatus::Failed(reason));
-            }
-        }
-        command = commands.recv() => {
-            inner.status_tx.send_replace(RuntimeStatus::ShuttingDown);
-            if matches!(command, Some(SupervisorCommand::Shutdown))
-                && timeout(shutdown_timeout, process.wait()).await.is_ok()
-            {
-                let _ = writer_close.send(());
-                return;
-            }
-            if let Err(error) = process.kill().await {
-                ora_error!(
-                    message = "failed to terminate plugin process tree",
-                    plugin_id = %inner.plugin_id,
-                    error = %error,
-                );
-            }
-            let _ = process.wait().await;
-        }
-    }
-    let _ = writer_close.send(());
-}
-
-/// Marks a protocol connection unusable and wakes every waiting caller.
-async fn fail_runtime(inner: &RuntimeInner, reason: String) {
-    inner
-        .status_tx
-        .send_replace(RuntimeStatus::Failed(reason.clone()));
-    fail_pending(inner, PluginRuntimeError::Unavailable(reason)).await;
-    let _ = inner.supervisor_tx.send(SupervisorCommand::ProtocolFailure);
-}
-
-/// Completes all pending requests with the same terminal runtime failure.
-async fn fail_pending(inner: &RuntimeInner, error: PluginRuntimeError) {
-    let pending = std::mem::take(&mut *inner.pending.lock().await);
-    for sender in pending.into_values() {
-        let _ = sender.send(Err(error.clone()));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{RuntimeInner, RuntimeStatus, handle_message, run_writer};
-    use pretty_assertions::assert_eq;
-    use serde_json::json;
-    use std::collections::{HashMap, HashSet};
-    use std::sync::atomic::AtomicU64;
-    use std::time::Duration;
-    use tokio::io::duplex;
-    use tokio::sync::{Mutex, RwLock, mpsc, oneshot, watch};
-    use tokio::time::timeout;
-
-    fn test_inner() -> RuntimeInner {
-        let (status_tx, _) = watch::channel(RuntimeStatus::Starting);
-        let (writer_tx, _) = mpsc::channel(1);
-        let (supervisor_tx, _) = mpsc::unbounded_channel();
-        RuntimeInner {
-            plugin_id: "example".to_string(),
-            methods: RwLock::new(HashSet::new()),
-            status_tx,
-            writer_tx,
-            supervisor_tx,
-            pending: Mutex::new(HashMap::new()),
-            next_request_id: AtomicU64::new(1),
-            call_timeout: Duration::from_secs(5),
-        }
-    }
-
-    /// Registration atomically publishes the complete immutable method set.
-    #[tokio::test]
-    async fn accepts_initial_registration() {
-        let inner = test_inner();
-
-        handle_message(
-            &inner,
-            json!({
-                "jsonrpc": "2.0",
-                "method": "ora/register",
-                "params": { "methods": ["example.echo"] },
-            }),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            inner.methods.read().await.clone(),
-            HashSet::from(["example.echo".to_string()])
-        );
-        assert_eq!(*inner.status_tx.borrow(), RuntimeStatus::Ready);
-    }
-
-    /// Duplicate method names invalidate registration rather than selecting one handler.
-    #[tokio::test]
-    async fn rejects_duplicate_registration() {
-        let inner = test_inner();
-
-        let error = handle_message(
-            &inner,
-            json!({
-                "jsonrpc": "2.0",
-                "method": "ora/register",
-                "params": { "methods": ["example.echo", "example.echo"] },
-            }),
-        )
-        .await
-        .unwrap_err();
-
-        assert_eq!(error, "plugin registered duplicate method example.echo");
-    }
-
-    /// A response resolves only the pending caller with the matching numeric ID.
-    #[tokio::test]
-    async fn routes_response_by_request_id() {
-        let inner = test_inner();
-        let (sender, receiver) = oneshot::channel();
-        inner.pending.lock().await.insert(7, sender);
-
-        handle_message(
-            &inner,
-            json!({ "jsonrpc": "2.0", "id": 7, "result": "cba" }),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(receiver.await.unwrap().unwrap(), json!("cba"));
-    }
-
-    /// Lets the supervisor end an idle writer task after the child process exits.
-    #[tokio::test]
-    async fn closes_idle_writer_on_supervisor_signal() {
-        let inner = std::sync::Arc::new(test_inner());
-        let (stdin, _host_reader) = duplex(64);
-        let (_messages, message_rx) = mpsc::channel(1);
-        let (close_tx, close_rx) = oneshot::channel();
-        let writer = tokio::spawn(run_writer(stdin, message_rx, close_rx, inner));
-
-        close_tx.send(()).unwrap();
-
-        timeout(Duration::from_secs(1), writer)
-            .await
-            .unwrap()
-            .unwrap();
     }
 }

--- a/crates/plugin-runtime/src/protocol.rs
+++ b/crates/plugin-runtime/src/protocol.rs
@@ -1,0 +1,148 @@
+use std::collections::HashSet;
+
+use serde_json::Value;
+
+use crate::PluginRuntimeError;
+use crate::state::{RuntimeInner, RuntimeStatus};
+
+pub(crate) const JSON_RPC_VERSION: &str = "2.0";
+pub(crate) const REGISTER_METHOD: &str = "ora/register";
+pub(crate) const SHUTDOWN_METHOD: &str = "ora/shutdown";
+
+/// Holds the immutable capability declaration one plugin publishes during its handshake.
+///
+/// The two sets are deliberately separate because they describe opposite directions: `methods`
+/// is what the host may invoke, `emits` is what the plugin may send unprompted. A method missing
+/// from the matching set is a protocol violation rather than a silently ignored message, so a
+/// plugin whose behaviour exceeds its declaration is rejected at the earliest possible moment.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PluginRegistration {
+    pub methods: HashSet<String>,
+    pub emits: HashSet<String>,
+}
+
+/// Carries one plugin-originated notification that passed the `emits` whitelist.
+///
+/// Notifications never carry a JSON-RPC id: the host does not answer them, and any correlation
+/// they need belongs to the payload's own protocol (ACP frames carry their own ids).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginNotification {
+    pub method: String,
+    pub params: Value,
+}
+
+/// Applies one validated registration, notification, or response message to runtime state.
+///
+/// Returning `Err` means the connection can no longer be trusted and the caller must invalidate
+/// the whole process; per-message recovery is intentionally absent because a host that guessed
+/// at a malformed frame could silently mis-correlate every later response.
+pub(crate) async fn handle_message(inner: &RuntimeInner, message: Value) -> Result<(), String> {
+    let object = message
+        .as_object()
+        .ok_or_else(|| "plugin message must be a JSON object".to_string())?;
+    if object.get("jsonrpc").and_then(Value::as_str) != Some(JSON_RPC_VERSION) {
+        return Err("plugin message has an invalid JSON-RPC version".to_string());
+    }
+
+    if let Some(method) = object.get("method").and_then(Value::as_str) {
+        return handle_plugin_originated(inner, object, method).await;
+    }
+
+    let request_id = object
+        .get("id")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| "plugin response has an invalid request ID".to_string())?;
+    let result = match (object.get("result"), object.get("error")) {
+        (Some(result), None) => Ok(result.clone()),
+        (None, Some(error)) => {
+            let code = error
+                .get("code")
+                .and_then(Value::as_i64)
+                .ok_or_else(|| "plugin error response has an invalid code".to_string())?;
+            let message = error
+                .get("message")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "plugin error response has an invalid message".to_string())?;
+            Err(PluginRuntimeError::Remote {
+                code,
+                message: message.to_string(),
+            })
+        }
+        _ => return Err("plugin response must contain exactly one result or error".to_string()),
+    };
+    let sender = inner
+        .pending
+        .lock()
+        .await
+        .remove(&request_id)
+        .ok_or_else(|| format!("plugin responded with unknown request ID {request_id}"))?;
+    let _ = sender.send(result);
+    Ok(())
+}
+
+/// Splits registration from whitelisted notifications and rejects everything else.
+async fn handle_plugin_originated(
+    inner: &RuntimeInner,
+    object: &serde_json::Map<String, Value>,
+    method: &str,
+) -> Result<(), String> {
+    if object.contains_key("id") {
+        return Err(format!(
+            "plugin sent request {method}; plugins may only send notifications"
+        ));
+    }
+
+    if method == REGISTER_METHOD {
+        if !matches!(*inner.status_tx.borrow(), RuntimeStatus::Starting) {
+            return Err("plugin registered methods more than once".to_string());
+        }
+        let params = object.get("params");
+        let registration = PluginRegistration {
+            methods: parse_method_list(params, "methods")?
+                .ok_or_else(|| "plugin registration is missing a methods array".to_string())?,
+            emits: parse_method_list(params, "emits")?.unwrap_or_default(),
+        };
+        *inner.registration.write().await = registration;
+        inner.status_tx.send_replace(RuntimeStatus::Ready);
+        return Ok(());
+    }
+
+    if !inner.registration.read().await.emits.contains(method) {
+        return Err(format!(
+            "plugin sent notification {method} without declaring it in emits"
+        ));
+    }
+    // A closed inbound receiver means the host stopped consuming this plugin's stream; that is a
+    // host-side lifecycle decision, so dropping the notification must not fail the connection.
+    let _ = inner.inbound.send(PluginNotification {
+        method: method.to_string(),
+        params: object.get("params").cloned().unwrap_or(Value::Null),
+    });
+    Ok(())
+}
+
+/// Reads one optional registration array into a duplicate-free method set.
+fn parse_method_list(
+    params: Option<&Value>,
+    field: &str,
+) -> Result<Option<HashSet<String>>, String> {
+    let Some(value) = params.and_then(|params| params.get(field)) else {
+        return Ok(None);
+    };
+    let entries = value
+        .as_array()
+        .ok_or_else(|| format!("plugin registration field {field} must be an array"))?;
+    let mut parsed = HashSet::with_capacity(entries.len());
+    for entry in entries {
+        let entry = entry
+            .as_str()
+            .filter(|entry| !entry.is_empty())
+            .ok_or_else(|| {
+                format!("plugin registration field {field} contains an invalid entry")
+            })?;
+        if !parsed.insert(entry.to_string()) {
+            return Err(format!("plugin registered duplicate {field} entry {entry}"));
+        }
+    }
+    Ok(Some(parsed))
+}

--- a/crates/plugin-runtime/src/state.rs
+++ b/crates/plugin-runtime/src/state.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::sync::{Mutex, RwLock, mpsc, oneshot, watch};
+
+use crate::PluginRuntimeError;
+use crate::protocol::{PluginNotification, PluginRegistration};
+
+pub(crate) type PendingResult = Result<Value, PluginRuntimeError>;
+
+/// Tracks the single lifecycle a plugin connection can be in at any moment.
+///
+/// `Failed` and `ShuttingDown` are distinct because only the latter is expected: it suppresses
+/// the restart and error reporting that an unexpected failure must trigger.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuntimeStatus {
+    Starting,
+    Ready,
+    Failed(String),
+    ShuttingDown,
+}
+
+/// Commands the process supervisor accepts from the protocol tasks and the public handle.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SupervisorCommand {
+    Shutdown,
+    ProtocolFailure,
+}
+
+/// Holds the state every protocol task shares for one launched plugin process.
+pub(crate) struct RuntimeInner {
+    pub plugin_id: String,
+    pub registration: RwLock<PluginRegistration>,
+    pub status_tx: watch::Sender<RuntimeStatus>,
+    pub writer_tx: mpsc::Sender<Value>,
+    pub supervisor_tx: mpsc::UnboundedSender<SupervisorCommand>,
+    pub inbound: mpsc::UnboundedSender<PluginNotification>,
+    pub pending: Mutex<HashMap<u64, oneshot::Sender<PendingResult>>>,
+    pub next_request_id: AtomicU64,
+    pub call_timeout: Duration,
+}
+
+/// Marks a protocol connection unusable and wakes every waiting caller.
+pub(crate) async fn fail_runtime(inner: &Arc<RuntimeInner>, reason: String) {
+    inner
+        .status_tx
+        .send_replace(RuntimeStatus::Failed(reason.clone()));
+    fail_pending(inner, PluginRuntimeError::Unavailable(reason)).await;
+    let _ = inner.supervisor_tx.send(SupervisorCommand::ProtocolFailure);
+}
+
+/// Completes all pending requests with the same terminal runtime failure.
+pub(crate) async fn fail_pending(inner: &RuntimeInner, error: PluginRuntimeError) {
+    let pending = std::mem::take(&mut *inner.pending.lock().await);
+    for sender in pending.into_values() {
+        let _ = sender.send(Err(error.clone()));
+    }
+}

--- a/crates/plugin-runtime/src/tasks.rs
+++ b/crates/plugin-runtime/src/tasks.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use ora_logging::{ora_error, ora_info, ora_warn};
+use ora_process::ManagedProcess;
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::timeout;
+
+use crate::PluginRuntimeError;
+use crate::codec::{read_frame, write_frame};
+use crate::protocol::handle_message;
+use crate::state::{RuntimeInner, RuntimeStatus, SupervisorCommand, fail_pending, fail_runtime};
+
+/// Serializes all outbound frames through one task so concurrent callers cannot interleave bytes.
+pub(crate) async fn run_writer<W>(
+    mut stdin: W,
+    mut messages: mpsc::Receiver<Value>,
+    mut close: oneshot::Receiver<()>,
+    inner: Arc<RuntimeInner>,
+) where
+    W: AsyncWrite + Unpin,
+{
+    loop {
+        let message = tokio::select! {
+            message = messages.recv() => match message {
+                Some(message) => message,
+                None => return,
+            },
+            _ = &mut close => return,
+        };
+        let payload = match serde_json::to_vec(&message) {
+            Ok(payload) => payload,
+            Err(error) => {
+                fail_runtime(&inner, format!("failed to encode plugin request: {error}")).await;
+                return;
+            }
+        };
+        if let Err(error) = write_frame(&mut stdin, &payload).await {
+            fail_runtime(&inner, format!("failed to write plugin frame: {error}")).await;
+            return;
+        }
+    }
+}
+
+/// Reads plugin registration, notifications, and responses from the stdout protocol stream.
+pub(crate) async fn run_reader<R>(mut stdout: R, inner: Arc<RuntimeInner>)
+where
+    R: AsyncRead + Unpin,
+{
+    loop {
+        let payload = match read_frame(&mut stdout).await {
+            Ok(Some(payload)) => payload,
+            Ok(None) => {
+                fail_runtime(&inner, "plugin stdout closed".to_string()).await;
+                return;
+            }
+            Err(error) => {
+                fail_runtime(&inner, format!("invalid plugin frame: {error}")).await;
+                return;
+            }
+        };
+        let message: Value = match serde_json::from_slice(&payload) {
+            Ok(message) => message,
+            Err(error) => {
+                fail_runtime(&inner, format!("invalid plugin JSON: {error}")).await;
+                return;
+            }
+        };
+        if let Err(reason) = handle_message(&inner, message).await {
+            fail_runtime(&inner, reason).await;
+            return;
+        }
+    }
+}
+
+/// Drains plugin stderr continuously so logging cannot block the child process.
+pub(crate) async fn run_stderr<R>(mut stderr: R, plugin_id: String)
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        match stderr.read(&mut buffer).await {
+            Ok(0) => return,
+            Ok(length) => {
+                let message = String::from_utf8_lossy(&buffer[..length]);
+                ora_info!(
+                    message = "plugin stderr",
+                    plugin_id = %plugin_id,
+                    output = %message.trim_end(),
+                );
+            }
+            Err(error) => {
+                ora_warn!(
+                    message = "failed to read plugin stderr",
+                    plugin_id = %plugin_id,
+                    error = %error,
+                );
+                return;
+            }
+        }
+    }
+}
+
+/// Supervises process exit and guarantees a bounded graceful shutdown.
+pub(crate) async fn run_supervisor<P>(
+    process: P,
+    mut commands: mpsc::UnboundedReceiver<SupervisorCommand>,
+    inner: Arc<RuntimeInner>,
+    shutdown_timeout: Duration,
+    writer_close: oneshot::Sender<()>,
+) where
+    P: ManagedProcess + Send + 'static,
+{
+    tokio::select! {
+        status = process.wait() => {
+            let reason = match status {
+                Ok(status) => format!("plugin process exited with {status}"),
+                Err(error) => format!("failed to wait for plugin process: {error}"),
+            };
+            fail_pending(&inner, PluginRuntimeError::Unavailable(reason.clone())).await;
+            if !matches!(*inner.status_tx.borrow(), RuntimeStatus::ShuttingDown) {
+                inner.status_tx.send_replace(RuntimeStatus::Failed(reason));
+            }
+        }
+        command = commands.recv() => {
+            inner.status_tx.send_replace(RuntimeStatus::ShuttingDown);
+            if matches!(command, Some(SupervisorCommand::Shutdown))
+                && timeout(shutdown_timeout, process.wait()).await.is_ok()
+            {
+                let _ = writer_close.send(());
+                return;
+            }
+            if let Err(error) = process.kill().await {
+                ora_error!(
+                    message = "failed to terminate plugin process tree",
+                    plugin_id = %inner.plugin_id,
+                    error = %error,
+                );
+            }
+            let _ = process.wait().await;
+        }
+    }
+    let _ = writer_close.send(());
+}

--- a/crates/plugin-runtime/src/tests.rs
+++ b/crates/plugin-runtime/src/tests.rs
@@ -1,0 +1,252 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::time::Duration;
+
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use tokio::io::duplex;
+use tokio::sync::{Mutex, RwLock, mpsc, oneshot, watch};
+use tokio::time::timeout;
+
+use crate::protocol::{PluginNotification, PluginRegistration, handle_message};
+use crate::state::{RuntimeInner, RuntimeStatus};
+use crate::tasks::run_writer;
+
+/// Builds one isolated protocol state whose inbound notifications the caller can observe.
+fn test_inner() -> (RuntimeInner, mpsc::UnboundedReceiver<PluginNotification>) {
+    let (status_tx, _) = watch::channel(RuntimeStatus::Starting);
+    let (writer_tx, _) = mpsc::channel(1);
+    let (supervisor_tx, _) = mpsc::unbounded_channel();
+    let (inbound, inbound_rx) = mpsc::unbounded_channel();
+    let inner = RuntimeInner {
+        plugin_id: "example".to_string(),
+        registration: RwLock::new(PluginRegistration::default()),
+        status_tx,
+        writer_tx,
+        supervisor_tx,
+        inbound,
+        pending: Mutex::new(HashMap::new()),
+        next_request_id: AtomicU64::new(1),
+        call_timeout: Duration::from_secs(5),
+    };
+    (inner, inbound_rx)
+}
+
+/// Registers a plugin that may both serve `method` and emit `emit`.
+async fn register(inner: &RuntimeInner, method: &str, emit: &str) {
+    handle_message(
+        inner,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "ora/register",
+            "params": { "methods": [method], "emits": [emit] },
+        }),
+    )
+    .await
+    .expect("register plugin");
+}
+
+/// Registration atomically publishes both directions of the immutable capability declaration.
+#[tokio::test]
+async fn accepts_initial_registration() {
+    let (inner, _inbound) = test_inner();
+
+    handle_message(
+        &inner,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "ora/register",
+            "params": { "methods": ["example.echo"], "emits": ["example.tick"] },
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        inner.registration.read().await.clone(),
+        PluginRegistration {
+            methods: HashSet::from(["example.echo".to_string()]),
+            emits: HashSet::from(["example.tick".to_string()]),
+        }
+    );
+    assert_eq!(*inner.status_tx.borrow(), RuntimeStatus::Ready);
+}
+
+/// A plugin that never emits stays valid, so `emits` is optional rather than required.
+#[tokio::test]
+async fn defaults_missing_emits_to_an_empty_whitelist() {
+    let (inner, _inbound) = test_inner();
+
+    handle_message(
+        &inner,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "ora/register",
+            "params": { "methods": ["example.echo"] },
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        inner.registration.read().await.clone(),
+        PluginRegistration {
+            methods: HashSet::from(["example.echo".to_string()]),
+            emits: HashSet::new(),
+        }
+    );
+}
+
+/// Duplicate method names invalidate registration rather than selecting one handler.
+#[tokio::test]
+async fn rejects_duplicate_registration() {
+    let (inner, _inbound) = test_inner();
+
+    let error = handle_message(
+        &inner,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "ora/register",
+            "params": { "methods": ["example.echo", "example.echo"] },
+        }),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        "plugin registered duplicate methods entry example.echo"
+    );
+}
+
+/// A whitelisted notification reaches the host stream with its payload untouched.
+#[tokio::test]
+async fn delivers_declared_notifications_to_the_inbound_stream() {
+    let (inner, mut inbound) = test_inner();
+    register(&inner, "example.echo", "example.tick").await;
+
+    handle_message(
+        &inner,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "example.tick",
+            "params": { "nested": [1, 2, 3] },
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        inbound.recv().await.unwrap(),
+        PluginNotification {
+            method: "example.tick".to_string(),
+            params: json!({ "nested": [1, 2, 3] }),
+        }
+    );
+}
+
+/// A notification outside the declared whitelist invalidates the connection.
+#[tokio::test]
+async fn rejects_undeclared_notifications() {
+    let (inner, _inbound) = test_inner();
+    register(&inner, "example.echo", "example.tick").await;
+
+    let error = handle_message(
+        &inner,
+        json!({ "jsonrpc": "2.0", "method": "example.other" }),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        "plugin sent notification example.other without declaring it in emits"
+    );
+}
+
+/// Plugins may not open reverse request/response traffic even for a whitelisted method.
+#[tokio::test]
+async fn rejects_plugin_originated_requests() {
+    let (inner, _inbound) = test_inner();
+    register(&inner, "example.echo", "example.tick").await;
+
+    let error = handle_message(
+        &inner,
+        json!({ "jsonrpc": "2.0", "id": 3, "method": "example.tick" }),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        "plugin sent request example.tick; plugins may only send notifications"
+    );
+}
+
+/// A response resolves only the pending caller with the matching numeric ID.
+#[tokio::test]
+async fn routes_response_by_request_id() {
+    let (inner, _inbound) = test_inner();
+    let (sender, receiver) = oneshot::channel();
+    inner.pending.lock().await.insert(7, sender);
+
+    handle_message(
+        &inner,
+        json!({ "jsonrpc": "2.0", "id": 7, "result": "cba" }),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(receiver.await.unwrap().unwrap(), json!("cba"));
+}
+
+/// Notifications interleaved with a response leave correlation state untouched.
+#[tokio::test]
+async fn keeps_correlation_intact_when_notifications_interleave() {
+    let (inner, mut inbound) = test_inner();
+    register(&inner, "example.echo", "example.tick").await;
+    let (sender, receiver) = oneshot::channel();
+    inner.pending.lock().await.insert(9, sender);
+
+    for message in [
+        json!({ "jsonrpc": "2.0", "method": "example.tick", "params": 1 }),
+        json!({ "jsonrpc": "2.0", "id": 9, "result": "done" }),
+        json!({ "jsonrpc": "2.0", "method": "example.tick", "params": 2 }),
+    ] {
+        handle_message(&inner, message).await.unwrap();
+    }
+
+    assert_eq!(receiver.await.unwrap().unwrap(), json!("done"));
+    assert!(inner.pending.lock().await.is_empty());
+    assert_eq!(
+        (inbound.recv().await.unwrap(), inbound.recv().await.unwrap()),
+        (
+            PluginNotification {
+                method: "example.tick".to_string(),
+                params: json!(1),
+            },
+            PluginNotification {
+                method: "example.tick".to_string(),
+                params: json!(2),
+            }
+        )
+    );
+}
+
+/// Lets the supervisor end an idle writer task after the child process exits.
+#[tokio::test]
+async fn closes_idle_writer_on_supervisor_signal() {
+    let (inner, _inbound) = test_inner();
+    let (stdin, _host_reader) = duplex(64);
+    let (_messages, message_rx) = mpsc::channel(1);
+    let (close_tx, close_rx) = oneshot::channel();
+    let writer = tokio::spawn(run_writer(stdin, message_rx, close_rx, Arc::new(inner)));
+
+    close_tx.send(()).unwrap();
+
+    timeout(Duration::from_secs(1), writer)
+        .await
+        .unwrap()
+        .unwrap();
+}

--- a/packages/app-shell/src/features/settings/filter-discovered-plugins.ts
+++ b/packages/app-shell/src/features/settings/filter-discovered-plugins.ts
@@ -12,7 +12,7 @@ export function filterDiscoveredPlugins(
       plugin.displayName,
       plugin.packageName,
       plugin.id,
-      ...plugin.agents.map((agent) => agent.displayName),
+      plugin.agent.displayName,
     ].some((value) => value.toLowerCase().includes(needle)),
   );
 }

--- a/packages/app-shell/src/features/settings/plugin-manager.test.ts
+++ b/packages/app-shell/src/features/settings/plugin-manager.test.ts
@@ -10,9 +10,7 @@ const plugins: InstalledPlugin[] = [
     version: "0.1.0",
     kind: "agent",
     main: "dist/index.js",
-    agents: [
-      { id: "reviewer", displayName: "Review Agent", contractVersion: 1 },
-    ],
+    agent: { displayName: "Review Agent", contractVersion: 1 },
   },
   {
     id: "ora.planner",
@@ -21,7 +19,7 @@ const plugins: InstalledPlugin[] = [
     version: "0.2.0",
     kind: "agent",
     main: "dist/index.js",
-    agents: [{ id: "planner", displayName: "Plan Agent", contractVersion: 1 }],
+    agent: { displayName: "Plan Agent", contractVersion: 1 },
   },
 ];
 

--- a/packages/app-shell/src/state/hooks/use-installed-plugins.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-installed-plugins.test.tsx
@@ -18,7 +18,7 @@ describe("useInstalledPlugins", () => {
       version: "0.1.0",
       kind: "agent",
       main: "dist/index.js",
-      agents: [],
+      agent: { displayName: "Reviewer", contractVersion: 1 },
     });
     const { result, queryClient } = renderHookWithClient(
       () => useInstalledPlugins(),

--- a/packages/contracts/src/plugin.ts
+++ b/packages/contracts/src/plugin.ts
@@ -10,14 +10,15 @@ export type InstalledPlugin = {
   version: string;
   kind: string;
   main: string;
-  agents: Array<InstalledPluginAgent>;
+  agent: InstalledPluginAgent;
 };
 
 /**
- * Describes one agent contribution from an installed plugin package.
+ * Describes the single agent contributed by an installed agent plugin package.
+ *
+ * The agent carries no id: one package provides exactly one agent, identified by the package.
  */
 export type InstalledPluginAgent = {
-  id: string;
   displayName: string;
   contractVersion: number;
 };

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -24,6 +24,22 @@ export type AgentCliRuntimeStatus = {
 export type AgentCliStatus = "ready" | "starting" | "unavailable";
 
 /**
+ * Describes one model an agent offers before any session exists.
+ *
+ * This is separate from the session config options an agent sends after `session/new`: the agent
+ * and model pickers must render before any session has been created. Agents that expose models
+ * only through session config options contribute nothing here.
+ */
+export type AgentModel = {
+  id: string;
+  displayName: string;
+  /**
+   * Whether the agent would select this model when the user expresses no preference.
+   */
+  default: boolean;
+};
+
+/**
  * Binds one warm session to its owning Task and persists the Ora record.
  */
 export type AttachSessionRequest = { sessionId: string; taskId: string };
@@ -67,6 +83,16 @@ export type GetSessionRequest = { sessionId: string };
  * Returns one session payload after a successful fetch.
  */
 export type GetSessionResponse = { session: Session };
+
+/**
+ * Requests the pre-session model list of one application-scoped agent runtime.
+ */
+export type ListAgentModelsRequest = { agentCli: AgentCli };
+
+/**
+ * Returns the models one agent advertises outside any session.
+ */
+export type ListAgentModelsResponse = { models: Array<AgentModel> };
 
 /**
  * Requests the full visible session list.

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -27,6 +27,47 @@ When the default Deno transport starts, the SDK redirects all `console` methods
 to stderr so normal plugin diagnostics cannot corrupt stdout. Plugins receive no
 Deno permissions unless the Ora host grants them when launching the process.
 
-`run()` sends a single `ora/register` notification, serves requests until it
+`run()` sends a single `ora/register` notification, serves host traffic until it
 receives `ora/shutdown` or stdin closes, then waits for current handlers to
 settle before returning.
+
+## Notifications
+
+Registration declares both directions. `registerMethod` lists what Ora may call;
+`declareEmit` lists what the plugin may send unprompted. Ora rejects any
+plugin-sent method outside that whitelist and terminates the process, so an
+undeclared `notify()` is a defect rather than a dropped message. `onNotification`
+handles host-sent notifications, which never produce a response; an unhandled one
+is logged rather than treated as fatal.
+
+Throw `PluginMethodError` from a handler to control the JSON-RPC error code Ora
+sees; a plain `Error` becomes `-32603`.
+
+## Agent plugins
+
+`defineAgent` builds a plugin that serves Ora's agent contract — `agent/start`,
+`agent/stop`, `agent/listModels`, and the `agent/acp` notification in both
+directions. Ora validates that whole contract when the handshake completes and
+refuses a plugin whose declaration is incomplete, so the helper registers all of
+it up front.
+
+```ts
+import { AGENT_NOT_INSTALLED, defineAgent, PluginMethodError } from "@ora-space/plugin-sdk";
+
+let send;
+const plugin = defineAgent({
+  start: (context, sender) => {
+    send = sender; // spawn the agent CLI here and own its lifetime
+  },
+  stop: () => {/* terminate the CLI this plugin spawned */},
+  listModels: () => [{ id: "opus", displayName: "Opus", default: true }],
+  onAcp: (frame) => {/* forward the frame to the CLI */},
+});
+await plugin.run();
+```
+
+The plugin spawns and owns its agent process. Ora never touches that process's
+stdio; it only sees `agent/acp` frames, whose payloads it passes through without
+parsing. Throw `new PluginMethodError(AGENT_NOT_INSTALLED, ...)` from `start`
+when the CLI is absent — Ora treats that as expected local configuration and
+retries quietly instead of reporting a fault.

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "format": "deno fmt src tests deno.json package.json README.md",
     "format:check": "deno fmt --check src tests deno.json package.json README.md",
-    "lint": "deno lint src tests && deno check src/mod.ts tests/plugin.test.ts",
+    "lint": "deno lint src tests && deno check src/mod.ts tests/plugin.test.ts tests/agent.test.ts",
     "test": "deno test tests"
   },
   "publishConfig": {

--- a/packages/plugin-sdk/src/agent.ts
+++ b/packages/plugin-sdk/src/agent.ts
@@ -1,0 +1,97 @@
+import { createPlugin, type Plugin, PluginMethodError } from "./plugin.ts";
+import type { JsonValue } from "./protocol.ts";
+
+const AGENT_START = "agent/start";
+const AGENT_STOP = "agent/stop";
+const AGENT_LIST_MODELS = "agent/listModels";
+const AGENT_ACP = "agent/acp";
+
+/**
+ * The error code that tells Ora the agent CLI is absent from this machine.
+ *
+ * Ora treats it as an expected local configuration: the connection retries quietly instead of
+ * reporting a fault, so use it only when the agent genuinely is not installed.
+ */
+export const AGENT_NOT_INSTALLED = -32001;
+
+/** Describes one model the agent offers before any session exists. */
+export interface AgentModel {
+  id: string;
+  displayName: string;
+  default?: boolean;
+}
+
+/** Carries the host context handed to an agent when it starts. */
+export interface AgentStartContext {
+  /** Neutral working directory the agent should start in. */
+  cwd: string;
+  /** Version of the Ora host that launched this plugin. */
+  hostVersion: string;
+}
+
+/** Sends one ACP frame from the agent back to the host. */
+export type AcpSender = (frame: JsonValue) => Promise<void>;
+
+/** Implements the agent contract Ora requires of every `kind: "agent"` plugin. */
+export interface AgentDefinition {
+  /**
+   * Brings the agent up so it can receive ACP frames.
+   *
+   * Throw `new PluginMethodError(AGENT_NOT_INSTALLED, ...)` when the underlying CLI is missing.
+   */
+  start(context: AgentStartContext, send: AcpSender): void | Promise<void>;
+  /** Terminates the agent while leaving this plugin process alive. */
+  stop(): void | Promise<void>;
+  /** Lists selectable models outside any session. */
+  listModels(): AgentModel[] | Promise<AgentModel[]>;
+  /** Receives one ACP frame the host is forwarding to the agent. */
+  onAcp(frame: JsonValue): void | Promise<void>;
+}
+
+/**
+ * Builds a plugin that serves Ora's agent contract.
+ *
+ * The whole contract is registered up front — the three control methods plus the `agent/acp`
+ * notification in both directions — because Ora validates it the moment the handshake completes
+ * and refuses to use a plugin whose declaration is incomplete.
+ */
+export function defineAgent(definition: AgentDefinition): Plugin {
+  const plugin = createPlugin();
+  const send: AcpSender = (frame) => plugin.notify(AGENT_ACP, frame);
+
+  plugin.declareEmit(AGENT_ACP);
+  plugin.registerMethod(AGENT_START, async (input) => {
+    await definition.start(parseStartContext(input), send);
+    // ACP is the only protocol Ora carries today; the field exists so a plugin that translates a
+    // private protocol can declare it later without changing the notification channel.
+    return { protocol: "acp", acpVersion: 1 };
+  });
+  plugin.registerMethod(AGENT_STOP, async () => {
+    await definition.stop();
+    return {};
+  });
+  plugin.registerMethod(AGENT_LIST_MODELS, async () => ({
+    models: (await definition.listModels()).map((model) => ({
+      id: model.id,
+      displayName: model.displayName,
+      default: model.default ?? false,
+    })),
+  }));
+  plugin.onNotification(AGENT_ACP, (params) => definition.onAcp(params));
+
+  return plugin;
+}
+
+/** Validates the host's start parameters before the agent implementation sees them. */
+function parseStartContext(input: JsonValue): AgentStartContext {
+  if (
+    typeof input !== "object" || input === null || Array.isArray(input) ||
+    typeof input.cwd !== "string" || typeof input.hostVersion !== "string"
+  ) {
+    throw new PluginMethodError(
+      -32602,
+      "agent/start requires a cwd and hostVersion",
+    );
+  }
+  return { cwd: input.cwd, hostVersion: input.hostVersion };
+}

--- a/packages/plugin-sdk/src/mod.ts
+++ b/packages/plugin-sdk/src/mod.ts
@@ -1,2 +1,16 @@
-export { createPlugin, type MethodHandler, Plugin } from "./plugin.ts";
+export {
+  AGENT_NOT_INSTALLED,
+  type AcpSender,
+  type AgentDefinition,
+  type AgentModel,
+  type AgentStartContext,
+  defineAgent,
+} from "./agent.ts";
+export {
+  createPlugin,
+  type MethodHandler,
+  type NotificationHandler,
+  Plugin,
+  PluginMethodError,
+} from "./plugin.ts";
 export type { JsonValue } from "./protocol.ts";

--- a/packages/plugin-sdk/src/plugin.ts
+++ b/packages/plugin-sdk/src/plugin.ts
@@ -13,18 +13,23 @@ export type MethodHandler = (
   input: JsonValue,
 ) => JsonValue | Promise<JsonValue>;
 
+export type NotificationHandler = (
+  params: JsonValue,
+) => void | Promise<void>;
+
 type PluginState = "registering" | "running" | "stopped";
 
-/** Stores a plugin's immutable method registry and serves host requests. */
+/** Stores a plugin's immutable capability registry and serves host traffic. */
 export class Plugin {
   readonly #methods = new Map<string, MethodHandler>();
+  readonly #emits = new Set<string>();
+  readonly #notificationHandlers = new Map<string, NotificationHandler>();
   #state: PluginState = "registering";
+  #writer: FrameWriter | undefined;
 
   /** Registers one uniquely named method before the plugin starts serving. */
   registerMethod(name: string, handler: MethodHandler): void {
-    if (this.#state !== "registering") {
-      throw new Error("Plugin methods cannot be registered after run() starts");
-    }
+    this.#assertRegistering();
     if (name.length === 0) {
       throw new Error("Plugin method names cannot be empty");
     }
@@ -34,7 +39,47 @@ export class Plugin {
     this.#methods.set(name, handler);
   }
 
-  /** Announces the method registry and serves requests until shutdown or EOF. */
+  /**
+   * Declares one method this plugin may send to the host unprompted.
+   *
+   * The declaration is part of the same immutable registration as `registerMethod`, so the host
+   * knows the plugin's whole behaviour before it serves anything.
+   */
+  declareEmit(name: string): void {
+    this.#assertRegistering();
+    if (name.length === 0) {
+      throw new Error("Emitted method names cannot be empty");
+    }
+    this.#emits.add(name);
+  }
+
+  /** Handles one host-sent notification, which never produces a response. */
+  onNotification(name: string, handler: NotificationHandler): void {
+    this.#assertRegistering();
+    if (this.#notificationHandlers.has(name)) {
+      throw new Error(`Notification ${name} already has a handler`);
+    }
+    this.#notificationHandlers.set(name, handler);
+  }
+
+  /**
+   * Sends one declared notification to the host while the plugin is running.
+   *
+   * Only methods declared through `declareEmit` may be sent: the host rejects anything outside
+   * that whitelist and terminates the process, so an undeclared method is a defect here rather
+   * than a message the host quietly drops.
+   */
+  async notify(method: string, params: JsonValue): Promise<void> {
+    if (!this.#emits.has(method)) {
+      throw new Error(`Plugin method ${method} was not declared in emits`);
+    }
+    if (this.#writer === undefined) {
+      throw new Error("A plugin can only notify the host while running");
+    }
+    await this.#writer.write({ jsonrpc: "2.0", method, params });
+  }
+
+  /** Announces the capability registry and serves host traffic until shutdown or EOF. */
   async run(transport: PluginTransport = createDenoTransport()): Promise<void> {
     if (this.#state !== "registering") {
       throw new Error("A plugin can only run once");
@@ -45,33 +90,62 @@ export class Plugin {
     }
 
     const writer = new FrameWriter(transport.writable);
+    this.#writer = writer;
     await writer.write({
       jsonrpc: "2.0",
       method: "ora/register",
-      params: { methods: [...this.#methods.keys()] },
+      params: {
+        methods: [...this.#methods.keys()],
+        emits: [...this.#emits],
+      },
     });
 
     const inFlight = new Set<Promise<void>>();
+    const track = (operation: Promise<void>) => {
+      inFlight.add(operation);
+      // Supplying both continuations observes transport failures without creating a rejected
+      // promise from `finally`; the host will invalidate the process when stdout closes.
+      void operation.then(
+        () => inFlight.delete(operation),
+        () => inFlight.delete(operation),
+      );
+    };
     try {
       for await (const message of decodeFrames(transport.readable)) {
         if (isShutdownNotification(message)) {
           break;
         }
-        const request = parseRequest(message);
-        const operation = this.#dispatch(request, writer);
-        inFlight.add(operation);
-        // Supplying both continuations observes transport failures without creating a rejected
-        // promise from `finally`; the host will invalidate the process when stdout closes.
-        void operation.then(
-          () => inFlight.delete(operation),
-          () => inFlight.delete(operation),
-        );
+        const notification = this.#matchNotification(message);
+        if (notification !== undefined) {
+          track(notification);
+          continue;
+        }
+        track(this.#dispatch(parseRequest(message), writer));
       }
       await Promise.allSettled(inFlight);
     } finally {
       this.#state = "stopped";
+      this.#writer = undefined;
       await writer.close();
     }
+  }
+
+  /** Runs the handler for a host notification, or reports that this was not a notification. */
+  #matchNotification(message: unknown): Promise<void> | undefined {
+    if (!isRecord(message) || message.jsonrpc !== "2.0" || "id" in message) {
+      return undefined;
+    }
+    if (typeof message.method !== "string") {
+      return undefined;
+    }
+    const handler = this.#notificationHandlers.get(message.method);
+    if (handler === undefined) {
+      // Notifications have no response channel, so an unhandled one can only be reported. Failing
+      // the process here would let a host that learned a new method take working plugins down.
+      console.warn(`Ignoring unhandled host notification ${message.method}`);
+      return Promise.resolve();
+    }
+    return Promise.resolve(handler((message.params ?? null) as JsonValue));
   }
 
   /** Executes one handler and maps expected method failures into JSON-RPC responses. */
@@ -99,11 +173,33 @@ export class Plugin {
       await writer.write(
         errorResponse(
           request.id,
-          -32603,
+          error instanceof PluginMethodError ? error.code : -32603,
           error instanceof Error ? error.message : "Plugin method failed",
         ),
       );
     }
+  }
+
+  #assertRegistering(): void {
+    if (this.#state !== "registering") {
+      throw new Error("Plugin capabilities cannot change after run() starts");
+    }
+  }
+}
+
+/**
+ * Carries a specific JSON-RPC error code from a method handler to the host.
+ *
+ * Ora distinguishes expected conditions from faults by code, so a handler that throws this instead
+ * of a plain `Error` controls how the host reacts.
+ */
+export class PluginMethodError extends Error {
+  readonly code: number;
+
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = "PluginMethodError";
+    this.code = code;
   }
 }
 

--- a/packages/plugin-sdk/tests/agent.test.ts
+++ b/packages/plugin-sdk/tests/agent.test.ts
@@ -1,0 +1,145 @@
+import {
+  type AcpSender,
+  AGENT_NOT_INSTALLED,
+  defineAgent,
+  PluginMethodError,
+} from "../src/mod.ts";
+import {
+  decodeFrames,
+  encodeFrame,
+  type JsonValue,
+  type PluginTransport,
+} from "../src/protocol.ts";
+
+/** Compares JSON-compatible values without a Node compatibility dependency. */
+function assertEquals(actual: unknown, expected: unknown): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`Expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+/** Creates paired in-memory streams for exercising the SDK without global stdio. */
+function createTransportHarness(): {
+  transport: PluginTransport;
+  send: (message: JsonValue) => Promise<void>;
+  responses: AsyncGenerator<unknown>;
+} {
+  const hostInput = new TransformStream<Uint8Array>();
+  const pluginOutput = new TransformStream<Uint8Array>();
+  const inputWriter = hostInput.writable.getWriter();
+  return {
+    transport: {
+      readable: hostInput.readable,
+      writable: pluginOutput.writable,
+      redirectConsole: false,
+    },
+    send: (message) => inputWriter.write(encodeFrame(message)),
+    responses: decodeFrames(pluginOutput.readable),
+  };
+}
+
+Deno.test("serves the whole agent contract over one run loop", async () => {
+  const received: JsonValue[] = [];
+  let send: AcpSender | undefined;
+  const plugin = defineAgent({
+    start: (_context, sender) => {
+      send = sender;
+    },
+    stop: () => {},
+    listModels: () => [{ id: "opus", displayName: "Opus" }],
+    onAcp: (frame) => {
+      received.push(frame);
+    },
+  });
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    method: "ora/register",
+    params: {
+      methods: ["agent/start", "agent/stop", "agent/listModels"],
+      emits: ["agent/acp"],
+    },
+  });
+
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "agent/start",
+    params: { cwd: "/home/user", hostVersion: "0.8.0" },
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 1,
+    result: { protocol: "acp", acpVersion: 1 },
+  });
+
+  await harness.send({
+    jsonrpc: "2.0",
+    method: "agent/acp",
+    params: { jsonrpc: "2.0", id: 7, method: "initialize" },
+  });
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "agent/listModels",
+    params: {},
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 2,
+    result: { models: [{ id: "opus", displayName: "Opus", default: false }] },
+  });
+  assertEquals(received, [{ jsonrpc: "2.0", id: 7, method: "initialize" }]);
+
+  await send?.({ jsonrpc: "2.0", id: 7, result: { protocolVersion: 1 } });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    method: "agent/acp",
+    params: { jsonrpc: "2.0", id: 7, result: { protocolVersion: 1 } },
+  });
+
+  await harness.send({ jsonrpc: "2.0", id: 3, method: "agent/stop", params: {} });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 3,
+    result: {},
+  });
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("reports a missing agent with the code Ora retries quietly", async () => {
+  const plugin = defineAgent({
+    start: () => {
+      throw new PluginMethodError(AGENT_NOT_INSTALLED, "claude-agent-acp is not installed");
+    },
+    stop: () => {},
+    listModels: () => [],
+    onAcp: () => {},
+  });
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+  await harness.responses.next();
+
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "agent/start",
+    params: { cwd: "/home/user", hostVersion: "0.8.0" },
+  });
+
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 1,
+    error: {
+      code: AGENT_NOT_INSTALLED,
+      message: "claude-agent-acp is not installed",
+    },
+  });
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});

--- a/packages/plugin-sdk/tests/plugin.test.ts
+++ b/packages/plugin-sdk/tests/plugin.test.ts
@@ -59,7 +59,7 @@ Deno.test(
     assertEquals((await harness.responses.next()).value, {
       jsonrpc: "2.0",
       method: "ora/register",
-      params: { methods: ["example.echo"] },
+      params: { methods: ["example.echo"], emits: [] },
     });
     await harness.send({
       jsonrpc: "2.0",
@@ -101,7 +101,7 @@ Deno.test("rejects duplicate and late method registration", async () => {
   await harness.responses.next();
   assertThrows(
     () => plugin.registerMethod("example.other", (input) => input),
-    /cannot be registered/,
+    /cannot change/,
   );
   await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
   await run;


### PR DESCRIPTION
Implements stages 1-4 of docs/plugin-doc/plugin-agent-runtime.md, so an installed `kind: "agent"` plugin can supply an agent that the runtime supervises exactly like a built-in CLI. Stage 5 (AgentCli -> AgentRef identity generalization) is not done.

ora-plugin-runtime becomes bidirectional. `ora/register` now declares both directions: `methods` is what the host may invoke, `emits` is what the plugin may send unprompted. Anything outside those, and any plugin message carrying a JSON-RPC id, invalidates the connection, so a plugin whose behaviour exceeds its declaration is rejected rather than half-trusted. `notify` occupies no correlation slot and is deliberately outside `call_timeout`, which exists to bound short control calls and would otherwise sever multi-minute prompts.

ora-acp is decoupled from byte streams. `AcpTransport` carries whole JSON-RPC messages and owns framing and ordering; `NdjsonTransport` serves stdio CLIs while plugin IPC avoids re-serializing values that were never bytes. A test asserts both transports produce identical `AcpInboundEvent` sequences.

Plugin manifests narrow to one agent per package (`contributes.agent`), matching the one-plugin-one-agent-one-process model that removes any need for addressing inside `agent/acp` frames.

The new backend `plugin_agent` module is the only place above the plugin crates that knows a plugin exists; everything else sees a `RuntimeConnection` and cannot tell which kind of provider produced it.

Three defects found while reviewing the first working version:

- A plugin process could outlive its supervisor. `RuntimeConnection.client` holds a `PluginRuntime` clone inside the transport, and session actors clone that, so drop-based teardown meant one surviving actor kept a failed plugin running forever. Teardown is now explicit, matching the CLI path's unconditional kill.
- `agent/stop` could swallow the whole shutdown grace. It was bounded by the 30s control-call timeout while teardown was capped at the 5s cancellation grace, so a hung plugin meant the explicit shutdown never ran. `agent/stop` now has its own short deadline and the plugin is ended whether or not it answers.
- Contract-incomplete plugins retried forever, against the fail-fast requirement. Startup failures now split into retryable and terminal: a plugin that cannot serve the contract will fail identically every time, so it is abandoned for the process lifetime instead of logging a warning per backoff interval.

One deliberate deviation from the design doc: it specifies `InstalledPlugin.agent: Option<InstalledPluginAgent>`, but the contribution is modelled as `PluginContribution::Agent(..)` so that "kind is agent yet no agent was declared" is unrepresentable rather than a case every consumer re-checks, per AGENTS.md. This also removes an impossible branch from the plugin call sites.

Known gap: agent plugins receive `--allow-run` and broad read/env/net access because they spawn and own the agent CLI, which makes them roughly as privileged as the host. This is deferred capability narrowing, not an oversight; closing it later changes only how the agent is started, never the `agent/acp` pipe.

Not verified: packages/plugin-sdk is reviewed by hand only, because deno is not available in this environment.