### PR TITLE
fix(app-shell): restore session selection and route New chat by tree focus

### DIFF
--- a/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
@@ -181,6 +181,7 @@ beforeEach(() => {
       draftId: null,
     },
     pendingRestore: null,
+    createFocus: null,
   });
   useDraftSessionsStore.getState().clear();
   useUiStore.setState({
@@ -237,6 +238,10 @@ describe("WorkspaceSidebar", () => {
       workflowRunId: null,
       draftId: null,
     });
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: PROJECT.id,
+      taskId: null,
+    });
     expect(useUiStore.getState().expandedProjects.has(PROJECT.id)).toBe(false);
   });
 
@@ -273,9 +278,10 @@ describe("WorkspaceSidebar", () => {
       await screen.findByRole("button", { name: /新建对话|New chat/ }),
     );
 
+    // Selection was a worktree session, so New chat lands under that worktree.
     expect(useWorkspaceSelectionStore.getState().selection).toMatchObject({
       projectId: PROJECT.id,
-      taskId: null,
+      taskId: TASK.id,
       sessionId: null,
       workflowRunId: null,
     });
@@ -283,6 +289,78 @@ describe("WorkspaceSidebar", () => {
       expect.any(String),
     );
     await waitFor(() => expect(treeRow(NEW_SESSION_LABEL)).not.toBeNull());
+  });
+
+  it("creates under the project last clicked even while another session stays selected", async () => {
+    const user = userEvent.setup();
+    const other: Project = {
+      id: "p2",
+      name: "Other App",
+      rootPath: "/other",
+    };
+    const state = workspaceWithOneSession();
+    state.projects = [PROJECT, other];
+    useWorkspaceSelectionStore
+      .getState()
+      .selectSession(SESSION.id, TASK.id, PROJECT.id);
+    renderSidebar(state);
+
+    await waitFor(() => expect(treeRow(other.name)).not.toBeNull());
+    await user.click(screen.getByText(other.name));
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      SESSION.id,
+    );
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: other.id,
+      taskId: null,
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: /新建对话|New chat/ }),
+    );
+
+    expect(useWorkspaceSelectionStore.getState().selection).toMatchObject({
+      projectId: other.id,
+      taskId: null,
+      sessionId: null,
+      workflowRunId: null,
+    });
+    expect(useWorkspaceSelectionStore.getState().selection.draftId).toEqual(
+      expect.any(String),
+    );
+  });
+
+  it("creates under a worktree after clicking that worktree row", async () => {
+    const user = userEvent.setup();
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [];
+    renderSidebar(state);
+
+    await waitFor(() => expect(treeRow(TASK.title)).not.toBeNull());
+    await user.click(screen.getByText(TASK.title));
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: PROJECT.id,
+      taskId: TASK.id,
+    });
+    expect(
+      useWorkspaceSelectionStore.getState().selection.sessionId,
+    ).toBeNull();
+
+    await user.click(
+      await screen.findByRole("button", { name: /新建对话|New chat/ }),
+    );
+
+    expect(useWorkspaceSelectionStore.getState().selection).toMatchObject({
+      projectId: PROJECT.id,
+      taskId: TASK.id,
+      sessionId: null,
+      workflowRunId: null,
+    });
+    expect(useWorkspaceSelectionStore.getState().selection.draftId).toEqual(
+      expect.any(String),
+    );
   });
 
   it("discards an empty draft when another session is selected", async () => {

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
@@ -171,7 +171,17 @@ function workspaceWithOneSession(): MockClientState {
 }
 
 beforeEach(() => {
-  useWorkspaceSelectionStore.getState().clearSelection();
+  window.localStorage.clear();
+  useWorkspaceSelectionStore.setState({
+    selection: {
+      projectId: null,
+      taskId: null,
+      sessionId: null,
+      workflowRunId: null,
+      draftId: null,
+    },
+    pendingRestore: null,
+  });
   useDraftSessionsStore.getState().clear();
   useUiStore.setState({
     expandedProjects: new Set(),

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
@@ -47,6 +47,7 @@ import { localizeContractError } from "../../i18n/contract-error";
 import { useProjects } from "../../state/hooks/use-projects";
 import { useTasks } from "../../state/hooks/use-tasks";
 import { useSessions } from "../../state/hooks/use-sessions";
+import { useRestoreWorkspaceSelection } from "../../state/hooks/use-restore-workspace-selection";
 import {
   useRenameWorkflowRun,
   useWorkflowRunsByProject,
@@ -174,6 +175,13 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
   const loading =
     projectsQuery.isPending || tasksQuery.isPending || sessionsQuery.isPending;
   const error = projectsQuery.error ?? tasksQuery.error ?? sessionsQuery.error;
+
+  useRestoreWorkspaceSelection({
+    projects,
+    tasks,
+    sessions,
+    treePending: loading,
+  });
 
   const tasksByProjectId = useMemo(() => {
     const grouped = new Map<string, Task[]>();

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
@@ -69,6 +69,7 @@ import {
 import {
   selectBoundDraftSession,
   startSessionDraft,
+  resolveNewChatScope,
 } from "../../state/session-drafts";
 import { OraMark } from "../../components/ora-mark";
 import { DragRegion } from "../../components/drag-region";
@@ -223,6 +224,8 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
   }, [visiblePlacements]);
 
   const selection = useWorkspaceSelectionStore((s) => s.selection);
+  const createFocus = useWorkspaceSelectionStore((s) => s.createFocus);
+  const setCreateFocus = useWorkspaceSelectionStore((s) => s.setCreateFocus);
   const selectTask = useWorkspaceSelectionStore((s) => s.selectTask);
   const selectWorkflowRun = useWorkspaceSelectionStore(
     (s) => s.selectWorkflowRun,
@@ -317,24 +320,31 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
   }, [loading, projects, tasks]);
 
   const openProject = (projectId: string) => {
+    // Remember create target without selecting — composer stays on the current chat.
+    setCreateFocus({ projectId, taskId: null });
     toggleProjectExpand(projectId);
   };
 
-  /** Same as projects: row click only toggles; new chat is the hover plus. */
-  const openTask = (taskId: string) => {
+  /** Same as projects: row click only toggles; New chat follows createFocus. */
+  const openTask = (taskId: string, projectId: string) => {
+    setCreateFocus({ projectId, taskId });
     toggleTaskExpand(taskId);
   };
 
-  const createProjectId = selection.projectId ?? projects[0]?.id ?? null;
-
-  /** Starts a blank direct chat in the current (or first) project; no project yet opens create. */
+  /** Starts a blank chat under create focus, selection, or the first project. */
   const startNewChat = useCallback(() => {
-    if (createProjectId === null) {
+    const scope = resolveNewChatScope(
+      useWorkspaceSelectionStore.getState().createFocus,
+      useWorkspaceSelectionStore.getState().selection,
+      projects[0]?.id ?? null,
+      { projects, tasks },
+    );
+    if (scope === null) {
       setDialog({ kind: "project" });
       return;
     }
-    startSessionDraft({ projectId: createProjectId, taskId: null });
-  }, [createProjectId, setDialog]);
+    startSessionDraft(scope);
+  }, [projects, setDialog, tasks]);
 
   // Match desktop IDE conventions while preventing the browser's new-window shortcut.
   useEffect(() => {
@@ -462,6 +472,15 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
                     selection.sessionId === null &&
                     selection.draftId === null &&
                     selection.workflowRunId === null
+                  }
+                  createFocused={
+                    createFocus !== null &&
+                    createFocus.projectId === project.id &&
+                    createFocus.taskId === null &&
+                    !(
+                      selection.projectId === createFocus.projectId &&
+                      selection.taskId === createFocus.taskId
+                    )
                   }
                   icon={
                     projectOpen ? (
@@ -597,6 +616,13 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
                             selection.sessionId === null &&
                             selection.draftId === null
                           }
+                          createFocused={
+                            createFocus?.taskId === task.id &&
+                            !(
+                              selection.projectId === createFocus.projectId &&
+                              selection.taskId === createFocus.taskId
+                            )
+                          }
                           icon={
                             <IconGitBranch
                               className="size-4 text-muted-foreground"
@@ -605,7 +631,7 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
                           }
                           label={task.title}
                           expanded={taskOpen}
-                          onClick={() => openTask(task.id)}
+                          onClick={() => openTask(task.id, task.projectId)}
                           action={
                             <NewSessionButton
                               onClick={() =>
@@ -735,6 +761,11 @@ interface TreeRowCommand {
 interface TreeRowProps {
   depth: 0 | 1 | 2;
   active: boolean;
+  /**
+   * Soft highlight for create-focus rows that are not the live selection — shows
+   * where New chat will land without implying the composer already switched.
+   */
+  createFocused?: boolean;
   icon: React.ReactNode;
   label: string;
   meta?: string;
@@ -758,6 +789,7 @@ interface TreeRowProps {
 function TreeRow({
   depth,
   active,
+  createFocused = false,
   icon,
   label,
   meta,
@@ -780,9 +812,16 @@ function TreeRow({
     maxLength,
   } = useInlineTreeRename({ value: label, onCommit: onRename });
 
+  const rowTone = active
+    ? "bg-sidebar-accent text-sidebar-accent-foreground"
+    : createFocused
+      ? "bg-sidebar-accent/45 text-sidebar-foreground ring-1 ring-inset ring-sidebar-accent/60"
+      : "hover:bg-sidebar-accent/70";
+
   return (
     <div
-      className={`group/tree flex h-9 items-center rounded-md transition-colors ${active ? "bg-sidebar-accent text-sidebar-accent-foreground" : "hover:bg-sidebar-accent/70"}`}
+      className={`group/tree flex h-9 items-center rounded-md transition-colors ${rowTone}`}
+      data-create-focus={createFocused && !active ? "true" : undefined}
     >
       <ContextMenu>
         <ContextMenuTrigger

--- a/packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts
+++ b/packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts
@@ -122,6 +122,11 @@ function applyRestoredSelection(selection: {
     return;
   }
 
+  // A tree click during restore only sets createFocus (selection stays empty).
+  // Preserve that gesture so New chat still follows the row the user pointed at
+  // instead of being overwritten when select* syncs focus from the restored leaf.
+  const createFocusBefore = store.createFocus;
+
   if (selection.sessionId !== null && selection.taskId !== null) {
     store.selectSession(
       selection.sessionId,
@@ -136,6 +141,10 @@ function applyRestoredSelection(selection: {
     store.selectTask(selection.taskId, selection.projectId);
   } else {
     store.selectProject(selection.projectId);
+  }
+
+  if (createFocusBefore !== null) {
+    store.setCreateFocus(createFocusBefore);
   }
 
   useUiStore.getState().expandProject(selection.projectId);

--- a/packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts
+++ b/packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useSyncExternalStore } from "react";
+import type { Project, Session, Task } from "@ora/contracts";
+import { useDraftSessionsStore } from "../stores/draft-sessions-store";
+import { useUiStore } from "../stores/ui-store";
+import { useWorkspaceSelectionStore } from "../stores/workspace-selection-store";
+import { isWorkspaceSelectionEmpty } from "../stores/sanitize-workspace-selection";
+import { resolveRestoredWorkspaceSelection } from "../resolve-restored-workspace-selection";
+import { useWorkflowRunsByProject } from "./use-workflow-runs";
+
+/**
+ * Subscribes to a zustand persist store's hydration so restore can wait for
+ * disk drafts before treating a missing draft id as deleted.
+ */
+function usePersistHydrated(persistApi: {
+  hasHydrated: () => boolean;
+  onFinishHydration: (fn: (state: unknown) => void) => () => void;
+}): boolean {
+  return useSyncExternalStore(
+    (onStoreChange) => persistApi.onFinishHydration(onStoreChange),
+    () => persistApi.hasHydrated(),
+    () => false,
+  );
+}
+
+/**
+ * Applies a validated disk selection once the workspace tree has settled.
+ *
+ * Must not run before projects/tasks/sessions finish their first fetch: putting
+ * a session id into live selection while the sessions list is still empty would
+ * look "unpersisted" to warm and open a stray provider session.
+ *
+ * Draft candidates also wait for `draft-sessions-store` rehydration — otherwise
+ * a still-empty in-memory draft list would look like "draft deleted" and clear
+ * a perfectly valid restore.
+ */
+export function useRestoreWorkspaceSelection(input: {
+  projects: readonly Project[];
+  tasks: readonly Task[];
+  sessions: readonly Session[];
+  /** True while any of the three tree queries is still pending. */
+  treePending: boolean;
+}): void {
+  const { projects, tasks, sessions, treePending } = input;
+  const pendingRestore = useWorkspaceSelectionStore((s) => s.pendingRestore);
+  const draftsHydrated = usePersistHydrated(useDraftSessionsStore.persist);
+
+  const needsWorkflowRuns =
+    pendingRestore !== null && pendingRestore.workflowRunId !== null;
+  const workflowProjectId =
+    needsWorkflowRuns && pendingRestore.projectId !== null
+      ? pendingRestore.projectId
+      : null;
+  const runsQuery = useWorkflowRunsByProject(workflowProjectId);
+
+  const workflowRuns = useMemo(() => {
+    if (!needsWorkflowRuns) return [];
+    // Sanitized candidates always carry a projectId with a run id. Without one
+    // the by-project query stays disabled and would never leave pending.
+    if (workflowProjectId === null) return [];
+    if (runsQuery.isPending) return null;
+    return runsQuery.data ?? [];
+  }, [
+    needsWorkflowRuns,
+    runsQuery.data,
+    runsQuery.isPending,
+    workflowProjectId,
+  ]);
+
+  useEffect(() => {
+    if (treePending || pendingRestore === null || !draftsHydrated) return;
+    if (needsWorkflowRuns && workflowRuns === null) return;
+
+    const live = useWorkspaceSelectionStore.getState().selection;
+    if (!isWorkspaceSelectionEmpty(live)) {
+      // User already navigated; keep their choice and stop retrying disk.
+      useWorkspaceSelectionStore.getState().clearPendingRestore();
+      return;
+    }
+
+    // Read drafts at apply time so keystroke updates do not re-trigger restore,
+    // while still seeing the post-rehydrate list once `draftsHydrated` flips.
+    const drafts = useDraftSessionsStore.getState().drafts;
+    const resolved = resolveRestoredWorkspaceSelection({
+      candidate: pendingRestore,
+      projects,
+      tasks,
+      sessions,
+      drafts,
+      workflowRuns,
+    });
+
+    if (resolved.kind === "waiting") return;
+
+    if (resolved.kind === "ready") {
+      applyRestoredSelection(resolved.selection);
+    } else {
+      useWorkspaceSelectionStore.getState().clearPendingRestore();
+    }
+  }, [
+    draftsHydrated,
+    needsWorkflowRuns,
+    pendingRestore,
+    projects,
+    sessions,
+    tasks,
+    treePending,
+    workflowRuns,
+  ]);
+}
+
+/** Routes a validated selection through the store APIs and expands ancestors. */
+function applyRestoredSelection(selection: {
+  projectId: string | null;
+  taskId: string | null;
+  sessionId: string | null;
+  workflowRunId: string | null;
+  draftId: string | null;
+}): void {
+  const store = useWorkspaceSelectionStore.getState();
+  if (selection.projectId === null) {
+    store.clearPendingRestore();
+    return;
+  }
+
+  if (selection.sessionId !== null && selection.taskId !== null) {
+    store.selectSession(
+      selection.sessionId,
+      selection.taskId,
+      selection.projectId,
+    );
+  } else if (selection.draftId !== null) {
+    store.selectDraft(selection.draftId, selection.taskId, selection.projectId);
+  } else if (selection.workflowRunId !== null) {
+    store.selectWorkflowRun(selection.workflowRunId, selection.projectId);
+  } else if (selection.taskId !== null) {
+    store.selectTask(selection.taskId, selection.projectId);
+  } else {
+    store.selectProject(selection.projectId);
+  }
+
+  useUiStore.getState().expandProject(selection.projectId);
+  if (selection.taskId !== null) {
+    useUiStore.getState().expandTask(selection.taskId);
+  }
+}

--- a/packages/app-shell/src/state/hooks/use-warm-session.ts
+++ b/packages/app-shell/src/state/hooks/use-warm-session.ts
@@ -11,6 +11,7 @@ import { queryKeys } from "./query-keys";
 import { useSessions } from "./use-sessions";
 import { usePendingSwitch } from "../stores/pending-agent-store";
 import { useAgentModelStore } from "../stores/agent-model-store";
+import { useWorkspaceSelectionStore } from "../stores/workspace-selection-store";
 
 /** The provider session backing one chat surface, and whether it is still being opened. */
 export interface WarmSession {
@@ -88,6 +89,12 @@ export function useWarmSession(
   const { data: sessions = [] } = useSessions();
   const pendingSwitch = usePendingSwitch(selection.sessionId);
   const rememberModels = useAgentModelStore((state) => state.remember);
+  // Two-phase selection restore stages disk ids in `pendingRestore` until the
+  // sessions list settles. Warming during that window would treat a not-yet-
+  // listed session id as unpersisted and open a stray provider session.
+  const restorePending = useWorkspaceSelectionStore(
+    (state) => state.pendingRestore !== null,
+  );
   // Selection can already point at a session that was never persisted — a chat
   // whose attach failed, for one — and that surface still needs a warm session
   // to retry with. Only a session the backend actually stored ends warming.
@@ -100,7 +107,9 @@ export function useWarmSession(
   // before the move is paid for. The backend claims this very session when the
   // move commits, so the model chosen on it survives into the rebind.
   const target =
-    isPersisted && pendingSwitch === undefined ? null : warmTarget(selection);
+    restorePending || (isPersisted && pendingSwitch === undefined)
+      ? null
+      : warmTarget(selection);
 
   // The backend keys warm sessions by exactly these values, so the same surface
   // always resolves to the same session and repeated calls are cache hits rather

--- a/packages/app-shell/src/state/hooks/use-workspace-mutations.ts
+++ b/packages/app-shell/src/state/hooks/use-workspace-mutations.ts
@@ -92,6 +92,10 @@ export function useDeleteProject() {
         const projects = readCache<Project>(queryClient, queryKeys.projects);
         const next = projects.find((project) => project.id !== projectId);
         useWorkspaceSelectionStore.getState().setProject(next?.id ?? null);
+      } else {
+        useWorkspaceSelectionStore
+          .getState()
+          .clearCreateFocusForProject(projectId);
       }
     },
   });
@@ -180,6 +184,8 @@ export function useDeleteTask() {
         useWorkspaceSelectionStore
           .getState()
           .clearTaskSelection(selection.projectId ?? "");
+      } else {
+        useWorkspaceSelectionStore.getState().clearCreateFocusForTask(taskId);
       }
     },
   });

--- a/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Project,
+  Session,
+  Task,
+  WorkflowRunSummary,
+} from "@ora/contracts";
+import type { SessionDraft } from "./stores/draft-sessions-store";
+import { resolveRestoredWorkspaceSelection } from "./resolve-restored-workspace-selection";
+import type { WorkspaceSelection } from "./stores/sanitize-workspace-selection";
+
+const PROJECT: Project = { id: "p1", name: "Ora", rootPath: "/ora" };
+const TASK: Task = {
+  id: "t1",
+  projectId: "p1",
+  title: "Refactor",
+  workspaceMode: "worktree",
+  type: "default",
+  workflowRunId: null,
+};
+const SESSION: Session = {
+  id: "s1",
+  taskId: "t1",
+  agentCli: "open_code",
+  status: "running",
+  title: null,
+  historyState: { type: "writable" },
+};
+
+const empty: WorkspaceSelection = {
+  projectId: null,
+  taskId: null,
+  sessionId: null,
+  workflowRunId: null,
+  draftId: null,
+};
+
+/** Builds a typed draft row with only the fields the resolver reads. */
+function draft(overrides: Partial<SessionDraft> = {}): SessionDraft {
+  return {
+    id: "d1",
+    projectId: "p1",
+    taskId: null,
+    text: "hello",
+    images: [],
+    retainedAttachments: false,
+    pendingSessionId: null,
+    returnTo: null,
+    sendInFlight: false,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("resolveRestoredWorkspaceSelection", () => {
+  it("returns miss for an empty candidate", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: empty,
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("resolves a session from authoritative task and project records", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "wrong-project",
+          taskId: "wrong-task",
+          sessionId: "s1",
+          workflowRunId: null,
+          draftId: null,
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [],
+      }),
+    ).toEqual({
+      kind: "ready",
+      selection: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+  });
+
+  it("misses when the session is absent from the list", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: "gone",
+          workflowRunId: null,
+          draftId: null,
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("misses when the session's project was deleted", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: "s1",
+          workflowRunId: null,
+          draftId: null,
+        },
+        projects: [],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("resolves a typed draft that still exists", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: null,
+          sessionId: null,
+          workflowRunId: null,
+          draftId: "d1",
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [draft()],
+        workflowRuns: [],
+      }),
+    ).toEqual({
+      kind: "ready",
+      selection: {
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: null,
+        draftId: "d1",
+      },
+    });
+  });
+
+  it("misses a draft that did not survive restart", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: null,
+          sessionId: null,
+          workflowRunId: null,
+          draftId: "d1",
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("waits when workflow runs have not settled", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: null,
+          sessionId: null,
+          workflowRunId: "run-1",
+          draftId: null,
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: null,
+      }),
+    ).toEqual({ kind: "waiting" });
+  });
+
+  it("misses a workflow run absent from the project list", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: null,
+          sessionId: null,
+          workflowRunId: "run-1",
+          draftId: null,
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [] as WorkflowRunSummary[],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("resolves project-only and task-only candidates", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: null,
+          sessionId: null,
+          workflowRunId: null,
+          draftId: null,
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [],
+      }),
+    ).toEqual({
+      kind: "ready",
+      selection: {
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: null,
+          workflowRunId: null,
+          draftId: null,
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [],
+      }),
+    ).toEqual({
+      kind: "ready",
+      selection: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: null,
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+  });
+});

--- a/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
@@ -21,7 +21,7 @@ const TASK: Task = {
 const SESSION: Session = {
   id: "s1",
   taskId: "t1",
-  agentCli: "open_code",
+  agentRef: "ora-space.opencode",
   status: "running",
   title: null,
   historyState: { type: "writable" },

--- a/packages/app-shell/src/state/resolve-restored-workspace-selection.ts
+++ b/packages/app-shell/src/state/resolve-restored-workspace-selection.ts
@@ -1,0 +1,147 @@
+import type {
+  Project,
+  Session,
+  Task,
+  WorkflowRunSummary,
+} from "@ora/contracts";
+import type { SessionDraft } from "./stores/draft-sessions-store";
+import type { WorkspaceSelection } from "./stores/sanitize-workspace-selection";
+import { isWorkspaceSelectionEmpty } from "./stores/sanitize-workspace-selection";
+
+export interface ResolveRestoredWorkspaceSelectionInput {
+  candidate: WorkspaceSelection;
+  projects: readonly Project[];
+  tasks: readonly Task[];
+  sessions: readonly Session[];
+  drafts: readonly SessionDraft[];
+  /**
+   * Runs for `candidate.projectId` when restoring a workflow run. Pass `null`
+   * when the run list has not settled yet so the caller can wait instead of
+   * treating a missing list as "run deleted".
+   */
+  workflowRuns: readonly WorkflowRunSummary[] | null;
+}
+
+export type ResolvedWorkspaceSelection =
+  | { kind: "ready"; selection: WorkspaceSelection }
+  | { kind: "waiting" }
+  | { kind: "miss" };
+
+/**
+ * Validates a disk restore candidate against the loaded workspace tree.
+ *
+ * `ready` carries a selection for `select*` APIs. `waiting` means a workflow
+ * run list is still loading. `miss` means the target no longer exists (or the
+ * payload was empty). Session ownership always comes from session/task records
+ * so a mismatched persisted projectId cannot point chat at the wrong project.
+ */
+export function resolveRestoredWorkspaceSelection(
+  input: ResolveRestoredWorkspaceSelectionInput,
+): ResolvedWorkspaceSelection {
+  const { candidate, projects, tasks, sessions, drafts, workflowRuns } = input;
+  if (isWorkspaceSelectionEmpty(candidate)) return { kind: "miss" };
+
+  if (candidate.sessionId !== null) {
+    const session = sessions.find((item) => item.id === candidate.sessionId);
+    if (session === undefined) return { kind: "miss" };
+    const task = tasks.find((item) => item.id === session.taskId);
+    if (task === undefined) return { kind: "miss" };
+    if (!projects.some((item) => item.id === task.projectId)) {
+      return { kind: "miss" };
+    }
+    return {
+      kind: "ready",
+      selection: {
+        projectId: task.projectId,
+        taskId: task.id,
+        sessionId: session.id,
+        workflowRunId: null,
+        draftId: null,
+      },
+    };
+  }
+
+  if (candidate.draftId !== null) {
+    const draft = drafts.find((item) => item.id === candidate.draftId);
+    if (draft === undefined) return { kind: "miss" };
+    if (!projects.some((item) => item.id === draft.projectId)) {
+      return { kind: "miss" };
+    }
+    if (
+      draft.taskId !== null &&
+      !tasks.some(
+        (item) =>
+          item.id === draft.taskId && item.projectId === draft.projectId,
+      )
+    ) {
+      return { kind: "miss" };
+    }
+    return {
+      kind: "ready",
+      selection: {
+        projectId: draft.projectId,
+        taskId: draft.taskId,
+        sessionId: null,
+        workflowRunId: null,
+        draftId: draft.id,
+      },
+    };
+  }
+
+  if (candidate.workflowRunId !== null) {
+    if (candidate.projectId === null) return { kind: "miss" };
+    if (!projects.some((item) => item.id === candidate.projectId)) {
+      return { kind: "miss" };
+    }
+    if (workflowRuns === null) return { kind: "waiting" };
+    if (!workflowRuns.some((run) => run.id === candidate.workflowRunId)) {
+      return { kind: "miss" };
+    }
+    return {
+      kind: "ready",
+      selection: {
+        projectId: candidate.projectId,
+        taskId: null,
+        sessionId: null,
+        workflowRunId: candidate.workflowRunId,
+        draftId: null,
+      },
+    };
+  }
+
+  if (candidate.taskId !== null) {
+    const task = tasks.find((item) => item.id === candidate.taskId);
+    if (task === undefined) return { kind: "miss" };
+    if (!projects.some((item) => item.id === task.projectId)) {
+      return { kind: "miss" };
+    }
+    return {
+      kind: "ready",
+      selection: {
+        projectId: task.projectId,
+        taskId: task.id,
+        sessionId: null,
+        workflowRunId: null,
+        draftId: null,
+      },
+    };
+  }
+
+  if (candidate.projectId !== null) {
+    if (!projects.some((item) => item.id === candidate.projectId)) {
+      return { kind: "miss" };
+    }
+    return {
+      kind: "ready",
+      selection: {
+        projectId: candidate.projectId,
+        taskId: null,
+        sessionId: null,
+        workflowRunId: null,
+        draftId: null,
+      },
+    };
+  }
+
+  return { kind: "miss" };
+}

--- a/packages/app-shell/src/state/session-drafts.test.ts
+++ b/packages/app-shell/src/state/session-drafts.test.ts
@@ -4,6 +4,7 @@ import {
   recoverFailedDraftSend,
   reparkDraftComposerContent,
   resetComposerSendAdoptionsForTests,
+  resolveNewChatScope,
   selectBoundDraftSession,
   startSessionDraft,
 } from "./session-drafts";
@@ -24,6 +25,79 @@ beforeEach(() => {
   useUiStore.setState({
     expandedProjects: new Set(),
     expandedTasks: new Set(),
+  });
+});
+
+describe("resolveNewChatScope", () => {
+  const emptySelection = {
+    projectId: null,
+    taskId: null,
+    sessionId: null,
+    workflowRunId: null,
+    draftId: null,
+  };
+
+  it("prefers createFocus over live selection", () => {
+    expect(
+      resolveNewChatScope(
+        { projectId: "p2", taskId: null },
+        {
+          ...emptySelection,
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: "s1",
+        },
+        "p-first",
+      ),
+    ).toEqual({ projectId: "p2", taskId: null });
+  });
+
+  it("uses the selection task when createFocus is absent", () => {
+    expect(
+      resolveNewChatScope(
+        null,
+        {
+          ...emptySelection,
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: "s1",
+        },
+        "p-first",
+      ),
+    ).toEqual({ projectId: "p1", taskId: "t1" });
+  });
+
+  it("falls back to the first project, then null", () => {
+    expect(resolveNewChatScope(null, emptySelection, "p-first")).toEqual({
+      projectId: "p-first",
+      taskId: null,
+    });
+    expect(resolveNewChatScope(null, emptySelection, null)).toBeNull();
+  });
+
+  it("ignores createFocus whose project is missing from the tree", () => {
+    expect(
+      resolveNewChatScope(
+        { projectId: "gone", taskId: null },
+        emptySelection,
+        "p-first",
+        { projects: [{ id: "p1" }], tasks: [] },
+      ),
+    ).toEqual({ projectId: "p-first", taskId: null });
+  });
+
+  it("demotes createFocus to project-root when its task is missing", () => {
+    expect(
+      resolveNewChatScope(
+        { projectId: "p1", taskId: "gone" },
+        emptySelection,
+        "p-first",
+        {
+          projects: [{ id: "p1" }],
+          tasks: [{ id: "t1", projectId: "p1" }],
+        },
+      ),
+    ).toEqual({ projectId: "p1", taskId: null });
   });
 });
 

--- a/packages/app-shell/src/state/session-drafts.ts
+++ b/packages/app-shell/src/state/session-drafts.ts
@@ -7,6 +7,8 @@ import { useComposerPluginSelectionStore } from "./stores/composer-plugin-select
 import { useUiStore } from "./stores/ui-store";
 import { useWorkflowStore } from "./stores/workflow-store";
 import { useWorkspaceSelectionStore } from "./stores/workspace-selection-store";
+import type { WorkspaceCreateFocus } from "./stores/workspace-selection-store";
+import type { WorkspaceSelection } from "./stores/sanitize-workspace-selection";
 
 /**
  * Thrown when a first send is abandoned (Stop / navigated away) so the
@@ -91,6 +93,67 @@ export function reparkDraftComposerContent(args: {
     images: parkedImages,
     ...(doc !== undefined ? { doc } : {}),
   });
+}
+
+/**
+ * Picks where global New chat / Ctrl+N should create a draft.
+ *
+ * Prefers the last tree create-focus (project/worktree row click), then the
+ * live selection's project/task, then the first project. Returns null only when
+ * the workspace has no projects at all.
+ *
+ * When `tree` is provided, a create-focus whose project vanished is ignored, and
+ * a missing worktree is demoted to project-root so New chat never orphans a draft.
+ */
+export function resolveNewChatScope(
+  createFocus: WorkspaceCreateFocus | null,
+  selection: WorkspaceSelection,
+  firstProjectId: string | null,
+  tree?: {
+    projects: readonly { id: string }[];
+    tasks: readonly { id: string; projectId: string }[];
+  },
+): DraftScope | null {
+  const focus = clampCreateFocus(createFocus, tree);
+  if (focus !== null) {
+    return {
+      projectId: focus.projectId,
+      taskId: focus.taskId,
+    };
+  }
+  if (selection.projectId !== null) {
+    return {
+      projectId: selection.projectId,
+      taskId: selection.taskId,
+    };
+  }
+  if (firstProjectId !== null) {
+    return { projectId: firstProjectId, taskId: null };
+  }
+  return null;
+}
+
+/** Drops or demotes create-focus that no longer matches the loaded tree. */
+function clampCreateFocus(
+  createFocus: WorkspaceCreateFocus | null,
+  tree:
+    | {
+        projects: readonly { id: string }[];
+        tasks: readonly { id: string; projectId: string }[];
+      }
+    | undefined,
+): WorkspaceCreateFocus | null {
+  if (createFocus === null) return null;
+  if (tree === undefined) return createFocus;
+  if (!tree.projects.some((project) => project.id === createFocus.projectId)) {
+    return null;
+  }
+  if (createFocus.taskId === null) return createFocus;
+  const task = tree.tasks.find((item) => item.id === createFocus.taskId);
+  if (task === undefined || task.projectId !== createFocus.projectId) {
+    return { projectId: createFocus.projectId, taskId: null };
+  }
+  return createFocus;
 }
 
 /**

--- a/packages/app-shell/src/state/stores/sanitize-workspace-selection.ts
+++ b/packages/app-shell/src/state/stores/sanitize-workspace-selection.ts
@@ -1,0 +1,78 @@
+export interface WorkspaceSelection {
+  projectId: string | null;
+  taskId: string | null;
+  sessionId: string | null;
+  /** Graph workflow run; mutually exclusive with task/session legs. */
+  workflowRunId: string | null;
+  /** Client-only new-chat row; mutually exclusive with a persisted session. */
+  draftId: string | null;
+}
+
+export const EMPTY_WORKSPACE_SELECTION: WorkspaceSelection = {
+  projectId: null,
+  taskId: null,
+  sessionId: null,
+  workflowRunId: null,
+  draftId: null,
+};
+
+/** True when every selection leg is unset. */
+export function isWorkspaceSelectionEmpty(
+  selection: WorkspaceSelection,
+): boolean {
+  return (
+    selection.projectId === null &&
+    selection.taskId === null &&
+    selection.sessionId === null &&
+    selection.workflowRunId === null &&
+    selection.draftId === null
+  );
+}
+
+/** Accepts only non-empty strings; anything else becomes null. */
+function optionalId(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Treats disk / merge payloads as untrusted and rebuilds a selection that
+ * obeys the same mutual-exclusion rules as the live store actions.
+ *
+ * Conversation legs are exclusive: draft, session, and workflow run cannot
+ * coexist. A missing projectId collapses everything to empty.
+ */
+export function sanitizeWorkspaceSelection(value: unknown): WorkspaceSelection {
+  if (typeof value !== "object" || value === null) {
+    return EMPTY_WORKSPACE_SELECTION;
+  }
+  const raw = value as Record<string, unknown>;
+  const projectId = optionalId(raw.projectId);
+  if (projectId === null) return EMPTY_WORKSPACE_SELECTION;
+
+  let taskId = optionalId(raw.taskId);
+  let sessionId = optionalId(raw.sessionId);
+  let workflowRunId = optionalId(raw.workflowRunId);
+  let draftId = optionalId(raw.draftId);
+
+  // Prefer draft, then workflow run, then session — matching the exclusivity
+  // each select* action enforces when navigating.
+  if (draftId !== null) {
+    sessionId = null;
+    workflowRunId = null;
+  } else if (workflowRunId !== null) {
+    taskId = null;
+    sessionId = null;
+    draftId = null;
+  } else if (sessionId !== null) {
+    workflowRunId = null;
+    draftId = null;
+  }
+
+  return {
+    projectId,
+    taskId,
+    sessionId,
+    workflowRunId,
+    draftId,
+  };
+}

--- a/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
   useWorkspaceSelectionStore.setState({
     selection: empty,
     pendingRestore: null,
+    createFocus: null,
   });
 });
 
@@ -22,6 +23,7 @@ afterEach(() => {
   useWorkspaceSelectionStore.setState({
     selection: empty,
     pendingRestore: null,
+    createFocus: null,
   });
 });
 
@@ -327,5 +329,69 @@ describe("useWorkspaceSelectionStore", () => {
     useWorkspaceSelectionStore.getState().clearPendingRestore();
     expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
     expect(useWorkspaceSelectionStore.getState().selection).toEqual(empty);
+  });
+
+  it("setCreateFocus records a create target without changing selection", () => {
+    useWorkspaceSelectionStore.getState().selectSession("s1", "t1", "p1");
+    useWorkspaceSelectionStore
+      .getState()
+      .setCreateFocus({ projectId: "p2", taskId: null });
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      "s1",
+    );
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: "p2",
+      taskId: null,
+    });
+  });
+
+  it("selectSession syncs createFocus to the session's project and task", () => {
+    useWorkspaceSelectionStore
+      .getState()
+      .setCreateFocus({ projectId: "p-old", taskId: null });
+    useWorkspaceSelectionStore.getState().selectSession("s1", "t1", "p1");
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: "p1",
+      taskId: "t1",
+    });
+  });
+
+  it("does not persist createFocus across rehydrate", async () => {
+    useWorkspaceSelectionStore
+      .getState()
+      .setCreateFocus({ projectId: "p1", taskId: "t1" });
+    const raw = window.localStorage.getItem(WORKSPACE_SELECTION_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(raw!).not.toContain("createFocus");
+
+    useWorkspaceSelectionStore.setState({
+      selection: empty,
+      pendingRestore: null,
+      createFocus: { projectId: "p1", taskId: "t1" },
+    });
+    await useWorkspaceSelectionStore.persist.rehydrate();
+    expect(useWorkspaceSelectionStore.getState().createFocus).toBeNull();
+  });
+
+  it("setCreateFocus is a no-op when the focus is unchanged", () => {
+    useWorkspaceSelectionStore
+      .getState()
+      .setCreateFocus({ projectId: "p1", taskId: null });
+    const before = useWorkspaceSelectionStore.getState().createFocus;
+    useWorkspaceSelectionStore
+      .getState()
+      .setCreateFocus({ projectId: "p1", taskId: null });
+    expect(useWorkspaceSelectionStore.getState().createFocus).toBe(before);
+  });
+
+  it("clearCreateFocusForTask demotes a worktree focus to the project", () => {
+    useWorkspaceSelectionStore
+      .getState()
+      .setCreateFocus({ projectId: "p1", taskId: "t1" });
+    useWorkspaceSelectionStore.getState().clearCreateFocusForTask("t1");
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: "p1",
+      taskId: null,
+    });
   });
 });

--- a/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
@@ -1,18 +1,28 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { useDraftSessionsStore } from "./draft-sessions-store";
-import { useWorkspaceSelectionStore } from "./workspace-selection-store";
+import {
+  useWorkspaceSelectionStore,
+  WORKSPACE_SELECTION_STORAGE_KEY,
+} from "./workspace-selection-store";
+import { EMPTY_WORKSPACE_SELECTION } from "./sanitize-workspace-selection";
 
-const empty = {
-  projectId: null,
-  taskId: null,
-  sessionId: null,
-  workflowRunId: null,
-  draftId: null,
-};
+const empty = EMPTY_WORKSPACE_SELECTION;
 
 beforeEach(() => {
+  window.localStorage.clear();
   useDraftSessionsStore.getState().clear();
-  useWorkspaceSelectionStore.getState().clearSelection();
+  useWorkspaceSelectionStore.setState({
+    selection: empty,
+    pendingRestore: null,
+  });
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  useWorkspaceSelectionStore.setState({
+    selection: empty,
+    pendingRestore: null,
+  });
 });
 
 describe("useWorkspaceSelectionStore", () => {
@@ -189,5 +199,133 @@ describe("useWorkspaceSelectionStore", () => {
       draftId: null,
     });
     cleanup.mockRestore();
+  });
+
+  it("persists selection to localStorage under the v1 key", () => {
+    useWorkspaceSelectionStore.getState().selectSession("s1", "t1", "p1");
+    const raw = window.localStorage.getItem(WORKSPACE_SELECTION_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as {
+      state: {
+        selection: typeof empty;
+        pendingRestore: typeof empty | null;
+      };
+    };
+    expect(parsed.state.selection).toEqual({
+      projectId: "p1",
+      taskId: "t1",
+      sessionId: "s1",
+      workflowRunId: null,
+      draftId: null,
+    });
+    expect(parsed.state.pendingRestore).toBeNull();
+  });
+
+  it("rehydrates disk selection into pendingRestore and keeps live selection empty", async () => {
+    window.localStorage.setItem(
+      WORKSPACE_SELECTION_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          selection: {
+            projectId: "p1",
+            taskId: "t1",
+            sessionId: "s1",
+            workflowRunId: null,
+            draftId: null,
+          },
+          pendingRestore: null,
+        },
+        version: 0,
+      }),
+    );
+    await useWorkspaceSelectionStore.persist.rehydrate();
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(empty);
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toEqual({
+      projectId: "p1",
+      taskId: "t1",
+      sessionId: "s1",
+      workflowRunId: null,
+      draftId: null,
+    });
+  });
+
+  it("prefers an in-flight pendingRestore over the last live selection on rehydrate", async () => {
+    window.localStorage.setItem(
+      WORKSPACE_SELECTION_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          selection: {
+            projectId: "p-old",
+            taskId: null,
+            sessionId: null,
+            workflowRunId: null,
+            draftId: null,
+          },
+          pendingRestore: {
+            projectId: "p1",
+            taskId: "t1",
+            sessionId: "s1",
+            workflowRunId: null,
+            draftId: null,
+          },
+        },
+        version: 0,
+      }),
+    );
+    await useWorkspaceSelectionStore.persist.rehydrate();
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(empty);
+    expect(
+      useWorkspaceSelectionStore.getState().pendingRestore?.sessionId,
+    ).toBe("s1");
+  });
+
+  it("sanitizes illegal session+draft combos on rehydrate", async () => {
+    window.localStorage.setItem(
+      WORKSPACE_SELECTION_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          selection: {
+            projectId: "p1",
+            taskId: "t1",
+            sessionId: "s1",
+            workflowRunId: null,
+            draftId: "d1",
+          },
+          pendingRestore: null,
+        },
+        version: 0,
+      }),
+    );
+    await useWorkspaceSelectionStore.persist.rehydrate();
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toEqual({
+      projectId: "p1",
+      taskId: "t1",
+      sessionId: null,
+      workflowRunId: null,
+      draftId: "d1",
+    });
+  });
+
+  it("falls back to empty pendingRestore when persisted JSON is corrupt", async () => {
+    window.localStorage.setItem(WORKSPACE_SELECTION_STORAGE_KEY, "{not json");
+    await useWorkspaceSelectionStore.persist.rehydrate();
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(empty);
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+  });
+
+  it("clearPendingRestore drops the candidate without changing live selection", () => {
+    useWorkspaceSelectionStore.setState({
+      selection: empty,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    useWorkspaceSelectionStore.getState().clearPendingRestore();
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(empty);
   });
 });

--- a/packages/app-shell/src/state/stores/workspace-selection-store.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.ts
@@ -1,18 +1,25 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import { useDraftSessionsStore } from "./draft-sessions-store";
+import {
+  EMPTY_WORKSPACE_SELECTION,
+  isWorkspaceSelectionEmpty,
+  sanitizeWorkspaceSelection,
+  type WorkspaceSelection,
+} from "./sanitize-workspace-selection";
 
-export interface WorkspaceSelection {
-  projectId: string | null;
-  taskId: string | null;
-  sessionId: string | null;
-  /** Graph workflow run; mutually exclusive with task/session legs. */
-  workflowRunId: string | null;
-  /** Client-only new-chat row; mutually exclusive with a persisted session. */
-  draftId: string | null;
-}
+export type { WorkspaceSelection };
+
+export const WORKSPACE_SELECTION_STORAGE_KEY = "ora.workspace-selection.v1";
 
 interface WorkspaceSelectionState {
   selection: WorkspaceSelection;
+  /**
+   * Disk candidate awaiting tree validation after rehydrate. Live `selection`
+   * stays empty until restore applies a validated value so a stale session id
+   * cannot warm a new provider session before sessions settle.
+   */
+  pendingRestore: WorkspaceSelection | null;
   /** Selects a project and clears any task/session/run underneath. */
   selectProject: (projectId: string) => void;
   /** Selects a task under a project and clears any session/run underneath. */
@@ -48,133 +55,167 @@ interface WorkspaceSelectionState {
   clearWorkflowRunSelection: (projectId: string) => void;
   /** Replaces the project leg, clearing task/session/run (used after the selected project is deleted). */
   setProject: (projectId: string | null) => void;
+  /**
+   * Drops a consumed or abandoned restore candidate. Clears without touching
+   * live selection so a user who already navigated keeps their choice.
+   */
+  clearPendingRestore: () => void;
 }
-
-const EMPTY_SELECTION: WorkspaceSelection = {
-  projectId: null,
-  taskId: null,
-  sessionId: null,
-  workflowRunId: null,
-  draftId: null,
-};
 
 /**
  * Owns the workspace tree selection without coupling to query data. Callers pass
  * the owning project/task ids they already have from react-query results, which
  * keeps this store a pure state machine that is trivial to unit-test.
+ *
+ * Live selection is mirrored to localStorage. On cold start the disk value is
+ * staged in `pendingRestore` only — never applied to `selection` until tree
+ * data validates it — so a missing sessions list cannot trigger a warm race.
  */
-export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>(
-  (set, get) => {
-    /**
-     * Replaces the complete selection before settling the draft being left.
-     * Navigation must remain responsive even if draft persistence cleanup fails.
-     */
-    const replaceSelection = (selection: WorkspaceSelection): void => {
-      const previousDraftId = get().selection.draftId;
-      set({ selection });
-      if (previousDraftId !== null && previousDraftId !== selection.draftId) {
-        useDraftSessionsStore.getState().discardIfEmpty(previousDraftId);
-      }
-    };
+export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
+  persist(
+    (set, get) => {
+      /**
+       * Replaces the complete selection before settling the draft being left.
+       * Navigation must remain responsive even if draft persistence cleanup fails.
+       */
+      const replaceSelection = (selection: WorkspaceSelection): void => {
+        const previousDraftId = get().selection.draftId;
+        // User navigation cancels any outstanding restore candidate.
+        set({ selection, pendingRestore: null });
+        if (previousDraftId !== null && previousDraftId !== selection.draftId) {
+          useDraftSessionsStore.getState().discardIfEmpty(previousDraftId);
+        }
+      };
 
-    return {
-      selection: EMPTY_SELECTION,
-      selectProject: (projectId) => {
-        replaceSelection({
-          projectId,
-          taskId: null,
-          sessionId: null,
-          workflowRunId: null,
-          draftId: null,
-        });
+      return {
+        selection: EMPTY_WORKSPACE_SELECTION,
+        pendingRestore: null,
+        selectProject: (projectId) => {
+          replaceSelection({
+            projectId,
+            taskId: null,
+            sessionId: null,
+            workflowRunId: null,
+            draftId: null,
+          });
+        },
+        selectTask: (taskId, projectId) => {
+          replaceSelection({
+            projectId,
+            taskId,
+            sessionId: null,
+            workflowRunId: null,
+            draftId: null,
+          });
+        },
+        selectSessionBeforeTask: (sessionId, projectId) => {
+          replaceSelection({
+            projectId,
+            taskId: null,
+            sessionId,
+            workflowRunId: null,
+            draftId: null,
+          });
+        },
+        selectSession: (sessionId, taskId, projectId) => {
+          replaceSelection({
+            projectId,
+            taskId,
+            sessionId,
+            workflowRunId: null,
+            draftId: null,
+          });
+        },
+        selectDraft: (draftId, taskId, projectId) => {
+          replaceSelection({
+            projectId,
+            taskId,
+            sessionId: null,
+            workflowRunId: null,
+            draftId,
+          });
+        },
+        selectWorkflowRun: (workflowRunId, projectId) => {
+          replaceSelection({
+            projectId,
+            taskId: null,
+            sessionId: null,
+            workflowRunId,
+            draftId: null,
+          });
+        },
+        clearSelection: () => replaceSelection(EMPTY_WORKSPACE_SELECTION),
+        clearSessionSelection: () => {
+          const current = get().selection;
+          replaceSelection({
+            projectId: current.projectId,
+            taskId: current.taskId,
+            sessionId: null,
+            workflowRunId: current.workflowRunId,
+            draftId: null,
+          });
+        },
+        clearTaskSelection: (projectId) => {
+          replaceSelection({
+            projectId,
+            taskId: null,
+            sessionId: null,
+            workflowRunId: null,
+            draftId: null,
+          });
+        },
+        clearWorkflowRunSelection: (projectId) => {
+          replaceSelection({
+            projectId,
+            taskId: null,
+            sessionId: null,
+            workflowRunId: null,
+            draftId: null,
+          });
+        },
+        setProject: (projectId) => {
+          replaceSelection(
+            projectId === null
+              ? EMPTY_WORKSPACE_SELECTION
+              : {
+                  projectId,
+                  taskId: null,
+                  sessionId: null,
+                  workflowRunId: null,
+                  draftId: null,
+                },
+          );
+        },
+        clearPendingRestore: () => set({ pendingRestore: null }),
+      };
+    },
+    {
+      name: WORKSPACE_SELECTION_STORAGE_KEY,
+      storage: createJSONStorage(() => window.localStorage),
+      partialize: (state) => ({
+        selection: state.selection,
+        pendingRestore: state.pendingRestore,
+      }),
+      merge: (persisted, current) => {
+        const slice =
+          typeof persisted === "object" && persisted !== null
+            ? (persisted as Record<string, unknown>)
+            : undefined;
+        const fromPending = sanitizeWorkspaceSelection(slice?.pendingRestore);
+        const fromSelection = sanitizeWorkspaceSelection(slice?.selection);
+        // Prefer an in-flight candidate (crash mid-restore) over the last live
+        // selection so a half-applied restore does not lose its intent.
+        const candidate = isWorkspaceSelectionEmpty(fromPending)
+          ? fromSelection
+          : fromPending;
+        return {
+          ...current,
+          selection: EMPTY_WORKSPACE_SELECTION,
+          pendingRestore: isWorkspaceSelectionEmpty(candidate)
+            ? null
+            : candidate,
+        };
       },
-      selectTask: (taskId, projectId) => {
-        replaceSelection({
-          projectId,
-          taskId,
-          sessionId: null,
-          workflowRunId: null,
-          draftId: null,
-        });
-      },
-      selectSessionBeforeTask: (sessionId, projectId) => {
-        replaceSelection({
-          projectId,
-          taskId: null,
-          sessionId,
-          workflowRunId: null,
-          draftId: null,
-        });
-      },
-      selectSession: (sessionId, taskId, projectId) => {
-        replaceSelection({
-          projectId,
-          taskId,
-          sessionId,
-          workflowRunId: null,
-          draftId: null,
-        });
-      },
-      selectDraft: (draftId, taskId, projectId) => {
-        replaceSelection({
-          projectId,
-          taskId,
-          sessionId: null,
-          workflowRunId: null,
-          draftId,
-        });
-      },
-      selectWorkflowRun: (workflowRunId, projectId) => {
-        replaceSelection({
-          projectId,
-          taskId: null,
-          sessionId: null,
-          workflowRunId,
-          draftId: null,
-        });
-      },
-      clearSelection: () => replaceSelection(EMPTY_SELECTION),
-      clearSessionSelection: () => {
-        const current = get().selection;
-        replaceSelection({
-          projectId: current.projectId,
-          taskId: current.taskId,
-          sessionId: null,
-          workflowRunId: current.workflowRunId,
-          draftId: null,
-        });
-      },
-      clearTaskSelection: (projectId) => {
-        replaceSelection({
-          projectId,
-          taskId: null,
-          sessionId: null,
-          workflowRunId: null,
-          draftId: null,
-        });
-      },
-      clearWorkflowRunSelection: (projectId) => {
-        replaceSelection({
-          projectId,
-          taskId: null,
-          sessionId: null,
-          workflowRunId: null,
-          draftId: null,
-        });
-      },
-      setProject: (projectId) => {
-        replaceSelection(
-          projectId === null
-            ? EMPTY_SELECTION
-            : {
-                projectId,
-                taskId: null,
-                sessionId: null,
-                workflowRunId: null,
-                draftId: null,
-              },
-        );
-      },
-    };
-  },
+    },
+  ),
 );

--- a/packages/app-shell/src/state/stores/workspace-selection-store.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.ts
@@ -12,6 +12,16 @@ export type { WorkspaceSelection };
 
 export const WORKSPACE_SELECTION_STORAGE_KEY = "ora.workspace-selection.v1";
 
+/**
+ * Where global New chat / Ctrl+N should create a draft. Ephemeral: not written
+ * to disk. Updated by tree row clicks (without changing the composer selection)
+ * and kept in sync when the live selection moves to a leaf.
+ */
+export interface WorkspaceCreateFocus {
+  projectId: string;
+  taskId: string | null;
+}
+
 interface WorkspaceSelectionState {
   selection: WorkspaceSelection;
   /**
@@ -20,6 +30,21 @@ interface WorkspaceSelectionState {
    * cannot warm a new provider session before sessions settle.
    */
   pendingRestore: WorkspaceSelection | null;
+  /**
+   * Last project/worktree the user pointed at for creating a chat. Independent
+   * of `selection` so expand/collapse clicks can retarget New chat without
+   * yanking the composer off the current session.
+   */
+  createFocus: WorkspaceCreateFocus | null;
+  /** Records where the next global New chat should land without changing selection. */
+  setCreateFocus: (focus: WorkspaceCreateFocus) => void;
+  /** Drops create focus when its project is deleted and selection did not move there. */
+  clearCreateFocusForProject: (projectId: string) => void;
+  /**
+   * Drops or demotes create focus when its task is deleted. A worktree focus
+   * becomes project-root so New chat still has a valid home.
+   */
+  clearCreateFocusForTask: (taskId: string) => void;
   /** Selects a project and clears any task/session/run underneath. */
   selectProject: (projectId: string) => void;
   /** Selects a task under a project and clears any session/run underneath. */
@@ -62,6 +87,14 @@ interface WorkspaceSelectionState {
   clearPendingRestore: () => void;
 }
 
+/** Maps a live selection onto the New-chat create target when a project is set. */
+function createFocusFromSelection(
+  selection: WorkspaceSelection,
+): WorkspaceCreateFocus | null {
+  if (selection.projectId === null) return null;
+  return { projectId: selection.projectId, taskId: selection.taskId };
+}
+
 /**
  * Owns the workspace tree selection without coupling to query data. Callers pass
  * the owning project/task ids they already have from react-query results, which
@@ -70,6 +103,7 @@ interface WorkspaceSelectionState {
  * Live selection is mirrored to localStorage. On cold start the disk value is
  * staged in `pendingRestore` only — never applied to `selection` until tree
  * data validates it — so a missing sessions list cannot trigger a warm race.
+ * `createFocus` stays memory-only so restart does not resurrect a stale create target.
  */
 export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
   persist(
@@ -77,11 +111,17 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
       /**
        * Replaces the complete selection before settling the draft being left.
        * Navigation must remain responsive even if draft persistence cleanup fails.
+       * Create focus follows the new selection so New chat stays coherent after
+       * opening a leaf; empty selection clears focus.
        */
       const replaceSelection = (selection: WorkspaceSelection): void => {
         const previousDraftId = get().selection.draftId;
         // User navigation cancels any outstanding restore candidate.
-        set({ selection, pendingRestore: null });
+        set({
+          selection,
+          pendingRestore: null,
+          createFocus: createFocusFromSelection(selection),
+        });
         if (previousDraftId !== null && previousDraftId !== selection.draftId) {
           useDraftSessionsStore.getState().discardIfEmpty(previousDraftId);
         }
@@ -90,6 +130,29 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
       return {
         selection: EMPTY_WORKSPACE_SELECTION,
         pendingRestore: null,
+        createFocus: null,
+        setCreateFocus: (focus) => {
+          const current = get().createFocus;
+          if (
+            current !== null &&
+            current.projectId === focus.projectId &&
+            current.taskId === focus.taskId
+          ) {
+            return;
+          }
+          set({ createFocus: focus });
+        },
+        clearCreateFocusForProject: (projectId) => {
+          const focus = get().createFocus;
+          if (focus?.projectId === projectId) set({ createFocus: null });
+        },
+        clearCreateFocusForTask: (taskId) => {
+          const focus = get().createFocus;
+          if (focus === null || focus.taskId !== taskId) return;
+          set({
+            createFocus: { projectId: focus.projectId, taskId: null },
+          });
+        },
         selectProject: (projectId) => {
           replaceSelection({
             projectId,
@@ -192,6 +255,7 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
     {
       name: WORKSPACE_SELECTION_STORAGE_KEY,
       storage: createJSONStorage(() => window.localStorage),
+      // createFocus is intentionally omitted — it is a session gesture, not a restore target.
       partialize: (state) => ({
         selection: state.selection,
         pendingRestore: state.pendingRestore,
@@ -214,6 +278,7 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
           pendingRestore: isWorkspaceSelectionEmpty(candidate)
             ? null
             : candidate,
+          createFocus: null,
         };
       },
     },

--- a/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
@@ -23,7 +23,7 @@ const TASK: Task = {
 const SESSION: Session = {
   id: "s1",
   taskId: "t1",
-  agentCli: "open_code",
+  agentRef: "ora-space.opencode",
   status: "running",
   title: null,
   historyState: { type: "writable" },
@@ -35,6 +35,7 @@ beforeEach(() => {
   useWorkspaceSelectionStore.setState({
     selection: EMPTY_WORKSPACE_SELECTION,
     pendingRestore: null,
+    createFocus: null,
   });
   useUiStore.setState({
     expandedProjects: new Set(),
@@ -317,6 +318,46 @@ describe("useRestoreWorkspaceSelection", () => {
       EMPTY_WORKSPACE_SELECTION,
     );
   });
+
+  it("preserves a user createFocus when applying a restored session", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+      createFocus: { projectId: "p2", taskId: null },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT, { id: "p2", name: "Other", rootPath: "/other" }];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await waitFor(() => {
+      expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+        "s1",
+      );
+    });
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: "p2",
+      taskId: null,
+    });
+  });
 });
 
 describe("useWarmSession restore gate", () => {
@@ -352,7 +393,7 @@ describe("useWarmSession restore gate", () => {
             taskId: "t1",
             sessionId: null,
           },
-          "open_code",
+          "ora-space.opencode",
         ),
       client,
       undefined,

--- a/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
@@ -1,0 +1,367 @@
+import { act, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, Session, Task } from "@ora/contracts";
+import { createChatStore } from "@ora/chat";
+import { createMockClient, createMockClientState } from "../test/mock-client";
+import { renderHookWithClient } from "../test/hook-harness";
+import { useRestoreWorkspaceSelection } from "./hooks/use-restore-workspace-selection";
+import { useWarmSession } from "./hooks/use-warm-session";
+import { useUiStore } from "./stores/ui-store";
+import { useWorkspaceSelectionStore } from "./stores/workspace-selection-store";
+import { useDraftSessionsStore } from "./stores/draft-sessions-store";
+import { EMPTY_WORKSPACE_SELECTION } from "./stores/sanitize-workspace-selection";
+
+const PROJECT: Project = { id: "p1", name: "Ora", rootPath: "/ora" };
+const TASK: Task = {
+  id: "t1",
+  projectId: "p1",
+  title: "Refactor",
+  workspaceMode: "worktree",
+  type: "default",
+  workflowRunId: null,
+};
+const SESSION: Session = {
+  id: "s1",
+  taskId: "t1",
+  agentCli: "open_code",
+  status: "running",
+  title: null,
+  historyState: { type: "writable" },
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useDraftSessionsStore.getState().clear();
+  useWorkspaceSelectionStore.setState({
+    selection: EMPTY_WORKSPACE_SELECTION,
+    pendingRestore: null,
+  });
+  useUiStore.setState({
+    expandedProjects: new Set(),
+    expandedTasks: new Set(),
+  });
+  vi.restoreAllMocks();
+});
+
+describe("useRestoreWorkspaceSelection", () => {
+  it("applies a validated session once the tree is settled", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await waitFor(() => {
+      expect(useWorkspaceSelectionStore.getState().selection).toEqual({
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      });
+    });
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+    expect(useUiStore.getState().expandedProjects.has("p1")).toBe(true);
+    expect(useUiStore.getState().expandedTasks.has("t1")).toBe(true);
+  });
+
+  it("clears a stale session candidate without applying it", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "missing",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await waitFor(() => {
+      expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+    });
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(
+      EMPTY_WORKSPACE_SELECTION,
+    );
+  });
+
+  it("does not overwrite a live selection the user already made", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: {
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: null,
+        draftId: null,
+      },
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await waitFor(() => {
+      expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+    });
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual({
+      projectId: "p1",
+      taskId: null,
+      sessionId: null,
+      workflowRunId: null,
+      draftId: null,
+    });
+  });
+
+  it("waits while the tree is still pending", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: true,
+        }),
+      client,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(
+      EMPTY_WORKSPACE_SELECTION,
+    );
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).not.toBeNull();
+  });
+
+  it("waits for draft rehydration before treating a draft candidate as missing", async () => {
+    const finishListeners: Array<(state: unknown) => void> = [];
+    const hasHydrated = vi
+      .spyOn(useDraftSessionsStore.persist, "hasHydrated")
+      .mockReturnValue(false);
+    vi.spyOn(
+      useDraftSessionsStore.persist,
+      "onFinishHydration",
+    ).mockImplementation((listener) => {
+      finishListeners.push(listener as (state: unknown) => void);
+      return () => {
+        const index = finishListeners.indexOf(
+          listener as (state: unknown) => void,
+        );
+        if (index >= 0) finishListeners.splice(index, 1);
+      };
+    });
+
+    const draftId = useDraftSessionsStore
+      .getState()
+      .ensureEmptyDraft({ projectId: "p1", taskId: null });
+    useDraftSessionsStore.getState().updateContent(draftId, { text: "parked" });
+
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: null,
+        draftId,
+      },
+    });
+
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).not.toBeNull();
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(
+      EMPTY_WORKSPACE_SELECTION,
+    );
+
+    hasHydrated.mockReturnValue(true);
+    await act(async () => {
+      for (const listener of finishListeners) listener({});
+    });
+
+    await waitFor(() => {
+      expect(useWorkspaceSelectionStore.getState().selection).toEqual({
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: null,
+        draftId,
+      });
+    });
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+  });
+
+  it("clears a workflow-run candidate that lacks a project id instead of waiting forever", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      // Bypass sanitize: a corrupt in-memory candidate must not hang restore.
+      pendingRestore: {
+        projectId: null,
+        taskId: null,
+        sessionId: null,
+        workflowRunId: "run-1",
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await waitFor(() => {
+      expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+    });
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(
+      EMPTY_WORKSPACE_SELECTION,
+    );
+  });
+});
+
+describe("useWarmSession restore gate", () => {
+  it("does not warm while pendingRestore is set", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: null,
+        workflowRunId: null,
+        draftId: null,
+      },
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [];
+    const client = createMockClient(state);
+    const warm = vi.spyOn(client.session, "warm");
+
+    renderHookWithClient(
+      () =>
+        useWarmSession(
+          {
+            projectId: "p1",
+            taskId: "t1",
+            sessionId: null,
+          },
+          "open_code",
+        ),
+      client,
+      undefined,
+      createChatStore(client.session),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(warm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Persist workspace selection in localStorage and restore it after restart with a two-phase validate-then-apply flow, so a stale session id cannot warm a stray provider session.
- Remember createFocus when clicking a project/worktree row (expand/collapse unchanged) so New chat / Ctrl+N lands under that scope; validate against the live tree and keep focus across selection restore.
- Fixes #421