### PR TITLE
fix(ci): add timeout and retries for apt dependencies

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -124,16 +124,43 @@ jobs:
           RG_VERSION: 15.2.0
       # System libraries required to compile Tauri 2 on ubuntu-latest (24.04).
       - name: Install Tauri system dependencies
+        timeout-minutes: 16
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libxdo-dev \
-            libssl-dev \
-            build-essential
+          install_tauri_dependencies() {
+            sudo apt-get update
+            sudo env DEBIAN_FRONTEND="$DEBIAN_FRONTEND" \
+              apt-get install -y --no-install-recommends \
+                libwebkit2gtk-4.1-dev \
+                libgtk-3-dev \
+                libayatana-appindicator3-dev \
+                librsvg2-dev \
+                libxdo-dev \
+                libssl-dev \
+                build-essential
+          }
+          export -f install_tauri_dependencies
+
+          for attempt in 1 2 3; do
+            echo "::group::Install Tauri system dependencies (attempt ${attempt}/3)"
+            if timeout --kill-after=10s 5m \
+              bash -euo pipefail -c install_tauri_dependencies; then
+              echo "::endgroup::"
+              exit 0
+            else
+              status=$?
+            fi
+            echo "::endgroup::"
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Tauri system dependency installation failed after 3 attempts (last exit code: ${status})"
+              exit "$status"
+            fi
+
+            echo "::warning::Tauri system dependency installation failed with exit code ${status}; retrying in 10 seconds"
+            sleep 10
+          done
       - run: task test:crates
 
   # Aggregate gate: the single check to mark as "required" in branch


### PR DESCRIPTION
## Summary

- bound each Tauri system dependency installation attempt to five minutes
- retry the complete `apt-get update` and install sequence up to three total attempts
- fail explicitly after the third attempt and add a 16-minute step-level safety limit
- run apt non-interactively and expose each attempt as a separate Actions log group

## Root cause

GitHub-hosted `ubuntu-latest` runners intermittently stopped producing output while `apt-get update` fetched package indexes from `azure.archive.ubuntu.com`. With no timeout on the step, affected `crates` jobs remained in progress for hours and never reached `task test:crates`.

## Impact

Transient mirror failures now retry on a fresh attempt. Persistent failures become an explicit CI failure in about 15 minutes instead of leaving the PR check pending indefinitely.

## Verification

- Prettier check for `.github/workflows/pr-tests.yml`
- YAML syntax parse
- extracted Bash script checked with `bash -n`
- GNU `timeout` and exported function invocation check
- simulated second-attempt success and three-attempt failure paths
- `git diff --check`
