### PR TITLE
fix(desktop): resolve development binaries from PATH

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -92,6 +92,17 @@ jobs:
         env:
           DENO_VERSION: v2.9.5
           RG_VERSION: 15.2.0
+      # Keep the checked-in config free of local sidecar requirements so
+      # `tauri dev` resolves rg and deno from PATH. Packaging enables the
+      # downloaded sidecars by editing this working copy in place.
+      - name: Configure Tauri sidecars
+        shell: node {0}
+        run: |
+          const fs = require("node:fs");
+          const configPath = "apps/desktop/src-tauri/tauri.conf.json";
+          const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+          config.bundle.externalBin = ["binaries/rg", "binaries/deno"];
+          fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
       - run: task build:desktop
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -102,6 +102,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.9.5
       # The root workspace now contains both shared crates and Tauri packages.
       - uses: Swatinem/rust-cache@v2
         with:
@@ -123,8 +126,6 @@ jobs:
             libxdo-dev \
             libssl-dev \
             build-essential
-      - name: Set up sidecar binaries
-        run: node scripts/setup-binary.mjs
       - run: task test:crates
 
   # Aggregate gate: the single check to mark as "required" in branch

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -142,6 +142,11 @@ tasks:
 
   test:crates:
     desc: Run all Rust workspace package test suites
+    preconditions:
+      - sh: command -v rg >/dev/null 2>&1
+        msg: "Ripgrep (rg) is not available on PATH. Install it before running Rust tests."
+      - sh: command -v deno >/dev/null 2>&1
+        msg: "Deno is not available on PATH. Install it before running Rust tests."
     cmds:
       - task: lint:crates
       - cargo test --workspace
@@ -152,6 +157,11 @@ tasks:
 
   run:desktop:
     desc: Run the desktop Tauri app in development mode
+    preconditions:
+      - sh: command -v rg >/dev/null 2>&1
+        msg: "Ripgrep (rg) is not available on PATH. Install it before running Desktop."
+      - sh: command -v deno >/dev/null 2>&1
+        msg: "Deno is not available on PATH. Install it before running Desktop."
     env:
       ORA_DATA_DIR: "{{.ROOT_DIR}}/.data"
       VSLANG: "1033"

--- a/apps/desktop/src-tauri/README.md
+++ b/apps/desktop/src-tauri/README.md
@@ -7,13 +7,20 @@ The crate does not own domain persistence or agent execution semantics; those re
 Native marketplace windows use isolated browser profiles and provider-specific navigation policies. Their download events are routed into Ora-owned application data before the frontend is notified.
 
 Ripgrep and Deno are bundled as Tauri sidecars under `binaries/rg` and
-`binaries/deno`. Their platform-specific executables are downloaded by
-`scripts/setup-binary.mjs` during dependency installation and are intentionally
-excluded from version control. `BundledBinaryPaths` resolves both paths during
-Desktop bootstrap and stores them in `DesktopState`; the shared backend and
-`ora-fs` receive the resolved ripgrep path, while Rust-owned Deno integrations
-receive the resolved Deno path. If either executable is missing, Desktop logs
-the failure and stops before constructing the application state.
+`binaries/deno` for release builds. Their platform-specific executables are
+downloaded by `scripts/setup-binary.mjs` during dependency installation and are
+intentionally excluded from version control. The packaging workflow adds the
+sidecars to Tauri's configuration in its checkout immediately before building;
+the checked-in configuration keeps `externalBin` empty so `tauri dev` does not
+depend on that directory.
+
+`BundledBinaryPaths` stores the paths in `DesktopState`. Debug builds, including
+development and tests, pass `rg` and `deno` as command names so the operating
+system resolves them from `PATH`. Release builds resolve the platform-specific
+sidecars next to the Tauri executable. The shared backend and `ora-fs` receive
+the resolved ripgrep path, while Rust-owned Deno integrations receive the
+resolved Deno path. If a release sidecar is missing, Desktop logs the failure
+and stops before constructing the application state.
 
 On Windows, `build.rs` omits Tauri's resource-embedded app manifest and instead
 attaches the Common-Controls v6 side-by-side dependency via the linker for every

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -16,7 +16,7 @@ pub struct BundledBinaryPaths {
 }
 
 impl BundledBinaryPaths {
-    /// Resolves all required binaries from the Tauri executable folder.
+    /// Resolves the command paths used by the current Desktop build.
     pub fn resolve() -> Result<Self, BinaryResolutionError> {
         Ok(Self {
             ripgrep: resolve_binary("rg")?,
@@ -38,13 +38,24 @@ impl BundledBinaryPaths {
 /// Reports why a required shipped executable could not be resolved.
 #[derive(Debug, Error)]
 pub enum BinaryResolutionError {
+    #[cfg(not(debug_assertions))]
     #[error("failed to resolve the Desktop executable directory")]
     CurrentExecutable(#[source] std::io::Error),
+    #[cfg(not(debug_assertions))]
     #[error("required bundled binary {name} was not found at {path:?}")]
     Missing { name: &'static str, path: PathBuf },
 }
 
-/// Resolves one external binary beside the Tauri process in development and release builds.
+/// Resolves one executable from PATH for debug builds and from the packaged app for releases.
+#[cfg(debug_assertions)]
+fn resolve_binary(executable_name: &'static str) -> Result<PathBuf, BinaryResolutionError> {
+    // Development and test processes must follow the developer or CI toolchain instead of
+    // requiring a target-specific download in the repository's binaries directory.
+    Ok(PathBuf::from(executable_name))
+}
+
+/// Resolves one external binary beside the Tauri process in release builds.
+#[cfg(not(debug_assertions))]
 fn resolve_binary(executable_name: &'static str) -> Result<PathBuf, BinaryResolutionError> {
     let path = executable_directory()?.join(platform_binary_name(executable_name));
     if path.is_file() {
@@ -57,7 +68,8 @@ fn resolve_binary(executable_name: &'static str) -> Result<PathBuf, BinaryResolu
     }
 }
 
-/// Locates the directory where Tauri dev and release place external binaries.
+/// Locates the directory where Tauri places external binaries in a packaged release.
+#[cfg(not(debug_assertions))]
 fn executable_directory() -> Result<PathBuf, BinaryResolutionError> {
     let executable = std::env::current_exe().map_err(BinaryResolutionError::CurrentExecutable)?;
     executable.parent().map(PathBuf::from).ok_or_else(|| {
@@ -69,6 +81,7 @@ fn executable_directory() -> Result<PathBuf, BinaryResolutionError> {
 }
 
 /// Adds the native executable suffix expected by the current target platform.
+#[cfg(not(debug_assertions))]
 fn platform_binary_name(name: &str) -> String {
     if cfg!(target_os = "windows") {
         format!("{name}.exe")
@@ -93,4 +106,22 @@ pub struct DesktopState {
 /// Retains process-scoped writer guards for the full Tauri application lifetime.
 pub struct DesktopRuntimeGuard {
     pub _logging: ora_logging::LoggingGuard,
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::{BundledBinaryPaths, PathBuf};
+    use pretty_assertions::assert_eq;
+
+    /// Verifies debug builds leave executable discovery to the inherited PATH.
+    #[test]
+    fn debug_builds_use_path_commands() {
+        assert_eq!(
+            BundledBinaryPaths::resolve().unwrap(),
+            BundledBinaryPaths {
+                ripgrep: PathBuf::from("rg"),
+                deno: PathBuf::from("deno"),
+            }
+        );
+    }
 }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
   "bundle": {
     "active": true,
     "targets": ["dmg", "nsis", "appimage", "deb"],
-    "externalBin": ["binaries/rg", "binaries/deno"],
+    "externalBin": [],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Closes #403

## Summary
- keep `externalBin` empty in the checked-in Tauri config
- resolve `rg` and `deno` from PATH in debug builds and tests
- inject sidecars in the desktop packaging workflow only
- install Deno in the crates test job

## Validation
- cargo fmt --all -- --check
- cargo clippy -p ora-desktop -- -D warnings
- cargo test -p ora-desktop state::tests::debug_builds_use_path_commands
- git diff --check