### PR TITLE
fix(composer): 修复提示框 Markdown 往返与 Enter 的真实缺陷

### DIFF
--- a/apps/desktop/src-tauri/README.md
+++ b/apps/desktop/src-tauri/README.md
@@ -2,6 +2,8 @@
 
 `ora-desktop` is the native Tauri host for Ora. It bootstraps the shared backend, exposes desktop-only commands to the frontend, owns native windows and dialogs, and adapts operating-system capabilities such as filesystem handoff, opening http(s)/mailto URLs in the host browser, and marketplace WebViews.
 
+Prompt-box `open_external_url` rejects disallowed schemes as `InvalidRequest` and reports OS launch failures as `Internal`, matching `open_location`. On Windows it calls `ShellExecuteW` on the async runtime thread because that API returns after handing the URL to the protocol handler; `open` / `xdg-open` on other hosts still run through `spawn_blocking`.
+
 File-manager handoff lives in `src/open_location.rs`. Explorer reveals files in the **system** file manager (`explorer /select,` on Windows, `open -R` on macOS) instead of opening them with the default editor. Directories still open as folder windows.
 
 The crate does not own domain persistence or agent execution semantics; those remain in the shared backend and contract crates. Desktop commands translate between Tauri IPC and those stable boundaries.

--- a/apps/desktop/src-tauri/src/open_external.rs
+++ b/apps/desktop/src-tauri/src/open_external.rs
@@ -64,14 +64,23 @@ fn is_browser_url(raw: &str) -> bool {
     lower.starts_with("https://") || lower.starts_with("http://") || lower.starts_with("mailto:")
 }
 
-/// Reports a URL the host OS refused or that the prompt box is not allowed to open.
-fn open_external_url_error(source: impl std::error::Error + Send + Sync + 'static) -> BackendError {
+/// Client sent a scheme Desktop will not open (javascript/file/data, etc.).
+fn open_external_url_scheme_error(
+    source: impl std::error::Error + Send + Sync + 'static,
+) -> BackendError {
     BackendError::with_source(
         ora_backend::ErrorClassification::InvalidRequest,
         PublicError::InvalidRequest(EmptyErrorParams {}),
-        "failed to open the requested URL",
+        "URL scheme is not allowed",
         source,
     )
+}
+
+/// Host OS refused to launch the browser; not a problem with the URL itself.
+fn open_external_url_os_error(
+    source: impl std::error::Error + Send + Sync + 'static,
+) -> BackendError {
+    BackendError::internal("failed to open the requested URL", source)
 }
 
 /// Launches the OS browser for one validated URL through the Windows shell.
@@ -87,7 +96,7 @@ fn open_external_url_blocking(url: &str) -> Result<(), BackendError> {
     use std::ptr;
 
     if !is_browser_url(url) {
-        return Err(open_external_url_error(std::io::Error::other(
+        return Err(open_external_url_scheme_error(std::io::Error::other(
             "URL scheme is not allowed",
         )));
     }
@@ -122,7 +131,7 @@ fn open_external_url_blocking(url: &str) -> Result<(), BackendError> {
         )
     };
     if result <= 32 {
-        return Err(open_external_url_error(std::io::Error::other(format!(
+        return Err(open_external_url_os_error(std::io::Error::other(format!(
             "ShellExecuteW failed with code {result}"
         ))));
     }
@@ -134,18 +143,18 @@ fn open_external_url_blocking(url: &str) -> Result<(), BackendError> {
 fn open_external_url_blocking(url: &str) -> Result<(), BackendError> {
     use std::process::Command;
     if !is_browser_url(url) {
-        return Err(open_external_url_error(std::io::Error::other(
+        return Err(open_external_url_scheme_error(std::io::Error::other(
             "URL scheme is not allowed",
         )));
     }
     let status = Command::new("open")
         .arg(url)
         .status()
-        .map_err(open_external_url_error)?;
+        .map_err(open_external_url_os_error)?;
     if status.success() {
         Ok(())
     } else {
-        Err(open_external_url_error(std::io::Error::other(format!(
+        Err(open_external_url_os_error(std::io::Error::other(format!(
             "open command exited with {status}"
         ))))
     }
@@ -156,7 +165,7 @@ fn open_external_url_blocking(url: &str) -> Result<(), BackendError> {
 fn open_external_url_blocking(url: &str) -> Result<(), BackendError> {
     use std::process::Command;
     if !is_browser_url(url) {
-        return Err(open_external_url_error(std::io::Error::other(
+        return Err(open_external_url_scheme_error(std::io::Error::other(
             "URL scheme is not allowed",
         )));
     }
@@ -164,7 +173,7 @@ fn open_external_url_blocking(url: &str) -> Result<(), BackendError> {
         .arg(url)
         .spawn()
         .map(|_| ())
-        .map_err(open_external_url_error)
+        .map_err(open_external_url_os_error)
 }
 
 #[cfg(test)]

--- a/packages/app-shell/src/features/chat/composer-action-menu.tsx
+++ b/packages/app-shell/src/features/chat/composer-action-menu.tsx
@@ -57,7 +57,10 @@ export function ComposerActionMenu({
   selectionLocked = false,
 }: ComposerActionMenuProps) {
   const { t } = useTranslation();
-  const allVisibleActions = visibleComposerActions(actions, expandedGroups);
+  const allVisibleActions = useMemo(
+    () => visibleComposerActions(actions, expandedGroups),
+    [actions, expandedGroups],
+  );
   const indexById = useMemo(() => {
     const map = new Map<string, number>();
     allVisibleActions.forEach((action, index) => {

--- a/packages/app-shell/src/features/chat/composer-actions.test.ts
+++ b/packages/app-shell/src/features/chat/composer-actions.test.ts
@@ -9,6 +9,7 @@ import {
   mentionEntriesFromDirectoryListing,
   mentionEntriesFromFileSearch,
   rankComposerMentionEntries,
+  mentionRelevanceScore,
   takeComposerFilePaths,
   visibleComposerActions,
 } from "./composer-actions";
@@ -49,6 +50,17 @@ describe("mentionEntriesFromDirectoryListing", () => {
       { path: "app.ts", kind: "file" },
       { path: "README.md", kind: "file" },
     ]);
+  });
+});
+
+describe("mentionRelevanceScore", () => {
+  it("matches Windows-style queries against slash-normalized paths", () => {
+    expect(
+      mentionRelevanceScore(
+        { path: "src/utils/index.ts", kind: "file" },
+        "src\\utils",
+      ),
+    ).toBeGreaterThan(0);
   });
 });
 

--- a/packages/app-shell/src/features/chat/composer-actions.ts
+++ b/packages/app-shell/src/features/chat/composer-actions.ts
@@ -200,17 +200,18 @@ export function mentionRelevanceScore(
 ): number {
   const base = fileBasename(entry.path).toLocaleLowerCase();
   const path = entry.path.replace(/\\/g, "/").toLocaleLowerCase();
-  if (base === normalizedQuery) return 100;
-  if (base.startsWith(normalizedQuery)) return 80;
-  if (base.includes(normalizedQuery)) return 60;
+  const query = normalizedQuery.replace(/\\/g, "/");
+  if (base === query) return 100;
+  if (base.startsWith(query)) return 80;
+  if (base.includes(query)) return 60;
   if (
-    path.startsWith(`${normalizedQuery}/`) ||
-    path.includes(`/${normalizedQuery}/`) ||
-    path.endsWith(`/${normalizedQuery}`)
+    path.startsWith(`${query}/`) ||
+    path.includes(`/${query}/`) ||
+    path.endsWith(`/${query}`)
   ) {
     return 40;
   }
-  if (path.includes(normalizedQuery)) return 20;
+  if (path.includes(query)) return 20;
   return 0;
 }
 

--- a/packages/app-shell/src/features/chat/composer.tsx
+++ b/packages/app-shell/src/features/chat/composer.tsx
@@ -403,9 +403,11 @@ export function Composer({
         editorRef.current?.focus({ at: "end" });
       } catch {
         lastInjectedRequestId.current = null;
+        consumeFileContext(keyAtSchedule, requestId);
+        setAttachmentError(t("chat.fileContext.injectFailed"));
       }
     });
-  }, [consumeFileContext, conversationKey, pendingFileContext]);
+  }, [consumeFileContext, conversationKey, pendingFileContext, t]);
   const slashQuery = query.slashQuery;
   const atQuery = query.atQuery;
   const fileMentionEnabled =

--- a/packages/app-shell/src/features/chat/markdown-message.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.tsx
@@ -16,7 +16,7 @@ import {
   IconChevronsUp,
   IconCopy,
 } from "@tabler/icons-react";
-import { Button } from "@ora/ui";
+import { Button, cn } from "@ora/ui";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import { useTranslation } from "react-i18next";
@@ -216,10 +216,13 @@ function createMarkdownComponents(density: MarkdownDensity): Components {
         {children}
       </del>
     ),
-    mark: ({ children, ...props }) => (
+    mark: ({ children, className, ...props }) => (
       <mark
-        className="composer-user-highlight rounded-sm bg-[rgb(255,255,0)] px-0.5 text-foreground dark:bg-yellow-300/90"
         {...props}
+        className={cn(
+          "composer-user-highlight rounded-sm bg-[rgb(255,255,0)] px-0.5 text-foreground dark:bg-yellow-300/90",
+          className,
+        )}
       >
         {children}
       </mark>

--- a/packages/app-shell/src/features/chat/user-message-markdown.test.ts
+++ b/packages/app-shell/src/features/chat/user-message-markdown.test.ts
@@ -20,6 +20,10 @@ describe("prepareUserMessageMarkdown", () => {
       prepareUserMessageMarkdown("before\n```\nkeep\nme\n```\nafter\nnext"),
     ).toBe("before\n```\nkeep\nme\n```\nafter\n\nnext");
   });
+
+  it("expands every single-character line, not only the first break", () => {
+    expect(prepareUserMessageMarkdown("a\nb\nc")).toBe("a\n\nb\n\nc");
+  });
 });
 
 describe("remarkComposerHighlight", () => {

--- a/packages/app-shell/src/features/chat/user-message-markdown.ts
+++ b/packages/app-shell/src/features/chat/user-message-markdown.ts
@@ -13,7 +13,7 @@ export function prepareUserMessageMarkdown(content: string): string {
       if (part.startsWith("```")) {
         return part;
       }
-      return part.replace(/([^\n])\n([^\n])/g, "$1\n\n$2");
+      return part.replace(/([^\n])\n(?=[^\n])/g, "$1\n\n");
     })
     .join("");
 }

--- a/packages/app-shell/src/features/editor/README.md
+++ b/packages/app-shell/src/features/editor/README.md
@@ -13,7 +13,9 @@ App-shell wrapper around `@ora/editor` for prompt boxes.
   when possible; slash-command chips and directory `kind` need the parked doc.
   Programmatic hydrate dismisses the `@`/`/` palette so a parked `@…` suffix
   does not reopen the menu. Explorer line selections queue per conversation
-  key. Pastes that include both files and plain text keep the text.
+  key and are refused (with a warning) when no session/draft/task is selected.
+  `appendText` inserts parsed blocks at the end so `/command` chips are not
+  flattened by a Markdown round-trip. Pastes that include both files and plain text keep the text.
   Typing an opener in front of existing closers (`**`, `==`, `~~`, and the
   rest of the prompt Markdown surface) stays source until a trailing space or
   newline, which then renders that line only. Backspace against contiguous
@@ -30,6 +32,9 @@ App-shell wrapper around `@ora/editor` for prompt boxes.
   type-icon + basename refs (Tabler via `WorkspaceFileIcon` / React node view),
   not bordered pills: soft teal basename ink with type-colored icons.
   `==highlight==` is a Typora yellow (`rgb(255, 255, 0)`; delimiters hidden).
+  File chips with a line range expose `data-start-line` / `data-end-line` and a
+  matching `title`. Compact user-message Markdown expands every single newline
+  outside fences (including runs of one-character lines).
   `/` skills and `$` commands are mint-wash pills with forest green ink
   (Cursor-style; no neon glow).
 - Sent user messages stay `documentPlainText` in the store and render read-only

--- a/packages/app-shell/src/features/editor/composer-editor.test.tsx
+++ b/packages/app-shell/src/features/editor/composer-editor.test.tsx
@@ -102,6 +102,10 @@ describe("ComposerEditor", () => {
     await waitFor(() =>
       expect(textbox.querySelector("[data-composer-file]")).not.toBeNull(),
     );
+    const chip = textbox.querySelector("[data-composer-file]");
+    expect(chip).toHaveAttribute("data-start-line", "4");
+    expect(chip).toHaveAttribute("data-end-line", "12");
+    expect(chip).toHaveAttribute("title", "src/app.ts:4-12");
     expect(composerText(textbox)).toContain("`src/app.ts:4-12`");
   });
 
@@ -162,6 +166,49 @@ describe("ComposerEditor", () => {
         },
       ],
     });
+  });
+
+  it("appendText keeps slash-command chips instead of round-tripping through Markdown", async () => {
+    const editorRef = createRef<ComposerEditorHandle>();
+    render(
+      <ComposerEditor ref={editorRef} ariaLabel="Message" onSubmit={vi.fn()} />,
+    );
+
+    act(() => {
+      editorRef.current?.replaceDocument({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "promptToken",
+                attrs: { kind: "command", name: "test" },
+              },
+            ],
+          },
+        ],
+      });
+    });
+    act(() => {
+      editorRef.current?.appendText("more");
+    });
+
+    await waitFor(() => {
+      expect(
+        editorRef.current
+          ?.getJSON()
+          .content?.some((block) =>
+            (block.content ?? []).some(
+              (node) =>
+                node.type === "promptToken" &&
+                node.attrs?.kind === "command" &&
+                node.attrs?.name === "test",
+            ),
+          ),
+      ).toBe(true);
+    });
+    expect(editorRef.current?.getText()).toMatch(/more/);
   });
 
   it("inserts a file chip at the caret without jumping to the document end", () => {
@@ -435,6 +482,21 @@ describe("ComposerEditor", () => {
     ).toBe(true);
   });
 
+  it("lifts an empty quote on Shift+Enter instead of inserting another paragraph inside it", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<ComposerEditor ariaLabel="Message" onSubmit={onSubmit} />);
+    const textbox = screen.getByRole("textbox", { name: "Message" });
+
+    await user.click(textbox);
+    await user.keyboard("> hello");
+    expect(textbox.querySelector("blockquote")).not.toBeNull();
+    await user.keyboard("{Control>}a{/Control}{Backspace}");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(textbox.querySelector("blockquote")).toBeNull();
+  });
+
   it("leaves a list on Enter and adds an item on Shift+Enter", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
@@ -454,6 +516,62 @@ describe("ComposerEditor", () => {
     expect(textbox.querySelector("ul")?.textContent).toMatch(/first/);
     expect(textbox.querySelector("ul")?.textContent).toMatch(/second/);
     expect(textbox.querySelector("ul")?.textContent).not.toMatch(/body/);
+  });
+
+  it("keeps a chip-only list item on Enter instead of lifting it as empty", async () => {
+    const user = userEvent.setup();
+    const editorRef = createRef<ComposerEditorHandle>();
+    const onSubmit = vi.fn();
+    render(
+      <ComposerEditor
+        ref={editorRef}
+        ariaLabel="Message"
+        onSubmit={onSubmit}
+      />,
+    );
+    const textbox = screen.getByRole("textbox", { name: "Message" });
+
+    act(() => {
+      editorRef.current?.replaceDocument({
+        type: "doc",
+        content: [
+          {
+            type: "bulletList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "composerFile",
+                        attrs: {
+                          path: "src/app.ts",
+                          startLine: null,
+                          endLine: null,
+                          kind: "file",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+    await waitFor(() =>
+      expect(textbox.querySelector("[data-composer-file]")).not.toBeNull(),
+    );
+    act(() => {
+      editorRef.current?.focus({ at: "end" });
+    });
+    await user.keyboard("{Enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(textbox.querySelector("ul")).not.toBeNull();
+    expect(textbox.querySelector("[data-composer-file]")).not.toBeNull();
   });
 
   it("leaves a heading on Enter without sending", async () => {

--- a/packages/app-shell/src/features/editor/composer-editor.tsx
+++ b/packages/app-shell/src/features/editor/composer-editor.tsx
@@ -58,6 +58,8 @@ export interface ComposerEditorProps {
   initialText?: string;
   enterKey?: "submit" | "newline";
   className?: string;
+  /** Optional DOM id so a `<label htmlFor>` can focus the contenteditable. */
+  id?: string;
   ariaLabel?: string;
   ariaAutoComplete?: "list" | "none";
   ariaHasPopup?: "listbox";
@@ -94,6 +96,7 @@ export const ComposerEditor = forwardRef<
     initialText = "",
     enterKey = "submit",
     className,
+    id,
     ariaLabel,
     ariaAutoComplete,
     ariaHasPopup,
@@ -211,6 +214,7 @@ export const ComposerEditor = forwardRef<
 
   useEffect(() => {
     const dom = editor.view.dom;
+    setOptionalAttr(dom, "id", id);
     setOptionalAttr(dom, "aria-label", ariaLabel);
     setOptionalAttr(dom, "aria-autocomplete", ariaAutoComplete);
     setOptionalAttr(dom, "aria-haspopup", ariaHasPopup);
@@ -235,6 +239,7 @@ export const ComposerEditor = forwardRef<
     ariaLabel,
     disabled,
     editor,
+    id,
   ]);
 
   useImperativeHandle(
@@ -291,14 +296,16 @@ export const ComposerEditor = forwardRef<
         editor.commands.insertComposerFiles(files);
       },
       appendText: (text) => {
-        const current = documentPlainText(editor.state.doc).trimEnd();
-        const next =
-          current.length === 0 ? `${text}\n\n` : `${current}\n\n${text}\n\n`;
-        editor
-          .chain()
-          .setContent(markdownToComposerContent(next))
-          .focus("end")
-          .run();
+        // Insert parsed blocks at the end so existing `/command` chips stay
+        // nodes. A full documentPlainText round-trip cannot rebuild slash chips.
+        const blocks = markdownToComposerContent(text).content ?? [];
+        if (blocks.length === 0) {
+          return;
+        }
+        const content = editor.isEmpty
+          ? blocks
+          : [{ type: "paragraph" }, ...blocks];
+        editor.chain().focus("end").insertContent(content).run();
       },
       removeAtToken: () => {
         deleteTriggerToken(editor, AT_TRIGGER_PATTERN);

--- a/packages/app-shell/src/features/editor/composer-file-chip-view.tsx
+++ b/packages/app-shell/src/features/editor/composer-file-chip-view.tsx
@@ -1,6 +1,7 @@
 import {
+  composerFileAttrsFromUnknown,
   composerFileLabel,
-  type ComposerFileAttrs,
+  composerFilePlainText,
 } from "@ora/editor/composer";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { WorkspaceFileIcon } from "../files/workspace-file-visuals";
@@ -10,19 +11,9 @@ import { WorkspaceFileIcon } from "../files/workspace-file-visuals";
  * Wired through `AppComposerFile` so the explorer and @ picker share one visual.
  */
 export function ComposerFileChipView({ node }: NodeViewProps) {
-  const kind =
-    node.attrs.kind === "directory"
-      ? ("directory" as const)
-      : ("file" as const);
-  const attrs: ComposerFileAttrs = {
-    path: String(node.attrs.path),
-    startLine:
-      node.attrs.startLine === null ? undefined : Number(node.attrs.startLine),
-    endLine:
-      node.attrs.endLine === null ? undefined : Number(node.attrs.endLine),
-    kind,
-  };
-  const title = attrs.path;
+  const attrs = composerFileAttrsFromUnknown(node.attrs);
+  const kind = attrs.kind === "directory" ? "directory" : "file";
+  const title = composerFilePlainText(attrs).replace(/`/g, "");
 
   return (
     <NodeViewWrapper
@@ -30,6 +21,12 @@ export function ComposerFileChipView({ node }: NodeViewProps) {
       className="composer-file-ref"
       data-composer-file={attrs.path}
       data-kind={kind}
+      {...(attrs.startLine === undefined
+        ? {}
+        : { "data-start-line": String(attrs.startLine) })}
+      {...(attrs.endLine === undefined
+        ? {}
+        : { "data-end-line": String(attrs.endLine) })}
       contentEditable={false}
       title={title}
     >

--- a/packages/app-shell/src/features/files/workspace-files-view.tsx
+++ b/packages/app-shell/src/features/files/workspace-files-view.tsx
@@ -233,6 +233,10 @@ export function WorkspaceFilesView({
     const conversationKey = conversationKeyFor(
       useWorkspaceSelectionStore.getState().selection,
     );
+    if (conversationKey === "__none__") {
+      toast.warning(t("files.lineSelectionNeedsChat"));
+      return;
+    }
     useComposerFileContextStore
       .getState()
       .addSelection(conversationKey, selection);

--- a/packages/app-shell/src/features/workflow-run/run-hitl-composer.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-hitl-composer.tsx
@@ -564,6 +564,7 @@ export function RunHitlComposer({
                 >
                   <div className="flex flex-col p-2">
                     <label
+                      htmlFor={`hitl-text-${request.id}-${field.name}`}
                       className={cn(
                         textFields.length > 1
                           ? "px-2 pb-1 text-[11px] font-medium text-muted-foreground"
@@ -574,6 +575,7 @@ export function RunHitlComposer({
                     </label>
                     <ComposerEditor
                       key={`${request.id}-${field.name}`}
+                      id={`hitl-text-${request.id}-${field.name}`}
                       ref={(handle) => {
                         if (handle === null) {
                           editorByFieldRef.current.delete(field.name);
@@ -593,10 +595,7 @@ export function RunHitlComposer({
                       enterKey={isPrimary ? "submit" : "newline"}
                       ariaLabel={field.label}
                       onSubmit={() => {
-                        if (
-                          !gateBusy &&
-                          missingRequired(collectFieldValues()) === null
-                        ) {
+                        if (!gateBusy) {
                           void submit();
                         }
                       }}

--- a/packages/app-shell/src/i18n/i18n-instance.ts
+++ b/packages/app-shell/src/i18n/i18n-instance.ts
@@ -1126,6 +1126,7 @@ export const translationResources = {
       "加入 AI 对话（第 {{startLine}}-{{endLine}} 行）",
     "files.lineSelectionAdded":
       "已将第 {{startLine}}-{{endLine}} 行加入 AI 对话",
+    "files.lineSelectionNeedsChat": "请先打开一个对话，再把选区加入提示词",
     "files.selectLine": "选择第 {{line}} 行",
     "diff.fileTree": "变更文件目录",
     "diff.toggleFileTree": "显示或隐藏变更文件目录",
@@ -1259,6 +1260,7 @@ export const translationResources = {
     "chat.attachments.tooLarge":
       "单张图片不能超过 5 MB，总大小不能超过 10 MB。",
     "chat.attachments.readFailed": "无法读取所选图片，请重试。",
+    "chat.fileContext.injectFailed": "无法把文件选区加入提示词，请重试。",
     "chat.loadingHistory": "正在加载历史记录…",
     "chat.emptyHistory": "尚无消息",
     "chat.typing": "助手正在运行",
@@ -2685,6 +2687,8 @@ export const translationResources = {
       "Add lines {{startLine}}-{{endLine}} to AI chat",
     "files.lineSelectionAdded":
       "Added lines {{startLine}}-{{endLine}} to AI chat",
+    "files.lineSelectionNeedsChat":
+      "Open a chat first, then add the selection to the prompt",
     "files.selectLine": "Select line {{line}}",
     "diff.fileTree": "Changed file tree",
     "diff.toggleFileTree": "Show or hide changed file tree",
@@ -2826,6 +2830,8 @@ export const translationResources = {
       "Images must be at most 5 MB each and 10 MB total.",
     "chat.attachments.readFailed":
       "The selected image could not be read. Try again.",
+    "chat.fileContext.injectFailed":
+      "The file selection could not be added to the prompt. Try again.",
     "chat.loadingHistory": "Loading history…",
     "chat.emptyHistory": "No messages yet",
     "chat.typing": "Assistant is working",

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -10,7 +10,9 @@ or product chrome.
 - `createComposerExtensions()` plus plain-text conversion for prompt boxes
   (`@ora/editor/composer`, no dashboard SCSS theme). `documentPlainText` is the
   payload/draft form; `markdownToComposerContent` is the inverse for paste and
-  restore. `COMPOSER_CAPABILITIES` is the prompt-box minimum set; slots can be
+  restore. Fenced code and inline code pick a fence longer than any backtick
+  run in the payload so nested ` ``` ` cannot close early; `javascript:` /
+  `data:` / `vbscript:` / `file:` hrefs stay text. `COMPOSER_CAPABILITIES` is the prompt-box minimum set; slots can be
   omitted or replaced.
 - Toolbar primitives for full-page editing; the chat composer uses `@ora/ui`
   instead so it does not pull the kit's SCSS theme.

--- a/packages/editor/src/composer/README.md
+++ b/packages/editor/src/composer/README.md
@@ -23,17 +23,25 @@ Tiptap preset and plain-text helpers for prompt boxes (chat composer, HITL).
   source extensions, dotfiles) and `$skill` tokens become chips on that text
   path; versions (`v1.0`), globs (`*.ts`), slash-command chips, and directory
   `kind` need TipTap JSON parking (chat composer) for a lossless round-trip.
-  Raw strings that must stay literal (`<`
+  Inline code that contains backticks, and fenced blocks that contain a ` ``` `
+  line, serialize with a longer CommonMark fence so parse cannot close early.
+  `[label](javascript:…)` / `data:` / `vbscript:` / `file:` hrefs stay literal
+  text instead of becoming a link mark. Link titles escape `\` then `"` so a
+  quoted title round-trips. Raw strings that must stay literal (`<`
   as text) use `plainTextToComposerContent`. `[ ] ` at the start of a paragraph
   or bullet becomes a task item (not a checklist nested under a disc). Marks
   reuse the kit Bold / Italic / Strike / Code / Highlight / Link / Underline
   extensions. Kit input rules require a leading ASCII space, which misses
   `你好**等等**`; composer keeps `markInputRule` and only relaxes flanking so
   CJK can sit against `*` / `**` / `***` / `~~` / `==`. Underline is Mod-u
-  (Markdown has no `__underline__` syntax; `__` is bold).
+  (Markdown has no `__underline__` syntax; `__` is bold). `documentPlainText`
+  therefore drops underline; park TipTap JSON to keep it across session switches.
 - Shift+Enter is always a newline inside the current structure (code, quote,
   list, heading). Enter leaves that structure and returns to body text, or
-  sends from a body paragraph. A trailing space after a fence info string also
+  sends from a body paragraph. An empty heading or list item is empty only
+  when it has no chips (content size, not `textContent`). Shift+Enter on an
+  empty quote lifts the quote instead of inserting another paragraph inside it.
+  A trailing space after a fence info string also
   opens the fence.
 - Prompt links open on pointerdown (not mouseup/`click`) so the first press
   leaves the editor instead of placing a caret. Desktop still routes through

--- a/packages/editor/src/composer/composer-enter.ts
+++ b/packages/editor/src/composer/composer-enter.ts
@@ -55,7 +55,7 @@ function exitHeading(view: EditorView, depth: number): boolean {
   if (paragraph === undefined) {
     return false;
   }
-  if ($from.parent.textContent.length === 0) {
+  if ($from.parent.content.size === 0) {
     const from = $from.before(depth);
     view.dispatch(
       state.tr
@@ -77,7 +77,9 @@ function exitHeading(view: EditorView, depth: number): boolean {
     tr.setBlockType(start, end, paragraph);
     tr.setSelection(TextSelection.near(tr.doc.resolve(start + 1)));
   } catch {
-    return false;
+    // A failed split must not fall through to submit; insert a body paragraph
+    // after the heading so Enter still leaves the structure.
+    return insertParagraphAfter(view, depth);
   }
   view.dispatch(tr.scrollIntoView());
   return true;
@@ -87,7 +89,7 @@ function exitList(view: EditorView, itemDepth: number): boolean {
   const { state } = view;
   const { $from } = state.selection;
   const item = $from.node(itemDepth);
-  if (item.textContent.length === 0) {
+  if (item.content.size === 0) {
     return liftCurrentListItem(view, item.type);
   }
   for (let depth = itemDepth - 1; depth > 0; depth -= 1) {

--- a/packages/editor/src/composer/composer-file.ts
+++ b/packages/editor/src/composer/composer-file.ts
@@ -35,9 +35,39 @@ export function composerFilePlainText(attrs: ComposerFileAttrs): string {
   return `\`${target}\``;
 }
 
+/**
+ * Normalizes chip attrs from TipTap/DOM so NaN line numbers never reach the
+ * agent payload as `:NaN`.
+ */
+export function composerFileAttrsFromUnknown(attrs: {
+  path?: unknown;
+  startLine?: unknown;
+  endLine?: unknown;
+  kind?: unknown;
+}): ComposerFileAttrs {
+  return {
+    path: String(attrs.path ?? ""),
+    startLine: optionalLineNumber(attrs.startLine),
+    endLine: optionalLineNumber(attrs.endLine),
+    kind: attrs.kind === "directory" ? "directory" : "file",
+  };
+}
+
 function fileName(path: string): string {
-  const parts = path.split(/[/\\]/);
+  const trimmed = path.replace(/[/\\]+$/, "");
+  const parts = trimmed.split(/[/\\]/);
   return parts[parts.length - 1] || path;
+}
+
+function optionalLineNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === "") {
+    return undefined;
+  }
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
 }
 
 function lineRange(attrs: ComposerFileAttrs): string | null {
@@ -100,8 +130,8 @@ export const ComposerFile = Node.create({
           return {
             path: element.getAttribute("data-composer-file") ?? "",
             kind,
-            startLine: startLine === null ? null : Number(startLine),
-            endLine: endLine === null ? null : Number(endLine),
+            startLine: optionalLineNumber(startLine) ?? null,
+            endLine: optionalLineNumber(endLine) ?? null,
           };
         },
       },
@@ -109,16 +139,7 @@ export const ComposerFile = Node.create({
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    const attrs: ComposerFileAttrs = {
-      path: String(node.attrs.path),
-      startLine:
-        node.attrs.startLine === null
-          ? undefined
-          : Number(node.attrs.startLine),
-      endLine:
-        node.attrs.endLine === null ? undefined : Number(node.attrs.endLine),
-      kind: node.attrs.kind === "directory" ? "directory" : "file",
-    };
+    const attrs = composerFileAttrsFromUnknown(node.attrs);
     return [
       "span",
       mergeAttributes(HTMLAttributes, {
@@ -140,15 +161,7 @@ export const ComposerFile = Node.create({
   },
 
   renderText({ node }) {
-    return composerFilePlainText({
-      path: String(node.attrs.path),
-      startLine:
-        node.attrs.startLine === null
-          ? undefined
-          : Number(node.attrs.startLine),
-      endLine:
-        node.attrs.endLine === null ? undefined : Number(node.attrs.endLine),
-    });
+    return composerFilePlainText(composerFileAttrsFromUnknown(node.attrs));
   },
 
   addCommands() {

--- a/packages/editor/src/composer/composer-link.ts
+++ b/packages/editor/src/composer/composer-link.ts
@@ -20,6 +20,15 @@ export function isComposerOpenableUrl(href: string): boolean {
 }
 
 /**
+ * Schemes that must never become a link mark or agent payload, even before
+ * `sanitizeUrl` (which needs a window base URL). Kept window-free so the
+ * Markdown parser can reuse this in Node tests.
+ */
+export function isDangerousComposerHref(href: string): boolean {
+  return /^(?:javascript|data|vbscript|file):/i.test(href.trim());
+}
+
+/**
  * Returns a browser-openable href, or null when the URL is javascript/data/etc.
  * or a scheme Desktop will not launch.
  */
@@ -103,6 +112,8 @@ export const ComposerLink = Link.extend({
   autolink: true,
   linkOnPaste: true,
   markdownLinks: true,
+  // `defaultProtocol` / `markdownLinks` need @tiptap/extension-link >= 3.26,
+  // which is why that package's specifier is higher than the other @tiptap/*.
   defaultProtocol: "https",
   HTMLAttributes: {
     target: "_blank",

--- a/packages/editor/src/composer/composer-markdown.ts
+++ b/packages/editor/src/composer/composer-markdown.ts
@@ -1,6 +1,7 @@
 import type { JSONContent } from "@tiptap/core";
 import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { isDangerousComposerHref } from "./composer-link";
 
 type MarkSpec = { type: string; attrs?: Record<string, string | null> };
 
@@ -8,8 +9,14 @@ const HEADING = /^(#{1,6})(?:\s+|$)(.*)$/;
 const TASK = /^(\s*)[-*+]\s+\[([ xX])\]\s+(.*)$/;
 const BULLET = /^(\s*)[-*+]\s+(.*)$/;
 const ORDERED = /^(\s*)(\d+)\.\s+(.*)$/;
-const FENCE = /^```([^\s`]*)$/;
+const FENCE = /^(```+)([^\s`]*)$/;
 const RULE = /^(?:---|\*\*\*|___)\s*$/;
+
+/** CommonMark: a closing fence is a line of backticks at least as long as the opener. */
+function isFenceClose(line: string, openLen: number): boolean {
+  const match = /^(```+)$/.exec(line);
+  return match !== null && (match[1]?.length ?? 0) >= openLen;
+}
 const HTML_CLIPBOARD =
   /<(p|div|h[1-6]|ul|ol|li|pre|blockquote|strong|em|a|code|hr)\b/i;
 const INLINE_MARKDOWN =
@@ -96,14 +103,21 @@ function parseBlocks(lines: string[], quoteDepth = 0): JSONContent[] {
 
     const fence = FENCE.exec(line);
     if (fence !== null) {
-      const language = fence[1] === "" ? null : fence[1];
+      const openTicks = fence[1] ?? "```";
+      const language = fence[2] === "" ? null : (fence[2] ?? null);
       const body: string[] = [];
       index += 1;
-      while (index < lines.length && lines[index] !== "```") {
+      while (
+        index < lines.length &&
+        !isFenceClose(lines[index] ?? "", openTicks.length)
+      ) {
         body.push(lines[index] ?? "");
         index += 1;
       }
-      if (index < lines.length && lines[index] === "```") {
+      if (
+        index < lines.length &&
+        isFenceClose(lines[index] ?? "", openTicks.length)
+      ) {
         index += 1;
       }
       blocks.push(codeBlock(language, body.join("\n")));
@@ -269,19 +283,16 @@ function parseInline(text: string): JSONContent[] {
   let rest = text;
 
   while (rest.length > 0) {
-    if (rest[0] === "`") {
-      const close = rest.indexOf("`", 1);
-      if (close !== -1) {
-        const inner = rest.slice(1, close);
-        const file = tryParseComposerFileChip(inner);
-        if (file !== null) {
-          nodes.push(file);
-        } else {
-          pushText(nodes, inner, [{ type: "code" }]);
-        }
-        rest = rest.slice(close + 1);
-        continue;
+    const inlineCode = takeInlineCode(rest);
+    if (inlineCode !== null) {
+      const file = tryParseComposerFileChip(inlineCode.inner);
+      if (file !== null) {
+        nodes.push(file);
+      } else {
+        pushText(nodes, inlineCode.inner, [{ type: "code" }]);
       }
+      rest = rest.slice(inlineCode.end);
+      continue;
     }
 
     const prompt = takePromptToken(rest, nodes);
@@ -309,6 +320,13 @@ function parseInline(text: string): JSONContent[] {
         last.text.endsWith("!");
       const link = afterImageBang ? null : parseLink(rest, 0);
       if (link !== null) {
+        // Dangerous schemes stay literal Markdown so they never enter a mark
+        // or the agent payload. Click-time `safeComposerHref` is the last line.
+        if (isDangerousComposerHref(link.href)) {
+          pushText(nodes, rest.slice(0, link.end), []);
+          rest = rest.slice(link.end);
+          continue;
+        }
         const attrs: Record<string, string | null> = { href: link.href };
         if (link.title !== undefined) {
           attrs.title = link.title;
@@ -460,13 +478,12 @@ function parseLink(
   let title: string | undefined;
   const quote = text[cursor];
   if (quote === '"' || quote === "'") {
-    const closeQuote = text.indexOf(quote, cursor + 1);
-    if (closeQuote === -1) {
+    const takenTitle = takeQuotedLinkTitle(text, cursor, quote);
+    if (takenTitle === null) {
       return null;
     }
-    const quoted = text.slice(cursor + 1, closeQuote);
-    title = quoted.length === 0 ? undefined : quoted;
-    cursor = closeQuote + 1;
+    title = takenTitle.title.length === 0 ? undefined : takenTitle.title;
+    cursor = takenTitle.end + 1;
     while (cursor < text.length && /\s/.test(text[cursor] ?? "")) {
       cursor += 1;
     }
@@ -475,6 +492,68 @@ function parseLink(
     return null;
   }
   return { label, href: taken.href, title, end: cursor + 1 };
+}
+
+/**
+ * CommonMark inline code: a run of opening backticks closed by the same
+ * number, not as part of a longer run. One leading/trailing space is padding
+ * so a payload that starts with a backtick can still round-trip.
+ */
+function takeInlineCode(text: string): { inner: string; end: number } | null {
+  if (text[0] !== "`") {
+    return null;
+  }
+  let ticks = 0;
+  while (text[ticks] === "`") {
+    ticks += 1;
+  }
+  let index = ticks;
+  while (index < text.length) {
+    if (text[index] !== "`") {
+      index += 1;
+      continue;
+    }
+    let run = 0;
+    while (text[index + run] === "`") {
+      run += 1;
+    }
+    if (run === ticks) {
+      let inner = text.slice(ticks, index);
+      if (inner.length >= 2 && inner.startsWith(" ") && inner.endsWith(" ")) {
+        inner = inner.slice(1, -1);
+      }
+      return { inner, end: index + ticks };
+    }
+    index += run;
+  }
+  return null;
+}
+
+/**
+ * Reads a quoted link title, honoring `\\` and `\"` / `\'` so serialization's
+ * escape of quotes does not close the title early.
+ */
+function takeQuotedLinkTitle(
+  text: string,
+  start: number,
+  quote: string,
+): { title: string; end: number } | null {
+  let index = start + 1;
+  let title = "";
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "\\" && index + 1 < text.length) {
+      title += text[index + 1];
+      index += 2;
+      continue;
+    }
+    if (char === quote) {
+      return { title, end: index };
+    }
+    title += char;
+    index += 1;
+  }
+  return null;
 }
 
 function takeLinkDestination(

--- a/packages/editor/src/composer/composer-newline.ts
+++ b/packages/editor/src/composer/composer-newline.ts
@@ -10,6 +10,8 @@ import { convertMarkdownFenceOpener } from "./composer-code-fence";
  */
 export const ComposerNewline = Extension.create({
   name: "composerNewline",
+  // Below composerCodeFence (1100) so Enter can still open a fence; above
+  // composerMarkdown (50) so Shift+Enter wins over paste/input rules.
   priority: 1000,
 
   addKeyboardShortcuts() {
@@ -41,11 +43,11 @@ function splitComposerBlock(editor: Editor): boolean {
     return editor.commands.splitListItem("taskItem");
   }
   const { $from } = editor.state.selection;
-  if ($from.parentOffset === 0 && $from.parent.type.isTextblock) {
-    return insertEmptyBlockBefore(editor);
-  }
   if (editor.isActive("blockquote") && $from.parent.content.size === 0) {
     return editor.commands.liftEmptyBlock();
+  }
+  if ($from.parentOffset === 0 && $from.parent.type.isTextblock) {
+    return insertEmptyBlockBefore(editor);
   }
   return editor.commands.splitBlock();
 }

--- a/packages/editor/src/composer/composer-plain-text.ts
+++ b/packages/editor/src/composer/composer-plain-text.ts
@@ -1,6 +1,9 @@
 import type { JSONContent } from "@tiptap/core";
 import type { Mark, Node as PmNode } from "@tiptap/pm/model";
-import { composerFilePlainText } from "./composer-file";
+import {
+  composerFileAttrsFromUnknown,
+  composerFilePlainText,
+} from "./composer-file";
 
 function leafPlainText(node: PmNode): string {
   switch (node.type.name) {
@@ -11,17 +14,7 @@ function leafPlainText(node: PmNode): string {
       return `${prefix}${String(node.attrs.name)}`;
     }
     case "composerFile":
-      return composerFilePlainText({
-        path: String(node.attrs.path),
-        startLine:
-          node.attrs.startLine === null || node.attrs.startLine === undefined
-            ? undefined
-            : Number(node.attrs.startLine),
-        endLine:
-          node.attrs.endLine === null || node.attrs.endLine === undefined
-            ? undefined
-            : Number(node.attrs.endLine),
-      });
+      return composerFilePlainText(composerFileAttrsFromUnknown(node.attrs));
     case "horizontalRule":
       return "---";
     default:
@@ -29,11 +22,40 @@ function leafPlainText(node: PmNode): string {
   }
 }
 
+/**
+ * CommonMark inline code: the fence is one backtick longer than the longest
+ * run inside the payload, with space padding so an inner `` ` `` cannot close
+ * the span. A single backtick stays the everyday `` `code` `` form.
+ */
+function wrapInlineCode(text: string): string {
+  const longestRun =
+    text.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+  const fence = "`".repeat(Math.max(1, longestRun + 1));
+  if (
+    longestRun > 0 ||
+    text.startsWith(" ") ||
+    text.endsWith(" ") ||
+    text.startsWith("`") ||
+    text.endsWith("`")
+  ) {
+    return `${fence} ${text} ${fence}`;
+  }
+  return `${fence}${text}${fence}`;
+}
+
+/**
+ * Escapes a Markdown link title so parse can find the real closing quote.
+ * Backslashes first, then quotes — otherwise `\"` would split into a stray `"`.
+ */
+function escapeLinkTitle(title: string): string {
+  return title.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 function wrapInlineMarkdown(text: string, marks: readonly Mark[]): string {
   let out = text;
   const names = new Set(marks.map((mark) => mark.type.name));
   if (names.has("code")) {
-    out = `\`${out}\``;
+    out = wrapInlineCode(out);
   } else {
     if (names.has("strike")) {
       out = `~~${out}~~`;
@@ -58,7 +80,7 @@ function wrapInlineMarkdown(text: string, marks: readonly Mark[]): string {
   }
   const title = link.attrs.title;
   if (typeof title === "string" && title.length > 0) {
-    return `[${out}](${href} "${title.replace(/"/g, '\\"')}")`;
+    return `[${out}](${href} "${escapeLinkTitle(title)}")`;
   }
   return `[${out}](${href})`;
 }
@@ -166,7 +188,14 @@ function serializeBlock(node: PmNode, indent = ""): string {
         node.attrs.language === ""
           ? ""
           : String(node.attrs.language);
-      return `${indent}\`\`\`${language}\n${node.textContent}\n${indent}\`\`\``;
+      const text = node.textContent;
+      // Longer than any backtick run in the body so a nested ``` line cannot
+      // close the fence on parse (CommonMark closing-fence rule).
+      const longestRun =
+        text.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ??
+        0;
+      const fence = "`".repeat(Math.max(3, longestRun + 1));
+      return `${indent}${fence}${language}\n${text}\n${indent}${fence}`;
     }
     case "blockquote": {
       const inner = joinChildBlocks(node, "");

--- a/packages/editor/src/composer/create-composer-extensions.ts
+++ b/packages/editor/src/composer/create-composer-extensions.ts
@@ -48,7 +48,8 @@ export const COMPOSER_HEADING_LEVELS = [1, 2, 3, 4, 5, 6] as const;
 /**
  * Prompt-box capability minimum set. Full-page kit nodes (images, TOC, video,
  * alignment) stay out; product chrome can replace a slot instead of forking
- * the preset.
+ * the preset. `underline` is Mod-u only — `documentPlainText` cannot encode it,
+ * so session switches must park TipTap JSON to keep the mark.
  */
 export const COMPOSER_CAPABILITIES = {
   blocks: [

--- a/packages/editor/src/composer/index.ts
+++ b/packages/editor/src/composer/index.ts
@@ -19,6 +19,7 @@ export type { PromptTokenKind } from "./prompt-token";
 export {
   ComposerLink,
   isComposerOpenableUrl,
+  isDangerousComposerHref,
   resolveComposerLinkHref,
   safeComposerHref,
 } from "./composer-link";
@@ -57,6 +58,7 @@ export {
 export { ComposerTaskItem } from "./composer-task-item";
 export {
   ComposerFile,
+  composerFileAttrsFromUnknown,
   composerFileLabel,
   composerFilePlainText,
 } from "./composer-file";

--- a/packages/editor/tests/composer-markdown.test.ts
+++ b/packages/editor/tests/composer-markdown.test.ts
@@ -465,6 +465,61 @@ test("markdownToComposerContent does not chip versions or globs", () => {
   });
 });
 
+test("markdownToComposerContent keeps backticks inside longer inline-code fences", () => {
+  assert.deepEqual(paragraphPlain(markdownToComposerContent("`` a`b ``")), {
+    text: "a`b",
+    marks: ["code"],
+  });
+});
+
+test("markdownToComposerContent does not close a fence on an inner ``` line", () => {
+  const doc = markdownToComposerContent("````\n```\ncode\n````");
+  assert.deepEqual(doc, {
+    type: "doc",
+    content: [
+      {
+        type: "codeBlock",
+        attrs: { language: null },
+        content: [{ type: "text", text: "```\ncode" }],
+      },
+    ],
+  });
+});
+
+test("markdownToComposerContent keeps escaped quotes in link titles", () => {
+  const doc = markdownToComposerContent(
+    '[Docs](https://example.com "say \\"hi\\"")',
+  );
+  assert.deepEqual(doc.content?.[0], {
+    type: "paragraph",
+    content: [
+      {
+        type: "text",
+        text: "Docs",
+        marks: [
+          {
+            type: "link",
+            attrs: { href: "https://example.com", title: 'say "hi"' },
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test("markdownToComposerContent keeps javascript hrefs as literal text", () => {
+  const doc = markdownToComposerContent("[xss](javascript:alert(1))");
+  assert.deepEqual(doc, {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "[xss](javascript:alert(1))" }],
+      },
+    ],
+  });
+});
+
 function paragraphPlain(doc: {
   content?: Array<{
     content?: Array<{ text?: string; marks?: Array<{ type: string }> }>;

--- a/packages/editor/tests/composer.test.ts
+++ b/packages/editor/tests/composer.test.ts
@@ -9,7 +9,10 @@ import {
   documentPlainText,
   plainTextToComposerContent,
 } from "../src/composer/composer-plain-text.ts";
-import { composerFilePlainText } from "../src/composer/composer-file.ts";
+import {
+  composerFileLabel,
+  composerFilePlainText,
+} from "../src/composer/composer-file.ts";
 import { parseFenceOpener } from "../src/composer/composer-code-fence.ts";
 import { highlightInputMatch } from "../src/composer/composer-highlight.ts";
 import { isComposerOpenableUrl } from "../src/composer/composer-link.ts";
@@ -390,4 +393,76 @@ test("range selection decorates intersecting chips for visual highlight", async 
     .filter(Boolean);
   assert.equal(classes.includes("composer-chip-in-selection"), true);
   editor.destroy();
+});
+
+test("documentPlainText uses a longer fence when the code block contains ```", () => {
+  const schema = new Schema({
+    nodes: {
+      doc: { content: "block+" },
+      paragraph: { content: "inline*", group: "block" },
+      text: { group: "inline" },
+      codeBlock: {
+        content: "text*",
+        group: "block",
+        code: true,
+        attrs: { language: { default: null } },
+      },
+    },
+  });
+  const doc = schema.node("doc", null, [
+    schema.node("codeBlock", { language: null }, [schema.text("```\ncode")]),
+  ]);
+  assert.equal(documentPlainText(doc), "````\n```\ncode\n````");
+});
+
+test("documentPlainText wraps inline code that contains backticks", () => {
+  const schema = new Schema({
+    nodes: {
+      doc: { content: "block+" },
+      paragraph: { content: "inline*", group: "block" },
+      text: { group: "inline" },
+    },
+    marks: { code: {} },
+  });
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, [schema.text("a`b", [schema.mark("code")])]),
+  ]);
+  assert.equal(documentPlainText(doc), "`` a`b ``");
+});
+
+test("documentPlainText escapes backslashes before quotes in link titles", () => {
+  const schema = new Schema({
+    nodes: {
+      doc: { content: "block+" },
+      paragraph: { content: "inline*", group: "block" },
+      text: { group: "inline" },
+    },
+    marks: {
+      link: {
+        attrs: { href: { default: null }, title: { default: null } },
+        inclusive: false,
+      },
+    },
+  });
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, [
+      schema.text("Docs", [
+        schema.mark("link", {
+          href: "https://example.com",
+          title: 'say "hi"',
+        }),
+      ]),
+    ]),
+  ]);
+  assert.equal(
+    documentPlainText(doc),
+    '[Docs](https://example.com "say \\"hi\\"")',
+  );
+});
+
+test("composerFileLabel uses the last path segment even when the path ends with a slash", () => {
+  assert.equal(
+    composerFileLabel({ path: "foo/bar/", kind: "directory" }),
+    "bar",
+  );
 });


### PR DESCRIPTION
## 摘要

这不是新功能，而是 [#416](https://github.com/ora-space/desktop/pull/416) 合并后的审查跟进。#416 把聊天输入从纯文本换成了 TipTap 提示框（一套所见即所得的富文本编辑器）。合并后的检视意见里，只有**已经接到聊天 / HITL 产品路径、并且对照源码核实存在**的缺陷进入本次修复。dashboard 里那套未接到聊天的编辑器模板不改。

后文会反复用到这些词，先用白话说清楚：

- **Markdown 往返（round-trip）**：编辑器里的标题、列表、代码、链接是带结构的文档；发给 Agent 时要写成纯文本 Markdown；切会话或重载草稿时再解析回结构。这一出一回必须对得上，否则用户刚打的反引号代码、代码块、链接标题会在恢复时被拆坏。
- **芯片（chip）**：提示框里的文件、`$skill`、`/command` 不是普通文字，而是不可拆开的节点。只含芯片、没有可见文字的标题或列表项，不能当成「空」。
- **围栏（fence）**：Markdown 用一串反引号包住代码。行内代码是一对 `` ` ``，代码块是至少三个 `` ``` ``。围栏必须比内容里最长的那串反引号更长，否则解析会在内部提前结束。
- **HITL（Human in the Loop，人在回路）**：工作流跑到需要人点头、补充或澄清时停下来，用同一套提示框收集回复。
- **scheme（URL 协议头）**：地址最前面的 `https:`、`javascript:` 这一段，告诉系统用什么程序打开。
- **InvalidRequest / Internal**：两套错误分类。前者是「请求本身不合法」（例如 Desktop 拒绝打开的 scheme）；后者是「请求合法，但操作系统打不开浏览器」（宿主故障）。前端可以据此决定提示文案。
- **spawn_blocking**：Rust 异步运行时里，把会卡住的同步系统调用丢到专用线程池，避免堵住其他任务。
- **TipTap JSON park**：切会话时不只存 Markdown 纯文本，还把编辑器内部的 JSON 文档原样存一份。Markdown 写不出来的样式（如下划线）只能靠这份 JSON 才能回来。

## 解决了什么问题

### 1. 序列化再解析会弄坏代码和链接

提示框发给 Agent、以及草稿恢复，都走「结构 → Markdown 纯文本 → 再解析回结构」。旧实现有几处和 CommonMark（Markdown 的通用语法约定）不一致：

- 行内代码内容本身含反引号时，旧实现仍用一对反引号包起来，解析会在内部反引号处提前结束。
- 代码块里如果出现 `` ``` `` 行，关闭围栏会认错，后面的内容被当成普通段落。
- 链接 title（方括号后面那句说明文字）里的 `\` 和 `"` 转义顺序不对，带引号的 title 无法完整回来。
- `javascript:` / `data:` / `vbscript:` / `file:` 这类危险地址会被解析成真正的链接标记。用户会以为点得开，实际上不该当链接。

### 2. Enter / Shift+Enter 会弄丢结构，或误提交

提示框约定：Enter 用来离开当前结构（标题、列表、引用）或提交；Shift+Enter 在结构内部换行。旧逻辑有三处会踩空：

- 判断「这一块是不是空」用的是可见文字（`textContent`）。芯片没有可见文字，只含芯片的标题 / 列表项会被当成空：Enter 会拆掉列表或标题。
- 退出标题失败时 `catch` 返回 `false`，事件落到提交。用户按 Enter 本意是离开标题或换行，结果整段发出去了。
- 空引用在行首按 Shift+Enter 时，退出引用的处理排在「在开头插入新段」之后，结果是在引用里再塞一段，而不是离开引用。

### 3. 文件芯片、用户消息和若干接线缺口

这些都在聊天或 HITL 真正会走到的代码上：

- 路径末尾分隔符、非法行号会生成坏的芯片属性；芯片的 React 节点视图缺行号 title / data 属性。
- 用户消息里连续的单字符换行只展开一部分，竖排单字对不齐。
- Markdown `mark`（行内样式标记，如高亮）的 `className` 被 `{...props}` 覆盖，高亮样式丢了。
- `@` 提及菜单的 `useMemo`（React 用来缓存计算结果的钩子）漏了依赖；Windows 路径的 `\` 在相关度计算里没有归一成 `/`，同样的文件在 Windows 上排序会偏。
- 注入文件上下文失败时吞掉 pending，界面像成功；没有会话时假装插入成功。
- HITL 标签的 `htmlFor` 对不上输入框的 `id`，点标签聚焦不到编辑器；`onSubmit` 重复做校验，和真正的提交函数打架。
- `appendText`（在提示框末尾追加一段文字）整篇走纯文本往返，会把已有的 `/command` 芯片打成普通文字。
- 打开外链时，非法 scheme 和操作系统启动失败都报成同一类错误，前端无法区分「不该打开」和「打开失败」。

## 为什么这么解决

产品只消费 `@ora/editor/composer`。dashboard 里 TOC / 图片 / 视频 / diff 等模板**没有接到聊天或 HITL**，那些检视意见不进本次修复。

1. **往返按 CommonMark 规则补齐**：行内代码按内容里最长反引号 run 加长围栏，并在两端加空格，避免内部的 `` ` `` 被当成结束符；代码块关闭围栏长度必须 ≥ 开围栏；title 先转义 `\` 再转义 `"`，解析按同样规则还原；危险 href 整段当纯文本，不进 link mark（链接样式标记）。
2. **空结构看节点尺寸，不看可见文字**：ProseMirror（TipTap 底层的文档模型）里 `content.size === 0` 才算空，芯片占尺寸，所以能保住。标题退出失败改为在标题后面插入普通段落，不再 `return false` 落到提交。空引用的 `liftEmptyBlock`（把空块从引用里抬出来）挪到「行首插段」之前。
3. **芯片属性只解析一次**：`composerFileAttrsFromUnknown` 给 `renderHTML` / `renderText` / 纯文本 / React 节点视图共用。行号必须是有限且大于 0 的数字。
4. **接线按调用方语义修**：`appendText` 在文档末尾 `insertContent`，不整篇 round-trip，已有芯片和结构都保留；文件上下文失败展示 `injectFailed`；无会话用 `__none__` 给 toast（屏幕一角的短暂提示），不装成功；HITL 用 `htmlFor` + `id` 把标签和输入框绑在一起。
5. **打开外链按故障责任分类**：非法 scheme 是 `InvalidRequest`（请求本身不合法）；操作系统打不开浏览器是 `Internal`（服务端 / 宿主故障）。Windows 仍不把 `ShellExecuteW`（把 URL 交给已注册协议处理器的系统调用）丢进 `spawn_blocking`：该 API 交出去就会返回，本身不堵；再绕一次冷的线程池，第一次点击反而会像卡住。这是有意设计，不是漏改。macOS 的 `open`、Linux 的 `xdg-open` 仍走 `spawn_blocking`，因为它们可能堵住。

## 检视意见里未改的部分（核实后不成立或不是产品路径）

| 意见 | 结论 |
|------|------|
| `stackedMarkInputRule` 的 function-`find` 在 TipTap 3 里不会触发 `***` | **不成立**。3.0.7 会把 function-`find` 转成数组再交给 handler，`***text***` 能触发，已用测试钉住。 |
| Windows `open_external` 应 `spawn_blocking` | **不改**。见上，冷线程池会让首击卡住。 |
| Linux `xdg-open` 静默成功 | **YAGNI**（You Aren't Gonna Need It：当前用不上就先不改）。交付宿主不是 Linux 桌面主路径。 |
| dashboard 模板 lookbehind / WebKit、死配置、风格意见 | **不改**。这些模板未被 chat / HITL 消费。 |
| `mode="edit"` 未实现 | **不是现网 bug**。当前调用不传 `mode`。 |
| 把 `@tiptap/extension-link` 降到 3.0.x | **不改**。`defaultProtocol` / `markdownLinks` 需要 3.26+；在 `composer-link.ts` 注释说明原因。 |
| 从能力表去掉 underline | **不改**。Mod-u 仍可用；Markdown 无法往返 underline，切会话时靠 park TipTap JSON 保留。README 已写明。 |

## 考虑了哪些点，做了什么权衡

| 选项 | 为什么没选 / 为什么选 |
|------|------------------------|
| 把 OCR 里 126 条意见全部改掉 | 大量针对未使用的 dashboard 模板，塞进去会扩大无关表面积，还可能引入新回归。只修产品路径。 |
| 往返改用第三方 Markdown 解析器 | 提示框是 GFM 子集（GitHub Flavored Markdown 的一部分）+ 芯片。完整解析器会吃 HTML、表格、图片，和「发给 Agent 的纯文本」契约不一致。继续用手写子集，只补 CommonMark 围栏 / 转义缺口。 |
| 危险 href 剥掉 scheme 后仍做成链接 | 用户会以为点得开。整段当字面量更安全。 |
| chip-only 项按 Enter 提交 | 用户在列表里插文件后按 Enter，预期是离开这一项，不是整段发出。 |
| `appendText` 继续整篇 `documentPlainText` | 会丢掉 `/command` 芯片。改为末尾插入，chip 和结构保留。 |
| 无会话插入文件时静默失败 | 用户以为已插入。改为 toast 说明需要先有聊天。 |
| Windows 打开外链也 `spawn_blocking` | 表面上「所有平台同一套异步封装」，实际上第一次点击会经过冷线程池，体感是卡住。Windows 保持同步调用 `ShellExecuteW`。 |

刻意保持不变：

- 产品仍只走 composer 预设，不启用 dashboard 全量 kit
- underline 仍在能力表里，但不保证 Markdown 往返（依赖 TipTap JSON park）
- Windows 打开外链仍同步调用 `ShellExecuteW`，不绕 `spawn_blocking`
- 不降 `@tiptap/extension-link`，不改未使用的 dashboard 模板，不补 Linux `xdg-open` 的等待 / 失败语义

## 测试计划

- [x] `@ora/editor`：47/47 通过（含更长围栏、链接 title 转义、危险 href、fileName 尾部分隔符）
- [x] app-shell 相关：`composer-editor` / `composer-markdown-live` / `user-message-markdown` / `composer-actions` / `markdown-message` / `workspace-files-view` / `use-theater-hitl`，145/145 通过
- [x] `open_external` Rust 单测：2/2 通过
- [x] `@ora/editor` composer eslint、改过的 app-shell 文件 eslint：`--max-warnings 0`
- [ ] 手动：提示框输入含反引号的行内代码、内含 `` ``` `` 的围栏、带 `\"` 的链接 title，切会话后再打开，结构仍在
- [ ] 手动：列表项里只放一个文件芯片再按 Enter，列表不被拆掉，也不会误提交
- [ ] 手动：空标题 Enter 离开标题且不发送；空引用 Shift+Enter 离开引用
- [ ] 手动：已有 `/test` 芯片时 `appendText`，芯片仍在
- [ ] 手动：无会话时从文件树选行号，出现「需要先打开聊天」提示，而不是假装插入
- [ ] 手动：点 `javascript:` 链接不会变成可点击的提示框链接

关联：#416（已合并；本 PR 是审查跟进，不关闭该 PR）。
