### PR TITLE
feat(plugin): publishable plugin SDK and deterministic plugin launch

### DIFF
--- a/.github/workflows/plugin-sdk-publish.yml
+++ b/.github/workflows/plugin-sdk-publish.yml
@@ -1,0 +1,48 @@
+name: plugin-sdk-publish
+
+on:
+  push:
+    tags:
+      - "plugin-sdk/v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/plugin-sdk
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Verify tag matches package versions
+        run: |
+          tag_version="${GITHUB_REF_NAME#plugin-sdk/v}"
+          deno_version="$(deno eval 'console.log(JSON.parse(Deno.readTextFileSync("deno.json")).version)')"
+          npm_version="$(deno eval 'console.log(JSON.parse(Deno.readTextFileSync("package.json")).version)')"
+          sdk_version="$(deno eval 'import { SDK_VERSION } from "./src/version.ts"; console.log(SDK_VERSION)')"
+          for candidate in "$deno_version" "$npm_version" "$sdk_version"; do
+            if [ "$candidate" != "$tag_version" ]; then
+              echo "tag $tag_version does not match $candidate" >&2
+              exit 1
+            fi
+          done
+      - run: deno task format:check
+      - run: deno task lint
+      - run: deno task check
+      - run: deno task test
+      - name: Publish to JSR
+        run: deno publish
+      - name: Publish npm mirror
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,6 +3069,7 @@ dependencies = [
 name = "ora-plugin-manager"
 version = "0.0.0"
 dependencies = [
+ "ora-domain",
  "ora-utils",
  "pretty_assertions",
  "semver",
@@ -3096,10 +3097,12 @@ dependencies = [
 name = "ora-plugin-runtime"
 version = "0.0.0"
 dependencies = [
+ "ora-domain",
  "ora-logging",
  "ora-process",
  "pretty_assertions",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tracing",

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -31,7 +31,7 @@ pub use ids::{
     WorktreeProvisioningLeaseId,
 };
 pub use namespace::Namespace;
-pub use plugin::{PluginEnabledState, PluginState};
+pub use plugin::{EnvPermission, PluginEnabledState, PluginPermissions, PluginState};
 pub use project::Project;
 pub use session::{AgentCli, HistoryState, Session, SessionStatus};
 pub use session_title::{MAX_SESSION_TITLE_CHARS, SessionTitle, SessionTitleError};

--- a/crates/domain/src/plugin.rs
+++ b/crates/domain/src/plugin.rs
@@ -61,3 +61,56 @@ impl PluginState {
         }
     }
 }
+
+/// Describes which environment variables a plugin process may read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum EnvPermission {
+    /// The process cannot read any environment variable.
+    #[default]
+    Denied,
+    /// The process may read exactly these variables (`--allow-env=A,B`).
+    Variables(Vec<String>),
+    /// The process may read the whole environment (`--allow-env`).
+    All,
+}
+
+/// Holds the Deno permissions a plugin declares in its manifest and the host grants at launch.
+///
+/// Declared permissions are the only ones a plugin process receives; the host no longer hands
+/// every plugin the same fixed set. A missing declaration means the plugin runs fully sandboxed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PluginPermissions {
+    /// `--allow-run`: spawn child processes, such as an external agent CLI.
+    pub run: bool,
+    /// `--allow-read`: read the filesystem beyond the module graph Deno already loads.
+    pub read: bool,
+    /// Environment variables the process may read.
+    pub env: EnvPermission,
+    /// `--allow-net`: open network connections from the plugin process itself.
+    pub net: bool,
+}
+
+impl PluginPermissions {
+    /// Renders the declared permissions as Deno CLI flags, in a stable order.
+    pub fn deno_flags(&self) -> Vec<String> {
+        let mut flags = Vec::new();
+        if self.run {
+            flags.push("--allow-run".to_string());
+        }
+        if self.read {
+            flags.push("--allow-read".to_string());
+        }
+        match &self.env {
+            EnvPermission::Denied => {}
+            EnvPermission::Variables(names) if names.is_empty() => {}
+            EnvPermission::Variables(names) => {
+                flags.push(format!("--allow-env={}", names.join(",")));
+            }
+            EnvPermission::All => flags.push("--allow-env".to_string()),
+        }
+        if self.net {
+            flags.push("--allow-net".to_string());
+        }
+        flags
+    }
+}

--- a/crates/domain/src/tests.rs
+++ b/crates/domain/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::{
     AgentCli, AgentDefinition, AgentDefinitionId, AuditFields, BACKUP_DIR_NAME, DomainModelError,
-    HistoryState, JOURNAL_DIR_NAME, Namespace, Project, ProjectId, STAGING_DIR_NAME, Session,
-    SessionId, SessionStatus, Skill, SkillId, Task, TaskId, TaskType, Worktree, WorktreeActivity,
-    WorktreeBaseline, WorktreeId,
+    EnvPermission, HistoryState, JOURNAL_DIR_NAME, Namespace, PluginPermissions, Project,
+    ProjectId, STAGING_DIR_NAME, Session, SessionId, SessionStatus, Skill, SkillId, Task, TaskId,
+    TaskType, Worktree, WorktreeActivity, WorktreeBaseline, WorktreeId,
 };
 use pretty_assertions::assert_eq;
 
@@ -298,5 +298,47 @@ fn rejects_invalid_database_values() {
     assert_eq!(
         SessionStatus::from_database_value(5),
         Err(DomainModelError::InvalidSessionStatus(5))
+    );
+}
+
+/// Declared permissions translate into the exact Deno flags the host passes, and nothing more.
+#[test]
+fn renders_plugin_permissions_as_deno_flags() {
+    assert_eq!(
+        PluginPermissions::default().deno_flags(),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        PluginPermissions {
+            run: true,
+            read: true,
+            env: EnvPermission::Variables(vec!["ORA_BIN".to_string(), "PATH".to_string()]),
+            net: true,
+        }
+        .deno_flags(),
+        vec![
+            "--allow-run".to_string(),
+            "--allow-read".to_string(),
+            "--allow-env=ORA_BIN,PATH".to_string(),
+            "--allow-net".to_string(),
+        ]
+    );
+    assert_eq!(
+        PluginPermissions {
+            run: false,
+            read: false,
+            env: EnvPermission::All,
+            net: false,
+        }
+        .deno_flags(),
+        vec!["--allow-env".to_string()]
+    );
+    assert_eq!(
+        PluginPermissions {
+            env: EnvPermission::Variables(Vec::new()),
+            ..PluginPermissions::default()
+        }
+        .deno_flags(),
+        Vec::<String>::new()
     );
 }

--- a/crates/plugin-lifecycle/README.md
+++ b/crates/plugin-lifecycle/README.md
@@ -17,7 +17,9 @@ over a partially refreshed result.
 Filesystem package parsing remains in `ora-plugin-manager`, process protocol ownership remains in
 `ora-plugin-runtime`, and durable eligibility remains behind the `ora-application` repository port.
 The production adapter launches Deno through the shared process-tree supervisor and waits for
-confirmed process exit before filesystem cleanup.
+confirmed process exit before filesystem cleanup. Every launch request carries the package root,
+the manifest-declared permissions, and the shared dependency cache at `<data-dir>/deno`
+(`DENO_CACHE_DIR_NAME`), so runtime behaviour depends only on what is installed on disk.
 
 Transport adapters and concrete dependency composition belong to `ora-backend` and Desktop. This
 crate does not depend on Tauri, SQLite, or backend-private state.

--- a/crates/plugin-lifecycle/src/lib.rs
+++ b/crates/plugin-lifecycle/src/lib.rs
@@ -14,7 +14,7 @@ use ora_contracts::{
     EnablePluginRequest, EnablePluginResponse, ListInstalledPluginsResponse, StopPluginRequest,
     StopPluginResponse, UninstallPluginRequest, UninstallPluginResponse,
 };
-use ora_domain::{PluginEnabledState, PluginId};
+use ora_domain::{PluginEnabledState, PluginId, PluginPermissions};
 use ora_plugin_manager::{InstalledPlugin as DiscoveredPlugin, PluginManager};
 use std::collections::BTreeMap;
 use std::future::Future;
@@ -30,12 +30,24 @@ pub struct PluginLifecycleConfig {
     pub deno_path: PathBuf,
 }
 
+/// Directory under the Ora data directory that holds the shared Deno dependency cache.
+///
+/// Keeping `DENO_DIR` inside the data directory means the host owns every cached module, can
+/// clear it wholesale, and never depends on the user's global Deno cache.
+pub const DENO_CACHE_DIR_NAME: &str = "deno";
+
 /// Describes one concrete process launch after package discovery has resolved its entrypoint.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginLaunchRequest {
     pub plugin_id: PluginId,
     pub deno_path: PathBuf,
+    /// Installed package root; the process working directory and `deno.json` discovery root.
+    pub package_root: PathBuf,
     pub entrypoint: PathBuf,
+    /// Host-owned Deno dependency cache shared by every plugin.
+    pub deno_dir: PathBuf,
+    /// Permissions the package manifest declared; the process receives exactly these.
+    pub permissions: PluginPermissions,
 }
 
 /// Preserves the reason a plugin process could not start or stopped unexpectedly.
@@ -572,7 +584,10 @@ async fn complete_launch<Repository, LifecycleClock, RuntimeLauncher, StatusPubl
         .launch(PluginLaunchRequest {
             plugin_id: plugin_id.clone(),
             deno_path: inner.config.deno_path.clone(),
+            package_root: plugin.package_root.clone(),
             entrypoint: plugin.package_root.join(plugin.main.to_path_buf()),
+            deno_dir: inner.config.data_directory.join(DENO_CACHE_DIR_NAME),
+            permissions: plugin.permissions.clone(),
         })
         .await;
 

--- a/crates/plugin-lifecycle/src/runtime.rs
+++ b/crates/plugin-lifecycle/src/runtime.rs
@@ -61,7 +61,10 @@ impl PluginRuntimeLauncher for DenoPluginRuntimeLauncher {
                 PluginRuntimeConfig {
                     plugin_id: request.plugin_id.to_string(),
                     deno_path: request.deno_path,
+                    package_root: request.package_root,
                     entrypoint: request.entrypoint,
+                    deno_dir: request.deno_dir,
+                    permissions: request.permissions,
                     ready_timeout: timeouts.ready,
                     call_timeout: timeouts.call,
                     shutdown_timeout: timeouts.shutdown,

--- a/crates/plugin-lifecycle/src/tests.rs
+++ b/crates/plugin-lifecycle/src/tests.rs
@@ -13,7 +13,7 @@ use ora_contracts::{
 use ora_db::{
     DatabaseBootstrapper, DatabaseLocation, SqlitePluginStateRepository, default_migration_catalog,
 };
-use ora_domain::{PluginEnabledState, PluginId};
+use ora_domain::{EnvPermission, PluginEnabledState, PluginId, PluginPermissions};
 use ora_logging::with_trace_logging;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -617,12 +617,20 @@ async fn activates_enabled_plugin_and_publishes_each_transition() {
         Some(PluginLaunchRequest {
             plugin_id: PluginId::new("ora.example"),
             deno_path: PathBuf::from("deno"),
+            package_root: temp_dir.path().join("plugins").join("example"),
             entrypoint: temp_dir
                 .path()
                 .join("plugins")
                 .join("example")
                 .join("dist")
                 .join("index.js"),
+            deno_dir: temp_dir.path().join("deno"),
+            permissions: PluginPermissions {
+                run: true,
+                read: false,
+                env: EnvPermission::Variables(vec!["ORA_EXAMPLE_BIN".to_string()]),
+                net: true,
+            },
         }),
     );
 
@@ -1385,8 +1393,7 @@ fn write_plugin_package(data_dir: &std::path::Path, directory: &str, id: &str, n
                 "main": "dist/index.js",
                 "engines": {
                     "ora": ">=0.1.0 <0.2.0",
-                    "pluginApi": 1,
-                    "bun": ">=1.0.0 <2.0.0"
+                    "pluginApi": 1
                 },
                 "contributes": {
                     "agents": [{
@@ -1394,6 +1401,11 @@ fn write_plugin_package(data_dir: &std::path::Path, directory: &str, id: &str, n
                         "displayName": "Example Agent",
                         "contractVersion": 1
                     }]
+                },
+                "permissions": {
+                    "run": true,
+                    "env": ["ORA_EXAMPLE_BIN"],
+                    "net": true
                 }
             }
         }))

--- a/crates/plugin-manager/Cargo.toml
+++ b/crates/plugin-manager/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
+ora-domain = { workspace = true }
 ora-utils = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/plugin-manager/README.md
+++ b/crates/plugin-manager/README.md
@@ -8,6 +8,8 @@
 - Read and validate each child package's `package.json`.
 - Resolve `ora.main` as an existing regular file whose canonical target remains inside its package,
   then retain its normalized portable relative path.
+- Convert the optional `ora.permissions` declaration (`run`, `read`, `env` as a boolean or a list
+  of variable names, `net`) into `PluginPermissions`; an absent declaration means no permissions.
 - Return a deterministic, immutable snapshot of valid installed plugins.
 - Isolate malformed or unsupported packages as structured discovery issues.
 

--- a/crates/plugin-manager/src/manifest.rs
+++ b/crates/plugin-manager/src/manifest.rs
@@ -22,6 +22,37 @@ pub(crate) struct OraManifest {
     pub main: String,
     pub engines: EngineManifest,
     pub contributes: ContributionManifest,
+    /// Deno permissions the plugin asks for; absent means fully sandboxed.
+    #[serde(default)]
+    pub permissions: Option<PermissionsManifest>,
+}
+
+/// Mirrors the Deno permissions a plugin declares; every field is optional and defaults to denied.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PermissionsManifest {
+    #[serde(default)]
+    pub run: bool,
+    #[serde(default)]
+    pub read: bool,
+    #[serde(default)]
+    pub env: EnvPermissionManifest,
+    #[serde(default)]
+    pub net: bool,
+}
+
+/// Mirrors `env: true | false | ["NAME", …]` without forcing plugin authors into one spelling.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum EnvPermissionManifest {
+    All(bool),
+    Variables(Vec<String>),
+}
+
+impl Default for EnvPermissionManifest {
+    fn default() -> Self {
+        Self::All(false)
+    }
 }
 
 /// Mirrors engine declarations while leaving npm-style ranges uninterpreted.
@@ -30,7 +61,6 @@ pub(crate) struct OraManifest {
 pub(crate) struct EngineManifest {
     pub ora: String,
     pub plugin_api: u32,
-    pub bun: String,
 }
 
 /// Mirrors contributions declared by one plugin package.

--- a/crates/plugin-manager/src/tests.rs
+++ b/crates/plugin-manager/src/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     MAX_MANIFEST_BYTES, PluginDiscoveryIssueKind, PluginKind, PluginManager, PluginPackageType,
 };
+use ora_domain::{EnvPermission, PluginPermissions};
 use ora_utils::path::PortableRelativePath;
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
@@ -38,11 +39,79 @@ fn discovers_complete_manifest() {
     );
     assert_eq!(plugin.engines.ora, ">=0.1.0 <0.2.0");
     assert_eq!(plugin.engines.plugin_api, 1);
-    assert_eq!(plugin.engines.bun, ">=1.0.0 <2.0.0");
     assert_eq!(plugin.agents.len(), 1);
     assert_eq!(plugin.agents[0].id, "claude-code");
     assert_eq!(plugin.agents[0].display_name, "Claude Code");
     assert_eq!(plugin.agents[0].contract_version, 1);
+    assert_eq!(plugin.permissions, PluginPermissions::default());
+}
+
+/// Declared permissions are carried through verbatim, with `env` accepting both spellings.
+#[test]
+fn discovers_declared_permissions() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut manifest = valid_manifest("ora.claude-code", "Claude Code", "0.1.0");
+    manifest["ora"]["permissions"] = json!({
+        "run": true,
+        "env": ["ORA_CLAUDE_ACP_BIN", "PATH"],
+        "net": true
+    });
+    write_manifest(temp_dir.path(), "claude", manifest);
+
+    let manager = PluginManager::discover(temp_dir.path());
+
+    assert_eq!(manager.discovery_issues(), &[]);
+    assert_eq!(
+        manager.installed_plugins()[0].permissions,
+        PluginPermissions {
+            run: true,
+            read: false,
+            env: EnvPermission::Variables(vec![
+                "ORA_CLAUDE_ACP_BIN".to_string(),
+                "PATH".to_string()
+            ]),
+            net: true,
+        }
+    );
+
+    let mut all_env = valid_manifest("ora.other", "Other", "0.1.0");
+    all_env["ora"]["permissions"] = json!({ "env": true });
+    write_manifest(temp_dir.path(), "other", all_env);
+    let manager = PluginManager::discover(temp_dir.path());
+    let other = manager
+        .installed_plugins()
+        .iter()
+        .find(|plugin| plugin.id == "ora.other")
+        .unwrap();
+    assert_eq!(
+        other.permissions,
+        PluginPermissions {
+            env: EnvPermission::All,
+            ..PluginPermissions::default()
+        }
+    );
+}
+
+/// An env variable name that would split the Deno flag is a manifest error, not a silent grant.
+#[test]
+fn rejects_invalid_env_permission_names() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut manifest = valid_manifest("ora.claude-code", "Claude Code", "0.1.0");
+    manifest["ora"]["permissions"] = json!({ "env": ["A,B"] });
+    write_manifest(temp_dir.path(), "claude", manifest);
+
+    let manager = PluginManager::discover(temp_dir.path());
+
+    assert_eq!(manager.installed_plugins(), &[]);
+    assert_eq!(manager.discovery_issues().len(), 1);
+    assert_eq!(
+        manager.discovery_issues()[0].kind(),
+        PluginDiscoveryIssueKind::InvalidManifest
+    );
+    assert_eq!(
+        manager.discovery_issues()[0].field_path(),
+        Some("ora.permissions.env")
+    );
 }
 
 /// Verifies a missing plugin root represents an empty installation.
@@ -262,7 +331,6 @@ fn rejects_empty_required_strings() {
         (vec!["ora", "displayName"], "ora.displayName"),
         (vec!["ora", "main"], "ora.main"),
         (vec!["ora", "engines", "ora"], "ora.engines.ora"),
-        (vec!["ora", "engines", "bun"], "ora.engines.bun"),
         (
             vec!["ora", "contributes", "agents", "0", "id"],
             "ora.contributes.agents[].id",
@@ -495,8 +563,7 @@ fn valid_manifest(id: &str, display_name: &str, version: &str) -> Value {
             "main": "dist/index.js",
             "engines": {
                 "ora": ">=0.1.0 <0.2.0",
-                "pluginApi": 1,
-                "bun": ">=1.0.0 <2.0.0"
+                "pluginApi": 1
             },
             "contributes": {
                 "agents": [{

--- a/crates/plugin-manager/src/validation.rs
+++ b/crates/plugin-manager/src/validation.rs
@@ -1,4 +1,5 @@
-use crate::manifest::{AgentManifest, PackageManifest};
+use crate::manifest::{AgentManifest, EnvPermissionManifest, PackageManifest, PermissionsManifest};
+use ora_domain::{EnvPermission, PluginPermissions};
 use ora_utils::path::{CanonicalPathRoot, PortableRelativePath};
 use semver::Version;
 use std::collections::HashSet;
@@ -35,7 +36,6 @@ impl PluginKind {
 pub struct PluginEngines {
     pub ora: String,
     pub plugin_api: u32,
-    pub bun: String,
 }
 
 /// Holds one validated agent contribution.
@@ -60,6 +60,8 @@ pub struct InstalledPlugin {
     pub main: PortableRelativePath,
     pub engines: PluginEngines,
     pub agents: Vec<InstalledPluginAgent>,
+    /// Permissions the host grants this plugin process; defaults to none when undeclared.
+    pub permissions: PluginPermissions,
 }
 
 /// Reports a semantic manifest constraint after structural deserialization succeeds.
@@ -123,9 +125,9 @@ pub(crate) fn validate(
             ),
         ));
     }
-    require_non_empty("ora.engines.bun", &manifest.ora.engines.bun)?;
 
     let agents = validate_agents(manifest.ora.contributes.agents)?;
+    let permissions = validate_permissions(manifest.ora.permissions.unwrap_or_default())?;
 
     Ok(InstalledPlugin {
         package_root: package_root.to_path_buf(),
@@ -140,9 +142,43 @@ pub(crate) fn validate(
         engines: PluginEngines {
             ora: manifest.ora.engines.ora,
             plugin_api: manifest.ora.engines.plugin_api,
-            bun: manifest.ora.engines.bun,
         },
         agents,
+        permissions,
+    })
+}
+
+/// Converts declared permissions into the domain shape, rejecting unusable env variable names.
+fn validate_permissions(
+    permissions: PermissionsManifest,
+) -> Result<PluginPermissions, ManifestValidationError> {
+    let env = match permissions.env {
+        EnvPermissionManifest::All(true) => EnvPermission::All,
+        EnvPermissionManifest::All(false) => EnvPermission::Denied,
+        EnvPermissionManifest::Variables(names) => {
+            // A comma would split the `--allow-env=A,B` flag into unintended grants, and an empty
+            // name can only be a mistake, so both are rejected rather than passed to Deno.
+            if let Some(name) = names
+                .iter()
+                .find(|name| name.trim().is_empty() || name.contains(','))
+            {
+                return Err(invalid(
+                    "ora.permissions.env",
+                    format!("environment variable name `{name}` is not valid"),
+                ));
+            }
+            if names.is_empty() {
+                EnvPermission::Denied
+            } else {
+                EnvPermission::Variables(names)
+            }
+        }
+    };
+    Ok(PluginPermissions {
+        run: permissions.run,
+        read: permissions.read,
+        env,
+        net: permissions.net,
     })
 }
 

--- a/crates/plugin-runtime/Cargo.toml
+++ b/crates/plugin-runtime/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
+ora-domain = { workspace = true }
 ora-logging = { workspace = true }
 ora-process = { workspace = true }
 serde_json = { workspace = true }
@@ -20,3 +21,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/plugin-runtime/README.md
+++ b/crates/plugin-runtime/README.md
@@ -12,6 +12,18 @@ plugin identifier, an entrypoint, a Deno executable, and the exact method to inv
 Application-level code remains responsible for mapping Ora capabilities to those
 plugin methods.
 
+Each plugin process is launched deterministically: `deno run --no-prompt --cached-only`, with
+`--frozen --lock <package>/deno.lock` when the package ships a lockfile, exactly the `--allow-*`
+flags its manifest declared (`PluginPermissions`), the package root as working directory so Deno
+discovers the package's own `deno.json`, and `DENO_DIR` pointed at the host-owned dependency cache.
+Module resolution therefore never reaches the network at launch; dependencies must already be in
+the cache or vendored inside the package.
+
+Registration (`ora/register`) carries the method set, the notification methods the plugin may emit,
+the SDK version, and named contract versions. A `pluginApi` contract the host does not support
+fails the handshake. Notifications whose method was declared in `emits` are delivered to
+`subscribe_notifications()` subscribers; any other plugin-originated method is a protocol failure.
+
 Stdout is reserved for framed protocol messages. Each frame contains a four-byte
 big-endian length, a one-byte frame type, and a UTF-8 JSON payload. Protocol failures
 invalidate the process because the host can no longer safely correlate responses.

--- a/crates/plugin-runtime/src/lib.rs
+++ b/crates/plugin-runtime/src/lib.rs
@@ -6,12 +6,13 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use ora_domain::PluginPermissions;
 use ora_logging::{ora_error, ora_info, ora_warn};
 use ora_process::{ManagedProcess, ProcessSpawner, ProcessSpec};
 use serde_json::{Value, json};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio::sync::{Mutex, RwLock, mpsc, oneshot, watch};
+use tokio::sync::{Mutex, RwLock, broadcast, mpsc, oneshot, watch};
 use tokio::time::timeout;
 
 use crate::codec::{read_frame, write_frame};
@@ -19,16 +20,47 @@ use crate::codec::{read_frame, write_frame};
 const JSON_RPC_VERSION: &str = "2.0";
 const REGISTER_METHOD: &str = "ora/register";
 const SHUTDOWN_METHOD: &str = "ora/shutdown";
+/// The plugin protocol version this host speaks; a plugin reporting another one is refused.
+const SUPPORTED_PLUGIN_API_VERSION: u64 = 1;
+/// Notifications a plugin emits faster than subscribers drain are dropped, never buffered forever.
+const NOTIFICATION_CHANNEL_CAPACITY: usize = 256;
+/// The Deno lockfile name a plugin package pins its dependency graph with.
+const DENO_LOCKFILE: &str = "deno.lock";
 
 /// Describes one eagerly started Deno plugin process and its lifecycle timeouts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginRuntimeConfig {
     pub plugin_id: String,
     pub deno_path: PathBuf,
+    /// Root of the installed package; Deno discovers `deno.json` and `deno.lock` from here.
+    pub package_root: PathBuf,
     pub entrypoint: PathBuf,
+    /// Host-owned `DENO_DIR` holding every plugin's pre-warmed dependency cache.
+    pub deno_dir: PathBuf,
+    /// Permissions the plugin declared; translated one-to-one into `--allow-*` flags.
+    pub permissions: PluginPermissions,
     pub ready_timeout: Duration,
     pub call_timeout: Duration,
     pub shutdown_timeout: Duration,
+}
+
+/// Records what one plugin announced in `ora/register`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PluginRegistration {
+    pub methods: HashSet<String>,
+    /// Notification methods the plugin may send to the host unprompted.
+    pub emits: HashSet<String>,
+    /// SDK release the plugin was built with; diagnostic only, the host checks contracts instead.
+    pub sdk_version: Option<String>,
+    /// Contract name to version, always including `pluginApi` for SDKs that report it.
+    pub contracts: HashMap<String, u64>,
+}
+
+/// One notification a plugin emitted; only methods declared in `emits` reach subscribers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginNotification {
+    pub method: String,
+    pub params: Value,
 }
 
 /// Reports why a plugin cannot start or serve a method invocation.
@@ -44,6 +76,8 @@ pub enum PluginRuntimeError {
     ReadyTimeout,
     #[error("plugin is unavailable: {0}")]
     Unavailable(String),
+    #[error("plugin reports plugin API version {0}, host supports {SUPPORTED_PLUGIN_API_VERSION}")]
+    UnsupportedPluginApi(u64),
     #[error("plugin did not register method {0}")]
     MethodNotRegistered(String),
     #[error("plugin request channel is closed")]
@@ -73,7 +107,8 @@ type PendingResult = Result<Value, PluginRuntimeError>;
 
 struct RuntimeInner {
     plugin_id: String,
-    methods: RwLock<HashSet<String>>,
+    registration: RwLock<PluginRegistration>,
+    notification_tx: broadcast::Sender<PluginNotification>,
     status_tx: watch::Sender<RuntimeStatus>,
     exited_tx: watch::Sender<bool>,
     writer_tx: mpsc::Sender<Value>,
@@ -119,10 +154,7 @@ impl PluginRuntime {
             return Err(PluginRuntimeError::MissingEntrypoint(config.entrypoint));
         }
 
-        let spec = ProcessSpec::new(config.deno_path.as_os_str())
-            .arg("run")
-            .arg("--no-prompt")
-            .arg(config.entrypoint.as_os_str());
+        let spec = build_launch_spec(&config);
         let mut process = spawner
             .spawn(spec)
             .map_err(|error| PluginRuntimeError::Spawn(error.to_string()))?;
@@ -141,9 +173,11 @@ impl PluginRuntime {
         let (supervisor_tx, supervisor_rx) = mpsc::unbounded_channel();
         let (status_tx, mut status_rx) = watch::channel(RuntimeStatus::Starting);
         let (exited_tx, _) = watch::channel(false);
+        let (notification_tx, _) = broadcast::channel(NOTIFICATION_CHANNEL_CAPACITY);
         let inner = Arc::new(RuntimeInner {
             plugin_id: config.plugin_id.clone(),
-            methods: RwLock::new(HashSet::new()),
+            registration: RwLock::new(PluginRegistration::default()),
+            notification_tx,
             status_tx,
             exited_tx,
             writer_tx: writer_tx.clone(),
@@ -212,6 +246,19 @@ impl PluginRuntime {
         Ok(runtime)
     }
 
+    /// Returns what the plugin announced in `ora/register`.
+    pub async fn registration(&self) -> PluginRegistration {
+        self.inner.registration.read().await.clone()
+    }
+
+    /// Subscribes to notifications the plugin emits; methods must have been declared in `emits`.
+    ///
+    /// A lagging subscriber loses the oldest notifications rather than stalling the protocol
+    /// reader, which is why the channel is bounded and broadcast.
+    pub fn subscribe_notifications(&self) -> broadcast::Receiver<PluginNotification> {
+        self.inner.notification_tx.subscribe()
+    }
+
     /// Invokes one registered method and returns its JSON result.
     pub async fn invoke(&self, method: &str, params: Value) -> Result<Value, PluginRuntimeError> {
         match self.inner.status_tx.borrow().clone() {
@@ -230,7 +277,14 @@ impl PluginRuntime {
                 ));
             }
         }
-        if !self.inner.methods.read().await.contains(method) {
+        if !self
+            .inner
+            .registration
+            .read()
+            .await
+            .methods
+            .contains(method)
+        {
             return Err(PluginRuntimeError::MethodNotRegistered(method.to_string()));
         }
 
@@ -376,28 +430,30 @@ async fn handle_message(inner: &RuntimeInner, message: Value) -> Result<(), Stri
         if !matches!(*inner.status_tx.borrow(), RuntimeStatus::Starting) {
             return Err("plugin registered methods more than once".to_string());
         }
-        let methods = object
+        let params = object
             .get("params")
-            .and_then(|params| params.get("methods"))
-            .and_then(Value::as_array)
-            .ok_or_else(|| "plugin registration is missing a methods array".to_string())?;
-        let mut registered = HashSet::with_capacity(methods.len());
-        for method in methods {
-            let method = method
-                .as_str()
-                .filter(|method| !method.is_empty())
-                .ok_or_else(|| "plugin registration contains an invalid method".to_string())?;
-            if !registered.insert(method.to_string()) {
-                return Err(format!("plugin registered duplicate method {method}"));
-            }
-        }
-        *inner.methods.write().await = registered;
+            .ok_or_else(|| "plugin registration is missing params".to_string())?;
+        let registration = parse_registration(params)?;
+        *inner.registration.write().await = registration;
         inner.status_tx.send_replace(RuntimeStatus::Ready);
         return Ok(());
     }
 
-    if object.contains_key("method") {
-        return Err("plugin sent an unsupported notification or request".to_string());
+    if let Some(method) = object.get("method").and_then(Value::as_str) {
+        if object.contains_key("id") {
+            return Err(format!("plugin sent an unsupported request {method}"));
+        }
+        // Only declared emits are delivered; an undeclared method is a protocol violation because
+        // the host validated the plugin's whole behaviour from its registration.
+        if !inner.registration.read().await.emits.contains(method) {
+            return Err(format!("plugin sent an undeclared notification {method}"));
+        }
+        // A send error only means nobody is subscribed right now, which is not a plugin fault.
+        let _ = inner.notification_tx.send(PluginNotification {
+            method: method.to_string(),
+            params: object.get("params").cloned().unwrap_or(Value::Null),
+        });
+        return Ok(());
     }
 
     let request_id = object
@@ -430,6 +486,92 @@ async fn handle_message(inner: &RuntimeInner, message: Value) -> Result<(), Stri
         .ok_or_else(|| format!("plugin responded with unknown request ID {request_id}"))?;
     let _ = sender.send(result);
     Ok(())
+}
+
+/// Builds the Deno command line for one plugin package.
+///
+/// The launch is deterministic by construction: modules come only from the host-owned
+/// `DENO_DIR` (`--cached-only`), a package lockfile is enforced when present (`--frozen`), and
+/// permissions are exactly the ones the manifest declared. The package root is the working
+/// directory so Deno discovers the package's own `deno.json` import map.
+fn build_launch_spec(config: &PluginRuntimeConfig) -> ProcessSpec {
+    let mut spec = ProcessSpec::new(config.deno_path.as_os_str())
+        .arg("run")
+        .arg("--no-prompt")
+        .arg("--cached-only");
+    let lockfile = config.package_root.join(DENO_LOCKFILE);
+    if lockfile.is_file() {
+        spec = spec.arg("--frozen").arg("--lock").arg(lockfile.as_os_str());
+    }
+    spec.args(config.permissions.deno_flags())
+        .arg(config.entrypoint.as_os_str())
+        .cwd(config.package_root.clone())
+        .env("DENO_DIR", config.deno_dir.as_os_str())
+}
+
+/// Validates `ora/register` params into the immutable registration record.
+fn parse_registration(params: &Value) -> Result<PluginRegistration, String> {
+    let methods = params
+        .get("methods")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "plugin registration is missing a methods array".to_string())?;
+    let mut registered = HashSet::with_capacity(methods.len());
+    for method in methods {
+        let method = method
+            .as_str()
+            .filter(|method| !method.is_empty())
+            .ok_or_else(|| "plugin registration contains an invalid method".to_string())?;
+        if !registered.insert(method.to_string()) {
+            return Err(format!("plugin registered duplicate method {method}"));
+        }
+    }
+
+    // `emits` is optional so SDKs without notification support still register.
+    let mut emits = HashSet::new();
+    if let Some(declared) = params.get("emits") {
+        let declared = declared
+            .as_array()
+            .ok_or_else(|| "plugin registration emits must be an array".to_string())?;
+        for method in declared {
+            let method = method
+                .as_str()
+                .filter(|method| !method.is_empty())
+                .ok_or_else(|| "plugin registration contains an invalid emit".to_string())?;
+            emits.insert(method.to_string());
+        }
+    }
+
+    let sdk_version = params
+        .get("sdkVersion")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    let mut contracts = HashMap::new();
+    if let Some(declared) = params.get("contracts") {
+        let declared = declared
+            .as_object()
+            .ok_or_else(|| "plugin registration contracts must be an object".to_string())?;
+        for (name, version) in declared {
+            let version = version
+                .as_u64()
+                .ok_or_else(|| format!("plugin contract {name} has an invalid version"))?;
+            contracts.insert(name.clone(), version);
+        }
+    }
+    // Refusing here turns a future protocol break into a precise handshake error instead of a
+    // confusing failure on the first call.
+    if let Some(&plugin_api) = contracts.get("pluginApi")
+        && plugin_api != SUPPORTED_PLUGIN_API_VERSION
+    {
+        return Err(PluginRuntimeError::UnsupportedPluginApi(plugin_api).to_string());
+    }
+
+    Ok(PluginRegistration {
+        methods: registered,
+        emits,
+        sdk_version,
+        contracts,
+    })
 }
 
 /// Drains plugin stderr continuously so logging cannot block the child process.
@@ -525,14 +667,20 @@ async fn fail_pending(inner: &RuntimeInner, error: PluginRuntimeError) {
 
 #[cfg(test)]
 mod tests {
-    use super::{RuntimeInner, RuntimeStatus, handle_message, run_writer};
+    use super::{
+        NOTIFICATION_CHANNEL_CAPACITY, PluginNotification, PluginRegistration, PluginRuntimeConfig,
+        RuntimeInner, RuntimeStatus, build_launch_spec, handle_message, run_writer,
+    };
+    use ora_domain::{EnvPermission, PluginPermissions};
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::collections::{HashMap, HashSet};
+    use std::ffi::OsStr;
+    use std::path::PathBuf;
     use std::sync::atomic::AtomicU64;
     use std::time::Duration;
     use tokio::io::duplex;
-    use tokio::sync::{Mutex, RwLock, mpsc, oneshot, watch};
+    use tokio::sync::{Mutex, RwLock, broadcast, mpsc, oneshot, watch};
     use tokio::time::timeout;
 
     fn test_inner() -> RuntimeInner {
@@ -540,9 +688,11 @@ mod tests {
         let (exited_tx, _) = watch::channel(false);
         let (writer_tx, _) = mpsc::channel(1);
         let (supervisor_tx, _) = mpsc::unbounded_channel();
+        let (notification_tx, _) = broadcast::channel(NOTIFICATION_CHANNEL_CAPACITY);
         RuntimeInner {
             plugin_id: "example".to_string(),
-            methods: RwLock::new(HashSet::new()),
+            registration: RwLock::new(PluginRegistration::default()),
+            notification_tx,
             status_tx,
             exited_tx,
             writer_tx,
@@ -570,10 +720,171 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            inner.methods.read().await.clone(),
-            HashSet::from(["example.echo".to_string()])
+            inner.registration.read().await.clone(),
+            PluginRegistration {
+                methods: HashSet::from(["example.echo".to_string()]),
+                emits: HashSet::new(),
+                sdk_version: None,
+                contracts: HashMap::new(),
+            }
         );
         assert_eq!(*inner.status_tx.borrow(), RuntimeStatus::Ready);
+    }
+
+    /// Registration keeps emits, SDK version, and contracts, and refuses a foreign plugin API.
+    #[tokio::test]
+    async fn records_extended_registration_and_checks_plugin_api() {
+        let inner = test_inner();
+        handle_message(
+            &inner,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "ora/register",
+                "params": {
+                    "methods": ["agent/start"],
+                    "emits": ["agent/acp"],
+                    "sdkVersion": "1.0.0",
+                    "contracts": { "pluginApi": 1, "agent": 1 },
+                },
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            inner.registration.read().await.clone(),
+            PluginRegistration {
+                methods: HashSet::from(["agent/start".to_string()]),
+                emits: HashSet::from(["agent/acp".to_string()]),
+                sdk_version: Some("1.0.0".to_string()),
+                contracts: HashMap::from([("pluginApi".to_string(), 1), ("agent".to_string(), 1)]),
+            }
+        );
+
+        let error = handle_message(
+            &test_inner(),
+            json!({
+                "jsonrpc": "2.0",
+                "method": "ora/register",
+                "params": { "methods": [], "contracts": { "pluginApi": 2 } },
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            error,
+            "plugin reports plugin API version 2, host supports 1"
+        );
+    }
+
+    /// Declared notifications reach subscribers; undeclared ones invalidate the protocol.
+    #[tokio::test]
+    async fn delivers_declared_notifications_only() {
+        let inner = test_inner();
+        handle_message(
+            &inner,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "ora/register",
+                "params": { "methods": [], "emits": ["agent/acp"] },
+            }),
+        )
+        .await
+        .unwrap();
+        let mut notifications = inner.notification_tx.subscribe();
+
+        handle_message(
+            &inner,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "agent/acp",
+                "params": { "jsonrpc": "2.0", "id": 1, "result": {} },
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            notifications.recv().await.unwrap(),
+            PluginNotification {
+                method: "agent/acp".to_string(),
+                params: json!({ "jsonrpc": "2.0", "id": 1, "result": {} }),
+            }
+        );
+
+        let error = handle_message(
+            &inner,
+            json!({ "jsonrpc": "2.0", "method": "agent/other", "params": {} }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error, "plugin sent an undeclared notification agent/other");
+        let error = handle_message(
+            &inner,
+            json!({ "jsonrpc": "2.0", "id": 3, "method": "agent/acp", "params": {} }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error, "plugin sent an unsupported request agent/acp");
+    }
+
+    /// The launch command is deterministic: cached-only modules, frozen lockfile when present,
+    /// declared permissions only, and the host-owned DENO_DIR.
+    #[test]
+    fn builds_deterministic_launch_spec() {
+        let package_root = tempfile::tempdir().unwrap();
+        let config = PluginRuntimeConfig {
+            plugin_id: "example".to_string(),
+            deno_path: PathBuf::from("deno"),
+            package_root: package_root.path().to_path_buf(),
+            entrypoint: package_root.path().join("src").join("main.ts"),
+            deno_dir: PathBuf::from("/data/deno"),
+            permissions: PluginPermissions {
+                run: true,
+                read: false,
+                env: EnvPermission::Variables(vec!["ORA_BIN".to_string()]),
+                net: true,
+            },
+            ready_timeout: Duration::from_secs(1),
+            call_timeout: Duration::from_secs(1),
+            shutdown_timeout: Duration::from_secs(1),
+        };
+
+        let spec = build_launch_spec(&config);
+        assert_eq!(
+            spec.args_iter().collect::<Vec<&OsStr>>(),
+            vec![
+                OsStr::new("run"),
+                OsStr::new("--no-prompt"),
+                OsStr::new("--cached-only"),
+                OsStr::new("--allow-run"),
+                OsStr::new("--allow-env=ORA_BIN"),
+                OsStr::new("--allow-net"),
+                config.entrypoint.as_os_str(),
+            ]
+        );
+        assert_eq!(spec.cwd_path(), Some(package_root.path()));
+        assert_eq!(
+            spec.envs().collect::<Vec<_>>(),
+            vec![(OsStr::new("DENO_DIR"), OsStr::new("/data/deno"))]
+        );
+
+        std::fs::write(package_root.path().join("deno.lock"), "{}").unwrap();
+        let spec = build_launch_spec(&config);
+        let lockfile = package_root.path().join("deno.lock");
+        assert_eq!(
+            spec.args_iter().collect::<Vec<&OsStr>>(),
+            vec![
+                OsStr::new("run"),
+                OsStr::new("--no-prompt"),
+                OsStr::new("--cached-only"),
+                OsStr::new("--frozen"),
+                OsStr::new("--lock"),
+                lockfile.as_os_str(),
+                OsStr::new("--allow-run"),
+                OsStr::new("--allow-env=ORA_BIN"),
+                OsStr::new("--allow-net"),
+                config.entrypoint.as_os_str(),
+            ]
+        );
     }
 
     /// Duplicate method names invalidate registration rather than selecting one handler.

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -1,7 +1,32 @@
 # @ora-space/plugin-sdk
 
-The Ora plugin SDK runs JavaScript plugins as persistent Deno processes. A
-plugin registers its complete method set before calling `run()`:
+The Ora plugin SDK is the in-process library for Ora plugins: it implements the
+plugin side of Ora's stdio protocol and ships the base classes and bridges each
+plugin family needs. It is published to JSR as `@ora-space/plugin-sdk` (with an
+npm mirror) from this directory, which is the only source of truth — plugins
+depend on a released version and never vendor these files.
+
+```jsonc
+// deno.json in a plugin package
+{
+  "imports": {
+    "@ora-space/plugin-sdk": "jsr:@ora-space/plugin-sdk@^1.0.0",
+    "@ora-space/plugin-sdk/": "jsr:@ora-space/plugin-sdk@^1.0.0/"
+  },
+  "lock": true
+}
+```
+
+## Entry points
+
+| Specifier                       | Contents                                                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `@ora-space/plugin-sdk`         | Protocol frames, `Plugin` (methods, notifications, emits, contracts), `PluginMethodError`, `SDK_VERSION`, `PLUGIN_API_VERSION` |
+| `@ora-space/plugin-sdk/agent`   | The agent contract: `defineAgent`, `AgentPlugin` base class, `runAgentPlugin`, wire-name route tables, `AGENT_NOT_INSTALLED`   |
+| `@ora-space/plugin-sdk/acp`     | `AcpProcessBridge` (owns an ACP child process and re-frames NDJSON ⇄ Ora frames), NDJSON codec, command-candidate helpers      |
+| `@ora-space/plugin-sdk/testing` | `HostSimulator`: launches a plugin with Deno and drives it exactly like the Ora host                                           |
+
+## Core
 
 ```ts
 import { createPlugin } from "@ora-space/plugin-sdk";
@@ -11,22 +36,76 @@ plugin.registerMethod("example.echo", (input) => input);
 await plugin.run();
 ```
 
-Methods receive JSON values and may return a value or a promise. Registration is
-immutable once `run()` begins; duplicate method names and late registration are
-rejected. Ora invokes independent requests concurrently and correlates responses
-by their JSON-RPC request IDs.
+A plugin registers its complete capability set before `run()`: methods it
+serves, notifications it handles (`onNotification`), notifications it may emit
+(`declareEmit`), and the contract versions it implements (`declareContract`).
+Registration is immutable once `run()` begins. `run()` sends one `ora/register`
+notification carrying `methods`, `emits`, `sdkVersion`, and `contracts` (always
+including `pluginApi`), serves requests until `ora/shutdown` or stdin EOF, then
+waits for in-flight handlers to settle.
+
+Throw `PluginMethodError(code, message)` from a handler to control the JSON-RPC
+error code the host sees; any other error maps to `-32603`.
+
+## Agent plugins
+
+```ts
+import { AgentPlugin, runAgentPlugin } from "@ora-space/plugin-sdk/agent";
+import { AcpProcessBridge, spawnPipedProcess } from "@ora-space/plugin-sdk/acp";
+
+class MyAgent extends AgentPlugin {
+  #send: AcpSender | undefined;
+  readonly #bridge = new AcpProcessBridge({
+    spawn: (cwd) => spawnPipedProcess("my-acp-server", [], cwd),
+    onAcpFrame: (frame) => void this.#send?.(frame),
+    logTag: "my-agent",
+  });
+  override onStart = async (ctx, send) => {
+    this.#send = send;
+    await this.#bridge.start(ctx.cwd);
+  };
+  override onStop = () => this.#bridge.stop();
+  override onAcp = (frame) => this.#bridge.forwardAcp(frame);
+  override onListModels = () => [];
+}
+await runAgentPlugin(new MyAgent(), { pluginId: "my.agent" });
+```
+
+`AgentPlugin` declares the required APIs as `abstract` so an incomplete plugin
+fails to compile; `runAgentPlugin` flattens the instance into a wire-name keyed
+dispatch table (fields such as `override onStart = …` count), redirects every
+`console` method to stderr before activation, and adapts the instance onto
+`defineAgent`, which owns the registration handshake and response shapes.
 
 ## Process contract
 
-The SDK reserves stdout for Ora's binary protocol. Each frame starts with a
-four-byte big-endian length, followed by the one-byte JSON-RPC frame type and a
-UTF-8 JSON payload. Frames larger than 16 MiB and malformed host messages stop
-the plugin.
+Stdout is reserved for Ora's binary protocol: a four-byte big-endian length, one
+frame-type byte (`0x01`), and a UTF-8 JSON payload, at most 16 MiB. All
+`console` methods are redirected to stderr when the Deno transport starts.
+Plugins receive only the Deno permissions the host grants at launch.
 
-When the default Deno transport starts, the SDK redirects all `console` methods
-to stderr so normal plugin diagnostics cannot corrupt stdout. Plugins receive no
-Deno permissions unless the Ora host grants them when launching the process.
+## Testing a plugin
 
-`run()` sends a single `ora/register` notification, serves requests until it
-receives `ora/shutdown` or stdin closes, then waits for current handlers to
-settle before returning.
+```ts
+import { HostSimulator } from "@ora-space/plugin-sdk/testing";
+
+const host = await HostSimulator.launch({
+  entrypoint: import.meta.resolve("../src/main.ts"),
+});
+await host.request("agent/start", { cwd: Deno.cwd(), hostVersion: "0.9.0" });
+const init = await host.acpRequest(1, "initialize", { protocolVersion: 1 });
+await host.request("agent/stop");
+await host.shutdown();
+```
+
+## Development
+
+- `deno task check` / `deno task lint` / `deno task test` / `deno task format`
+- `deno task publish:dry-run` validates the JSR package locally.
+
+## Releasing
+
+Bump `version` in both `deno.json` and `package.json` and the `SDK_VERSION`
+constant in `src/version.ts` to the same value, then push a tag
+`plugin-sdk/vX.Y.Z`. The `plugin-sdk-publish` workflow verifies the three agree,
+runs the checks, publishes to JSR via OIDC, and publishes the npm mirror.

--- a/packages/plugin-sdk/deno.json
+++ b/packages/plugin-sdk/deno.json
@@ -1,4 +1,25 @@
 {
+  "name": "@ora-space/plugin-sdk",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./src/mod.ts",
+    "./agent": "./src/agent/mod.ts",
+    "./acp": "./src/acp/mod.ts",
+    "./testing": "./src/testing/mod.ts"
+  },
+  "publish": {
+    "include": ["src", "README.md", "deno.json"],
+    "exclude": ["tests"]
+  },
+  "tasks": {
+    "check": "deno check src/mod.ts src/agent/mod.ts src/acp/mod.ts src/testing/mod.ts tests/*.ts tests/fixtures/*.ts",
+    "lint": "deno lint src tests",
+    "format": "deno fmt src tests deno.json package.json README.md",
+    "format:check": "deno fmt --check src tests deno.json package.json README.md",
+    "test": "deno test --allow-run --allow-read --allow-env tests",
+    "publish:dry-run": "deno publish --dry-run"
+  },
   "compilerOptions": {
     "lib": ["deno.ns", "dom", "esnext"],
     "strict": true
@@ -7,5 +28,10 @@
     "lineWidth": 80,
     "semiColons": true,
     "singleQuote": false
+  },
+  "lint": {
+    "rules": {
+      "tags": ["recommended"]
+    }
   }
 }

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ora-space/plugin-sdk",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "description": "Ora plugin development SDK",
   "type": "module",
   "license": "Apache-2.0",
@@ -13,13 +13,26 @@
       "types": "./src/mod.ts",
       "default": "./src/mod.ts"
     },
+    "./agent": {
+      "types": "./src/agent/mod.ts",
+      "default": "./src/agent/mod.ts"
+    },
+    "./acp": {
+      "types": "./src/acp/mod.ts",
+      "default": "./src/acp/mod.ts"
+    },
+    "./testing": {
+      "types": "./src/testing/mod.ts",
+      "default": "./src/testing/mod.ts"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
-    "format": "deno fmt src tests deno.json package.json README.md",
-    "format:check": "deno fmt --check src tests deno.json package.json README.md",
-    "lint": "deno lint src tests && deno check src/mod.ts tests/plugin.test.ts",
-    "test": "deno test tests"
+    "check": "deno task check",
+    "format": "deno task format",
+    "format:check": "deno task format:check",
+    "lint": "deno task lint && deno task check",
+    "test": "deno task test"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-sdk/src/acp/bridge.ts
+++ b/packages/plugin-sdk/src/acp/bridge.ts
@@ -1,0 +1,206 @@
+import type { JsonValue } from "../protocol.ts";
+import { decodeLines, encodeLine } from "./ndjson.ts";
+
+/** The subset of a spawned child process an ACP bridge depends on, so tests can substitute one. */
+export interface SpawnedProcess {
+  stdin: WritableStream<Uint8Array>;
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  readonly pid: number;
+  kill(): void;
+  readonly exited: Promise<void>;
+}
+
+export interface AcpProcessBridgeOptions {
+  /**
+   * Launches the external ACP program in `cwd`.
+   *
+   * The command, its arguments, and how candidates are tried are the plugin's business; the
+   * bridge only needs a live process with all three stdio pipes.
+   */
+  spawn: (cwd: string) => SpawnedProcess | Promise<SpawnedProcess>;
+  /** Receives every ACP frame emitted by the child, in output order. */
+  onAcpFrame: (frame: JsonValue) => void;
+  /** Invoked after the child exits on its own, never after an explicit stop. */
+  onExited?: () => void;
+  /** Prefix for the child's stderr lines when republished on this plugin's stderr. */
+  logTag: string;
+}
+
+interface RunningProcess {
+  process: SpawnedProcess;
+  stdinWriter: WritableStreamDefaultWriter<Uint8Array>;
+}
+
+/**
+ * Owns one ACP child process and bridges ACP frames between its stdio and Ora.
+ *
+ * The plugin owns the child's whole lifetime: spawn on `agent/start`, kill on `agent/stop`. Ora
+ * never sees the child's stdio, which is what lets the external program use ACP methods the host
+ * has never heard of. Nothing here parses ACP; frames are re-framed between Ora's binary envelope
+ * and the child's NDJSON and otherwise passed through verbatim.
+ */
+export class AcpProcessBridge {
+  readonly #spawn: AcpProcessBridgeOptions["spawn"];
+  readonly #onAcpFrame: (frame: JsonValue) => void;
+  readonly #onExited: () => void;
+  readonly #logTag: string;
+  #running: RunningProcess | undefined;
+  #expectedExit = false;
+
+  constructor(options: AcpProcessBridgeOptions) {
+    this.#spawn = options.spawn;
+    this.#onAcpFrame = options.onAcpFrame;
+    this.#onExited = options.onExited ?? (() => {});
+    this.#logTag = options.logTag;
+  }
+
+  get running(): boolean {
+    return this.#running !== undefined;
+  }
+
+  /**
+   * Spawns the child in the given working directory and starts bridging its stdio.
+   *
+   * Any previous child is stopped first so a restart cannot leave two children writing frames
+   * into the same host connection.
+   */
+  async start(cwd: string): Promise<void> {
+    await this.stop();
+    this.#expectedExit = false;
+    const process = await this.#spawn(cwd);
+    this.#running = { process, stdinWriter: process.stdin.getWriter() };
+    this.#attach(process);
+  }
+
+  /**
+   * Forwards one host ACP frame into the child's stdin as NDJSON.
+   *
+   * Awaiting the write is what lets the child's backpressure reach the host instead of growing an
+   * unbounded queue inside this process.
+   */
+  async writeAcp(frame: JsonValue): Promise<void> {
+    const running = this.#running;
+    if (running === undefined) {
+      throw new Error(`the ${this.#logTag} agent is not running`);
+    }
+    await running.stdinWriter.write(encodeLine(JSON.stringify(frame)));
+  }
+
+  /**
+   * Forwards one host frame when the child is up, otherwise drops it with a warning.
+   *
+   * Notifications have no response channel, so throwing here would never reach the host and
+   * could not recover the frame either; a warning is the most useful outcome.
+   */
+  forwardAcp(frame: JsonValue): Promise<void> | void {
+    if (!this.running) {
+      console.warn(
+        `dropping ACP frame: the ${this.#logTag} agent is not running`,
+      );
+      return;
+    }
+    return this.writeAcp(frame);
+  }
+
+  /** Kills the child and releases every pipe; idempotent when already stopped. */
+  async stop(): Promise<void> {
+    const running = this.#running;
+    this.#running = undefined;
+    this.#expectedExit = true;
+    if (running === undefined) {
+      return;
+    }
+    try {
+      await running.stdinWriter.close();
+    } catch {
+      // The child already exited and closed its stdin; nothing is left to flush.
+    }
+    try {
+      running.process.kill();
+    } catch {
+      // Already dead.
+    }
+  }
+
+  /** Wires stdout, stderr, and exit bookkeeping for one live child. */
+  #attach(process: SpawnedProcess): void {
+    void this.#pumpStdout(process);
+    void this.#pumpStderr(process);
+    void process.exited.then(() => {
+      if (this.#running?.process === process) {
+        this.#running = undefined;
+      }
+      if (!this.#expectedExit) {
+        console.warn(`${this.#logTag} ACP process exited unexpectedly`);
+        this.#onExited();
+      }
+    });
+  }
+
+  /**
+   * Forwards every NDJSON line the child prints as one ACP frame.
+   *
+   * A line that is not a JSON object is dropped with a warning rather than failing the bridge:
+   * Ora rejects non-object frames anyway, and one stray diagnostic line must not end every live
+   * session on this agent.
+   */
+  async #pumpStdout(process: SpawnedProcess): Promise<void> {
+    try {
+      for await (const line of decodeLines(process.stdout)) {
+        let frame: JsonValue;
+        try {
+          frame = JSON.parse(line) as JsonValue;
+        } catch {
+          console.warn(`dropping non-JSON stdout line: ${line}`);
+          continue;
+        }
+        if (
+          frame === null || typeof frame !== "object" || Array.isArray(frame)
+        ) {
+          console.warn(`dropping non-object ACP frame from ${this.#logTag}`);
+          continue;
+        }
+        this.#onAcpFrame(frame);
+      }
+    } catch (error) {
+      console.warn(`${this.#logTag} stdout read failed: ${error}`);
+    }
+  }
+
+  /** Republishes the child's diagnostics on this plugin's stderr, which Ora logs. */
+  async #pumpStderr(process: SpawnedProcess): Promise<void> {
+    try {
+      for await (const line of decodeLines(process.stderr)) {
+        if (line.length > 0) {
+          console.error(`[${this.#logTag}] ${line}`);
+        }
+      }
+    } catch (error) {
+      console.warn(`${this.#logTag} stderr read failed: ${error}`);
+    }
+  }
+}
+
+/** Spawns a command with all three stdio pipes exposed for streaming. */
+export function spawnPipedProcess(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+): SpawnedProcess {
+  const child = new Deno.Command(command, {
+    args: [...args],
+    cwd,
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn();
+  return {
+    stdin: child.stdin,
+    stdout: child.stdout,
+    stderr: child.stderr,
+    pid: child.pid,
+    kill: () => child.kill(),
+    exited: child.status.then(() => undefined),
+  };
+}

--- a/packages/plugin-sdk/src/acp/command.ts
+++ b/packages/plugin-sdk/src/acp/command.ts
@@ -1,0 +1,71 @@
+import { PluginMethodError } from "../plugin.ts";
+import { AGENT_NOT_INSTALLED } from "../agent/contract.ts";
+
+/** Classifies a spawn failure as a missing binary, tolerating platform error wording. */
+export function isCommandNotFound(error: unknown): boolean {
+  if (error instanceof Deno.errors.NotFound) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /not found|cannot find|no such file|is not recognized/i.test(message);
+}
+
+/**
+ * Runs `attempt` against every candidate command until one does not throw.
+ *
+ * Failures are classified on the way out: a failure that is not "binary missing" is the real
+ * startup fault and is rethrown as-is, while an exhausted candidate list means the external
+ * program is simply absent. That distinction is the whole point — Ora retries
+ * `AGENT_NOT_INSTALLED` quietly as expected local configuration, and logs anything else as a
+ * fault. `notInstalledMessage` receives the tried candidates so the plugin can name its own
+ * install instructions.
+ */
+export async function tryEachCandidate<T>(
+  candidates: readonly string[],
+  attempt: (command: string) => T | Promise<T>,
+  notInstalledMessage: (tried: readonly string[]) => string,
+): Promise<T> {
+  if (candidates.length === 0) {
+    throw new Error("tryEachCandidate needs at least one command candidate");
+  }
+  const failures: unknown[] = [];
+  for (const command of candidates) {
+    try {
+      return await attempt(command);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+
+  const realFailure = failures.find((error) => !isCommandNotFound(error));
+  if (realFailure !== undefined) {
+    throw realFailure instanceof Error
+      ? realFailure
+      : new Error(String(realFailure));
+  }
+  throw new PluginMethodError(
+    AGENT_NOT_INSTALLED,
+    notInstalledMessage(candidates),
+  );
+}
+
+/** Reads an env var, treating a missing read permission as an unset value. */
+export function readEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    // The host may not grant --allow-env; absence is indistinguishable from "not set".
+    return undefined;
+  }
+}
+
+/**
+ * Expands a bare command into the spellings a Windows npm or standalone install exposes.
+ *
+ * npm installs only a `<name>.cmd` shim while scoop, bun, or a standalone binary expose the bare
+ * name; trying both keeps either installation style working with no user configuration. On other
+ * platforms the bare name is the only candidate.
+ */
+export function platformCommandCandidates(name: string): string[] {
+  return Deno.build.os === "windows" ? [`${name}.cmd`, name] : [name];
+}

--- a/packages/plugin-sdk/src/acp/mod.ts
+++ b/packages/plugin-sdk/src/acp/mod.ts
@@ -1,0 +1,13 @@
+export {
+  AcpProcessBridge,
+  type AcpProcessBridgeOptions,
+  type SpawnedProcess,
+  spawnPipedProcess,
+} from "./bridge.ts";
+export {
+  isCommandNotFound,
+  platformCommandCandidates,
+  readEnv,
+  tryEachCandidate,
+} from "./command.ts";
+export { decodeLines, encodeLine } from "./ndjson.ts";

--- a/packages/plugin-sdk/src/acp/ndjson.ts
+++ b/packages/plugin-sdk/src/acp/ndjson.ts
@@ -1,0 +1,48 @@
+/**
+ * Splits a byte stream into newline-delimited strings, tolerating CRLF and empty lines.
+ *
+ * ACP runs over a child process's stdio as one JSON object per line; this codec is the only
+ * framing an ACP bridge adds on top of Ora's own binary frames.
+ */
+export async function* decodeLines(
+  readable: ReadableStream<Uint8Array>,
+): AsyncGenerator<string> {
+  const reader = readable.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      while (true) {
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) {
+          break;
+        }
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line.length > 0) {
+          yield stripCarriageReturn(line);
+        }
+      }
+    }
+    const tail = decoder.decode() + buffer;
+    if (tail.length > 0) {
+      yield stripCarriageReturn(tail);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Encodes one ACP NDJSON line for a child process's stdin pipe. */
+export function encodeLine(line: string): Uint8Array {
+  return new TextEncoder().encode(line + "\n");
+}
+
+function stripCarriageReturn(line: string): string {
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}

--- a/packages/plugin-sdk/src/agent/base.ts
+++ b/packages/plugin-sdk/src/agent/base.ts
@@ -1,0 +1,204 @@
+import type { JsonValue } from "../protocol.ts";
+import {
+  type AcpSender,
+  AGENT_ACP,
+  AGENT_LIST_MODELS,
+  AGENT_START,
+  AGENT_STOP,
+  type AgentModel,
+  type AgentStartContext,
+  defineAgent,
+} from "./contract.ts";
+
+/**
+ * Carries the process-level facts a plugin instance may need outside any agent session.
+ *
+ * The host hands session-scoped data (cwd, host version) to `onStart` instead, so this stays
+ * limited to what is true for the whole plugin process.
+ */
+export interface PluginContext {
+  readonly pluginId: string;
+}
+
+/**
+ * Maps every class method onto the JSON-RPC method the Ora host invokes.
+ *
+ * The host contract fixes the wire names, so the mapping is explicit rather than derived from the
+ * method name: a plugin that renamed `onListModels` would otherwise silently stop serving
+ * `agent/listModels`.
+ */
+export const AGENT_METHOD_ROUTES = {
+  onStart: AGENT_START,
+  onStop: AGENT_STOP,
+  onListModels: AGENT_LIST_MODELS,
+} as const;
+
+/** Maps the class method that consumes host notifications onto its wire name. */
+export const AGENT_NOTIFICATION_ROUTES = {
+  onAcp: AGENT_ACP,
+} as const;
+
+/**
+ * Base class for a `kind: "agent"` plugin, exposing the agent contract as class methods.
+ *
+ * Required APIs are `abstract` so the compiler rejects an incomplete plugin, while optional APIs
+ * ship a default implementation that can be overridden. Each method may also be mounted from a
+ * separate module (`override onStart = handleStart`), which keeps a plugin with many APIs from
+ * collapsing into one oversized entrypoint.
+ */
+export abstract class AgentPlugin {
+  readonly type = "agent";
+
+  // ------------------------- lifecycle hooks (optional) -------------------------
+
+  /** Runs once before the plugin answers anything, for eager setup that must not race a call. */
+  onActivate(_context: PluginContext): void | Promise<void> {}
+
+  /** Runs once after the host closed the connection, for cleanup the host will not wait on. */
+  onDeactivate(): void | Promise<void> {}
+
+  // ------------------------- required agent contract ---------------------------
+
+  /**
+   * [agent/start] Brings the agent up so it can receive ACP frames.
+   *
+   * `send` stays valid for the rest of the process and is how every agent-originated ACP frame
+   * reaches the host. Throw `PluginMethodError(AGENT_NOT_INSTALLED, ...)` when the underlying CLI
+   * is missing, which the host treats as expected local configuration instead of a fault.
+   */
+  abstract onStart(
+    context: AgentStartContext,
+    send: AcpSender,
+  ): void | Promise<void>;
+
+  /** [agent/acp] Receives one ACP frame the host is forwarding to the agent. */
+  abstract onAcp(frame: JsonValue): void | Promise<void>;
+
+  /** [agent/listModels] Lists selectable models before any session exists. */
+  abstract onListModels(): AgentModel[] | Promise<AgentModel[]>;
+
+  // ------------------------- optional agent contract ---------------------------
+
+  /** [agent/stop] Terminates the agent while leaving this plugin process alive. */
+  onStop(): void | Promise<void> {}
+}
+
+/** One entry of the flattened dispatch table, already bound to its plugin instance. */
+type BoundHandler = (...args: never[]) => unknown;
+
+/**
+ * Serves one agent plugin instance until the host shuts the process down.
+ *
+ * The instance is first flattened into a wire-name keyed table so dispatch never walks the
+ * prototype chain, then adapted onto the SDK's agent definition, which owns the registration
+ * handshake and the response shapes the host validates.
+ */
+export async function runAgentPlugin(
+  plugin: AgentPlugin,
+  context: PluginContext,
+): Promise<void> {
+  const routes = flattenRoutes(plugin);
+  protectProtocolStdout();
+  await plugin.onActivate(context);
+
+  const definition = defineAgent({
+    start: (startContext, send) =>
+      invoke(routes, AGENT_METHOD_ROUTES.onStart, startContext, send) as
+        | void
+        | Promise<void>,
+    stop: () =>
+      invoke(routes, AGENT_METHOD_ROUTES.onStop) as void | Promise<void>,
+    listModels: () =>
+      invoke(routes, AGENT_METHOD_ROUTES.onListModels) as
+        | AgentModel[]
+        | Promise<AgentModel[]>,
+    onAcp: (frame) =>
+      invoke(routes, AGENT_NOTIFICATION_ROUTES.onAcp, frame) as
+        | void
+        | Promise<void>,
+  });
+
+  try {
+    await definition.run();
+  } finally {
+    await plugin.onDeactivate();
+  }
+}
+
+/**
+ * Sends every console method to stderr before any plugin code can run.
+ *
+ * The SDK does the same when `run()` starts, but activation happens before that, and stdout is
+ * the binary protocol channel: a single `console.log` in `onActivate` would be read by the host
+ * as a corrupt frame and take the whole plugin down.
+ */
+function protectProtocolStdout(): void {
+  const encoder = new TextEncoder();
+  const write = (level: string, values: unknown[]) => {
+    const rendered = values
+      .map((value) => (typeof value === "string" ? value : Deno.inspect(value)))
+      .join(" ");
+    Deno.stderr.writeSync(encoder.encode(`[plugin:${level}] ${rendered}\n`));
+  };
+  console.debug = (...values: unknown[]) => write("debug", values);
+  console.info = (...values: unknown[]) => write("info", values);
+  console.log = (...values: unknown[]) => write("log", values);
+  console.warn = (...values: unknown[]) => write("warn", values);
+  console.error = (...values: unknown[]) => write("error", values);
+}
+
+/**
+ * Collects every implemented API of one instance into a wire-name keyed dispatch table.
+ *
+ * Both class methods and instance fields are scanned, because mounting a handler module as a
+ * field (`override onStart = handleStart`) is a supported way to organize a large plugin. Own
+ * properties win over inherited ones, so an override always shadows the base implementation.
+ */
+function flattenRoutes(plugin: AgentPlugin): Map<string, BoundHandler> {
+  const routes = new Map<string, BoundHandler>();
+  const implemented = collectCallableNames(plugin);
+  const source = plugin as unknown as Record<string, BoundHandler>;
+  for (
+    const [name, method] of Object.entries({
+      ...AGENT_METHOD_ROUTES,
+      ...AGENT_NOTIFICATION_ROUTES,
+    })
+  ) {
+    if (!implemented.has(name)) {
+      throw new Error(
+        `Agent plugin does not implement ${name}, required for ${method}`,
+      );
+    }
+    routes.set(method, source[name].bind(plugin));
+  }
+  return routes;
+}
+
+/** Walks the prototype chain once, returning the names that resolve to callable members. */
+function collectCallableNames(instance: object): Set<string> {
+  const names = new Set<string>();
+  const source = instance as Record<string, unknown>;
+  let current: object | null = instance;
+  while (current !== null && current !== Object.prototype) {
+    for (const name of Object.getOwnPropertyNames(current)) {
+      if (name !== "constructor" && typeof source[name] === "function") {
+        names.add(name);
+      }
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return names;
+}
+
+/** Dispatches one wire method through the flattened table. */
+function invoke(
+  routes: Map<string, BoundHandler>,
+  method: string,
+  ...args: unknown[]
+): unknown {
+  const handler = routes.get(method);
+  if (handler === undefined) {
+    throw new Error(`Method '${method}' is not implemented by this plugin.`);
+  }
+  return handler(...(args as never[]));
+}

--- a/packages/plugin-sdk/src/agent/contract.ts
+++ b/packages/plugin-sdk/src/agent/contract.ts
@@ -1,0 +1,111 @@
+import { createPlugin, type Plugin, PluginMethodError } from "../plugin.ts";
+import type { JsonValue } from "../protocol.ts";
+
+/** The wire names of the agent contract; fixed by the host, never derived. */
+export const AGENT_START = "agent/start";
+export const AGENT_STOP = "agent/stop";
+export const AGENT_LIST_MODELS = "agent/listModels";
+export const AGENT_ACP = "agent/acp";
+
+/** The agent contract version implemented by this module, reported in `ora/register`. */
+export const AGENT_CONTRACT_VERSION = 1;
+
+/**
+ * The error code that tells Ora the agent CLI is absent from this machine.
+ *
+ * Ora treats it as an expected local configuration: the connection retries quietly instead of
+ * reporting a fault, so use it only when the agent genuinely is not installed.
+ */
+export const AGENT_NOT_INSTALLED = -32001;
+
+/** The JSON-RPC code for a request the plugin refuses because its parameters are unusable. */
+export const INVALID_PARAMS = -32602;
+
+/** Describes one model the agent offers before any session exists. */
+export interface AgentModel {
+  id: string;
+  displayName: string;
+  default?: boolean;
+}
+
+/** Carries the host context handed to an agent when it starts. */
+export interface AgentStartContext {
+  /** Neutral working directory the agent should start in. */
+  cwd: string;
+  /** Version of the Ora host that launched this plugin. */
+  hostVersion: string;
+}
+
+/** Sends one ACP frame from the agent back to the host. */
+export type AcpSender = (frame: JsonValue) => Promise<void>;
+
+/** Implements the agent contract Ora requires of every `kind: "agent"` plugin. */
+export interface AgentDefinition {
+  /**
+   * Brings the agent up so it can receive ACP frames.
+   *
+   * Throw `new PluginMethodError(AGENT_NOT_INSTALLED, ...)` when the underlying CLI is missing.
+   */
+  start(context: AgentStartContext, send: AcpSender): void | Promise<void>;
+  /** Terminates the agent while leaving this plugin process alive. */
+  stop(): void | Promise<void>;
+  /** Lists selectable models outside any session; an empty list is an ordinary answer. */
+  listModels(): AgentModel[] | Promise<AgentModel[]>;
+  /** Receives one ACP frame the host is forwarding to the agent. */
+  onAcp(frame: JsonValue): void | Promise<void>;
+}
+
+/**
+ * Builds a plugin that serves Ora's agent contract.
+ *
+ * The whole contract is registered up front — the three control methods plus the `agent/acp`
+ * notification in both directions — because Ora validates it the moment the handshake completes
+ * and refuses to use a plugin whose declaration is incomplete.
+ */
+export function defineAgent(definition: AgentDefinition): Plugin {
+  const plugin = createPlugin();
+  const send: AcpSender = (frame) => plugin.notify(AGENT_ACP, frame);
+
+  plugin.declareContract("agent", AGENT_CONTRACT_VERSION);
+  plugin.declareEmit(AGENT_ACP);
+  plugin.registerMethod(AGENT_START, async (input) => {
+    await definition.start(parseStartContext(input), send);
+    // ACP is the only protocol Ora carries today; the field exists so a plugin that translates a
+    // private protocol can declare it later without changing the notification channel.
+    return { protocol: "acp", acpVersion: 1 };
+  });
+  plugin.registerMethod(AGENT_STOP, async () => {
+    await definition.stop();
+    return {};
+  });
+  plugin.registerMethod(AGENT_LIST_MODELS, async () => ({
+    models: (await definition.listModels()).map((model) => ({
+      id: model.id,
+      displayName: model.displayName,
+      default: model.default ?? false,
+    })),
+  }));
+  plugin.onNotification(AGENT_ACP, (params) => definition.onAcp(params));
+
+  return plugin;
+}
+
+/** Validates the host's start parameters before the agent implementation sees them. */
+function parseStartContext(input: JsonValue): AgentStartContext {
+  if (
+    typeof input !== "object" || input === null || Array.isArray(input) ||
+    typeof input.cwd !== "string" || typeof input.hostVersion !== "string"
+  ) {
+    throw new PluginMethodError(
+      INVALID_PARAMS,
+      "agent/start requires a cwd and hostVersion",
+    );
+  }
+  if (input.cwd.trim() === "") {
+    throw new PluginMethodError(
+      INVALID_PARAMS,
+      "agent/start requires a non-empty cwd",
+    );
+  }
+  return { cwd: input.cwd, hostVersion: input.hostVersion };
+}

--- a/packages/plugin-sdk/src/agent/mod.ts
+++ b/packages/plugin-sdk/src/agent/mod.ts
@@ -1,0 +1,21 @@
+export {
+  AGENT_METHOD_ROUTES,
+  AGENT_NOTIFICATION_ROUTES,
+  AgentPlugin,
+  type PluginContext,
+  runAgentPlugin,
+} from "./base.ts";
+export {
+  type AcpSender,
+  AGENT_ACP,
+  AGENT_CONTRACT_VERSION,
+  AGENT_LIST_MODELS,
+  AGENT_NOT_INSTALLED,
+  AGENT_START,
+  AGENT_STOP,
+  type AgentDefinition,
+  type AgentModel,
+  type AgentStartContext,
+  defineAgent,
+  INVALID_PARAMS,
+} from "./contract.ts";

--- a/packages/plugin-sdk/src/mod.ts
+++ b/packages/plugin-sdk/src/mod.ts
@@ -1,2 +1,18 @@
-export { createPlugin, type MethodHandler, Plugin } from "./plugin.ts";
-export type { JsonValue } from "./protocol.ts";
+export {
+  createPlugin,
+  type MethodHandler,
+  type NotificationHandler,
+  Plugin,
+  PluginMethodError,
+} from "./plugin.ts";
+export {
+  createDenoTransport,
+  decodeFrames,
+  encodeFrame,
+  type JsonRpcNotification,
+  type JsonRpcRequest,
+  type JsonValue,
+  type PluginTransport,
+  type RequestId,
+} from "./protocol.ts";
+export { PLUGIN_API_VERSION, SDK_VERSION } from "./version.ts";

--- a/packages/plugin-sdk/src/plugin.ts
+++ b/packages/plugin-sdk/src/plugin.ts
@@ -8,23 +8,30 @@ import {
   type PluginTransport,
   type RequestId,
 } from "./protocol.ts";
+import { PLUGIN_API_VERSION, SDK_VERSION } from "./version.ts";
 
 export type MethodHandler = (
   input: JsonValue,
 ) => JsonValue | Promise<JsonValue>;
 
+export type NotificationHandler = (
+  params: JsonValue,
+) => void | Promise<void>;
+
 type PluginState = "registering" | "running" | "stopped";
 
-/** Stores a plugin's immutable method registry and serves host requests. */
+/** Stores a plugin's immutable capability registry and serves host traffic. */
 export class Plugin {
   readonly #methods = new Map<string, MethodHandler>();
+  readonly #emits = new Set<string>();
+  readonly #notificationHandlers = new Map<string, NotificationHandler>();
+  readonly #contracts = new Map<string, number>();
   #state: PluginState = "registering";
+  #writer: FrameWriter | undefined;
 
   /** Registers one uniquely named method before the plugin starts serving. */
   registerMethod(name: string, handler: MethodHandler): void {
-    if (this.#state !== "registering") {
-      throw new Error("Plugin methods cannot be registered after run() starts");
-    }
+    this.#assertRegistering();
     if (name.length === 0) {
       throw new Error("Plugin method names cannot be empty");
     }
@@ -34,7 +41,65 @@ export class Plugin {
     this.#methods.set(name, handler);
   }
 
-  /** Announces the method registry and serves requests until shutdown or EOF. */
+  /**
+   * Declares one method this plugin may send to the host unprompted.
+   *
+   * The declaration is part of the same immutable registration as `registerMethod`, so the host
+   * knows the plugin's whole behaviour before it serves anything.
+   */
+  declareEmit(name: string): void {
+    this.#assertRegistering();
+    if (name.length === 0) {
+      throw new Error("Emitted method names cannot be empty");
+    }
+    this.#emits.add(name);
+  }
+
+  /**
+   * Declares which version of a named host contract this plugin implements.
+   *
+   * Contract versions travel with `ora/register` so the host can reject an incompatible plugin at
+   * the handshake with a precise message instead of failing on the first call. The plugin protocol
+   * itself is always reported; families such as `agent` add their own entry.
+   */
+  declareContract(name: string, version: number): void {
+    this.#assertRegistering();
+    if (name.length === 0) {
+      throw new Error("Contract names cannot be empty");
+    }
+    if (!Number.isInteger(version) || version < 1) {
+      throw new Error(`Contract ${name} needs a positive integer version`);
+    }
+    this.#contracts.set(name, version);
+  }
+
+  /** Handles one host-sent notification, which never produces a response. */
+  onNotification(name: string, handler: NotificationHandler): void {
+    this.#assertRegistering();
+    if (this.#notificationHandlers.has(name)) {
+      throw new Error(`Notification ${name} already has a handler`);
+    }
+    this.#notificationHandlers.set(name, handler);
+  }
+
+  /**
+   * Sends one declared notification to the host while the plugin is running.
+   *
+   * Only methods declared through `declareEmit` may be sent: the host rejects anything outside
+   * that whitelist and terminates the process, so an undeclared method is a defect here rather
+   * than a message the host quietly drops.
+   */
+  async notify(method: string, params: JsonValue): Promise<void> {
+    if (!this.#emits.has(method)) {
+      throw new Error(`Plugin method ${method} was not declared in emits`);
+    }
+    if (this.#writer === undefined) {
+      throw new Error("A plugin can only notify the host while running");
+    }
+    await this.#writer.write({ jsonrpc: "2.0", method, params });
+  }
+
+  /** Announces the capability registry and serves host traffic until shutdown or EOF. */
   async run(transport: PluginTransport = createDenoTransport()): Promise<void> {
     if (this.#state !== "registering") {
       throw new Error("A plugin can only run once");
@@ -45,33 +110,67 @@ export class Plugin {
     }
 
     const writer = new FrameWriter(transport.writable);
+    this.#writer = writer;
     await writer.write({
       jsonrpc: "2.0",
       method: "ora/register",
-      params: { methods: [...this.#methods.keys()] },
+      params: {
+        methods: [...this.#methods.keys()],
+        emits: [...this.#emits],
+        sdkVersion: SDK_VERSION,
+        contracts: {
+          pluginApi: PLUGIN_API_VERSION,
+          ...Object.fromEntries(this.#contracts),
+        },
+      },
     });
 
     const inFlight = new Set<Promise<void>>();
+    const track = (operation: Promise<void>) => {
+      inFlight.add(operation);
+      // Supplying both continuations observes transport failures without creating a rejected
+      // promise from `finally`; the host will invalidate the process when stdout closes.
+      void operation.then(
+        () => inFlight.delete(operation),
+        () => inFlight.delete(operation),
+      );
+    };
     try {
       for await (const message of decodeFrames(transport.readable)) {
         if (isShutdownNotification(message)) {
           break;
         }
-        const request = parseRequest(message);
-        const operation = this.#dispatch(request, writer);
-        inFlight.add(operation);
-        // Supplying both continuations observes transport failures without creating a rejected
-        // promise from `finally`; the host will invalidate the process when stdout closes.
-        void operation.then(
-          () => inFlight.delete(operation),
-          () => inFlight.delete(operation),
-        );
+        const notification = this.#matchNotification(message);
+        if (notification !== undefined) {
+          track(notification);
+          continue;
+        }
+        track(this.#dispatch(parseRequest(message), writer));
       }
       await Promise.allSettled(inFlight);
     } finally {
       this.#state = "stopped";
+      this.#writer = undefined;
       await writer.close();
     }
+  }
+
+  /** Runs the handler for a host notification, or reports that this was not a notification. */
+  #matchNotification(message: unknown): Promise<void> | undefined {
+    if (!isRecord(message) || message.jsonrpc !== "2.0" || "id" in message) {
+      return undefined;
+    }
+    if (typeof message.method !== "string") {
+      return undefined;
+    }
+    const handler = this.#notificationHandlers.get(message.method);
+    if (handler === undefined) {
+      // Notifications have no response channel, so an unhandled one can only be reported. Failing
+      // the process here would let a host that learned a new method take working plugins down.
+      console.warn(`Ignoring unhandled host notification ${message.method}`);
+      return Promise.resolve();
+    }
+    return Promise.resolve(handler((message.params ?? null) as JsonValue));
   }
 
   /** Executes one handler and maps expected method failures into JSON-RPC responses. */
@@ -99,11 +198,33 @@ export class Plugin {
       await writer.write(
         errorResponse(
           request.id,
-          -32603,
+          error instanceof PluginMethodError ? error.code : -32603,
           error instanceof Error ? error.message : "Plugin method failed",
         ),
       );
     }
+  }
+
+  #assertRegistering(): void {
+    if (this.#state !== "registering") {
+      throw new Error("Plugin capabilities cannot change after run() starts");
+    }
+  }
+}
+
+/**
+ * Carries a specific JSON-RPC error code from a method handler to the host.
+ *
+ * Ora distinguishes expected conditions from faults by code, so a handler that throws this instead
+ * of a plain `Error` controls how the host reacts.
+ */
+export class PluginMethodError extends Error {
+  readonly code: number;
+
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = "PluginMethodError";
+    this.code = code;
   }
 }
 

--- a/packages/plugin-sdk/src/testing/host-simulator.ts
+++ b/packages/plugin-sdk/src/testing/host-simulator.ts
@@ -1,0 +1,259 @@
+import {
+  decodeFrames,
+  encodeFrame,
+  type JsonValue,
+  type RequestId,
+} from "../protocol.ts";
+
+/** The permissions Ora grants an agent plugin process; the default for simulations. */
+export const AGENT_PLUGIN_PERMISSIONS = [
+  "--allow-run",
+  "--allow-read",
+  "--allow-env",
+  "--allow-net",
+] as const;
+
+export interface HostSimulatorOptions {
+  /** Plugin entrypoint, as a path or a module URL (`import.meta.resolve("../src/main.ts")`). */
+  entrypoint: string | URL;
+  /** Deno permission flags to launch with; defaults to what Ora grants an agent plugin. */
+  permissions?: readonly string[];
+  /** Deno executable; defaults to the one running the simulator. */
+  denoPath?: string;
+  /**
+   * Explicit Deno config for the plugin process (`--config`), replacing the package's own
+   * `deno.json`; useful to point SDK imports at a local checkout while developing both sides.
+   */
+  configPath?: string;
+  /** Working directory for the plugin process. */
+  cwd?: string;
+  /** Extra environment for the plugin process. */
+  env?: Record<string, string>;
+  /** How long to wait for any single expected frame before failing. */
+  timeoutMs?: number;
+}
+
+/** The registration the plugin announced in `ora/register`. */
+export interface PluginRegistration {
+  methods: string[];
+  emits: string[];
+  sdkVersion?: string;
+  contracts?: Record<string, number>;
+}
+
+/** One JSON-RPC response as the host sees it. */
+export interface HostResponse {
+  id: RequestId;
+  result?: JsonValue;
+  error?: { code: number; message: string };
+}
+
+type Frame = Record<string, JsonValue>;
+
+/**
+ * Drives one plugin process exactly the way the Ora host does.
+ *
+ * The simulator launches the entrypoint with Deno, speaks Ora's binary frame protocol on its
+ * stdio, and exposes the handshake, request/response, notification, and ACP pass-through flows as
+ * awaitable steps. Frames that arrive while waiting for a specific one — typically streamed
+ * `agent/acp` notifications — are kept in `passedFrames` so a test can assert on them later
+ * without the wait desynchronizing.
+ */
+export class HostSimulator {
+  readonly registration: PluginRegistration;
+  readonly passedFrames: Frame[] = [];
+  readonly #child: Deno.ChildProcess;
+  readonly #writer: WritableStreamDefaultWriter<Uint8Array>;
+  readonly #inbound: AsyncIterator<unknown>;
+  readonly #timeoutMs: number;
+  #nextId = 1;
+
+  private constructor(
+    child: Deno.ChildProcess,
+    inbound: AsyncIterator<unknown>,
+    registration: PluginRegistration,
+    timeoutMs: number,
+  ) {
+    this.#child = child;
+    this.#writer = child.stdin.getWriter();
+    this.#inbound = inbound;
+    this.registration = registration;
+    this.#timeoutMs = timeoutMs;
+  }
+
+  /** Launches the plugin and waits for its `ora/register` handshake. */
+  static async launch(options: HostSimulatorOptions): Promise<HostSimulator> {
+    const entrypoint = options.entrypoint instanceof URL
+      ? moduleUrlToPath(options.entrypoint)
+      : options.entrypoint.startsWith("file:")
+      ? moduleUrlToPath(new URL(options.entrypoint))
+      : options.entrypoint;
+    const child = new Deno.Command(options.denoPath ?? Deno.execPath(), {
+      args: [
+        "run",
+        "--no-prompt",
+        ...(options.configPath === undefined
+          ? []
+          : ["--config", options.configPath]),
+        ...(options.permissions ?? AGENT_PLUGIN_PERMISSIONS),
+        entrypoint,
+      ],
+      cwd: options.cwd,
+      env: options.env,
+      stdin: "piped",
+      stdout: "piped",
+      stderr: "inherit",
+    }).spawn();
+    const inbound = decodeFrames(child.stdout)[Symbol.asyncIterator]();
+    const timeoutMs = options.timeoutMs ?? 30_000;
+    const register = await waitForFrame(
+      inbound,
+      (frame) => frame.method === "ora/register",
+      "ora/register",
+      timeoutMs,
+      [],
+    );
+    const params = (register.params ?? {}) as Record<string, JsonValue>;
+    const registration: PluginRegistration = {
+      methods: (params.methods as string[] | undefined) ?? [],
+      emits: (params.emits as string[] | undefined) ?? [],
+      sdkVersion: params.sdkVersion as string | undefined,
+      contracts: params.contracts as Record<string, number> | undefined,
+    };
+    return new HostSimulator(child, inbound, registration, timeoutMs);
+  }
+
+  /** Sends one host request and waits for the response carrying the same id. */
+  async request(method: string, params: JsonValue = {}): Promise<HostResponse> {
+    const id = this.#nextId++;
+    await this.#send({ jsonrpc: "2.0", id, method, params });
+    const frame = await this.#waitFor(
+      (candidate) => candidate.id === id,
+      method,
+    );
+    return {
+      id,
+      result: frame.result,
+      error: frame.error as HostResponse["error"],
+    };
+  }
+
+  /** Sends one host notification; nothing is awaited beyond the write. */
+  notify(method: string, params: JsonValue = {}): Promise<void> {
+    return this.#send({ jsonrpc: "2.0", method, params });
+  }
+
+  /**
+   * Forwards one ACP request through `agent/acp` and waits for the ACP response with its id.
+   *
+   * The ACP id space is the plugin's own, independent of the host request ids, so the caller
+   * supplies it explicitly.
+   */
+  async acpRequest(
+    id: RequestId,
+    method: string,
+    params: JsonValue = {},
+  ): Promise<Frame> {
+    await this.notify("agent/acp", { jsonrpc: "2.0", id, method, params });
+    const frame = await this.#waitFor(
+      (candidate) =>
+        candidate.method === "agent/acp" && acpPayload(candidate).id === id,
+      `ACP ${method}`,
+    );
+    return acpPayload(frame);
+  }
+
+  /** Forwards one ACP notification through `agent/acp`. */
+  acpNotify(method: string, params: JsonValue = {}): Promise<void> {
+    return this.notify("agent/acp", { jsonrpc: "2.0", method, params });
+  }
+
+  /** Waits for the next `agent/acp` frame the plugin emits that satisfies `match`. */
+  async nextAcp(
+    match: (payload: Frame) => boolean = () => true,
+    label = "agent/acp",
+  ): Promise<Frame> {
+    const frame = await this.#waitFor(
+      (candidate) =>
+        candidate.method === "agent/acp" && match(acpPayload(candidate)),
+      label,
+    );
+    return acpPayload(frame);
+  }
+
+  /** Sends `ora/shutdown`, closes stdin, and returns the plugin's exit code. */
+  async shutdown(): Promise<number> {
+    await this.notify("ora/shutdown");
+    await this.#writer.close();
+    const status = await this.#child.status;
+    return status.code;
+  }
+
+  /** Kills the plugin without a handshake, for tests that exercise failure paths. */
+  async kill(): Promise<void> {
+    try {
+      this.#child.kill();
+    } catch {
+      // Already gone.
+    }
+    await this.#child.status;
+  }
+
+  #send(message: JsonValue): Promise<void> {
+    return this.#writer.write(encodeFrame(message));
+  }
+
+  #waitFor(match: (frame: Frame) => boolean, label: string): Promise<Frame> {
+    return waitForFrame(
+      this.#inbound,
+      match,
+      label,
+      this.#timeoutMs,
+      this.passedFrames,
+    );
+  }
+}
+
+/** Reads frames until one satisfies `match`, parking the others so the stream never desyncs. */
+async function waitForFrame(
+  inbound: AsyncIterator<unknown>,
+  match: (frame: Frame) => boolean,
+  label: string,
+  timeoutMs: number,
+  passed: Frame[],
+): Promise<Frame> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    const next = await Promise.race([
+      inbound.next(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`timed out waiting for ${label}`)),
+          remaining,
+        )
+      ),
+    ]);
+    if (next.done) {
+      throw new Error(`plugin closed stdout while waiting for ${label}`);
+    }
+    const frame = next.value as Frame;
+    if (match(frame)) {
+      return frame;
+    }
+    passed.push(frame);
+  }
+}
+
+/** Extracts the nested ACP message from one `agent/acp` frame. */
+function acpPayload(frame: Frame): Frame {
+  return (frame.params ?? {}) as Frame;
+}
+
+/** Converts a module URL into a host path, including a Windows drive prefix. */
+function moduleUrlToPath(url: URL): string {
+  return decodeURIComponent(url.pathname).replace(/^\/([A-Za-z]:)/, "$1");
+}

--- a/packages/plugin-sdk/src/testing/mod.ts
+++ b/packages/plugin-sdk/src/testing/mod.ts
@@ -1,0 +1,7 @@
+export {
+  AGENT_PLUGIN_PERMISSIONS,
+  type HostResponse,
+  HostSimulator,
+  type HostSimulatorOptions,
+  type PluginRegistration,
+} from "./host-simulator.ts";

--- a/packages/plugin-sdk/src/version.ts
+++ b/packages/plugin-sdk/src/version.ts
@@ -1,0 +1,11 @@
+/**
+ * The SDK release this module tree was published as.
+ *
+ * Reported to the host in `ora/register` so a mismatch between a plugin's SDK and the host's
+ * expectations is visible at the handshake instead of at the first failing call. The release
+ * workflow rewrites this constant from the tag; it must match `deno.json` and `package.json`.
+ */
+export const SDK_VERSION = "1.0.0";
+
+/** The plugin protocol version this SDK speaks (frame format, `ora/register`, `ora/shutdown`). */
+export const PLUGIN_API_VERSION = 1;

--- a/packages/plugin-sdk/tests/acp.test.ts
+++ b/packages/plugin-sdk/tests/acp.test.ts
@@ -1,0 +1,192 @@
+import {
+  AcpProcessBridge,
+  decodeLines,
+  encodeLine,
+  isCommandNotFound,
+  type SpawnedProcess,
+  tryEachCandidate,
+} from "../src/acp/mod.ts";
+import { type JsonValue, PluginMethodError } from "../src/mod.ts";
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`Expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+/** An in-memory child process whose stdout/stderr the test feeds and whose stdin it reads. */
+function fakeProcess(): {
+  process: SpawnedProcess;
+  stdout: WritableStreamDefaultWriter<Uint8Array>;
+  stderr: WritableStreamDefaultWriter<Uint8Array>;
+  stdinLines: () => Promise<string[]>;
+  exit: () => void;
+  killed: () => boolean;
+} {
+  const stdin = new TransformStream<Uint8Array>();
+  const stdout = new TransformStream<Uint8Array>();
+  const stderr = new TransformStream<Uint8Array>();
+  let resolveExit!: () => void;
+  const exited = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+  let killed = false;
+  const collected: string[] = [];
+  const stdinRead = (async () => {
+    for await (const line of decodeLines(stdin.readable)) {
+      collected.push(line);
+    }
+  })();
+  return {
+    process: {
+      stdin: stdin.writable,
+      stdout: stdout.readable,
+      stderr: stderr.readable,
+      pid: 42,
+      kill: () => {
+        killed = true;
+        resolveExit();
+      },
+      exited,
+    },
+    stdout: stdout.writable.getWriter(),
+    stderr: stderr.writable.getWriter(),
+    stdinLines: async () => {
+      await stdinRead;
+      return collected;
+    },
+    exit: resolveExit,
+    killed: () => killed,
+  };
+}
+
+Deno.test("decodeLines splits CRLF and partial chunks into lines", async () => {
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode('{"a":1}\r\n{"b"'));
+      controller.enqueue(encoder.encode(':2}\n\n{"c":3}'));
+      controller.close();
+    },
+  });
+  const lines: string[] = [];
+  for await (const line of decodeLines(readable)) {
+    lines.push(line);
+  }
+  assertEquals(lines, ['{"a":1}', '{"b":2}', '{"c":3}']);
+  assertEquals(new TextDecoder().decode(encodeLine("x")), "x\n");
+});
+
+Deno.test("bridge forwards frames both ways and drops non-object lines", async () => {
+  const fake = fakeProcess();
+  const received: JsonValue[] = [];
+  const bridge = new AcpProcessBridge({
+    spawn: () => fake.process,
+    onAcpFrame: (frame) => received.push(frame),
+    logTag: "fake",
+  });
+  assertEquals(bridge.running, false);
+  await bridge.start("/tmp");
+  assertEquals(bridge.running, true);
+
+  await bridge.writeAcp({ jsonrpc: "2.0", id: 1, method: "initialize" });
+  const encoder = new TextEncoder();
+  await fake.stdout.write(
+    encoder.encode('not json\n[1,2]\n{"jsonrpc":"2.0","id":1,"result":{}}\n'),
+  );
+  await fake.stdout.close();
+  // Let the stdout pump drain.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assertEquals(received, [{ jsonrpc: "2.0", id: 1, result: {} }]);
+
+  await bridge.stop();
+  assertEquals(bridge.running, false);
+  assertEquals(fake.killed(), true);
+  assertEquals(await fake.stdinLines(), [
+    '{"jsonrpc":"2.0","id":1,"method":"initialize"}',
+  ]);
+});
+
+Deno.test("bridge reports an unexpected exit but not an explicit stop", async () => {
+  const unexpected = fakeProcess();
+  let exitedCalls = 0;
+  const bridge = new AcpProcessBridge({
+    spawn: () => unexpected.process,
+    onAcpFrame: () => {},
+    onExited: () => exitedCalls++,
+    logTag: "fake",
+  });
+  await bridge.start("/tmp");
+  unexpected.exit();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assertEquals(exitedCalls, 1);
+  assertEquals(bridge.running, false);
+  // forwardAcp while down drops instead of throwing.
+  assertEquals(bridge.forwardAcp({ jsonrpc: "2.0", method: "x" }), undefined);
+
+  const expected = fakeProcess();
+  const quiet = new AcpProcessBridge({
+    spawn: () => expected.process,
+    onAcpFrame: () => {},
+    onExited: () => exitedCalls++,
+    logTag: "fake",
+  });
+  await quiet.start("/tmp");
+  await quiet.stop();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assertEquals(exitedCalls, 1);
+});
+
+Deno.test("tryEachCandidate distinguishes not-installed from real faults", async () => {
+  const tried: string[] = [];
+  const value = await tryEachCandidate(
+    ["a", "b"],
+    (command) => {
+      tried.push(command);
+      if (command === "a") {
+        throw new Deno.errors.NotFound("a");
+      }
+      return `ran ${command}`;
+    },
+    (candidates) => `missing (${candidates.join(", ")})`,
+  );
+  assertEquals(value, "ran b");
+  assertEquals(tried, ["a", "b"]);
+
+  let notInstalled: unknown;
+  try {
+    await tryEachCandidate(
+      ["a"],
+      () => {
+        throw new Error("command not found");
+      },
+      (candidates) => `missing (${candidates.join(", ")})`,
+    );
+  } catch (error) {
+    notInstalled = error;
+  }
+  assertEquals(notInstalled instanceof PluginMethodError, true);
+  assertEquals((notInstalled as PluginMethodError).code, -32001);
+  assertEquals((notInstalled as Error).message, "missing (a)");
+
+  let real: unknown;
+  try {
+    await tryEachCandidate(
+      ["a", "b"],
+      (command) => {
+        if (command === "a") {
+          throw new Deno.errors.NotFound("a");
+        }
+        throw new Error("exit code 2");
+      },
+      () => "unused",
+    );
+  } catch (error) {
+    real = error;
+  }
+  assertEquals((real as Error).message, "exit code 2");
+  assertEquals(isCommandNotFound(new Error("'x' is not recognized")), true);
+  assertEquals(isCommandNotFound(new Error("permission denied")), false);
+});

--- a/packages/plugin-sdk/tests/agent.test.ts
+++ b/packages/plugin-sdk/tests/agent.test.ts
@@ -1,0 +1,176 @@
+import {
+  AGENT_CONTRACT_VERSION,
+  AGENT_NOT_INSTALLED,
+  AgentPlugin,
+  defineAgent,
+  runAgentPlugin,
+} from "../src/agent/mod.ts";
+import {
+  decodeFrames,
+  encodeFrame,
+  type JsonValue,
+  PLUGIN_API_VERSION,
+  PluginMethodError,
+  type PluginTransport,
+  SDK_VERSION,
+} from "../src/mod.ts";
+
+/** Compares JSON-compatible values without a Node compatibility dependency. */
+function assertEquals(actual: unknown, expected: unknown): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`Expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+function createTransportHarness(): {
+  transport: PluginTransport;
+  send: (message: JsonValue) => Promise<void>;
+  responses: AsyncGenerator<unknown>;
+} {
+  const hostInput = new TransformStream<Uint8Array>();
+  const pluginOutput = new TransformStream<Uint8Array>();
+  const inputWriter = hostInput.writable.getWriter();
+  return {
+    transport: {
+      readable: hostInput.readable,
+      writable: pluginOutput.writable,
+      redirectConsole: false,
+    },
+    send: (message) => inputWriter.write(encodeFrame(message)),
+    responses: decodeFrames(pluginOutput.readable),
+  };
+}
+
+Deno.test("defineAgent registers the full agent contract", async () => {
+  const frames: JsonValue[] = [];
+  let sender: ((frame: JsonValue) => Promise<void>) | undefined;
+  const plugin = defineAgent({
+    start: (_context, send) => {
+      sender = send;
+    },
+    stop: () => {},
+    listModels: () => [{ id: "a/b", displayName: "b" }],
+    onAcp: (frame) => {
+      frames.push(frame);
+    },
+  });
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    method: "ora/register",
+    params: {
+      methods: ["agent/start", "agent/stop", "agent/listModels"],
+      emits: ["agent/acp"],
+      sdkVersion: SDK_VERSION,
+      contracts: {
+        pluginApi: PLUGIN_API_VERSION,
+        agent: AGENT_CONTRACT_VERSION,
+      },
+    },
+  });
+
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "agent/start",
+    params: { cwd: "/tmp", hostVersion: "0.9.0" },
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 1,
+    result: { protocol: "acp", acpVersion: 1 },
+  });
+
+  await harness.send({
+    jsonrpc: "2.0",
+    method: "agent/acp",
+    params: { jsonrpc: "2.0", id: 7, method: "initialize" },
+  });
+  // The in-memory transport has no buffer, so the emitted frame resolves only once it is read.
+  const emitted = sender!({ jsonrpc: "2.0", id: 7, result: {} });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    method: "agent/acp",
+    params: { jsonrpc: "2.0", id: 7, result: {} },
+  });
+  await emitted;
+  assertEquals(frames, [{ jsonrpc: "2.0", id: 7, method: "initialize" }]);
+
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "agent/listModels",
+    params: {},
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 2,
+    result: { models: [{ id: "a/b", displayName: "b", default: false }] },
+  });
+
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("agent/start rejects an empty cwd and surfaces not-installed", async () => {
+  const plugin = defineAgent({
+    start: () => {
+      throw new PluginMethodError(AGENT_NOT_INSTALLED, "missing cli");
+    },
+    stop: () => {},
+    listModels: () => [],
+    onAcp: () => {},
+  });
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+  await harness.responses.next();
+
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "agent/start",
+    params: { cwd: "  ", hostVersion: "0.9.0" },
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 1,
+    error: { code: -32602, message: "agent/start requires a non-empty cwd" },
+  });
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "agent/start",
+    params: { cwd: "/tmp", hostVersion: "0.9.0" },
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 2,
+    error: { code: AGENT_NOT_INSTALLED, message: "missing cli" },
+  });
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("runAgentPlugin refuses a class that lacks a required route", async () => {
+  // Bypass the compile-time guarantee on purpose: the runtime check is what protects a plugin
+  // built with a looser TypeScript configuration or plain JavaScript.
+  const Broken = class extends AgentPlugin {
+    onStart() {}
+    onAcp() {}
+    onListModels = undefined as unknown as () => never;
+  };
+  let message = "";
+  try {
+    await runAgentPlugin(new Broken(), { pluginId: "test.broken" });
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertEquals(
+    message,
+    "Agent plugin does not implement onListModels, required for agent/listModels",
+  );
+});

--- a/packages/plugin-sdk/tests/fixtures/echo-agent.ts
+++ b/packages/plugin-sdk/tests/fixtures/echo-agent.ts
@@ -1,0 +1,42 @@
+/**
+ * A minimal agent plugin used to exercise the SDK end to end through a real Deno process.
+ *
+ * It echoes every ACP request back as a response and answers a fixed model list, which is enough
+ * to prove the handshake, request/response, notification pass-through, and shutdown paths.
+ */
+import {
+  type AcpSender,
+  type AgentModel,
+  AgentPlugin,
+  type AgentStartContext,
+  runAgentPlugin,
+} from "../../src/agent/mod.ts";
+import type { JsonValue } from "../../src/mod.ts";
+
+class EchoAgent extends AgentPlugin {
+  #send: AcpSender | undefined;
+  #started = 0;
+
+  override onStart(_context: AgentStartContext, send: AcpSender): void {
+    this.#send = send;
+    this.#started += 1;
+  }
+
+  override onAcp(frame: JsonValue): Promise<void> | void {
+    const request = frame as { id?: JsonValue; method?: string };
+    if (request.id === undefined) {
+      return;
+    }
+    return this.#send?.({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: { echoed: request.method ?? null, started: this.#started },
+    });
+  }
+
+  override onListModels(): AgentModel[] {
+    return [{ id: "echo/one", displayName: "one", default: true }];
+  }
+}
+
+await runAgentPlugin(new EchoAgent(), { pluginId: "test.echo" });

--- a/packages/plugin-sdk/tests/plugin.test.ts
+++ b/packages/plugin-sdk/tests/plugin.test.ts
@@ -1,4 +1,9 @@
-import { createPlugin } from "../src/mod.ts";
+import {
+  createPlugin,
+  PLUGIN_API_VERSION,
+  PluginMethodError,
+  SDK_VERSION,
+} from "../src/mod.ts";
 import {
   decodeFrames,
   encodeFrame,
@@ -59,7 +64,12 @@ Deno.test(
     assertEquals((await harness.responses.next()).value, {
       jsonrpc: "2.0",
       method: "ora/register",
-      params: { methods: ["example.echo"] },
+      params: {
+        methods: ["example.echo"],
+        emits: [],
+        sdkVersion: SDK_VERSION,
+        contracts: { pluginApi: PLUGIN_API_VERSION },
+      },
     });
     await harness.send({
       jsonrpc: "2.0",
@@ -101,7 +111,7 @@ Deno.test("rejects duplicate and late method registration", async () => {
   await harness.responses.next();
   assertThrows(
     () => plugin.registerMethod("example.other", (input) => input),
-    /cannot be registered/,
+    /cannot change after run/,
   );
   await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
   await run;
@@ -127,6 +137,88 @@ Deno.test("maps handler failures to JSON-RPC errors", async () => {
     id: 3,
     error: { code: -32603, message: "expected failure" },
   });
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("carries PluginMethodError codes and declared contracts", async () => {
+  const plugin = createPlugin();
+  plugin.declareContract("agent", 1);
+  plugin.registerMethod("example.missing", () => {
+    throw new PluginMethodError(-32001, "not installed");
+  });
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    method: "ora/register",
+    params: {
+      methods: ["example.missing"],
+      emits: [],
+      sdkVersion: SDK_VERSION,
+      contracts: { pluginApi: PLUGIN_API_VERSION, agent: 1 },
+    },
+  });
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 4,
+    method: "example.missing",
+    params: null,
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 4,
+    error: { code: -32001, message: "not installed" },
+  });
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("routes host notifications and emits declared notifications", async () => {
+  const plugin = createPlugin();
+  const received: unknown[] = [];
+  plugin.declareEmit("example.event");
+  plugin.onNotification("example.ping", (params) => {
+    received.push(params);
+    return plugin.notify("example.event", { echo: params });
+  });
+  assertThrows(
+    () => plugin.onNotification("example.ping", () => {}),
+    /already has a handler/,
+  );
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+  await harness.responses.next();
+
+  await harness.send({
+    jsonrpc: "2.0",
+    method: "example.ping",
+    params: { n: 1 },
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    method: "example.event",
+    params: { echo: { n: 1 } },
+  });
+  assertEquals(received, [{ n: 1 }]);
+  // An unhandled notification is ignored rather than failing the process.
+  await harness.send({ jsonrpc: "2.0", method: "example.unknown" });
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("refuses to emit a notification that was not declared", async () => {
+  const plugin = createPlugin();
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+  await harness.responses.next();
+  let message = "";
+  try {
+    await plugin.notify("example.undeclared", null);
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertEquals(/not declared in emits/.test(message), true);
   await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
   await run;
 });

--- a/packages/plugin-sdk/tests/testing.test.ts
+++ b/packages/plugin-sdk/tests/testing.test.ts
@@ -1,0 +1,48 @@
+import { HostSimulator } from "../src/testing/mod.ts";
+import { AGENT_CONTRACT_VERSION } from "../src/agent/mod.ts";
+import { PLUGIN_API_VERSION, SDK_VERSION } from "../src/mod.ts";
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`Expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+Deno.test("HostSimulator drives a real agent plugin process end to end", async () => {
+  const host = await HostSimulator.launch({
+    entrypoint: new URL("./fixtures/echo-agent.ts", import.meta.url),
+    permissions: [],
+  });
+  assertEquals(host.registration, {
+    methods: ["agent/start", "agent/stop", "agent/listModels"],
+    emits: ["agent/acp"],
+    sdkVersion: SDK_VERSION,
+    contracts: { pluginApi: PLUGIN_API_VERSION, agent: AGENT_CONTRACT_VERSION },
+  });
+
+  const started = await host.request("agent/start", {
+    cwd: Deno.cwd(),
+    hostVersion: "0.9.0",
+  });
+  assertEquals(started.result, { protocol: "acp", acpVersion: 1 });
+
+  const initialized = await host.acpRequest(1, "initialize", {
+    protocolVersion: 1,
+  });
+  assertEquals(initialized, {
+    jsonrpc: "2.0",
+    id: 1,
+    result: { echoed: "initialize", started: 1 },
+  });
+
+  const models = await host.request("agent/listModels");
+  assertEquals(models.result, {
+    models: [{ id: "echo/one", displayName: "one", default: true }],
+  });
+
+  const stopped = await host.request("agent/stop");
+  assertEquals(stopped.result, {});
+  assertEquals(await host.shutdown(), 0);
+});


### PR DESCRIPTION
## Summary

Makes `packages/plugin-sdk` the single, publishable source of truth for the plugin-side protocol and moves the host towards deterministic, permission-scoped plugin launches. This is the first slice of the "插件 SDK 发布与分发" design: SDK back-flow + publishing (steps 1–4) and runtime determinism + manifest permissions (steps 5–6). The installer, registry, and offline import/export are follow-ups.

### `@ora-space/plugin-sdk` (`packages/plugin-sdk`)

- Back-flows what the plugin repositories had vendored and never released: notification handlers, `declareEmit`/`notify`, `PluginMethodError`.
- New entry points, each with tests:
  - `./agent` — `defineAgent`, the `AgentPlugin` base class, explicit wire-name route tables, `runAgentPlugin` (previously duplicated as `src/base/agent-plugin.ts` in every plugin repo).
  - `./acp` — `AcpProcessBridge` (NDJSON ⇄ Ora frames around an ACP child process), `tryEachCandidate` / `platformCommandCandidates` / `readEnv`.
  - `./testing` — `HostSimulator`, which launches a plugin with Deno and drives it exactly like the host; exercised by an end-to-end fixture plugin in this repo.
- `ora/register` now carries `sdkVersion` and `contracts` (always `pluginApi`, plus `agent` for agent plugins) so the host can refuse an incompatible plugin at the handshake.
- `deno.json` gains `name`/`version`/`exports`/`publish`; `deno publish --dry-run` passes. A `plugin-sdk/vX.Y.Z` tag triggers `.github/workflows/plugin-sdk-publish.yml` (JSR via OIDC + npm mirror; needs `NPM_TOKEN`).

### Host (`ora-domain`, `ora-plugin-manager`, `ora-plugin-runtime`, `ora-plugin-lifecycle`)

- `PluginPermissions` / `EnvPermission` in `ora-domain`, rendered as Deno flags.
- `plugin-manager` parses optional `ora.permissions` (`run`, `read`, `env: bool | string[]`, `net`) and drops the unused `engines.bun` requirement.
- `plugin-runtime` launches with `--cached-only`, `--frozen --lock <pkg>/deno.lock` when the package ships a lockfile, only the declared `--allow-*` flags, the package root as cwd (so Deno discovers the package's `deno.json`), and `DENO_DIR=<data>/deno`. It records `emits`/`sdkVersion`/`contracts`, refuses an unsupported `pluginApi`, and delivers declared plugin notifications to `subscribe_notifications()` instead of treating them as protocol failures.
- `plugin-lifecycle` passes package root, permissions, and `<data>/deno` through the launch request.

### Companion changes (separate repositories, branches pushed)

- `zhangxinhao/opencode-agent@refactor/consume-published-plugin-sdk`
- `zhangxinhao/claude-code-agent@refactor/consume-published-plugin-sdk`

Both delete `vendor/`, `src/base`, `src/handlers`, `src/services` and import `jsr:@ora-space/plugin-sdk@^1.0.0` (`/agent`, `/acp`, `/testing`); each drops from ~900 to ~150 lines. Their `deno.lock` will be generated on the first `deno install` after `1.0.0` is published.

## Test plan

- [x] `pnpm --filter @ora-space/plugin-sdk lint` / `test` (14 tests, including a real-process end-to-end run through `HostSimulator`) / `format:check`; `deno publish --dry-run`
- [x] `cargo test -p ora-domain -p ora-plugin-manager -p ora-plugin-runtime -p ora-plugin-lifecycle -p ora-backend`; `cargo clippy --workspace -- -D warnings`; `cargo fmt --all -- --check`
- [x] Both refactored plugins pass their `HostSimulator` simulations against the real `opencode` CLI and the real `claude-agent-acp` adapter, using a `--config` override that maps `@ora-space/plugin-sdk/*` to this branch's `packages/plugin-sdk/src`

## Follow-ups (not in this PR)

- Publish `1.0.0` (tag `plugin-sdk/v1.0.0`) so the plugin repositories can lock against it.
- `ora-plugin-installer`: download → verify → stage → `deno install --frozen` warm-up → `--cached-only` smoke → atomic swap; registry index; devDirs; dependency cache export/import.
- A shared contract description asserted from both the Rust host and the SDK.
