### PR TITLE
feat(plugin): add plugin registry and distribution list validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,6 +3093,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ora-plugin-registry"
+version = "0.0.0"
+dependencies = [
+ "gitlancer",
+ "ora-logging",
+ "ora-plugin-manifest",
+ "ora-utils",
+ "pretty_assertions",
+ "semver",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
 name = "ora-plugin-runtime"
 version = "0.0.0"
 dependencies = [
@@ -3168,6 +3185,8 @@ version = "0.0.0"
 dependencies = [
  "flate2",
  "pretty_assertions",
+ "quick-xml",
+ "sha2",
  "tar",
  "tempfile",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/plugin-lifecycle",
     "crates/plugin-manager",
     "crates/plugin-runtime",
+    "crates/plugin-registry",
     "crates/process",
     "crates/pty",
     "crates/scheduler",
@@ -38,6 +39,7 @@ default-members = [
     "crates/plugin-lifecycle",
     "crates/plugin-manager",
     "crates/plugin-runtime",
+    "crates/plugin-registry",
     "crates/process",
     "crates/pty",
     "crates/scheduler",
@@ -71,6 +73,7 @@ ora-logging = { path = "crates/logging" }
 ora-plugin-manifest = { path = "crates/plugin-manifest" }
 ora-plugin-lifecycle = { path = "crates/plugin-lifecycle" }
 ora-plugin-manager = { path = "crates/plugin-manager" }
+ora-plugin-registry = { path = "crates/plugin-registry" }
 ora-plugin-runtime = { path = "crates/plugin-runtime" }
 ora-process = { path = "crates/process" }
 ora-pty = { path = "crates/pty" }
@@ -98,6 +101,8 @@ pretty_assertions = "1"
 r2d2 = "0.8"
 regex = "1"
 semver = "1"
+quick-xml = "0.41"
+sha2 = "0.10"
 rusqlite = "0.37"
 serde = "1.0"
 similar = "2"

--- a/crates/gitlancer/src/git/README.md
+++ b/crates/gitlancer/src/git/README.md
@@ -12,6 +12,7 @@ This module exposes the operations callers perform through `Git<R: GitRunner>` a
 - Commit operations stage `RepoRelativePath` values, create commits without GPG signing, and return typed commit metadata.
 - Push operations publish the verified checked-out branch to its default remote without enabling credential prompts.
 - Status uses porcelain v2 NUL-delimited output; global identity reads treat an unset Git key as `None`, not an execution failure.
+- Sync operations clone a repository into a fresh directory, fetch a remote, check out a branch, and fast-forward a branch against its remote so marketplace sources can be refreshed deterministically.
 
 Every command is classified by `GitIntent` and executed through the injected runner. Mutating operations perform domain checks such as duplicate/missing branch validation before issuing the mutation when the use case requires it.
 

--- a/crates/gitlancer/src/git/mod.rs
+++ b/crates/gitlancer/src/git/mod.rs
@@ -6,6 +6,7 @@ pub mod diff;
 pub mod push;
 pub mod repository;
 pub mod status;
+pub mod sync;
 pub mod worktree;
 
 use crate::exec::runner::GitRunner;

--- a/crates/gitlancer/src/git/sync.rs
+++ b/crates/gitlancer/src/git/sync.rs
@@ -1,0 +1,159 @@
+use crate::domain::refs::BranchName;
+use crate::domain::repo::Repository;
+use crate::error::GitlancerError;
+use crate::exec::command::{GitCommand, GitIntent};
+use crate::exec::env::GitEnv;
+use crate::exec::runner::GitRunner;
+use crate::git::Git;
+
+/// Carries the information needed to clone a repository into a fresh directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloneRequest<'a> {
+    /// Git repository URL or local filesystem path to clone from.
+    pub repository_url: &'a str,
+    /// Directory where the clone should be created.
+    pub destination: std::path::PathBuf,
+    /// Existing directory the clone command runs in (the destination's parent).
+    pub working_dir: std::path::PathBuf,
+    /// Optional branch to check out after cloning via `--branch`.
+    pub branch: Option<BranchName>,
+}
+
+/// Carries the information needed to fetch refs for an existing repository.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchRequest<'a> {
+    pub repository: &'a Repository,
+    /// Remote name to fetch from, normally `origin`.
+    pub remote: &'a str,
+}
+
+/// Carries the information needed to check out a branch in an existing repository.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckoutRequest<'a> {
+    pub repository: &'a Repository,
+    pub branch: &'a BranchName,
+}
+
+/// Carries the information needed to fast-forward one branch against its remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PullRequest<'a> {
+    pub repository: &'a Repository,
+    pub branch: &'a BranchName,
+}
+
+impl<R: GitRunner> Git<R> {
+    /// Clones a repository into a fresh directory so callers never build `git clone` themselves.
+    pub fn clone(&self, request: CloneRequest<'_>) -> Result<(), GitlancerError> {
+        self.runner().run(&build_clone_command(&request))?;
+        Ok(())
+    }
+
+    /// Fetches refs from a remote so a later pull can refresh an existing checkout.
+    pub fn fetch(&self, request: FetchRequest<'_>) -> Result<(), GitlancerError> {
+        self.runner().run(&GitCommand::new(
+            request.repository.root().as_path().to_path_buf(),
+            vec!["fetch".to_string(), request.remote.to_string()],
+            GitEnv::default(),
+            GitIntent::Network,
+        ))?;
+        Ok(())
+    }
+
+    /// Switches an existing checkout onto the supplied branch.
+    pub fn checkout(&self, request: CheckoutRequest<'_>) -> Result<(), GitlancerError> {
+        self.runner().run(&GitCommand::new(
+            request.repository.root().as_path().to_path_buf(),
+            vec!["checkout".to_string(), request.branch.as_str().to_string()],
+            GitEnv::default(),
+            GitIntent::Mutating,
+        ))?;
+        Ok(())
+    }
+
+    /// Fast-forwards the supplied branch against its remote so a sync converges deterministically.
+    pub fn pull(&self, request: PullRequest<'_>) -> Result<(), GitlancerError> {
+        self.runner().run(&GitCommand::new(
+            request.repository.root().as_path().to_path_buf(),
+            vec![
+                "pull".to_string(),
+                "--ff-only".to_string(),
+                "origin".to_string(),
+                request.branch.as_str().to_string(),
+            ],
+            GitEnv::default(),
+            GitIntent::Network,
+        ))?;
+        Ok(())
+    }
+}
+
+/// Builds a stable `git clone` command so clone assembly can be tested without process execution.
+pub fn build_clone_command(request: &CloneRequest<'_>) -> GitCommand {
+    let mut args = vec!["clone".to_string()];
+    if let Some(branch) = &request.branch {
+        args.push("--branch".to_string());
+        args.push(branch.as_str().to_string());
+    }
+    args.push(request.repository_url.to_string());
+    args.push(request.destination.to_string_lossy().into_owned());
+
+    GitCommand::new(
+        request.working_dir.clone(),
+        args,
+        GitEnv::default(),
+        GitIntent::Network,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_clone_command;
+    use crate::domain::refs::BranchName;
+    use crate::exec::command::GitIntent;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    /// Verifies a plain clone assembles `git clone <url> <destination>` in the working directory.
+    #[test]
+    fn assembles_plain_clone_command() {
+        let command = build_clone_command(&super::CloneRequest {
+            repository_url: "https://example.com/marketplace.git",
+            destination: PathBuf::from("sources/marketplace"),
+            working_dir: PathBuf::from("sources"),
+            branch: None,
+        });
+
+        assert_eq!(
+            command.args,
+            vec![
+                "clone",
+                "https://example.com/marketplace.git",
+                "sources/marketplace"
+            ]
+        );
+        assert_eq!(command.cwd, PathBuf::from("sources"));
+        assert_eq!(command.intent, GitIntent::Network);
+    }
+
+    /// Verifies `--branch` is inserted between clone and the URL when a branch is requested.
+    #[test]
+    fn assembles_branch_clone_command() {
+        let command = build_clone_command(&super::CloneRequest {
+            repository_url: "https://example.com/marketplace.git",
+            destination: PathBuf::from("sources/marketplace"),
+            working_dir: PathBuf::from("sources"),
+            branch: Some(BranchName::new("main")),
+        });
+
+        assert_eq!(
+            command.args,
+            vec![
+                "clone",
+                "--branch",
+                "main",
+                "https://example.com/marketplace.git",
+                "sources/marketplace"
+            ]
+        );
+    }
+}

--- a/crates/plugin-registry/Cargo.toml
+++ b/crates/plugin-registry/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ora-plugin-registry"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+name = "ora_plugin_registry"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+gitlancer = { workspace = true }
+ora-logging = { workspace = true }
+ora-plugin-manifest = { workspace = true }
+ora-utils = { workspace = true }
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/plugin-registry/README.md
+++ b/crates/plugin-registry/README.md
@@ -1,0 +1,29 @@
+# ora-plugin-registry
+
+`ora-plugin-registry` syncs marketplace source repositories over Git and builds the lightweight
+`registry_index.json` that lists available plugins for consumers such as the UI.
+
+## Responsibilities
+
+- `RegistrySync::sync` clones a marketplace source when absent, otherwise fetches, checks out the
+  tracked branch, and fast-forwards it against its remote through an injected `gitlancer::Git`.
+- `RegistryIndex::build` recursively scans a directory for `orax.toml` files, parses each valid
+  manifest into a `RegistryEntry`, and returns a deterministically ordered index built at an
+  injected Unix timestamp.
+- `RegistryIndex::load` reads a previously written index file; `RegistryIndex::write` replaces the
+  target file atomically through `ora-utils` so readers never observe a partial index.
+- A single malformed or unreadable `orax.toml` is skipped, logged as a warning, and reported through
+  `RegistryBuild::skipped` without blocking the whole build.
+
+## Non-responsibilities
+
+- Installing, enabling, disabling, or removing plugins.
+- Resolving dependency trees or evaluating host version requirements.
+- Choosing where source checkouts live under the data directory; callers supply the checkout path.
+
+## Public interface
+
+`RegistryIndex::build(dir, updated_at)` returns a `RegistryBuild` carrying the ordered index and any
+skipped manifests. `RegistryIndex::load(path)` / `RegistryIndex::write(path)` read and atomically
+persist an index. `RegistrySync::sync(&git, &source)` returns the checkout directory so callers can
+then build an index from it.

--- a/crates/plugin-registry/src/entry.rs
+++ b/crates/plugin-registry/src/entry.rs
@@ -1,0 +1,55 @@
+use ora_plugin_manifest::PluginManifest;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+/// One lightweight metadata record surfaced in the registry index for UI consumption.
+///
+/// The index is a derived artifact, so this type stores the display fields as plain strings
+/// rather than re-validating manifest invariants at load time.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RegistryEntry {
+    id: String,
+    name: String,
+    namespace: String,
+    version: Version,
+    description: String,
+}
+
+impl RegistryEntry {
+    /// Builds one index record from a validated plugin manifest.
+    pub(crate) fn from_manifest(manifest: &PluginManifest) -> Self {
+        let id = format!("{}/{}", manifest.namespace(), manifest.name());
+        Self {
+            id,
+            name: manifest.name().as_str().to_owned(),
+            namespace: manifest.namespace().as_str().to_owned(),
+            version: manifest.version().clone(),
+            description: manifest.description().to_owned(),
+        }
+    }
+
+    /// Returns the unique `namespace/name` identifier.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the plugin name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the plugin source namespace.
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// Returns the published plugin version.
+    pub fn version(&self) -> &Version {
+        &self.version
+    }
+
+    /// Returns the plugin description.
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+}

--- a/crates/plugin-registry/src/error.rs
+++ b/crates/plugin-registry/src/error.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use gitlancer::GitlancerError;
+use thiserror::Error;
+
+/// Reports failures produced while syncing a registry source or reading/writing an index.
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    /// Wraps a Git sync failure so marketplace refresh surfaces the underlying git error.
+    #[error("registry source sync failed: {0}")]
+    Git(#[from] GitlancerError),
+
+    /// Wraps a manifest parse failure so a single malformed file can be diagnosed.
+    #[error("plugin manifest parse failed: {0}")]
+    Manifest(#[from] ora_plugin_manifest::ManifestError),
+
+    /// Wraps a filesystem failure while scanning the registry tree or reading/writing files.
+    #[error("registry file operation failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Wraps an index serialization or deserialization failure.
+    #[error("registry index JSON failed: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Returned when a sync target has no usable parent directory to clone into.
+    #[error("registry source clone destination has no parent directory: {0}")]
+    MissingCloneParent(PathBuf),
+}

--- a/crates/plugin-registry/src/index.rs
+++ b/crates/plugin-registry/src/index.rs
@@ -1,0 +1,298 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use ora_logging::ora_warn;
+use ora_plugin_manifest::PluginManifest;
+
+use crate::entry::RegistryEntry;
+use crate::error::RegistryError;
+
+/// The index schema version reported in every built index file.
+const INDEX_VERSION: &str = "1.0";
+
+/// Holds one immutable registry index that lists every discoverable marketplace plugin.
+///
+/// The index is a lightweight derived artifact: callers read it instead of re-scanning and
+/// parsing every `orax.toml`, so `updated_at` and the schema `version` are stable pointers
+/// that help consumers detect staleness and schema changes.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RegistryIndex {
+    updated_at: i64,
+    version: String,
+    plugins: Vec<RegistryEntry>,
+}
+
+impl RegistryIndex {
+    /// Scans `dir` recursively for `orax.toml` files, parses each valid manifest, and returns a
+    /// deterministically ordered index built at the injected Unix `updated_at` instant.
+    ///
+    /// Malformed or unreadable manifests are skipped, logged as warnings, and reported through
+    /// the returned [`RegistryBuild`] so a single bad file never blocks the whole build.
+    pub fn build(dir: &Path, updated_at: i64) -> RegistryBuild {
+        let mut entries = Vec::new();
+        let mut skipped = Vec::new();
+        for path in orax_manifest_paths(dir) {
+            match parse_manifest(&path) {
+                Ok(manifest) => entries.push(RegistryEntry::from_manifest(&manifest)),
+                Err(error) => {
+                    ora_warn!(path = %path.display(), %error, "skipping invalid registry plugin manifest");
+                    skipped.push(SkippedManifest {
+                        path,
+                        reason: error.to_string(),
+                    });
+                }
+            }
+        }
+        entries.sort_by(|left, right| left.id().cmp(right.id()));
+
+        let index = Self {
+            updated_at,
+            version: INDEX_VERSION.to_owned(),
+            plugins: entries,
+        };
+        RegistryBuild { index, skipped }
+    }
+
+    /// Loads an index from a previously written JSON file so consumers can read it without rescanning.
+    pub fn load(path: &Path) -> Result<Self, RegistryError> {
+        let bytes = fs::read(path)?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    /// Atomically replaces `path` with this index's JSON serialization through a same-directory
+    /// temporary file, so concurrent readers never observe a partially written index.
+    pub fn write(&self, path: &Path) -> Result<(), RegistryError> {
+        let bytes = serde_json::to_vec(self)?;
+        ora_utils::atomic::write(path, &bytes)?;
+        Ok(())
+    }
+
+    /// Returns the Unix timestamp (seconds) at which this index was built.
+    pub fn updated_at(&self) -> i64 {
+        self.updated_at
+    }
+
+    /// Returns the schema version this index conforms to.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// Returns the listed plugins.
+    pub fn plugins(&self) -> &[RegistryEntry] {
+        &self.plugins
+    }
+}
+
+/// Holds one built index together with every manifest that was skipped during the scan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegistryBuild {
+    index: RegistryIndex,
+    skipped: Vec<SkippedManifest>,
+}
+
+impl RegistryBuild {
+    /// Returns the completed, deterministically ordered index.
+    pub fn index(&self) -> &RegistryIndex {
+        &self.index
+    }
+
+    /// Returns the manifests that were skipped during the build, in path order.
+    pub fn skipped(&self) -> &[SkippedManifest] {
+        &self.skipped
+    }
+}
+
+/// Describes one `orax.toml` that could not be parsed into the index.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkippedManifest {
+    path: PathBuf,
+    reason: String,
+}
+
+impl SkippedManifest {
+    /// Returns the path of the manifest that was skipped.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the human-readable reason the manifest was skipped.
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+/// Collects every `orax.toml` beneath `root` in deterministic path order.
+fn orax_manifest_paths(root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    collect_orax_manifests(root, &mut paths);
+    paths.sort();
+    paths
+}
+
+/// Recursively accumulates `orax.toml` paths without following symlinks or reporting missing roots.
+fn collect_orax_manifests(dir: &Path, paths: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_orax_manifests(&path, paths);
+        } else if path
+            .file_name()
+            .is_some_and(|name| name == std::ffi::OsStr::new("orax.toml"))
+        {
+            paths.push(path);
+        }
+    }
+}
+
+/// Reads and parses one manifest, mapping both I/O and semantic failures onto [`RegistryError`].
+fn parse_manifest(path: &Path) -> Result<PluginManifest, RegistryError> {
+    let source = fs::read_to_string(path)?;
+    Ok(PluginManifest::parse(&source)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const UPDATED_AT: i64 = 1_776_244_428;
+
+    /// Builds a syntactically valid `orax.toml` string for a named plugin.
+    fn valid_manifest(name: &str, description: &str) -> String {
+        format!(
+            "resolver = 1\n\
+             name = \"{name}\"\n\
+             namespace = \"official\"\n\
+             kind = \"workbench\"\n\
+             version = \"1.2.0\"\n\
+             description = \"{description}\"\n\
+             homepage = \"https://example.com\"\n\
+             license = \"MIT\"\n\
+             url = \"https://example.com/{name}.orax\"\n\
+             sha256 = \"{}\"\n",
+            "ab".repeat(32)
+        )
+    }
+
+    /// Writes a manifest at a nesting level that mimics the two-tier marketplace layout.
+    fn write_manifest(root: &Path, name: &str, source: &str) -> Result<PathBuf, std::io::Error> {
+        let path = root
+            .join("registry")
+            .join(&name[..1])
+            .join(name)
+            .join("orax.toml");
+        let parent = path
+            .parent()
+            .ok_or_else(|| std::io::Error::other("no parent"))?;
+        fs::create_dir_all(parent)?;
+        fs::write(&path, source)?;
+        Ok(path)
+    }
+
+    /// Verifies entries are ordered by their `namespace/name` identifier regardless of scan order.
+    #[test]
+    fn builds_deterministically_ordered_index() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        write_manifest(root.path(), "z", &valid_manifest("z", "Z plugin"))?;
+        write_manifest(root.path(), "a", &valid_manifest("a", "A plugin"))?;
+
+        let build = RegistryIndex::build(root.path(), UPDATED_AT);
+
+        let a_manifest = PluginManifest::parse(&valid_manifest("a", "A plugin"))?;
+        let z_manifest = PluginManifest::parse(&valid_manifest("z", "Z plugin"))?;
+        let expected_plugins = vec![
+            RegistryEntry::from_manifest(&a_manifest),
+            RegistryEntry::from_manifest(&z_manifest),
+        ];
+
+        assert_eq!(build.index().plugins().to_vec(), expected_plugins);
+        assert_eq!(build.index().updated_at(), UPDATED_AT);
+        assert_eq!(build.index().version(), INDEX_VERSION);
+        assert_eq!(build.skipped().len(), 0);
+        Ok(())
+    }
+
+    /// Verifies a malformed manifest is skipped, logged, and reported without blocking the build.
+    #[test]
+    fn skips_invalid_manifest_and_reports_it() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        write_manifest(root.path(), "good", &valid_manifest("good", "Good plugin"))?;
+        let bad_path = write_manifest(root.path(), "bad", "this is not valid toml")?;
+
+        let build =
+            ora_logging::with_trace_logging(|| RegistryIndex::build(root.path(), UPDATED_AT));
+
+        assert_eq!(build.index().plugins().len(), 1);
+        assert_eq!(build.index().plugins()[0].id(), "official/good");
+        assert_eq!(build.skipped().len(), 1);
+        assert_eq!(build.skipped()[0].path(), bad_path);
+        assert!(!build.skipped()[0].reason().is_empty());
+        Ok(())
+    }
+
+    /// Verifies a written index loads back into an equal in-memory value.
+    #[test]
+    fn load_round_trips_written_index() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        write_manifest(root.path(), "a", &valid_manifest("a", "A plugin"))?;
+
+        let index = RegistryIndex::build(root.path(), UPDATED_AT)
+            .index()
+            .clone();
+        let target = root.path().join("cache").join("registry_index.json");
+        let parent = target
+            .parent()
+            .ok_or_else(|| std::io::Error::other("no parent"))?;
+        fs::create_dir_all(parent)?;
+        index.write(&target)?;
+
+        let loaded = RegistryIndex::load(&target)?;
+        assert_eq!(loaded, index);
+        Ok(())
+    }
+
+    /// Verifies write replaces prior content and leaves no same-directory temporary files behind.
+    #[test]
+    fn write_overwrites_atomically_without_leftovers() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        write_manifest(root.path(), "a", &valid_manifest("a", "A plugin"))?;
+
+        let target = root.path().join("registry_index.json");
+        RegistryIndex::build(root.path(), UPDATED_AT)
+            .index()
+            .write(&target)?;
+        let first = fs::read_to_string(&target)?;
+
+        let second_index = RegistryIndex::build(root.path(), UPDATED_AT + 1)
+            .index()
+            .clone();
+        second_index.write(&target)?;
+        let second = fs::read_to_string(&target)?;
+
+        assert_ne!(first, second);
+        assert_eq!(
+            serde_json::from_str::<RegistryIndex>(&second)?,
+            second_index
+        );
+        let leftover_temps = fs::read_dir(root.path())?
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+            .count();
+        assert_eq!(leftover_temps, 0);
+        Ok(())
+    }
+
+    /// Verifies loading a missing file surfaces an error instead of an empty index.
+    #[test]
+    fn load_missing_file_is_an_error() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+
+        assert!(RegistryIndex::load(&root.path().join("missing.json")).is_err());
+        Ok(())
+    }
+}

--- a/crates/plugin-registry/src/lib.rs
+++ b/crates/plugin-registry/src/lib.rs
@@ -1,0 +1,12 @@
+//! Syncs marketplace source repositories and builds the lightweight registry index that surfaces
+//! available plugins to consumers.
+
+mod entry;
+mod error;
+mod index;
+mod source;
+
+pub use entry::RegistryEntry;
+pub use error::RegistryError;
+pub use index::{RegistryBuild, RegistryIndex, SkippedManifest};
+pub use source::{RegistrySource, RegistrySync};

--- a/crates/plugin-registry/src/source.rs
+++ b/crates/plugin-registry/src/source.rs
@@ -1,0 +1,184 @@
+use std::path::{Path, PathBuf};
+
+use gitlancer::git::sync::{CheckoutRequest, CloneRequest, FetchRequest, PullRequest};
+use gitlancer::{BranchName, Git, GitRunner, RepoRoot, Repository};
+
+use crate::error::RegistryError;
+
+/// Describes one marketplace source repository and where its local checkout lives.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegistrySource {
+    url: String,
+    branch: BranchName,
+    checkout_dir: PathBuf,
+}
+
+impl RegistrySource {
+    /// Creates a source bound to a git URL, a tracked branch, and a local checkout directory.
+    pub fn new(
+        url: impl Into<String>,
+        branch: BranchName,
+        checkout_dir: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            url: url.into(),
+            branch,
+            checkout_dir: checkout_dir.into(),
+        }
+    }
+
+    /// Returns the git URL that hosts this registry source.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Returns the branch this source tracks.
+    pub fn branch(&self) -> &BranchName {
+        &self.branch
+    }
+
+    /// Returns the local directory where this source is checked out.
+    pub fn checkout_dir(&self) -> &Path {
+        &self.checkout_dir
+    }
+}
+
+/// Syncs marketplace sources through an injected [`gitlancer::Git`] runtime.
+pub struct RegistrySync;
+
+impl RegistrySync {
+    /// Ensures `source` is present and up to date: clones it when absent, otherwise fetches,
+    /// checks out the tracked branch, and fast-forwards against its remote.
+    ///
+    /// Returns the checkout directory so callers can scan the registry contents directly.
+    pub fn sync<R: GitRunner>(
+        git: &Git<R>,
+        source: &RegistrySource,
+    ) -> Result<PathBuf, RegistryError> {
+        let checkout_dir = source.checkout_dir();
+        if checkout_dir.join(".git").exists() {
+            let repository = Repository::new(RepoRoot::new(checkout_dir));
+            git.fetch(FetchRequest {
+                repository: &repository,
+                remote: "origin",
+            })?;
+            git.checkout(CheckoutRequest {
+                repository: &repository,
+                branch: source.branch(),
+            })?;
+            git.pull(PullRequest {
+                repository: &repository,
+                branch: source.branch(),
+            })?;
+        } else {
+            let parent = checkout_dir
+                .parent()
+                .filter(|directory| !directory.as_os_str().is_empty())
+                .ok_or_else(|| RegistryError::MissingCloneParent(checkout_dir.to_path_buf()))?;
+            std::fs::create_dir_all(parent)?;
+            git.clone(CloneRequest {
+                repository_url: source.url(),
+                destination: checkout_dir.to_path_buf(),
+                working_dir: parent.to_path_buf(),
+                branch: Some(source.branch().clone()),
+            })?;
+        }
+        Ok(checkout_dir.to_path_buf())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gitlancer::{GitCommand, GitExecError, GitIntent, GitOutput, GitRunner};
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    /// Records every issued command so sync behavior can be asserted without executing Git.
+    #[derive(Clone, Default)]
+    struct RecordingRunner {
+        commands: Arc<Mutex<Vec<GitCommand>>>,
+    }
+
+    impl GitRunner for RecordingRunner {
+        fn run(&self, command: &GitCommand) -> Result<GitOutput, GitExecError> {
+            self.commands
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(command.clone());
+            Ok(GitOutput::new(Some(0), String::new(), String::new(), 0))
+        }
+    }
+
+    /// Verifies an absent checkout clones the source with its tracked branch into the parent.
+    #[test]
+    fn clones_a_fresh_source() -> Result<(), Box<dyn std::error::Error>> {
+        let runner = RecordingRunner::default();
+        let git = Git::new(runner.clone());
+        let temp = TempDir::new()?;
+        let checkout = temp.path().join("sources").join("marketplace");
+        let source = RegistrySource::new(
+            "https://example.com/marketplace.git",
+            BranchName::new("main"),
+            &checkout,
+        );
+
+        let result = RegistrySync::sync(&git, &source)?;
+
+        assert_eq!(result, checkout);
+        let parent = checkout
+            .parent()
+            .ok_or_else(|| std::io::Error::other("no parent"))?;
+        assert!(parent.exists());
+        let commands = runner
+            .commands
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].args[0], "clone");
+        assert!(commands[0].args.contains(&"--branch".to_string()));
+        assert!(commands[0].args.contains(&"main".to_string()));
+        assert!(commands[0].args.contains(&source.url().to_string()));
+        assert_eq!(commands[0].cwd, parent);
+        assert_eq!(commands[0].intent, GitIntent::Network);
+        Ok(())
+    }
+
+    /// Verifies an existing checkout fetches, checks out the branch, and fast-forwards its remote.
+    #[test]
+    fn updates_an_existing_source() -> Result<(), Box<dyn std::error::Error>> {
+        let runner = RecordingRunner::default();
+        let git = Git::new(runner.clone());
+        let temp = TempDir::new()?;
+        let checkout = temp.path().join("marketplace");
+        fs::create_dir_all(checkout.join(".git"))?;
+        let source = RegistrySource::new(
+            "https://example.com/marketplace.git",
+            BranchName::new("main"),
+            &checkout,
+        );
+
+        let result = RegistrySync::sync(&git, &source)?;
+
+        assert_eq!(result, checkout);
+        let commands = runner
+            .commands
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        assert_eq!(commands.len(), 3);
+        assert_eq!(commands[0].args, vec!["fetch", "origin"]);
+        assert_eq!(commands[0].intent, GitIntent::Network);
+        assert_eq!(commands[1].args, vec!["checkout", "main"]);
+        assert_eq!(commands[1].intent, GitIntent::Mutating);
+        assert_eq!(
+            commands[2].args,
+            vec!["pull", "--ff-only", "origin", "main"]
+        );
+        assert_eq!(commands[2].intent, GitIntent::Network);
+        Ok(())
+    }
+}

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -7,12 +7,16 @@ edition.workspace = true
 workspace = true
 
 [features]
-default = []
+default = ["validation"]
 archive = ["dep:zip", "dep:tar", "dep:flate2"]
+validation = ["dep:sha2", "dep:quick-xml"]
 
 [dependencies]
 flate2 = { workspace = true, optional = true }
+quick-xml = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 tar = { workspace = true, optional = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 zip = { workspace = true, optional = true }
@@ -21,5 +25,4 @@ zip = { workspace = true, optional = true }
 flate2 = { workspace = true }
 pretty_assertions = { workspace = true }
 tar = { workspace = true }
-tempfile = { workspace = true }
 zip = { workspace = true }

--- a/crates/utils/README.md
+++ b/crates/utils/README.md
@@ -11,8 +11,21 @@ that any other crate can consume without introducing dependency cycles.
 - `archive` (Cargo feature `archive`): safe materialization of untrusted `.zip` / `.tar.gz`
   archives and folder trees into a destination directory with zip-slip defenses, encrypted and
   special-entry rejection, portable case-conflict detection, and cumulative entry/byte budgets.
+- `atomic`: atomically replacing a file by writing a same-directory temporary file and renaming
+  it over the destination, so readers never observe partial content.
+- `hash` (Cargo feature `validation`): streaming SHA-256 digests over a reader or file without
+  buffering the whole input.
+- `html` (Cargo feature `validation`): conservative validation rejecting README text that embeds
+  scriptable HTML (forbidden tags, `on*` event handlers, `javascript:`/`data:` URIs).
+- `svg` (Cargo feature `validation`): security validation for SVG icons — accepts well-formed
+  XML only, forbidding `<script>`/`<foreignObject>`, event-handler attributes, external `href`
+  references, and files over the 50 KiB cap.
 - `Slug`: an owned lowercase ASCII slug segment with stable syntax and byte-length guarantees.
 - `GitBranchName`: an owned short Git branch name validated without starting a Git process.
+
+The `validation` feature is enabled by default because its dependencies are small and already in
+the workspace dependency graph; path-only consumers can opt out with `default-features = false`.
+Heavier capabilities such as `archive` stay opt-in.
 
 ## Non-responsibilities
 

--- a/crates/utils/src/atomic.rs
+++ b/crates/utils/src/atomic.rs
@@ -1,0 +1,65 @@
+//! Atomic replacement of a single file by writing through a same-directory temporary file.
+
+use std::io::{self, Write};
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+/// Atomically replaces `path` with `contents`.
+///
+/// The payload is flushed and synced into a temporary file in the target's directory, then
+/// renamed over the destination. Readers never observe a partially written file, and a failed
+/// write leaves any existing destination untouched. The target's parent directory must exist.
+pub fn write(path: impl AsRef<Path>, contents: &[u8]) -> io::Result<()> {
+    let target = path.as_ref();
+    let parent = target
+        .parent()
+        .filter(|directory| !directory.as_os_str().is_empty());
+    let mut temporary = match parent {
+        Some(parent) => NamedTempFile::new_in(parent)?,
+        None => NamedTempFile::new()?,
+    };
+    temporary.write_all(contents)?;
+    temporary.flush()?;
+    temporary.as_file().sync_all()?;
+    temporary.persist(target).map_err(|error| error.error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Writes fresh content to a path that did not previously exist.
+    #[test]
+    fn writes_new_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let target = temp_dir.path().join("index.json");
+        write(&target, b"first").unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"first");
+    }
+
+    /// Replaces existing content so the destination is never left partially updated.
+    #[test]
+    fn overwrites_existing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let target = temp_dir.path().join("index.json");
+        fs::write(&target, b"old").unwrap();
+
+        write(&target, b"new").unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"new");
+    }
+
+    /// Propagates the missing-directory error instead of silently falling back to cwd writes.
+    #[test]
+    fn refuses_missing_parent_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let target = temp_dir.path().join("missing").join("index.json");
+
+        assert!(write(&target, b"data").is_err());
+    }
+}

--- a/crates/utils/src/hash.rs
+++ b/crates/utils/src/hash.rs
@@ -1,0 +1,95 @@
+//! Streaming SHA-256 digest helpers that never load large inputs fully into memory.
+
+use sha2::{Digest, Sha256};
+use std::io::{self, Read};
+use std::path::Path;
+
+/// Read buffer size used while hashing a reader; 64 KiB balances syscalls and CPU pressure.
+const BUFFER_SIZE: usize = 64 * 1024;
+
+/// Streams `reader` through SHA-256 and returns the lowercase hex digest.
+///
+/// The reader is consumed incrementally so callers can digest arbitrarily large downloads
+/// without buffering them, matching the needs of `.orax` release verification.
+pub fn sha256_reader(reader: impl Read) -> io::Result<String> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; BUFFER_SIZE];
+    let mut reader = reader;
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(digest_hex(&hasher.finalize()))
+}
+
+/// Streams the file at `path` through SHA-256, returning the lowercase hex digest.
+///
+/// Wraps [`sha256_reader`] so callers that already have an open handle can reuse either API.
+pub fn sha256_file(path: impl AsRef<Path>) -> io::Result<String> {
+    sha256_reader(std::fs::File::open(path)?)
+}
+
+/// Renders a digest as lowercase hex without aggregating hex formatting per call.
+fn digest_hex(bytes: &[u8]) -> String {
+    const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(char::from(HEX_DIGITS[(byte >> 4) as usize]));
+        output.push(char::from(HEX_DIGITS[(byte & 0x0f) as usize]));
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sha256_file, sha256_reader};
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::io::Cursor;
+    use tempfile::TempDir;
+
+    const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const ABC_SHA256: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    /// Verifies the digest of an empty stream against the published SHA-256 vector.
+    #[test]
+    fn hashes_empty_stream() {
+        assert_eq!(
+            sha256_reader(Cursor::new(Vec::<u8>::new())).unwrap(),
+            EMPTY_SHA256
+        );
+    }
+
+    /// Verifies the digest of short known input against the published SHA-256 vector.
+    #[test]
+    fn hashes_known_input() {
+        assert_eq!(
+            sha256_reader(Cursor::new(b"abc".to_vec())).unwrap(),
+            ABC_SHA256
+        );
+    }
+
+    /// Confirms streaming a large body matches reading the same bytes from disk.
+    #[test]
+    fn file_and_reader_agree_across_many_blocks() {
+        let temp_dir = TempDir::new().unwrap();
+        let payload: Vec<u8> = (0..=u8::MAX).cycle().take(2 * 1024 * 1024).collect();
+        let path = temp_dir.path().join("payload.bin");
+        fs::write(&path, &payload).unwrap();
+
+        let from_disk = sha256_file(&path).unwrap();
+        let from_memory = sha256_reader(Cursor::new(payload)).unwrap();
+        assert_eq!(from_disk, from_memory);
+    }
+
+    /// Verifies the digest is always lowercase hex.
+    #[test]
+    fn digest_is_lowercase_hex() {
+        let digest = sha256_reader(Cursor::new(b"abc".to_vec())).unwrap();
+        assert_eq!(digest, digest.to_ascii_lowercase());
+        assert!(digest.bytes().all(|byte| byte.is_ascii_hexdigit()) && digest.len() == 64);
+    }
+}

--- a/crates/utils/src/html.rs
+++ b/crates/utils/src/html.rs
@@ -1,0 +1,170 @@
+//! Rejects user-authored text that embeds scriptable (unfiltered) HTML.
+
+use thiserror::Error;
+
+/// HTML tags whose presence in marketplace README text makes it unsafe to render.
+const FORBIDDEN_TAGS: &[&str] = &[
+    "script", "style", "iframe", "object", "embed", "base", "form", "link", "meta", "template",
+];
+
+/// Reports the first unsafe HTML construct discovered while validating README text.
+///
+/// Validation stops at the first offence in a stable order so callers get deterministic errors.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum HtmlValidationError {
+    #[error("README embeds the forbidden HTML tag `{tag}`")]
+    ForbiddenTag { tag: &'static str },
+    #[error("README uses the event-handler attribute `{attribute}`")]
+    EventAttribute { attribute: String },
+    #[error("README uses `{attribute}` with a script-capable URI")]
+    UnsafeUri { attribute: String },
+}
+
+/// Returns `Ok(())` when `source` contains no scriptable HTML.
+///
+/// The scan is intentionally conservative and fails closed: any occurrence of a forbidden tag,
+/// an `on*` event-handler attribute, or a `javascript:` / `data:` / `vbscript:` URI rejects the
+/// whole text, even inside comments or code fences, because the caller may render it as HTML.
+pub fn validate(source: &str) -> Result<(), HtmlValidationError> {
+    let lowercase = source.to_ascii_lowercase();
+    for tag in FORBIDDEN_TAGS {
+        if contains_tag(&lowercase, tag) {
+            return Err(HtmlValidationError::ForbiddenTag { tag });
+        }
+    }
+    scan_tags(&lowercase)?;
+    Ok(())
+}
+
+/// Detects an open or close form of `tag` whose next character is a real tag boundary.
+fn contains_tag(source: &str, tag: &str) -> bool {
+    let open = format!("<{tag}");
+    let close = format!("</{tag}");
+    contains_delimited(source, &open) || contains_delimited(source, &close)
+}
+
+/// Returns whether `needle` occurs in `source` immediately followed by a tag boundary.
+fn contains_delimited(source: &str, needle: &str) -> bool {
+    let haystack = source.as_bytes();
+    let needle = needle.as_bytes();
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return false;
+    }
+    let mut index = 0;
+    while index + needle.len() <= haystack.len() {
+        if &haystack[index..index + needle.len()] == needle {
+            let following = haystack.get(index + needle.len());
+            let bounded = following.is_none_or(|byte| {
+                matches!(
+                    byte,
+                    b' ' | b'\t' | b'\n' | b'\r' | b'/' | b'>' | b'"' | b'\''
+                )
+            });
+            if bounded {
+                return true;
+            }
+            index += needle.len();
+        } else {
+            index += 1;
+        }
+    }
+    false
+}
+
+/// Inspects each `<…>` tag body for event handlers and script-capable attribute values.
+fn scan_tags(source: &str) -> Result<(), HtmlValidationError> {
+    let mut remaining = source;
+    while let Some(offset) = remaining.find('<') {
+        let after_open = &remaining[offset + 1..];
+        let Some(close) = after_open.find('>') else {
+            break;
+        };
+        scan_tag(&after_open[..close])?;
+        remaining = &after_open[close + 1..];
+    }
+    Ok(())
+}
+
+/// Rejects event-handler attributes and script-capable URIs inside a single tag body.
+fn scan_tag(tag: &str) -> Result<(), HtmlValidationError> {
+    for token in tag.split_whitespace() {
+        let attribute = token.to_ascii_lowercase();
+        let Some((name, raw_value)) = attribute.split_once('=') else {
+            continue;
+        };
+        let value = raw_value.trim_matches(|c| matches!(c, '"' | '\'')).trim();
+        if is_event_handler(name) {
+            return Err(HtmlValidationError::EventAttribute {
+                attribute: name.into(),
+            });
+        }
+        if is_script_uri(value) {
+            return Err(HtmlValidationError::UnsafeUri {
+                attribute: name.into(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Returns whether an attribute name is an `on*` event handler such as `onload`.
+fn is_event_handler(attribute: &str) -> bool {
+    let bytes = attribute.as_bytes();
+    bytes.len() >= 3 && bytes.starts_with(b"on") && bytes[2].is_ascii_alphabetic()
+}
+
+/// Returns whether a URL value enables script execution through its scheme.
+fn is_script_uri(value: &str) -> bool {
+    value.starts_with("javascript:") || value.starts_with("data:") || value.starts_with("vbscript:")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HtmlValidationError, validate};
+    use pretty_assertions::assert_eq;
+
+    /// Accepts plain prose and benign inline markup.
+    #[test]
+    fn accepts_benign_markup() {
+        assert_eq!(validate("A weather plugin for Oracle.").unwrap(), ());
+        assert_eq!(validate("Use the **bold** and `code`.").unwrap(), ());
+        assert_eq!(
+            validate("<em>tip</em> and <code>config</code>").unwrap(),
+            ()
+        );
+    }
+
+    /// Rejects a `<script>` tag regardless of case or attribute spacing.
+    #[test]
+    fn rejects_script_tag() {
+        let error = validate("<p>hi</p><script>alert(1)</script>").unwrap_err();
+        assert_eq!(error, HtmlValidationError::ForbiddenTag { tag: "script" });
+        assert!(validate("<SCRIPT>alert(1)</SCRIPT>").is_err());
+    }
+
+    /// Rejects an `on*` event-handler attribute.
+    #[test]
+    fn rejects_event_handler() {
+        let error = validate("<img src=\"x\" onerror=\"alert(1)\">").unwrap_err();
+        assert_eq!(
+            error,
+            HtmlValidationError::EventAttribute {
+                attribute: "onerror".into()
+            }
+        );
+    }
+
+    /// Rejects `javascript:` and `data:` URIs in attributes.
+    #[test]
+    fn rejects_script_uris() {
+        assert!(validate("<a href=\"javascript:void(0)\">x</a>").is_err());
+        assert!(validate("<img src=\"data:text/html;base64,PHNjcmlwdD4=\">").is_err());
+    }
+
+    /// Returns the first forbidden tag in a stable, deterministic order.
+    #[test]
+    fn first_forbidden_tag_is_deterministic() {
+        let error = validate("<iframe></iframe><script>x()</script>").unwrap_err();
+        assert_eq!(error, HtmlValidationError::ForbiddenTag { tag: "script" });
+    }
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -7,9 +7,16 @@
 
 #[cfg(feature = "archive")]
 pub mod archive;
+pub mod atomic;
 mod git_branch;
+#[cfg(feature = "validation")]
+pub mod hash;
+#[cfg(feature = "validation")]
+pub mod html;
 pub mod path;
 mod slug;
+#[cfg(feature = "validation")]
+pub mod svg;
 
 pub use git_branch::{GitBranchName, GitBranchNameError};
 pub use slug::{Slug, SlugError};

--- a/crates/utils/src/svg.rs
+++ b/crates/utils/src/svg.rs
@@ -1,0 +1,212 @@
+//! Security validation for SVG icons distributed as plugin assets.
+
+use quick_xml::Reader;
+use quick_xml::events::BytesStart;
+use quick_xml::events::Event;
+use thiserror::Error;
+
+/// The size cap for an SVG icon, matching the marketplace packaging limit of 50 KiB.
+pub const DEFAULT_MAX_SVG_BYTES: usize = 50 * 1024;
+
+/// Reports the first unsafe construct discovered while validating an SVG.
+///
+/// The XML stream is checked element by element so the first violation is reported in the same
+/// order it appears in the document, giving callers deterministic diagnostics.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SvgValidationError {
+    #[error("SVG exceeds the {max} byte security limit")]
+    TooLarge { max: usize },
+    #[error("SVG is not well-formed XML: {0}")]
+    MalformedXml(String),
+    #[error("SVG contains the forbidden element `<{element}>`")]
+    ForbiddenElement { element: String },
+    #[error("SVG element `{element}` references an external resource in `{attribute}`")]
+    ExternalReference { element: String, attribute: String },
+    #[error("SVG element `{element}` uses the event-handler attribute `{attribute}`")]
+    EventAttribute { element: String, attribute: String },
+}
+
+/// Validates `svg` bytes against the marketplace icon security policy.
+///
+/// Rejects oversized files, malformed XML, `<script>` / `<foreignObject>` elements, event-handler
+/// attributes, and any `href` / `xlink:href` that targets an external network resource. The
+/// check is conservative and fails closed: anything ambiguous is rejected.
+pub fn validate(svg: &[u8]) -> Result<(), SvgValidationError> {
+    if svg.len() > DEFAULT_MAX_SVG_BYTES {
+        return Err(SvgValidationError::TooLarge {
+            max: DEFAULT_MAX_SVG_BYTES,
+        });
+    }
+
+    let mut reader = Reader::from_reader(svg);
+    let mut buffer = Vec::new();
+    loop {
+        let event = reader
+            .read_event_into(&mut buffer)
+            .map_err(|error| SvgValidationError::MalformedXml(error.to_string()))?;
+        match event {
+            Event::Start(element) | Event::Empty(element) => inspect_start(&element)?,
+            Event::Eof => return Ok(()),
+            _ => {}
+        }
+        buffer.clear();
+    }
+}
+
+/// Inspects one start (or empty) element for forbidden names and unsafe attributes.
+fn inspect_start(element: &BytesStart<'_>) -> Result<(), SvgValidationError> {
+    let element_name = ascii_lowercase(element.local_name().as_ref());
+    let element_spelling = String::from_utf8_lossy(&element_name).into_owned();
+    if let Some(forbidden) = forbidden_element(&element_name) {
+        return Err(SvgValidationError::ForbiddenElement {
+            element: forbidden.into(),
+        });
+    }
+
+    for attribute in element.attributes() {
+        let attribute =
+            attribute.map_err(|error| SvgValidationError::MalformedXml(error.to_string()))?;
+        let attribute_name = ascii_lowercase(attribute.key.local_name().as_ref());
+        let value = attribute
+            .normalized_value(quick_xml::XmlVersion::Implicit1_0)
+            .map_err(|error| SvgValidationError::MalformedXml(error.to_string()))?;
+        let attribute_spelling = String::from_utf8_lossy(&attribute_name);
+
+        if is_event_handler(&attribute_name) {
+            return Err(SvgValidationError::EventAttribute {
+                element: element_spelling,
+                attribute: attribute_spelling.into_owned(),
+            });
+        }
+        if attribute_name == b"href" && is_external_reference(&value) {
+            return Err(SvgValidationError::ExternalReference {
+                element: element_spelling,
+                attribute: attribute_spelling.into_owned(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Maps an element's lowercase local name to its forbidden public spelling.
+fn forbidden_element(element_lower: &[u8]) -> Option<&'static str> {
+    match element_lower {
+        b"script" => Some("script"),
+        b"foreignobject" => Some("foreignObject"),
+        _ => None,
+    }
+}
+
+/// Returns whether an attribute name is an `on*` event handler such as `onload`.
+fn is_event_handler(attribute: &[u8]) -> bool {
+    attribute.len() >= 3 && attribute.starts_with(b"on") && attribute[2].is_ascii_alphabetic()
+}
+
+/// Returns whether an `href` value escapes to an external or script-capable resource.
+fn is_external_reference(value: &str) -> bool {
+    let value = value.trim();
+    value.starts_with("//")
+        || value.starts_with("http:")
+        || value.starts_with("https:")
+        || value.starts_with("javascript:")
+        || value.starts_with("data:")
+}
+
+/// Lowercases ASCII bytes in place, keeping multi-byte UTF-8 sequences untouched.
+fn ascii_lowercase(bytes: &[u8]) -> Vec<u8> {
+    bytes.iter().map(u8::to_ascii_lowercase).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_MAX_SVG_BYTES, SvgValidationError, validate};
+    use pretty_assertions::assert_eq;
+
+    /// Accepts a minimal, well-formed SVG with local fragment references.
+    #[test]
+    fn accepts_benign_svg() {
+        let svg = br##"<svg xmlns="http://www.w3.org/2000/svg"><use href="#icon"/></svg>"##;
+        assert_eq!(validate(svg).unwrap(), ());
+    }
+
+    /// Rejects an embedded `<script>` element regardless of capitalization.
+    #[test]
+    fn rejects_script_element() {
+        let svg = b"<svg><script>evil()</script></svg>";
+        assert_eq!(
+            validate(svg).unwrap_err(),
+            SvgValidationError::ForbiddenElement {
+                element: "script".into()
+            }
+        );
+        assert!(validate(b"<svg><SCRIPT>evil()</SCRIPT></svg>").is_err());
+    }
+
+    /// Rejects a `<foreignObject>` element.
+    #[test]
+    fn rejects_foreign_object() {
+        let svg = b"<svg><foreignObject><div>x</div></foreignObject></svg>";
+        assert_eq!(
+            validate(svg).unwrap_err(),
+            SvgValidationError::ForbiddenElement {
+                element: "foreignObject".into()
+            }
+        );
+    }
+
+    /// Rejects external resources referenced from `href` and `xlink:href`.
+    #[test]
+    fn rejects_external_reference() {
+        let svg = br#"<svg xmlns:xlink="http://www.w3.org/1999/xlink"><image xlink:href="https://evil.example/x.png"/></svg>"#;
+        assert!(matches!(
+            validate(svg).unwrap_err(),
+            SvgValidationError::ExternalReference { .. }
+        ));
+
+        let svg = br#"<svg><image href="http://evil.example/x.png"/></svg>"#;
+        assert!(matches!(
+            validate(svg).unwrap_err(),
+            SvgValidationError::ExternalReference { .. }
+        ));
+    }
+
+    /// Allows fragment links that stay inside the same document.
+    #[test]
+    fn allows_fragment_reference() {
+        let svg = br##"<svg><use href="#icon"/></svg>"##;
+        assert_eq!(validate(svg).unwrap(), ());
+    }
+
+    /// Rejects event-handler attributes.
+    #[test]
+    fn rejects_event_handler() {
+        let svg = br#"<svg onload="evil()"></svg>"#;
+        assert!(matches!(
+            validate(svg).unwrap_err(),
+            SvgValidationError::EventAttribute { .. }
+        ));
+    }
+
+    /// Rejects structurally malformed XML instead of guessing an interpretation.
+    #[test]
+    fn rejects_malformed_xml() {
+        let svg = br#"<svg><rect width="10"</svg>"#;
+        assert!(matches!(
+            validate(svg).unwrap_err(),
+            SvgValidationError::MalformedXml(_)
+        ));
+    }
+
+    /// Rejects a document that exceeds the 50 KiB icon limit.
+    #[test]
+    fn rejects_oversized_svg() {
+        let padding = [b'a'; DEFAULT_MAX_SVG_BYTES];
+        let svg = format!("<svg>{}</svg>", String::from_utf8_lossy(&padding));
+        assert_eq!(
+            validate(svg.as_bytes()).unwrap_err(),
+            SvgValidationError::TooLarge {
+                max: DEFAULT_MAX_SVG_BYTES
+            }
+        );
+    }
+}

--- a/docs/gitlancer-architecture.md
+++ b/docs/gitlancer-architecture.md
@@ -26,7 +26,7 @@ Owns repository facts and invariants: `RepoRoot`, `WorktreeRoot`, `GitDir`, `Rep
 
 It answers questions such as which repo a worktree belongs to, and whether a path is safe to pass to `git add` from this worktree. `WorktreeHandle::resolve_repo_relative_path` lexically normalizes a caller path and rejects absolute paths and traversal outside the worktree; it does not require the target to exist and does not canonicalize through the filesystem. `RepoRelativePath` is obtainable only through that worktree-aware boundary.
 
-Constructors for repository and worktree roots assume their callers already validated Git identity — discovery and validation belong to `git`. This layer spawns no processes and parses no output.
+Constructors for repository and worktree roots assume their callers already validated Git identity —discovery and validation belong to `git`. This layer spawns no processes and parses no output.
 
 ### `exec`
 
@@ -36,7 +36,7 @@ It exists so upper layers can inject a fake runner in tests, record commands for
 
 ### `git`
 
-Exposes the typed use cases Ora calls directly — repository discovery, worktree discovery and lifecycle, branch read and lifecycle, add/commit, diff, push, status, and global identity. Each takes a typed request and returns a typed response, which keeps option growth manageable and produces better call boundaries for agent orchestration.
+Exposes the typed use cases Ora calls directly -repository discovery, worktree discovery and lifecycle, branch read and lifecycle, add/commit, diff, push, status, global identity, and repository sync (clone/fetch/checkout/fast-forward pull). Each takes a typed request and returns a typed response, which keeps option growth manageable and produces better call boundaries for agent orchestration.
 
 Worktree-base discovery is a separate local branch read path because worktree selection must not have network or repository-state side effects.
 
@@ -110,7 +110,7 @@ Branch and worktree lifecycle commands are typed APIs, so callers never assemble
 - `add` stages `RepoRelativePath` values; `commit` creates commits without GPG signing.
 - `push_branch` is the only networked use case in this module. It derives the branch from `WorktreeHandle` rather than accepting a free-form ref from an upper layer.
 
-Mutating operations perform domain validation *before* invoking Git whenever the invalid state is determinable from repository and worktree metadata, and no Git command is issued when validation fails:
+Mutating operations perform domain validation _before_ invoking Git whenever the invalid state is determinable from repository and worktree metadata, and no Git command is issued when validation fails:
 
 - Deleting the repository's main worktree returns `DomainError::CannotDeleteMainWorktree`.
 - Deleting a linked worktree that belongs to a different repository returns `DomainError::WorktreeMismatch`.
@@ -177,11 +177,11 @@ Command telemetry is opt-in through `gitlancer::logging::register`; `ora-logging
 
 gitlancer relies on stable machine-readable outputs:
 
-- `git worktree list --porcelain` — repository discovery, worktree listing, and worktree resolution
-- `git for-each-ref refs/heads` — local worktree-base discovery without remote or repository-state side effects
-- `git rev-parse <ref>^{commit}` — immutable worktree-base resolution
-- `git status --porcelain=v2 -z` — status entries
-- `git rev-parse HEAD` and `git log -1 --pretty=%s` — commit id and summary after a commit
+- `git worktree list --porcelain` -repository discovery, worktree listing, and worktree resolution
+- `git for-each-ref refs/heads` -local worktree-base discovery without remote or repository-state side effects
+- `git rev-parse <ref>^{commit}` -immutable worktree-base resolution
+- `git status --porcelain=v2 -z` -status entries
+- `git rev-parse HEAD` and `git log -1 --pretty=%s` -commit id and summary after a commit
 
 `discover_repository` reads the main checkout out of the porcelain worktree list rather than calling `git rev-parse --show-toplevel`, so discovery from a nested directory and from inside a linked worktree both resolve to the owning repository root. A non-zero exit there is reported as `DomainError::NotARepository` rather than a raw execution error.
 


### PR DESCRIPTION
## What
Adds `ora-plugin-registry`, a new crate that syncs marketplace source
repositories over Git and builds a deterministic `registry_index.json`, plus
general-purpose hashing and static-asset validation primitives in `ora-utils`
for safe ingestion of untrusted plugin manifests/assets.

## Why
Marketplace discovery needs an ordered, atomically-persisted plugin index and
validated asset ingestion before the plugin lifecycle/runtime work consumes
them.

## Changes
- crates/plugin-registry: new crate (RegistrySync::sync, RegistryIndex build/load/write,
  RegistryEntry, RegistryError)
- crates/utils: atomic write, SHA-256 helpers, HTML/SVG validation; new `validation` feature
- crates/gitlancer: expose git sync for reuse by the registry
- workspace/docs: register the crate; update docs and crate READMEs

## Testing
- `task test:crates` passed:
  - `cargo fmt --all -- --check` ✓
  - `cargo clippy --workspace -- -D warnings` ✓
  - `cargo test --workspace` — all suites pass
- `task test:frontend` passed:
  - `export-contracts` ✓
  - frontend lint + all test suites ✓
- Targeted crates:
  - `cargo test -p ora-plugin-registry` — <N> passed
  - `cargo test -p ora-utils` — <M> passed

## Notes
- Discovery layer only; not yet wired to the UI or plugin lifecycle.