### PR TITLE
fix(app-shell): address #424 review feedback (orphan draft, restore hardening)

### DIFF
--- a/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
@@ -60,6 +60,23 @@ const SESSION: Session = {
   title: null,
   historyState: { type: "writable" },
 };
+// A direct (project-root) chat: its task carries workspaceMode "project_root".
+const DIRECT_TASK: Task = {
+  id: "t-direct",
+  projectId: "p1",
+  title: "Direct chat",
+  workspaceMode: "project_root",
+  type: "default",
+  workflowRunId: null,
+};
+const DIRECT_SESSION: Session = {
+  id: "s-direct",
+  taskId: "t-direct",
+  agentRef: "ora-space.opencode",
+  status: "running",
+  title: null,
+  historyState: { type: "writable" },
+};
 
 /** Renders the sidebar with the same provider stack AppShell gives it. */
 function renderSidebar(
@@ -332,21 +349,26 @@ describe("WorkspaceSidebar", () => {
 
   it("creates under a worktree after clicking that worktree row", async () => {
     const user = userEvent.setup();
-    const state = createMockClientState();
-    state.projects = [PROJECT];
-    state.tasks = [TASK];
-    state.sessions = [];
+    const state = workspaceWithOneSession();
+    // Preselect a live session so a regression that wrongly routes the worktree
+    // row through selectTask (yanking the composer) is caught: starting from
+    // an empty selection, a null-sessionId assertion would pass either way.
+    useWorkspaceSelectionStore
+      .getState()
+      .selectSession(SESSION.id, TASK.id, PROJECT.id);
     renderSidebar(state);
 
     await waitFor(() => expect(treeRow(TASK.title)).not.toBeNull());
     await user.click(screen.getByText(TASK.title));
+    // Clicking a worktree row only retargets New chat; it must not move the
+    // composer off the live session.
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      SESSION.id,
+    );
     expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
       projectId: PROJECT.id,
       taskId: TASK.id,
     });
-    expect(
-      useWorkspaceSelectionStore.getState().selection.sessionId,
-    ).toBeNull();
 
     await user.click(
       await screen.findByRole("button", { name: /新建对话|New chat/ }),
@@ -361,6 +383,37 @@ describe("WorkspaceSidebar", () => {
     expect(useWorkspaceSelectionStore.getState().selection.draftId).toEqual(
       expect.any(String),
     );
+  });
+
+  it("keeps New chat visible when the selected chat is a direct (project-root) chat", async () => {
+    const user = userEvent.setup();
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [DIRECT_TASK];
+    state.sessions = [DIRECT_SESSION];
+    // Selecting the direct chat syncs createFocus to its project-root task id.
+    useWorkspaceSelectionStore
+      .getState()
+      .selectSession(DIRECT_SESSION.id, DIRECT_TASK.id, PROJECT.id);
+    renderSidebar(state);
+
+    await user.click(
+      await screen.findByRole("button", { name: /新建对话|New chat/ }),
+    );
+
+    // The project-root task id must demote to a direct (project-level) draft so
+    // the row renders under the project instead of being orphaned in the
+    // worktree-draft map, which the project-root branch never renders.
+    expect(useWorkspaceSelectionStore.getState().selection).toMatchObject({
+      projectId: PROJECT.id,
+      taskId: null,
+      sessionId: null,
+      workflowRunId: null,
+    });
+    expect(useWorkspaceSelectionStore.getState().selection.draftId).toEqual(
+      expect.any(String),
+    );
+    await waitFor(() => expect(treeRow(NEW_SESSION_LABEL)).not.toBeNull());
   });
 
   it("discards an empty draft when another session is selected", async () => {

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
+  cn,
   toast,
 } from "@ora/ui";
 import {
@@ -181,7 +182,11 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
     projects,
     tasks,
     sessions,
-    treePending: loading,
+    // Restore must wait not only while the tree queries are pending but also
+    // while any has errored: a settled-but-failed query yields an empty list,
+    // which would make the resolver discard a valid candidate as a miss and
+    // overwrite the disk selection. Keep the loading indicator on isPending.
+    treePending: loading || error !== null,
   });
 
   const tasksByProjectId = useMemo(() => {
@@ -812,15 +817,20 @@ function TreeRow({
     maxLength,
   } = useInlineTreeRename({ value: label, onCommit: onRename });
 
-  const rowTone = active
-    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-    : createFocused
-      ? "bg-sidebar-accent/45 text-sidebar-foreground ring-1 ring-inset ring-sidebar-accent/60"
-      : "hover:bg-sidebar-accent/70";
+  // Conditional class names are composed with `cn` instead of a nested ternary
+  // so each branch reads as a standalone predicate, matching the rest of the UI.
+  const rowTone = cn(
+    "group/tree flex h-9 items-center rounded-md transition-colors",
+    active && "bg-sidebar-accent text-sidebar-accent-foreground",
+    !active &&
+      createFocused &&
+      "bg-sidebar-accent/45 text-sidebar-foreground ring-1 ring-inset ring-sidebar-accent/60",
+    !active && !createFocused && "hover:bg-sidebar-accent/70",
+  );
 
   return (
     <div
-      className={`group/tree flex h-9 items-center rounded-md transition-colors ${rowTone}`}
+      className={rowTone}
       data-create-focus={createFocused && !active ? "true" : undefined}
     >
       <ContextMenu>

--- a/packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts
+++ b/packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts
@@ -37,7 +37,7 @@ export function useRestoreWorkspaceSelection(input: {
   projects: readonly Project[];
   tasks: readonly Task[];
   sessions: readonly Session[];
-  /** True while any of the three tree queries is still pending. */
+  /** True while any of the three tree queries is still pending or has errored. */
   treePending: boolean;
 }): void {
   const { projects, tasks, sessions, treePending } = input;
@@ -57,11 +57,16 @@ export function useRestoreWorkspaceSelection(input: {
     // Sanitized candidates always carry a projectId with a run id. Without one
     // the by-project query stays disabled and would never leave pending.
     if (workflowProjectId === null) return [];
-    if (runsQuery.isPending) return null;
+    // Treat an errored run list like a still-pending one: return null so the
+    // effect keeps waiting instead of resolving against an empty error list,
+    // which would discard a valid restore candidate as a miss. A later refetch
+    // that succeeds re-runs the effect with the real list.
+    if (runsQuery.isPending || runsQuery.isError) return null;
     return runsQuery.data ?? [];
   }, [
     needsWorkflowRuns,
     runsQuery.data,
+    runsQuery.isError,
     runsQuery.isPending,
     workflowProjectId,
   ]);

--- a/packages/app-shell/src/state/hooks/use-workspace-mutations.ts
+++ b/packages/app-shell/src/state/hooks/use-workspace-mutations.ts
@@ -86,16 +86,22 @@ export function useDeleteProject() {
         ]);
       useDraftSessionsStore.getState().clearReturnToForSessions(sessionIds);
       useDraftSessionsStore.getState().removeForProject(projectId);
-      const selection = useWorkspaceSelectionStore.getState().selection;
+      const store = useWorkspaceSelectionStore.getState();
+      const selection = store.selection;
       if (selection.projectId === projectId) {
         // Pick the next surviving project from the stale cache; invalidate already triggered refetch.
         const projects = readCache<Project>(queryClient, queryKeys.projects);
         const next = projects.find((project) => project.id !== projectId);
-        useWorkspaceSelectionStore.getState().setProject(next?.id ?? null);
+        // setProject resyncs createFocus to the new selection. Preserve a
+        // create-focus the user pointed at a different surviving project so New
+        // chat still follows their last click, matching applyRestoredSelection.
+        const focusBefore = store.createFocus;
+        store.setProject(next?.id ?? null);
+        if (focusBefore !== null && focusBefore.projectId !== projectId) {
+          store.setCreateFocus(focusBefore);
+        }
       } else {
-        useWorkspaceSelectionStore
-          .getState()
-          .clearCreateFocusForProject(projectId);
+        store.clearCreateFocusForProject(projectId);
       }
     },
   });
@@ -179,13 +185,19 @@ export function useDeleteTask() {
         .clearKeys([...sessionIds, `task:${taskId}`]);
       useDraftSessionsStore.getState().clearReturnToForSessions(sessionIds);
       useDraftSessionsStore.getState().removeForTask(taskId);
-      const selection = useWorkspaceSelectionStore.getState().selection;
+      const store = useWorkspaceSelectionStore.getState();
+      const selection = store.selection;
       if (selection.taskId === taskId) {
-        useWorkspaceSelectionStore
-          .getState()
-          .clearTaskSelection(selection.projectId ?? "");
+        // clearTaskSelection resyncs createFocus to the project. Preserve a
+        // create-focus the user pointed at a different surviving task so New
+        // chat still follows their last click, matching applyRestoredSelection.
+        const focusBefore = store.createFocus;
+        store.clearTaskSelection(selection.projectId ?? "");
+        if (focusBefore !== null && focusBefore.taskId !== taskId) {
+          store.setCreateFocus(focusBefore);
+        }
       } else {
-        useWorkspaceSelectionStore.getState().clearCreateFocusForTask(taskId);
+        store.clearCreateFocusForTask(taskId);
       }
     },
   });

--- a/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
@@ -26,6 +26,16 @@ const SESSION: Session = {
   title: null,
   historyState: { type: "writable" },
 };
+const WORKFLOW_RUN: WorkflowRunSummary = {
+  id: "run-1",
+  name: "Deploy",
+  projectId: "p1",
+  workflowId: "wf-1",
+  status: "succeeded",
+  startedAt: null,
+  finishedAt: null,
+  createdAt: 0n,
+};
 
 const empty: WorkspaceSelection = {
   projectId: null,
@@ -132,6 +142,27 @@ describe("resolveRestoredWorkspaceSelection", () => {
     ).toEqual({ kind: "miss" });
   });
 
+  it("misses when the session exists but its task was deleted (orphan warm guard)", () => {
+    // The task lookup is the guard PR #424 added to stop a stale session id from
+    // warming a provider session whose owning task no longer exists.
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: "s1",
+          workflowRunId: null,
+          draftId: null,
+        },
+        projects: [PROJECT],
+        tasks: [],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
   it("resolves a typed draft that still exists", () => {
     expect(
       resolveRestoredWorkspaceSelection({
@@ -179,6 +210,72 @@ describe("resolveRestoredWorkspaceSelection", () => {
     ).toEqual({ kind: "miss" });
   });
 
+  it("resolves a draft whose task still exists and matches the project", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: null,
+          workflowRunId: null,
+          draftId: "d1",
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [draft({ taskId: "t1" })],
+        workflowRuns: [],
+      }),
+    ).toEqual({
+      kind: "ready",
+      selection: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: null,
+        workflowRunId: null,
+        draftId: "d1",
+      },
+    });
+  });
+
+  it("misses a draft whose task was deleted", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: null,
+          workflowRunId: null,
+          draftId: "d1",
+        },
+        projects: [PROJECT],
+        tasks: [],
+        sessions: [SESSION],
+        drafts: [draft({ taskId: "t1" })],
+        workflowRuns: [],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("misses a draft whose task moved to another project", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: "t1",
+          sessionId: null,
+          workflowRunId: null,
+          draftId: "d1",
+        },
+        projects: [PROJECT],
+        tasks: [{ ...TASK, projectId: "p2" }],
+        sessions: [SESSION],
+        drafts: [draft({ taskId: "t1" })],
+        workflowRuns: [],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
   it("waits when workflow runs have not settled", () => {
     expect(
       resolveRestoredWorkspaceSelection({
@@ -198,7 +295,36 @@ describe("resolveRestoredWorkspaceSelection", () => {
     ).toEqual({ kind: "waiting" });
   });
 
-  it("misses a workflow run absent from the project list", () => {
+  it("resolves a workflow run that is still in the run list", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: null,
+          sessionId: null,
+          workflowRunId: "run-1",
+          draftId: null,
+        },
+        projects: [PROJECT],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [WORKFLOW_RUN],
+      }),
+    ).toEqual({
+      kind: "ready",
+      selection: {
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: "run-1",
+        draftId: null,
+      },
+    });
+  });
+
+  it("misses a workflow run absent from the run list", () => {
+    // The project is still in the list; the miss comes from the empty run list.
     expect(
       resolveRestoredWorkspaceSelection({
         candidate: {
@@ -213,6 +339,46 @@ describe("resolveRestoredWorkspaceSelection", () => {
         sessions: [SESSION],
         drafts: [],
         workflowRuns: [] as WorkflowRunSummary[],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("misses a workflow run whose project was deleted", () => {
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: null,
+          sessionId: null,
+          workflowRunId: "run-1",
+          draftId: null,
+        },
+        projects: [],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [WORKFLOW_RUN],
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("misses a workflow run whose authoritative project differs from the candidate", () => {
+    // Ownership is re-derived from the run record, so a corrupt persisted
+    // projectId cannot retarget the restored run at another project.
+    expect(
+      resolveRestoredWorkspaceSelection({
+        candidate: {
+          projectId: "p1",
+          taskId: null,
+          sessionId: null,
+          workflowRunId: "run-1",
+          draftId: null,
+        },
+        projects: [PROJECT, { ...PROJECT, id: "p2", name: "Other" }],
+        tasks: [TASK],
+        sessions: [SESSION],
+        drafts: [],
+        workflowRuns: [{ ...WORKFLOW_RUN, projectId: "p2" }],
       }),
     ).toEqual({ kind: "miss" });
   });

--- a/packages/app-shell/src/state/resolve-restored-workspace-selection.ts
+++ b/packages/app-shell/src/state/resolve-restored-workspace-selection.ts
@@ -32,8 +32,9 @@ export type ResolvedWorkspaceSelection =
  *
  * `ready` carries a selection for `select*` APIs. `waiting` means a workflow
  * run list is still loading. `miss` means the target no longer exists (or the
- * payload was empty). Session ownership always comes from session/task records
- * so a mismatched persisted projectId cannot point chat at the wrong project.
+ * payload was empty). Ownership always comes from the authoritative
+ * session/task/run records, so a mismatched persisted projectId cannot point
+ * chat at the wrong project.
  */
 export function resolveRestoredWorkspaceSelection(
   input: ResolveRestoredWorkspaceSelectionInput,
@@ -94,16 +95,23 @@ export function resolveRestoredWorkspaceSelection(
       return { kind: "miss" };
     }
     if (workflowRuns === null) return { kind: "waiting" };
-    if (!workflowRuns.some((run) => run.id === candidate.workflowRunId)) {
-      return { kind: "miss" };
-    }
+    // Re-derive ownership from the authoritative run record instead of the
+    // persisted candidate, matching the session/draft/task branches. The run
+    // list is project-scoped today, but a future caller passing an unscoped
+    // list must not let a corrupt candidate.projectId retarget the run.
+    const run = workflowRuns.find(
+      (item) =>
+        item.id === candidate.workflowRunId &&
+        item.projectId === candidate.projectId,
+    );
+    if (run === undefined) return { kind: "miss" };
     return {
       kind: "ready",
       selection: {
-        projectId: candidate.projectId,
+        projectId: run.projectId,
         taskId: null,
         sessionId: null,
-        workflowRunId: candidate.workflowRunId,
+        workflowRunId: run.id,
         draftId: null,
       },
     };

--- a/packages/app-shell/src/state/session-drafts.test.ts
+++ b/packages/app-shell/src/state/session-drafts.test.ts
@@ -94,10 +94,104 @@ describe("resolveNewChatScope", () => {
         "p-first",
         {
           projects: [{ id: "p1" }],
-          tasks: [{ id: "t1", projectId: "p1" }],
+          tasks: [{ id: "t1", projectId: "p1", workspaceMode: "worktree" }],
         },
       ),
     ).toEqual({ projectId: "p1", taskId: null });
+  });
+
+  it("keeps a createFocus whose project and worktree task both still exist", () => {
+    expect(
+      resolveNewChatScope(
+        { projectId: "p1", taskId: "t1" },
+        emptySelection,
+        "p-first",
+        {
+          projects: [{ id: "p1" }],
+          tasks: [{ id: "t1", projectId: "p1", workspaceMode: "worktree" }],
+        },
+      ),
+    ).toEqual({ projectId: "p1", taskId: "t1" });
+  });
+
+  it("demotes a project-root task createFocus to a direct draft", () => {
+    // A project-root task id would create a draft the sidebar only renders
+    // under worktree branches, orphaning it. New chat must fall to project-root.
+    expect(
+      resolveNewChatScope(
+        { projectId: "p1", taskId: "t-direct" },
+        emptySelection,
+        "p-first",
+        {
+          projects: [{ id: "p1" }],
+          tasks: [
+            {
+              id: "t-direct",
+              projectId: "p1",
+              workspaceMode: "project_root",
+            },
+          ],
+        },
+      ),
+    ).toEqual({ projectId: "p1", taskId: null });
+  });
+
+  it("keeps the selection's worktree task when createFocus is absent and the task is in the tree", () => {
+    expect(
+      resolveNewChatScope(
+        null,
+        { ...emptySelection, projectId: "p1", taskId: "t1" },
+        "p-first",
+        {
+          projects: [{ id: "p1" }],
+          tasks: [{ id: "t1", projectId: "p1", workspaceMode: "worktree" }],
+        },
+      ),
+    ).toEqual({ projectId: "p1", taskId: "t1" });
+  });
+
+  it("demotes a project-root task in the selection fallback to a direct draft", () => {
+    expect(
+      resolveNewChatScope(
+        null,
+        {
+          ...emptySelection,
+          projectId: "p1",
+          taskId: "t-direct",
+          sessionId: "s-direct",
+        },
+        "p-first",
+        {
+          projects: [{ id: "p1" }],
+          tasks: [
+            {
+              id: "t-direct",
+              projectId: "p1",
+              workspaceMode: "project_root",
+            },
+          ],
+        },
+      ),
+    ).toEqual({ projectId: "p1", taskId: null });
+  });
+
+  it("falls back to the first project when the selection's project is gone from the tree", () => {
+    expect(
+      resolveNewChatScope(
+        null,
+        {
+          ...emptySelection,
+          projectId: "gone",
+          taskId: "t1",
+          sessionId: "s1",
+        },
+        "p-first",
+        {
+          projects: [{ id: "p1" }],
+          tasks: [{ id: "t1", projectId: "p1", workspaceMode: "worktree" }],
+        },
+      ),
+    ).toEqual({ projectId: "p-first", taskId: null });
   });
 });
 

--- a/packages/app-shell/src/state/session-drafts.ts
+++ b/packages/app-shell/src/state/session-drafts.ts
@@ -1,5 +1,6 @@
 import type * as acp from "@agentclientprotocol/sdk";
 import type { JSONContent } from "@tiptap/core";
+import type { TaskWorkspaceMode } from "@ora/contracts";
 import { useDraftSessionsStore } from "./stores/draft-sessions-store";
 import type { DraftScope } from "./stores/draft-sessions-store";
 import { useComposerInputStore } from "./stores/composer-input-store";
@@ -95,24 +96,34 @@ export function reparkDraftComposerContent(args: {
   });
 }
 
+/** Loaded tree shape `resolveNewChatScope` validates New-chat targets against. */
+type NewChatTree = {
+  projects: readonly { id: string }[];
+  tasks: readonly {
+    id: string;
+    projectId: string;
+    workspaceMode: TaskWorkspaceMode;
+  }[];
+};
+
 /**
  * Picks where global New chat / Ctrl+N should create a draft.
  *
  * Prefers the last tree create-focus (project/worktree row click), then the
- * live selection's project/task, then the first project. Returns null only when
- * the workspace has no projects at all.
+ * live selection's project/task, then the first project. Returns null only
+ * when the workspace has no projects at all.
  *
- * When `tree` is provided, a create-focus whose project vanished is ignored, and
- * a missing worktree is demoted to project-root so New chat never orphans a draft.
+ * When `tree` is provided, a create-focus or selection whose project vanished
+ * is ignored, a missing worktree is demoted to project-root, and a project-root
+ * task is demoted to a direct (project-level) draft. The sidebar only renders a
+ * task-scoped draft under a worktree branch, so New chat must never keep a
+ * project-root task id — that would create a draft no tree row can show.
  */
 export function resolveNewChatScope(
   createFocus: WorkspaceCreateFocus | null,
   selection: WorkspaceSelection,
   firstProjectId: string | null,
-  tree?: {
-    projects: readonly { id: string }[];
-    tasks: readonly { id: string; projectId: string }[];
-  },
+  tree?: NewChatTree,
 ): DraftScope | null {
   const focus = clampCreateFocus(createFocus, tree);
   if (focus !== null) {
@@ -122,10 +133,11 @@ export function resolveNewChatScope(
     };
   }
   if (selection.projectId !== null) {
-    return {
-      projectId: selection.projectId,
-      taskId: selection.taskId,
-    };
+    const scope = scopeDraftTarget(
+      { projectId: selection.projectId, taskId: selection.taskId },
+      tree,
+    );
+    if (scope !== null) return scope;
   }
   if (firstProjectId !== null) {
     return { projectId: firstProjectId, taskId: null };
@@ -133,27 +145,43 @@ export function resolveNewChatScope(
   return null;
 }
 
+/**
+ * Validates a {project, task} target against the loaded tree and returns the
+ * draft scope New chat should create under. A missing/mismatched/project-root
+ * task demotes to a project-root (direct) draft — worktree drafts render under
+ * the task branch, so a project-root task id would orphan the row. Returns null
+ * only when the project itself is gone, so the caller falls through to the next
+ * preference instead of creating a draft under a deleted project.
+ */
+function scopeDraftTarget(
+  scope: { projectId: string; taskId: string | null },
+  tree: NewChatTree | undefined,
+): { projectId: string; taskId: string | null } | null {
+  if (tree === undefined) return scope;
+  if (!tree.projects.some((project) => project.id === scope.projectId)) {
+    return null;
+  }
+  if (scope.taskId === null) return scope;
+  const task = tree.tasks.find((item) => item.id === scope.taskId);
+  if (
+    task === undefined ||
+    task.projectId !== scope.projectId ||
+    task.workspaceMode === "project_root"
+  ) {
+    return { projectId: scope.projectId, taskId: null };
+  }
+  return scope;
+}
+
 /** Drops or demotes create-focus that no longer matches the loaded tree. */
 function clampCreateFocus(
   createFocus: WorkspaceCreateFocus | null,
-  tree:
-    | {
-        projects: readonly { id: string }[];
-        tasks: readonly { id: string; projectId: string }[];
-      }
-    | undefined,
+  tree: NewChatTree | undefined,
 ): WorkspaceCreateFocus | null {
   if (createFocus === null) return null;
   if (tree === undefined) return createFocus;
-  if (!tree.projects.some((project) => project.id === createFocus.projectId)) {
-    return null;
-  }
-  if (createFocus.taskId === null) return createFocus;
-  const task = tree.tasks.find((item) => item.id === createFocus.taskId);
-  if (task === undefined || task.projectId !== createFocus.projectId) {
-    return { projectId: createFocus.projectId, taskId: null };
-  }
-  return createFocus;
+  const scoped = scopeDraftTarget(createFocus, tree);
+  return scoped === null ? null : scoped;
 }
 
 /**

--- a/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
@@ -331,6 +331,46 @@ describe("useWorkspaceSelectionStore", () => {
     expect(useWorkspaceSelectionStore.getState().selection).toEqual(empty);
   });
 
+  it("selectProject clears pendingRestore when the user navigates", () => {
+    useWorkspaceSelectionStore.setState({
+      selection: empty,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "stale",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    useWorkspaceSelectionStore.getState().selectProject("p-other");
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual({
+      projectId: "p-other",
+      taskId: null,
+      sessionId: null,
+      workflowRunId: null,
+      draftId: null,
+    });
+  });
+
+  it("selectSession clears pendingRestore when the user navigates", () => {
+    useWorkspaceSelectionStore.setState({
+      selection: empty,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "stale",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    useWorkspaceSelectionStore.getState().selectSession("s-live", "t1", "p1");
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      "s-live",
+    );
+  });
+
   it("setCreateFocus records a create target without changing selection", () => {
     useWorkspaceSelectionStore.getState().selectSession("s1", "t1", "p1");
     useWorkspaceSelectionStore
@@ -391,6 +431,25 @@ describe("useWorkspaceSelectionStore", () => {
     useWorkspaceSelectionStore.getState().clearCreateFocusForTask("t1");
     expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
       projectId: "p1",
+      taskId: null,
+    });
+  });
+
+  it("clearCreateFocusForProject drops focus on the deleted project", () => {
+    useWorkspaceSelectionStore
+      .getState()
+      .setCreateFocus({ projectId: "p1", taskId: null });
+    useWorkspaceSelectionStore.getState().clearCreateFocusForProject("p1");
+    expect(useWorkspaceSelectionStore.getState().createFocus).toBeNull();
+  });
+
+  it("clearCreateFocusForProject leaves focus on a different project untouched", () => {
+    useWorkspaceSelectionStore
+      .getState()
+      .setCreateFocus({ projectId: "p2", taskId: null });
+    useWorkspaceSelectionStore.getState().clearCreateFocusForProject("p1");
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: "p2",
       taskId: null,
     });
   });

--- a/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
@@ -319,6 +319,109 @@ describe("useRestoreWorkspaceSelection", () => {
     );
   });
 
+  it("applies a validated workflow run once its run list settles", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: "run-1",
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    state.workflowRuns = [
+      {
+        id: "run-1",
+        projectId: "p1",
+        workflowId: "wf-1",
+        snapshotId: "snap-1",
+        name: "Deploy",
+        status: "succeeded",
+        taskId: "t-run",
+        createdAt: 0n,
+        updatedAt: 0n,
+      },
+    ];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await waitFor(() => {
+      expect(
+        useWorkspaceSelectionStore.getState().selection.workflowRunId,
+      ).toBe("run-1");
+    });
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+    expect(useUiStore.getState().expandedProjects.has("p1")).toBe(true);
+  });
+
+  it("waits while the workflow-run query has errored instead of discarding the candidate", async () => {
+    // Offline restart: the run list query fails. A guardless implementation
+    // would resolve against the empty error list, miss the run, and clear
+    // pendingRestore — permanently losing the restore candidate.
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: null,
+        sessionId: null,
+        workflowRunId: "run-1",
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    state.workflowRuns = [];
+    const client = createMockClient(state);
+    const listSpy = vi
+      .spyOn(client.workflowRun, "list")
+      .mockRejectedValue(new Error("offline"));
+
+    const { queryClient } = renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryState(["workflowRun", "byProject", "p1"])?.status,
+      ).toBe("error");
+    });
+    // Let the errored query re-render and re-run the effect so a guardless
+    // implementation would have cleared the candidate by now.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(listSpy).toHaveBeenCalled();
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).not.toBeNull();
+    expect(useWorkspaceSelectionStore.getState().selection).toEqual(
+      EMPTY_WORKSPACE_SELECTION,
+    );
+  });
+
   it("preserves a user createFocus when applying a restored session", async () => {
     useWorkspaceSelectionStore.setState({
       selection: EMPTY_WORKSPACE_SELECTION,


### PR DESCRIPTION
## 背景

这是已合并 PR #424 的后续修复 PR（分支 `fix/pr424-review-followup`，base=main）。#424 做了两件事：一是重启后用“两阶段校验-再应用（validate-then-apply）”恢复上次工作区选择——先用 resolver（解析器）把磁盘上的恢复候选值在已加载的目录树上校验，只在通过时才写入 store 应用，防止一个过期的 session id 在数据还没加载完时就去 warm（预热，即提前用对话历史初始化一个底层 AI 提供商 provider 的会话上下文）一个无人认领的游离 provider 会话；二是记住用户在侧边栏点过的 project/worktree 行（createFocus，一个内存态的 `{projectId, taskId}` 指针，决定 New chat / Ctrl+N 新建草稿落点范围，独立于当前选中项 selection），让 New chat 落在该范围。#424 的 AI 检视（glm-5.2 生成）提了 14 条意见，本 PR 逐条对照代码核实后修复了其中合理的 13 条；另 1 条（称 `rowTone` 嵌套三元违反仓库 `no-nested-ternary` 规则）定性不准确——仓库根 `eslint.config.js` 实际未配置该规则（已核实无匹配），但“改用 `cn()` 拼接条件 className”的建议本身合理，仍采纳。

---

## 1. 提交了什么功能

本 PR 不引入新能力，只对 #424 已落地逻辑做五处修复加一处风格清理，并为每处补回归测试。

- **直聊会话下 New chat 落点降级**（`packages/app-shell/src/state/session-drafts.ts`）：`resolveNewChatScope` 与 `clampCreateFocus` 现在感知 task 的 `workspaceMode`（TaskWorkspaceMode，取值 `project_root` 或 `worktree`）。`project_root` task 即“直聊”——不挂 worktree 分支、挂在 project 下的会话。当选中一个 `project_root` task 时，New chat 落点从 `{projectId, taskId}` 降级为 `{projectId, taskId: null}`（project-level draft，即 taskId 为空、挂在 project 下渲染的直聊草稿），不再产出 taskId 非空的 draft。实现上抽出纯函数 `scopeDraftTarget`，统一承担“按 live tree（已加载的目录树）校验 `{project, task}` 目标”的职责，被 `clampCreateFocus` 与 selection 回退路径共用。`NewChatTree` 类型随之要求 `tasks` 携带 `workspaceMode`。
- **workflow-run 恢复分支从权威 run 记录重派生 projectId**（`packages/app-shell/src/state/resolve-restored-workspace-selection.ts`）：匹配条件从“只比 `run.id` 存在”收紧为 `item.id === candidate.workflowRunId && item.projectId === candidate.projectId`，命中后返回 `run.projectId` 与 `run.id`，不再用候选里的 `candidate.projectId` / `candidate.workflowRunId`。
- **查询出错也保持等待**（`packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts` + `packages/app-shell/src/features/workspace/workspace-sidebar.tsx`）：workflow-run 的 `useMemo` 把守卫从 `runsQuery.isPending` 扩为 `runsQuery.isPending || runsQuery.isError`（出错返回 `null` 让 effect 继续等）；sidebar 传给恢复 hook 的 `treePending` 从 `loading` 改为 `loading || error !== null`（`loading` 仅取三棵树查询的 `isPending`，`error` 取 `projectsQuery.error ?? tasksQuery.error ?? sessionsQuery.error` 的合并）。加载指示仍只挂在 `isPending`。
- **删除当前选中实体时快照 createFocus**（`packages/app-shell/src/state/hooks/use-workspace-mutations.ts`）：`useDeleteProject` / `useDeleteTask` 的“删的是当前选中实体”分支在调用 `setProject` / `clearTaskSelection` 之前取 `const focusBefore = store.createFocus`，删除后若 `focusBefore` 不指向被删实体（`focusBefore.projectId !== projectId` / `focusBefore.taskId !== taskId`）就 `setCreateFocus(focusBefore)` 恢复，做法仿 `applyRestoredSelection`。
- **`rowTone` 改用 `cn()`**（`workspace-sidebar.tsx`）：`TreeRow` 的行底色由嵌套三元改为用 `@ora/ui` 的 `cn()`（条件 className 拼接工具，按谓词合并/去重 class）逐分支拼接，原写死的布局 className `group/tree flex h-9 …` 也并入 `cn()` 返回值，`className={rowTone}` 一行即可。
- **回归测试**：为上述每项补测试——直聊 New chat 可见性的端到端用例、workflow-run ready 与 error 两条恢复路径、孤儿 session/draft 守卫、跨 project draft 校验、导航清 `pendingRestore`、`clearCreateFocusForProject`。据作者自述，对其中两项做了 teeth-check（反向验证：临时回退修复 → 确认对应测试会失败 → 恢复修复），证明测试不是与修复同形的“伪绿”，而是真能抓到 bug。

## 2. 解决了什么问题

每条都对应一个真实回归或健壮性缺口。

### 问题 A：选中直聊会话后按 New chat 会创建侧栏不可见的“孤儿 draft”

孤儿 draft 指一个创建了但侧栏树找不到对应行、用户看不见也点不到的草稿。Ora 的侧栏只在 worktree 分支下渲染 task-scoped（taskId 非空）的 draft，`project_root` 分支从不渲染 task 级行。#424 之前 `resolveNewChatScope` 在 createFocus / selection 携带一个 `project_root` task 的 `taskId` 时会原样保留，于是 New chat 产出一个 `{projectId, taskId: "t-direct"}` 的 draft——它既不属于任何 worktree 分支，又带了非空 taskId，在侧栏树里完全不可见，成为孤儿。用户选中一个直聊会话后按 New chat，看不到自己刚建的草稿。

### 问题 B：selection 回退路径放行陈旧指向

此前只有 createFocus 路径按目录树校验，selection 回退分支（`selection.projectId !== null`）直接原样返回 `{projectId, taskId}`，连 project 是否还在都不查。一个 project 已被删、task 已不存在的 selection 仍会被 New chat 当作有效落点。本 PR 让该分支也走 `scopeDraftTarget`。

### 问题 C：workflow-run 恢复分支信任了磁盘上的 candidate.projectId

#424 给 session、draft、task 三个恢复分支都确立了“不可信载荷（untrusted payload）”姿态——指来自磁盘、可能过时或被污染的候选输入，其携带的 `projectId` 等字段只作查找线索，最终归属一律从权威记录（session.taskId → task.projectId，或 draft 自身的 projectId 经 task 校验）重派生。唯独 workflow-run 分支漏了：它校验 `candidate.projectId` 在 projects 列表里、校验 `run.id` 存在，然后直接把 `candidate.projectId` 放回返回的 selection。当前 run 列表是按 project 作用域查询的（`workflowRun.list` by projectId），所以“恰好”自洽；但一旦未来有调用方传入未作用域化的 run 列表，一个被污染/陈旧的 `candidate.projectId` 就能把恢复后的 run 指向错误的项目。

### 问题 D：离线重启时查询出错被当成“已加载为空”，导致有效候选被永久丢弃

react-query 出错态（`isError`）下 `data` 为空数组、`isError` 为 true。#424 的恢复 hook 只看 `isPending`：查询进入 error 态就不再 pending，`useMemo` 返回 `[]`，resolver 在空列表里找不到目标 run → 判 `miss`（目标已不存在，应丢弃）→ `clearPendingRestore`（清空 store 里暂存的待恢复候选）永久丢弃这个有效候选。更糟的是，`clearPendingRestore` 的 `set({ pendingRestore: null })` 会触发 zustand persist 序列化，而此时水合后内存里的 `selection` 仍是空（恢复尚未应用），partialize 会把当前空 `selection` 与 `null` 的 `pendingRestore` 一起写回磁盘——于是磁盘上原本保存的上次选择也被覆盖成空。一次暂时的查询失败变成不可恢复的选择丢失。sidebar 侧 `treePending` 只传 `loading` 同理，三棵树查询任一出错时恢复 hook 会提前放行。

### 问题 E（风格）：rowTone 嵌套三元

`TreeRow` 的 `rowTone` 用了三层嵌套三元。AI 检视称其违反仓库 `no-nested-ternary` 规则——经核实仓库 `eslint.config.js` 未配置该规则，所以“违反规则”的定性不准确；但改用 `cn()` 拼接条件 className 的建议本身合理，且与仓库其他 UI 文件一致，仍采纳。

### 问题 F：删除当前选中实体时无条件重算 createFocus，覆盖用户在另一行的点选

`useDeleteProject` 在删的是当前选中 project 时调 `setProject(next)`；`useDeleteTask` 在删的是当前选中 task 时调 `clearTaskSelection`。store 的 `replaceSelection`（`setProject` / `clearTaskSelection` 的共同底层，见 store 第 117–128 行）会无条件用新 selection 重算 createFocus（`createFocus: createFocusFromSelection(selection)`）。如果用户此前在侧栏点了另一行（createFocus 指向一个存活的 project/task），这一删就把用户的手势抹掉，New chat 不再跟随用户最后的点选。`applyRestoredSelection` 在恢复路径里已用 `createFocusBefore` 快照 + 事后回填解决了同一类问题，但 mutation（数据变更）路径没有对齐。

## 3. 为什么这么解决

### A/B 的解法：统一用 `scopeDraftTarget`，按 workspaceMode 降级而非判 miss

抽出一个共用纯函数 `scopeDraftTarget`，对 `{projectId, taskId}` 目标在 live tree 上校验：project 不在则返回 `null`（让调用方 fall through 到下一优先级，而不是在已删 project 下凭空造 draft）；task 不在、或 task 的 `projectId` 与目标不匹配、或 `task.workspaceMode === "project_root"` 时，降级为 `{projectId, taskId: null}`（直聊 draft）。`clampCreateFocus` 和 selection 回退都改走这个函数，消除两条路径的校验不对称。

关键取舍：对 `project_root` task 选降级而非判 miss。判 miss 会让 createFocus 失效、落到 selection 再落到 firstProject，丢失用户选中的 project 语义；降级则保留 project、只丢 taskId——New chat 仍落在用户选中的 project 下，且产出的是侧栏能渲染的 project 级 draft。判定依据是 task 的工作区模式本身（`task.workspaceMode === "project_root"` 就降级），而非“树里有没有这个 task”——因为侧栏的渲染规则是“task-scoped draft 只画在 worktree 分支下”，project_root task 根本没有 worktree 分支。

### C 的解法：从权威 run 记录重派生，匹配收紧到 id+projectId

把 `workflowRuns.some(run => run.id === candidate.workflowRunId)` 改为 `workflowRuns.find(item => item.id === candidate.workflowRunId && item.projectId === candidate.projectId)`，命中后返回 `run.projectId` 与 `run.id`。这样既保留了“candidate.projectId 与 run 不一致则 miss”的校验（一个被污染的 candidate 指向另一 project 的 run 会被判 miss，而非被 run 的 projectId 覆盖），又在命中时用权威记录的 projectId 而非 candidate 的。与 session/draft/task 三分支姿态统一，注释也点明“run 列表今日是 project 作用域，但未来传入未作用域化列表的调用方不能让坏 candidate 重定目标”。

### D 的解法：把 error 态视同 pending

react-query 的 `isError` 表示查询已结束但失败，`data` 是空数组——语义上是“我不知道有没有”，既不代表“目标已删”也不代表“目标在”。把判定扩成 `isPending || isError`，出错时 `useMemo` 返回 `null`（`workflowRuns: null`），resolver 在 `workflowRuns === null` 时返回 `{ kind: "waiting" }`（数据未就绪，继续等），effect 不推进、不调 `clearPendingRestore`、不覆写磁盘。后续 refetch 成功后 effect 重跑，拿到真实列表再解析。sidebar 的 `treePending` 同步改为 `loading || error !== null`，让恢复 hook 在三棵树查询任一出错时也保持等待。注释明确：加载指示仍只看 `isPending`——出错态对用户表现为“还在加载”，但内部用保持等待避免数据丢失，这是有意为之的语义分离。

### F 的解法：快照 + 条件回填 createFocus

仿 `applyRestoredSelection`：在调 `setProject` / `clearTaskSelection` 之前取 `const focusBefore = store.createFocus`，调用后若 `focusBefore` 不为 null 且不指向被删实体则 `store.setCreateFocus(focusBefore)` 回填。判断条件是“不指向被删实体”而非“非空就恢复”，避免把指向已删实体的 stale focus 救回来。删的是非当前实体时仍走 `clearCreateFocusForProject` / `clearCreateFocusForTask` 的既有路径（只清指向被删实体的 focus，不动别的），两条分支职责不重叠。

### E 的解法：`cn()` 拼接

把三元改为 `cn(base, active && "…", !active && createFocused && "…", !active && !createFocused && "…")`，每个分支读作一个独立谓词，互斥且独立可读，无需在脑子里展开三元嵌套；同时把原本拼在 `className` 模板字符串里的 base class 也并进 `cn`。

## 4. 考虑了哪些点

- **live tree 校验的统一性**：A/B 的修复让 createFocus 路径和 selection 回退路径走同一个 `scopeDraftTarget`，不再出现“#424 只在 createFocus 路径校验、selection 回退原样放行陈旧指向”的不对称。
- **降级 vs miss 的取舍**：对 `project_root` task 选 miss 会丢掉用户选中的 project 语义；选降级（保留 project、丢 taskId）既保证可见性又保留 project 范围。对 worktree task 不在树里的情况，仍按 #424 既有逻辑降级到 project-root（不 miss）。
- **error 态的副作用边界**：只把 error 当 pending 用于“是否推进恢复”这一个判定；UI 的 loading 指示仍只看 `isPending`，不让 error 在视觉上无限转圈。refetch 成功后 effect 自然重跑，无需手动重试逻辑。用户一旦主动导航（`selectProject` / `selectSession` 会经 `replaceSelection` 清 `pendingRestore`，已有测试覆盖），effect 检测到 `selection` 非空即清 `pendingRestore` 并停止，构成脱离挂起态的逃生口，不构成死锁。
- **mutation 与 restore 的对齐**：F 的快照+回填模式复用 `applyRestoredSelection` 的既有做法，保证两条路径（删除当前选中 / 恢复选择）对 createFocus 的保护语义一致，不引入第三套逻辑。注意 `applyRestoredSelection` 的事后回填是无条件的（`createFocusBefore !== null` 即回填），mutation 版多了“不指向被删实体”的守卫，因为删除场景必须排除指向被删实体的 stale focus。
- **workflow-run 重派生的校验严格性**：C 的 `find` 同时匹配 `id` 和 `projectId`，一个 `projectId` 不一致的 run 会被判 miss（而非“用 run 的 projectId 覆盖”），避免给坏 candidate 开后门。
- **stderr 门控**：前端测试在 `scripts/run-with-clean-stderr.mjs` 下运行——任何 React Testing Library 写到 stderr 的告警（尤其 `act(...)` 未包裹的异步状态更新）即便 Vitest 报绿也会让整轮 `task test` 失败。新增的 workflow-run error 测试用 `await act(async () => { await Promise.resolve(); await Promise.resolve(); })` 让出错查询重渲染并重跑 effect 后再断言，正是为了把“effect 在 act 外更新 React”这类逃逸挡在门内。
- **测试的可证伪性**：teeth-check（临时回退修复、确认对应测试会失败、再恢复）针对其中两项做了反向验证，确保新测试不是永远绿的废测。

## 5. 做了什么权衡、取舍

- **workflow-run 分支今日无实际漏洞，仍修**：C 在当前代码下（run 列表按 project 作用域查询）不会被触发，属于纵深防御。取舍是“接受少量额外 `find` + 注释开销，换取未来调用方变更时的不变式”，而非“等出了 bug 再补”。今日行为不变（project 作用域下 `item.projectId === candidate.projectId` 恒成立，`find` 退化为 id 匹配，返回的 `run.projectId` 等于 `candidate.projectId`）。
- **error 态表现为“仍在加载”而非显式报错**：D 的选择是“宁可让用户多等一次 refetch，也不丢磁盘选择”。代价是网络长期错误时恢复会一直挂起；但用户主动导航即可脱离挂起态，不构成死锁。判 miss 不可逆（`clearPendingRestore` 永久丢弃并覆写磁盘），等错的成本（多等一次 refetch）远低于丢候选的成本，这是典型的不对称风险取舍。
- **降级而非清空 createFocus / 拒绝创建**：A 对 `project_root` task 选降级到 project 级 draft。`project_root` task 本就不该有 task 级 draft（侧栏不渲染），所以不存在“牺牲”，只是把不该有的 taskId 去掉；降级让用户立即能打字，落点语义上仍是直聊（`taskId=null` 的 project-level draft 即直聊 draft），用户感知不到差异。若选“拒绝创建并提示”，则直聊范围里 New chat 直接不可用，体验劣化。
- **`project_root` 降级仅靠 `workspaceMode` 判定**：依赖 task 记录的 `workspaceMode === "project_root"` 字段。若该字段被上游错误标为 `worktree`，降级不会触发。取舍是：校验只能基于权威记录字段，不另起一套启发式判定直聊形态，避免逻辑分叉。
- **采纳 E 的建议但纠正其定性**：AI 检视称嵌套三元“违反仓库规则”是不准确的（`eslint.config.js` 未配 `no-nested-ternary`），但改用 `cn()` 的建议合理且与仓库风格一致，仍采纳。取舍是“不为了反驳错误定性就放弃合理的可读性改进”，PR 描述也不沿用那条不准确的理由。`cn()` 重构纯可读性、不改运行时行为（产出相同的 className 串）。
- **未把 mutation 的 createFocus 保护提到 store 层**：F 在 mutation hook 里就地快照+回填，而非给 `replaceSelection` 加 `preserveCreateFocus` 形参。`replaceSelection` 的“createFocus 跟随 selection”是 New chat 连贯性的全局不变量，不宜为删除路径破例——后者会污染一个被多处共用的核心 API 的语义，每处调用方都要记得传参。前者把局部需求留在局部，复用 `applyRestoredSelection` 的成熟模式，代价是 mutation 文件多了几行模板。这与 `applyRestoredSelection` 在 hook 层而非 store 层处理是同一立场。
- **workflow-run 匹配收紧到 id+projectId**：比“只匹配 id”更严，意味着即便 run id 存在但 projectId 不符也判 miss。取舍：宁可对“候选 projectId 被污染”这种罕见情形判 miss（用户看到恢复失败、退到默认，可重新点选自愈），也不冒“把 run 恢复到错误 project”的静默错位风险。前者用户可自愈，后者更难发现。
- **测试覆盖“已存在的既有不变式”**：如 `selectProject` / `selectSession` 清 `pendingRestore`、`clearCreateFocusForProject` 只清指定 project，这些是 #424 已有但无显式测试覆盖的不变式。本 PR 补测试锁定它们，取舍是“测试面略超本次修复的直接范围，但这些都是恢复正确性的前置不变式，补测能防未来回归”。分层策略：在可信的最低层用最廉价的纯函数测试覆盖最多分支，端到端只留给真正需要渲染树才能证伪的场景（孤儿行不可见）。

---

## 验证状态

> 以下为作者自述，非本 PR diff 可直接佐证：

- `pnpm -C packages/app-shell test`（含 `scripts/run-with-clean-stderr.mjs` 的 stderr 门控）：874/874 通过。
- `task test:frontend`：全前端包通过。
- `task lint:frontend`（tsc + eslint `--max-warnings 0`）：通过。
- `prettier`：通过。