### PR TITLE
feat(plugin): 在插件设置界面展示包 logo

### DIFF
--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -243,5 +243,6 @@ fn available_plugin(entry: &RegistryEntry) -> ora_contracts::AvailablePlugin {
         namespace: entry.namespace().to_owned(),
         version: entry.version().to_string(),
         description: entry.description().to_owned(),
+        logo: entry.logo().map(str::to_owned),
     }
 }

--- a/crates/contracts/src/plugin.rs
+++ b/crates/contracts/src/plugin.rs
@@ -40,6 +40,12 @@ pub struct InstalledPlugin {
     pub main: String,
     pub agent: InstalledPluginAgent,
     pub enabled: bool,
+    /// Security-validated SVG source for the package icon, absent when the package ships none.
+    ///
+    /// The icon travels as inline source instead of a filesystem path because the webview cannot
+    /// read the plugin directory; surfaces render it from a `data:` URL and fall back to a
+    /// generic mark when it is absent.
+    pub logo: Option<String>,
     #[serde(flatten)]
     #[ts(flatten)]
     pub runtime: PluginRuntimeStatus,
@@ -55,6 +61,8 @@ pub struct AvailablePlugin {
     pub namespace: String,
     pub version: String,
     pub description: String,
+    /// Security-validated SVG source for the marketplace icon, absent when none is published.
+    pub logo: Option<String>,
 }
 
 /// Requests the cached marketplace registry index used to populate the plugin catalog.
@@ -265,6 +273,7 @@ mod tests {
                 contract_version: 1,
             },
             enabled: false,
+            logo: Some("<svg/>".to_string()),
             runtime: PluginRuntimeStatus::Stopped,
         };
 
@@ -290,6 +299,7 @@ mod tests {
                         "contractVersion": 1
                     },
                     "enabled": false,
+                    "logo": "<svg/>",
                     "runtime": "stopped"
                 }]
             })
@@ -324,6 +334,7 @@ mod tests {
                     namespace: "official".to_string(),
                     version: "1.2.0".to_string(),
                     description: "Weather plugin".to_string(),
+                    logo: None,
                 }],
             })
             .unwrap(),
@@ -334,7 +345,8 @@ mod tests {
                     "name": "weather",
                     "namespace": "official",
                     "version": "1.2.0",
-                    "description": "Weather plugin"
+                    "description": "Weather plugin",
+                    "logo": null
                 }]
             })
         );
@@ -394,6 +406,7 @@ mod tests {
                 contract_version: 1,
             },
             enabled: true,
+            logo: None,
             runtime: PluginRuntimeStatus::Running,
         };
 
@@ -411,6 +424,7 @@ mod tests {
                     "contractVersion": 1
                 },
                 "enabled": true,
+                "logo": null,
                 "runtime": "running"
             }),
         );
@@ -431,6 +445,7 @@ mod tests {
                 contract_version: 1,
             },
             enabled: true,
+            logo: None,
             runtime: PluginRuntimeStatus::Failed {
                 failure_reason: "process crashed".to_string(),
             },
@@ -450,6 +465,7 @@ mod tests {
                     "contractVersion": 1
                 },
                 "enabled": true,
+                "logo": null,
                 "runtime": "failed",
                 "failureReason": "process crashed"
             }),

--- a/crates/plugin-lifecycle/src/state.rs
+++ b/crates/plugin-lifecycle/src/state.rs
@@ -106,6 +106,7 @@ pub(super) fn discovered_plugin_contract<Runtime>(
             contract_version: agent.contract_version,
         },
         enabled,
+        logo: plugin.logo.clone(),
         runtime,
     }
 }

--- a/crates/plugin-lifecycle/src/tests.rs
+++ b/crates/plugin-lifecycle/src/tests.rs
@@ -1119,6 +1119,7 @@ fn expected_plugin_with_runtime(
             contract_version: 1,
         },
         enabled: enabled.is_enabled(),
+        logo: Some(PACKAGE_LOGO.to_string()),
         runtime,
     }
 }
@@ -1383,10 +1384,15 @@ impl PluginStatusPublisher for RecordingStatusPublisher {
     }
 }
 
+/// The icon shipped by the shared package fixture, which proves a discovered logo reaches the
+/// wire contract unchanged.
+const PACKAGE_LOGO: &str = r#"<svg xmlns="http://www.w3.org/2000/svg"><rect width="8"/></svg>"#;
+
 /// Writes one complete installed package in the shared orax manifest schema.
 fn write_plugin_package(data_dir: &std::path::Path, directory: &str) {
     let package_root = data_dir.join("plugins").join("installed").join(directory);
     fs::create_dir_all(&package_root).expect("create plugin package");
+    fs::write(package_root.join("logo.svg"), PACKAGE_LOGO).expect("write plugin logo");
     fs::write(package_root.join("main.js"), "export {};\n").expect("write plugin entrypoint");
     fs::write(
         package_root.join("orax.toml"),

--- a/crates/plugin-manager/README.md
+++ b/crates/plugin-manager/README.md
@@ -11,6 +11,9 @@ orax package shape, and orchestrates installing new plugin releases.
   inside its package, then retain its normalized portable relative path.
 - Normalize plugin identity to `namespace/name` and retain the validated orax metadata needed by the
   lifecycle layer.
+- Read the package's optional `logo.svg` icon and retain its source text once
+  `ora-utils::svg` accepts it. A package without an icon is ordinary; an icon that is present but
+  unreadable or unsafe becomes a discovery issue and leaves the plugin itself discovered without one.
 - Return a deterministic, immutable snapshot of valid installed plugins.
 - Isolate malformed or unsupported packages as structured discovery issues.
 - Install a plugin release: download the `.orax` package (through an injected `ora-utils::http`

--- a/crates/plugin-manager/src/discovery.rs
+++ b/crates/plugin-manager/src/discovery.rs
@@ -1,5 +1,6 @@
 use crate::MAX_MANIFEST_BYTES;
 use crate::issue::{PluginDiscoveryIssue, PluginDiscoveryIssueKind};
+use crate::logo;
 use crate::validation::{InstalledPlugin, validate};
 use ora_plugin_manifest::{ManifestError, PluginManifest};
 use std::collections::HashMap;
@@ -31,7 +32,16 @@ pub(crate) fn discover(data_dir: &Path) -> PluginDiscovery {
     let mut first_path_by_id = HashMap::<String, PathBuf>::new();
     for package_root in entries {
         let manifest_path = package_root.join("orax.toml");
-        match read_and_validate_manifest(&package_root, &manifest_path) {
+        // An unusable icon is reported on its own and never blocks the package: presentation
+        // metadata must not decide whether a plugin is discovered.
+        let logo = match logo::read(&package_root) {
+            Ok(logo) => logo,
+            Err(issue) => {
+                issues.push(issue);
+                None
+            }
+        };
+        match read_and_validate_manifest(&package_root, &manifest_path, logo) {
             Ok(plugin) => {
                 if let Some(first_path) = first_path_by_id.get(&plugin.id) {
                     issues.push(PluginDiscoveryIssue::new(
@@ -109,6 +119,7 @@ fn sorted_package_directories(
 fn read_and_validate_manifest(
     package_root: &Path,
     manifest_path: &Path,
+    logo: Option<String>,
 ) -> Result<InstalledPlugin, PluginDiscoveryIssue> {
     let file_type = match fs::symlink_metadata(manifest_path) {
         Ok(metadata) => metadata.file_type(),
@@ -168,7 +179,7 @@ fn read_and_validate_manifest(
         ),
     })?;
 
-    validate(package_root, &manifest).map_err(|error| {
+    validate(package_root, &manifest, logo).map_err(|error| {
         PluginDiscoveryIssue::new(
             manifest_path.to_path_buf(),
             PluginDiscoveryIssueKind::InvalidManifest,

--- a/crates/plugin-manager/src/issue.rs
+++ b/crates/plugin-manager/src/issue.rs
@@ -13,6 +13,7 @@ pub enum PluginDiscoveryIssueKind {
     InvalidToml,
     InvalidManifest,
     DuplicatePluginId,
+    UnusableLogo,
 }
 
 impl PluginDiscoveryIssueKind {
@@ -28,6 +29,7 @@ impl PluginDiscoveryIssueKind {
             Self::InvalidToml => "invalid_toml",
             Self::InvalidManifest => "invalid_manifest",
             Self::DuplicatePluginId => "duplicate_plugin_id",
+            Self::UnusableLogo => "unusable_logo",
         }
     }
 }

--- a/crates/plugin-manager/src/lib.rs
+++ b/crates/plugin-manager/src/lib.rs
@@ -3,6 +3,7 @@
 mod discovery;
 mod install;
 mod issue;
+mod logo;
 mod validation;
 
 #[cfg(test)]

--- a/crates/plugin-manager/src/logo.rs
+++ b/crates/plugin-manager/src/logo.rs
@@ -1,0 +1,31 @@
+use crate::issue::{PluginDiscoveryIssue, PluginDiscoveryIssueKind};
+use ora_utils::svg::{SvgReadError, read_validated};
+use std::io;
+use std::path::Path;
+
+/// The fixed package-relative filename every plugin ships its icon under.
+///
+/// The icon is a convention rather than a manifest field: keeping it out of `orax.toml` means a
+/// package can gain or lose its icon without a schema change, and the host never has to resolve
+/// an author-supplied path that could escape the package root.
+const LOGO_FILE_NAME: &str = "logo.svg";
+
+/// Reads one package's optional icon into trusted SVG source text.
+///
+/// `Ok(None)` means the package simply ships no icon, which is a normal state that every host
+/// surface renders with its generic fallback mark. An `Err` means the file is there but cannot be
+/// trusted or read, which is reported as a non-fatal discovery issue so a bad icon degrades the
+/// package's presentation without hiding the plugin itself.
+pub(crate) fn read(package_root: &Path) -> Result<Option<String>, PluginDiscoveryIssue> {
+    let logo_path = package_root.join(LOGO_FILE_NAME);
+    match read_validated(&logo_path) {
+        Ok(source) => Ok(Some(source)),
+        Err(SvgReadError::Unreadable(error)) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(PluginDiscoveryIssue::new(
+            logo_path,
+            PluginDiscoveryIssueKind::UnusableLogo,
+            None,
+            error.to_string(),
+        )),
+    }
+}

--- a/crates/plugin-manager/src/tests.rs
+++ b/crates/plugin-manager/src/tests.rs
@@ -483,6 +483,50 @@ fn write_orax_package(data_dir: &Path, directory: &str, toml: &str) -> std::path
     package_root
 }
 
+/// Verifies a package's `logo.svg` is discovered as trusted icon source text.
+#[test]
+fn discovers_package_logo() {
+    let temp_dir = TempDir::new().unwrap();
+    let logo = r#"<svg xmlns="http://www.w3.org/2000/svg"><rect width="8"/></svg>"#;
+    let package_root = write_orax_package(temp_dir.path(), "demo", VALID_ORAX);
+    fs::write(package_root.join("logo.svg"), logo).unwrap();
+
+    let manager = PluginManager::discover(temp_dir.path());
+
+    assert_eq!(manager.discovery_issues(), &[]);
+    assert_eq!(manager.installed_plugins()[0].logo, Some(logo.to_string()));
+}
+
+/// Verifies a package without an icon is discovered cleanly instead of reporting a problem.
+#[test]
+fn discovers_package_without_a_logo() {
+    let temp_dir = TempDir::new().unwrap();
+    write_orax_package(temp_dir.path(), "demo", VALID_ORAX);
+
+    let manager = PluginManager::discover(temp_dir.path());
+
+    assert_eq!(manager.discovery_issues(), &[]);
+    assert_eq!(manager.installed_plugins()[0].logo, None);
+}
+
+/// Verifies an unsafe icon is reported and dropped while the plugin itself stays discovered.
+#[test]
+fn reports_an_unsafe_logo_without_hiding_the_plugin() {
+    let temp_dir = TempDir::new().unwrap();
+    let package_root = write_orax_package(temp_dir.path(), "demo", VALID_ORAX);
+    let logo_path = package_root.join("logo.svg");
+    fs::write(&logo_path, "<svg><script>evil()</script></svg>").unwrap();
+
+    let manager = PluginManager::discover(temp_dir.path());
+
+    assert_eq!(manager.discovery_issues().len(), 1);
+    let issue = &manager.discovery_issues()[0];
+    assert_eq!(issue.path(), logo_path);
+    assert_eq!(issue.kind(), PluginDiscoveryIssueKind::UnusableLogo);
+    assert_eq!(manager.installed_plugins().len(), 1);
+    assert_eq!(manager.installed_plugins()[0].logo, None);
+}
+
 /// Writes arbitrary bytes as one installed package manifest.
 fn write_raw_orax(data_dir: &Path, directory: &str, bytes: &[u8]) {
     let package_root = data_dir.join("plugins").join("installed").join(directory);

--- a/crates/plugin-manager/src/validation.rs
+++ b/crates/plugin-manager/src/validation.rs
@@ -68,6 +68,8 @@ pub struct InstalledPlugin {
     pub main: PortableRelativePath,
     pub engines: PluginEngines,
     pub contributes: PluginContribution,
+    /// Trusted SVG source for the package icon, absent when the package ships none.
+    pub logo: Option<String>,
 }
 
 /// Reports a semantic manifest constraint after structural deserialization succeeds.
@@ -91,9 +93,13 @@ impl ManifestValidationError {
 /// only re-checks the runtime invariants: the entrypoint must exist inside the package and the
 /// kind must be one the host can run. Fields the orax schema omits (`display_name`, engines) fall
 /// back to stable host defaults because the rest of the codebase does not interpret them.
+///
+/// `logo` arrives already read and security-validated by the discovery layer, so this function
+/// keeps its filesystem work limited to the entrypoint it must resolve.
 pub(crate) fn validate(
     package_root: &Path,
     manifest: &PluginManifest,
+    logo: Option<String>,
 ) -> Result<InstalledPlugin, ManifestValidationError> {
     let name = manifest.name().as_str().to_owned();
     let id = format!(
@@ -119,6 +125,7 @@ pub(crate) fn validate(
             bun: String::new(),
         },
         contributes,
+        logo,
     })
 }
 

--- a/crates/plugin-registry/README.md
+++ b/crates/plugin-registry/README.md
@@ -12,6 +12,9 @@
   injected Unix timestamp.
 - `RegistryIndex::load` reads a previously written index file; `RegistryIndex::write` replaces the
   target file atomically through `ora-utils` so readers never observe a partial index.
+- Each entry's optional `logo.svg`, read from the directory holding its `orax.toml` and accepted by
+  `ora-utils::svg`, is inlined into the index so consumers can render the listing from the cached
+  index alone. A missing, unreadable, or unsafe icon leaves the entry listed without one.
 - A single malformed or unreadable `orax.toml` is skipped, logged as a warning, and reported through
   `RegistryBuild::skipped` without blocking the whole build.
 

--- a/crates/plugin-registry/src/entry.rs
+++ b/crates/plugin-registry/src/entry.rs
@@ -13,18 +13,25 @@ pub struct RegistryEntry {
     namespace: String,
     version: Version,
     description: String,
+    /// Trusted SVG source for the entry icon, absent when the entry ships none.
+    ///
+    /// The icon is inlined into the index rather than referenced by path so consumers can render
+    /// the marketplace listing straight from the cached index without reaching back into the
+    /// source checkout, which install-time resolution is the only step that still needs.
+    #[serde(default)]
+    logo: Option<String>,
 }
 
 impl RegistryEntry {
-    /// Builds one index record from a validated plugin manifest.
-    pub(crate) fn from_manifest(manifest: &PluginManifest) -> Self {
-        let id = format!("{}/{}", manifest.namespace(), manifest.name());
+    /// Builds one index record from a validated plugin manifest and its already-validated icon.
+    pub(crate) fn from_manifest(manifest: &PluginManifest, logo: Option<String>) -> Self {
         Self {
-            id,
+            id: entry_id(manifest),
             name: manifest.name().as_str().to_owned(),
             namespace: manifest.namespace().as_str().to_owned(),
             version: manifest.version().clone(),
             description: manifest.description().to_owned(),
+            logo,
         }
     }
 
@@ -52,4 +59,17 @@ impl RegistryEntry {
     pub fn description(&self) -> &str {
         &self.description
     }
+
+    /// Returns the trusted SVG source of the entry icon, when one is published.
+    pub fn logo(&self) -> Option<&str> {
+        self.logo.as_deref()
+    }
+}
+
+/// Derives the unique `namespace/name` identifier a manifest resolves to.
+///
+/// Identifier construction is shared by index building and install-time lookup, so both agree on
+/// what a marketplace identifier means without the lookup path having to build a whole entry.
+pub(crate) fn entry_id(manifest: &PluginManifest) -> String {
+    format!("{}/{}", manifest.namespace(), manifest.name())
 }

--- a/crates/plugin-registry/src/index.rs
+++ b/crates/plugin-registry/src/index.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 use ora_logging::ora_warn;
 use ora_plugin_manifest::PluginManifest;
 
-use crate::entry::RegistryEntry;
+use crate::entry::{RegistryEntry, entry_id};
 use crate::error::RegistryError;
+use crate::logo;
 
 /// The index schema version reported in every built index file.
 const INDEX_VERSION: &str = "1.0";
@@ -33,7 +34,10 @@ impl RegistryIndex {
         let mut skipped = Vec::new();
         for path in orax_manifest_paths(dir) {
             match parse_manifest(&path) {
-                Ok(manifest) => entries.push(RegistryEntry::from_manifest(&manifest)),
+                Ok(manifest) => {
+                    let logo = logo::read_beside_manifest(&path);
+                    entries.push(RegistryEntry::from_manifest(&manifest, logo));
+                }
                 Err(error) => {
                     ora_warn!(path = %path.display(), %error, "skipping invalid registry plugin manifest");
                     skipped.push(SkippedManifest {
@@ -72,7 +76,7 @@ impl RegistryIndex {
                     continue;
                 }
             };
-            if RegistryEntry::from_manifest(&manifest).id() == id {
+            if entry_id(&manifest) == id {
                 return Ok(Some(manifest));
             }
         }
@@ -231,8 +235,8 @@ mod tests {
         let a_manifest = PluginManifest::parse(&valid_manifest("a", "A plugin"))?;
         let z_manifest = PluginManifest::parse(&valid_manifest("z", "Z plugin"))?;
         let expected_plugins = vec![
-            RegistryEntry::from_manifest(&a_manifest),
-            RegistryEntry::from_manifest(&z_manifest),
+            RegistryEntry::from_manifest(&a_manifest, /*logo*/ None),
+            RegistryEntry::from_manifest(&z_manifest, /*logo*/ None),
         ];
 
         assert_eq!(build.index().plugins().to_vec(), expected_plugins);
@@ -263,6 +267,47 @@ mod tests {
         assert!(missing.is_none());
         Ok(())
     }
+    /// Verifies the `logo.svg` beside a manifest is inlined into that entry's index record.
+    #[test]
+    fn inlines_the_logo_beside_each_manifest() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        let logo = r#"<svg xmlns="http://www.w3.org/2000/svg"><rect width="8"/></svg>"#;
+        let manifest_path = write_manifest(root.path(), "a", &valid_manifest("a", "A plugin"))?;
+        let entry_dir = manifest_path
+            .parent()
+            .ok_or_else(|| std::io::Error::other("no parent"))?;
+        fs::write(entry_dir.join("logo.svg"), logo)?;
+        write_manifest(root.path(), "b", &valid_manifest("b", "B plugin"))?;
+
+        let build = RegistryIndex::build(root.path(), UPDATED_AT);
+
+        assert_eq!(build.index().plugins()[0].logo(), Some(logo));
+        assert_eq!(build.index().plugins()[1].logo(), None);
+        Ok(())
+    }
+
+    /// Verifies an unsafe logo is dropped while its plugin still reaches the marketplace listing.
+    #[test]
+    fn indexes_a_plugin_whose_logo_is_unsafe() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        let manifest_path = write_manifest(root.path(), "a", &valid_manifest("a", "A plugin"))?;
+        let entry_dir = manifest_path
+            .parent()
+            .ok_or_else(|| std::io::Error::other("no parent"))?;
+        fs::write(
+            entry_dir.join("logo.svg"),
+            "<svg><script>evil()</script></svg>",
+        )?;
+
+        let build =
+            ora_logging::with_trace_logging(|| RegistryIndex::build(root.path(), UPDATED_AT));
+
+        assert_eq!(build.index().plugins().len(), 1);
+        assert_eq!(build.index().plugins()[0].logo(), None);
+        assert_eq!(build.skipped().len(), 0);
+        Ok(())
+    }
+
     /// Verifies a missing or empty marketplace registry directory builds a valid empty index.
     #[test]
     fn builds_an_empty_index_for_a_missing_registry_directory()

--- a/crates/plugin-registry/src/lib.rs
+++ b/crates/plugin-registry/src/lib.rs
@@ -4,6 +4,7 @@
 mod entry;
 mod error;
 mod index;
+mod logo;
 mod source;
 
 pub use entry::RegistryEntry;

--- a/crates/plugin-registry/src/logo.rs
+++ b/crates/plugin-registry/src/logo.rs
@@ -1,0 +1,29 @@
+use ora_logging::ora_warn;
+use ora_utils::svg::{SvgReadError, read_validated};
+use std::io;
+use std::path::Path;
+
+/// The fixed filename every marketplace registry entry ships its icon under, beside `orax.toml`.
+///
+/// The icon is a directory convention rather than a manifest field, so a registry entry can gain
+/// or lose its icon without a schema change and the index build never resolves an author-supplied
+/// path.
+const LOGO_FILE_NAME: &str = "logo.svg";
+
+/// Reads the optional icon that sits beside one registry manifest into trusted SVG source text.
+///
+/// The index is a derived artifact built from many entries, so an entry whose icon is missing,
+/// unreadable, or unsafe still gets indexed without one: an icon problem must never remove a
+/// plugin from the marketplace listing. Unsafe and unreadable icons are logged, while an absent
+/// icon is the ordinary case and stays silent.
+pub(crate) fn read_beside_manifest(manifest_path: &Path) -> Option<String> {
+    let logo_path = manifest_path.parent()?.join(LOGO_FILE_NAME);
+    match read_validated(&logo_path) {
+        Ok(source) => Some(source),
+        Err(SvgReadError::Unreadable(error)) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => {
+            ora_warn!(path = %logo_path.display(), %error, "skipping unusable registry plugin logo");
+            None
+        }
+    }
+}

--- a/crates/utils/README.md
+++ b/crates/utils/README.md
@@ -25,7 +25,8 @@ that any other crate can consume without introducing dependency cycles.
   scriptable HTML (forbidden tags, `on*` event handlers, `javascript:`/`data:` URIs).
 - `svg` (Cargo feature `validation`): security validation for SVG icons — accepts well-formed
   XML only, forbidding `<script>`/`<foreignObject>`, event-handler attributes, external `href`
-  references, and files over the 50 KiB cap.
+  references, and files over the 50 KiB cap. `read_validated` reads one SVG file through that
+  policy with a bounded read and returns its source text, so callers never hold untrusted markup.
 - `Slug`: an owned lowercase ASCII slug segment with stable syntax and byte-length guarantees.
 - `GitBranchName`: an owned short Git branch name validated without starting a Git process.
 

--- a/crates/utils/src/svg.rs
+++ b/crates/utils/src/svg.rs
@@ -3,6 +3,9 @@
 use quick_xml::Reader;
 use quick_xml::events::BytesStart;
 use quick_xml::events::Event;
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
 use thiserror::Error;
 
 /// The size cap for an SVG icon, matching the marketplace packaging limit of 50 KiB.
@@ -24,6 +27,32 @@ pub enum SvgValidationError {
     ExternalReference { element: String, attribute: String },
     #[error("SVG element `{element}` uses the event-handler attribute `{attribute}`")]
     EventAttribute { element: String, attribute: String },
+}
+
+/// Reports why one SVG file could not be turned into trusted icon source text.
+#[derive(Debug, Error)]
+pub enum SvgReadError {
+    #[error("failed to read the SVG file: {0}")]
+    Unreadable(#[from] io::Error),
+    #[error("SVG file is not valid UTF-8 text")]
+    NotUtf8,
+    #[error(transparent)]
+    Invalid(#[from] SvgValidationError),
+}
+
+/// Reads one SVG file and returns its source text once the icon security policy passes.
+///
+/// The read is bounded to one byte past [`DEFAULT_MAX_SVG_BYTES`] so an arbitrarily large file
+/// can never be pulled into memory: the extra byte is what makes [`validate`] report `TooLarge`
+/// instead of silently accepting a truncated document.
+pub fn read_validated(path: &Path) -> Result<String, SvgReadError> {
+    let mut bytes = Vec::new();
+    File::open(path)?
+        .take(DEFAULT_MAX_SVG_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)?;
+    validate(&bytes)?;
+
+    String::from_utf8(bytes).map_err(|_| SvgReadError::NotUtf8)
 }
 
 /// Validates `svg` bytes against the marketplace icon security policy.
@@ -119,13 +148,25 @@ fn ascii_lowercase(bytes: &[u8]) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_MAX_SVG_BYTES, SvgValidationError, validate};
+    use super::{
+        DEFAULT_MAX_SVG_BYTES, SvgReadError, SvgValidationError, read_validated, validate,
+    };
     use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
 
     /// Accepts a minimal, well-formed SVG with local fragment references.
     #[test]
     fn accepts_benign_svg() {
         let svg = br##"<svg xmlns="http://www.w3.org/2000/svg"><use href="#icon"/></svg>"##;
+        assert_eq!(validate(svg).unwrap(), ());
+    }
+
+    /// Accepts the shapes real marketplace icons are exported with: single-quoted attributes and
+    /// `url(#id)` references into `<defs>`, neither of which reaches outside the document.
+    #[test]
+    fn accepts_an_exported_marketplace_icon() {
+        let svg = br#"<svg width='24' height='24' xmlns='http://www.w3.org/2000/svg'><g clip-path='url(#clip0)'><mask id='mask0' style='mask-type:luminance'><path d='M24 0H0V24H24V0Z' fill='white'/></mask></g><defs><clipPath id='clip0'><rect width='24' height='24'/></clipPath></defs></svg>"#;
         assert_eq!(validate(svg).unwrap(), ());
     }
 
@@ -208,5 +249,57 @@ mod tests {
                 max: DEFAULT_MAX_SVG_BYTES
             }
         );
+    }
+
+    /// Returns the source text of a file that passes the icon policy.
+    #[test]
+    fn reads_validated_svg_source() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        let path = root.path().join("logo.svg");
+        let source = r#"<svg xmlns="http://www.w3.org/2000/svg"><rect width="10"/></svg>"#;
+        fs::write(&path, source)?;
+
+        assert_eq!(read_validated(&path)?, source);
+        Ok(())
+    }
+
+    /// Refuses a file whose contents violate the icon policy instead of returning its text.
+    #[test]
+    fn refuses_to_read_unsafe_svg() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        let path = root.path().join("logo.svg");
+        fs::write(&path, "<svg><script>evil()</script></svg>")?;
+
+        assert!(matches!(
+            read_validated(&path).unwrap_err(),
+            SvgReadError::Invalid(SvgValidationError::ForbiddenElement { .. })
+        ));
+        Ok(())
+    }
+
+    /// Reports the size violation for an oversized file rather than a truncated document.
+    #[test]
+    fn refuses_to_read_oversized_svg() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+        let path = root.path().join("logo.svg");
+        fs::write(&path, "a".repeat(DEFAULT_MAX_SVG_BYTES + 1))?;
+
+        assert!(matches!(
+            read_validated(&path).unwrap_err(),
+            SvgReadError::Invalid(SvgValidationError::TooLarge { .. })
+        ));
+        Ok(())
+    }
+
+    /// Reports a missing file as an I/O failure so callers can distinguish it from a bad icon.
+    #[test]
+    fn reports_a_missing_svg_file() -> Result<(), Box<dyn std::error::Error>> {
+        let root = TempDir::new()?;
+
+        assert!(matches!(
+            read_validated(&root.path().join("absent.svg")).unwrap_err(),
+            SvgReadError::Unreadable(_)
+        ));
+        Ok(())
     }
 }

--- a/packages/app-shell/src/features/settings/plugin-logo.tsx
+++ b/packages/app-shell/src/features/settings/plugin-logo.tsx
@@ -1,0 +1,35 @@
+import { IconPlug } from "@tabler/icons-react";
+
+/**
+ * Renders a plugin's own brand mark, shipped as the `logo.svg` inside its package and delivered
+ * inline by the backend after security validation.
+ *
+ * The mark is drawn through an `<img>` rather than inlined into the DOM: an SVG referenced as an
+ * image never runs scripts or loads external resources, so it stays inert even if a future
+ * package slips something past validation. Plugins without a logo fall back to the generic plug
+ * mark so every row keeps the same shape.
+ */
+export function PluginLogo({ logo }: { logo: string | null }) {
+  return (
+    <span className="flex size-10 shrink-0 items-center justify-center text-muted-foreground">
+      {logo === null ? (
+        <IconPlug className="size-6" />
+      ) : (
+        <img
+          src={svgDataUrl(logo)}
+          alt=""
+          aria-hidden="true"
+          className="size-6 object-contain"
+        />
+      )}
+    </span>
+  );
+}
+
+/**
+ * Wraps SVG source in a `data:` URL. Percent-encoding rather than base64 keeps the markup
+ * readable in devtools and avoids pulling in an encoder for what is already text.
+ */
+function svgDataUrl(svg: string) {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}

--- a/packages/app-shell/src/features/settings/plugin-manager.test.ts
+++ b/packages/app-shell/src/features/settings/plugin-manager.test.ts
@@ -12,6 +12,7 @@ const plugins: InstalledPlugin[] = [
     main: "dist/index.js",
     agent: { displayName: "Review Agent", contractVersion: 1 },
     enabled: false,
+    logo: null,
     runtime: "stopped",
   },
   {
@@ -23,6 +24,7 @@ const plugins: InstalledPlugin[] = [
     main: "dist/index.js",
     agent: { displayName: "Plan Agent", contractVersion: 1 },
     enabled: false,
+    logo: null,
     runtime: "stopped",
   },
 ];

--- a/packages/app-shell/src/features/settings/plugin-manager.tsx
+++ b/packages/app-shell/src/features/settings/plugin-manager.tsx
@@ -20,12 +20,12 @@ import {
 import {
   IconDots,
   IconLoader2,
-  IconPlug,
   IconRefresh,
   IconSearch,
   IconTrash,
 } from "@tabler/icons-react";
 import { filterDiscoveredPlugins } from "./filter-discovered-plugins";
+import { PluginLogo } from "./plugin-logo";
 import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
 import { usePluginScan } from "../../state/hooks/use-plugin-scan";
 
@@ -134,9 +134,7 @@ function InstalledPluginRow({ plugin }: { plugin: InstalledPlugin }) {
 
   return (
     <div className="flex items-center gap-3 py-3">
-      <span className="flex size-10 shrink-0 items-center justify-center text-muted-foreground">
-        <IconPlug className="size-6" />
-      </span>
+      <PluginLogo logo={plugin.logo} />
       <span className="min-w-0 flex-1">
         <span className="block truncate text-sm font-medium">
           {plugin.displayName}

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -27,7 +27,11 @@ function renderSettings(client: ContractsClient) {
   );
 }
 
-function clientWithWeather() {
+/** The registry-supplied brand mark, already security-validated by the backend. */
+const WEATHER_LOGO =
+  '<svg xmlns="http://www.w3.org/2000/svg"><rect width="8"/></svg>';
+
+function clientWithWeather(logo: string | null = null) {
   const state = createMockClientState();
   state.availablePlugins.push({
     id: "official/weather",
@@ -35,6 +39,7 @@ function clientWithWeather() {
     namespace: "official",
     version: "1.2.0",
     description: "Weather plugin",
+    logo,
   });
   return { state, client: createMockClient(state) };
 }
@@ -83,4 +88,45 @@ it("syncs the marketplace through the backend", async () => {
   );
 
   await waitFor(() => expect(syncSpy).toHaveBeenCalled());
+});
+
+/** A registry entry's own brand mark is drawn as an inert image instead of the generic mark. */
+it("renders the brand mark shipped with a marketplace plugin", async () => {
+  const { client } = clientWithWeather(WEATHER_LOGO);
+  const { container } = renderSettings(client);
+
+  await screen.findByText("weather");
+  const logo = container.querySelector("img");
+  expect(logo).toHaveAttribute(
+    "src",
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(WEATHER_LOGO)}`,
+  );
+});
+
+/** Plugins that ship no mark keep the row shape by falling back to the generic plug icon. */
+it("falls back to the generic mark when a plugin ships no logo", async () => {
+  const { client } = clientWithWeather();
+  const { container } = renderSettings(client);
+
+  await screen.findByText("weather");
+  expect(container.querySelector("img")).toBeNull();
+});
+
+/** The installed manager surfaces the logo carried by the installed package. */
+it("renders the brand mark of an installed plugin in the manager", async () => {
+  const user = userEvent.setup();
+  const { state, client } = clientWithWeather(WEATHER_LOGO);
+  const { container } = renderSettings(client);
+
+  await user.click(await screen.findByRole("button", { name: /安装|Install/ }));
+  await waitFor(() => expect(state.installedPlugins).toHaveLength(1));
+  await user.click(
+    screen.getByRole("button", { name: /管理插件|Manage plugins/ }),
+  );
+
+  await screen.findByText("official/weather");
+  expect(container.querySelector("img")).toHaveAttribute(
+    "src",
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(WEATHER_LOGO)}`,
+  );
 });

--- a/packages/app-shell/src/features/settings/plugins-settings.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.tsx
@@ -2,18 +2,14 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AvailablePlugin, InstalledPlugin } from "@ora/contracts";
 import { Button, Input, toast } from "@ora/ui";
-import {
-  IconLoader2,
-  IconPlug,
-  IconRefresh,
-  IconSearch,
-} from "@tabler/icons-react";
+import { IconLoader2, IconRefresh, IconSearch } from "@tabler/icons-react";
 import { localizeContractError } from "../../i18n/contract-error";
 import { useAvailablePlugins } from "../../state/hooks/use-available-plugins";
 import { useInstallPlugin } from "../../state/hooks/use-install-plugin";
 import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
 import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
 import { usePluginRegistrySync } from "../../state/hooks/use-plugin-registry-sync";
+import { PluginLogo } from "./plugin-logo";
 import { PluginManager } from "./plugin-manager";
 
 /**
@@ -148,9 +144,7 @@ function AvailablePluginRow({
 
   return (
     <div className="flex items-center gap-3 py-3">
-      <span className="flex size-10 shrink-0 items-center justify-center text-muted-foreground">
-        <IconPlug className="size-6" />
-      </span>
+      <PluginLogo logo={plugin.logo} />
       <span className="min-w-0 flex-1">
         <span className="block truncate text-sm font-medium">
           {plugin.name}

--- a/packages/app-shell/src/state/hooks/use-available-plugins.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-available-plugins.test.tsx
@@ -17,6 +17,7 @@ describe("useAvailablePlugins", () => {
       namespace: "official",
       version: "1.2.0",
       description: "Weather plugin",
+      logo: null,
     });
     const { result, queryClient } = renderHookWithClient(
       () => useAvailablePlugins(),

--- a/packages/app-shell/src/state/hooks/use-install-plugin.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-install-plugin.test.tsx
@@ -16,6 +16,7 @@ describe("useInstallPlugin", () => {
       namespace: "official",
       version: "1.2.0",
       description: "Weather",
+      logo: null,
     });
     const client = createMockClient(state);
     const { result } = renderHookWithClient(

--- a/packages/app-shell/src/state/hooks/use-installed-plugins.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-installed-plugins.test.tsx
@@ -20,6 +20,7 @@ describe("useInstalledPlugins", () => {
       main: "dist/index.js",
       agent: { displayName: "Reviewer", contractVersion: 1 },
       enabled: false,
+      logo: null,
       runtime: "stopped",
     });
     const { result, queryClient } = renderHookWithClient(

--- a/packages/app-shell/src/test/mock-client.ts
+++ b/packages/app-shell/src/test/mock-client.ts
@@ -418,6 +418,7 @@ export function createMockClient(state: MockClientState): ContractsClient {
           main: "main.js",
           agent: { displayName: available.name, contractVersion: 1 },
           enabled: true,
+          logo: available.logo,
           runtime: "stopped",
         });
         return { pluginId: req.pluginId };

--- a/packages/contracts/src/plugin.ts
+++ b/packages/contracts/src/plugin.ts
@@ -19,6 +19,10 @@ export type AvailablePlugin = {
   namespace: string;
   version: string;
   description: string;
+  /**
+   * Security-validated SVG source for the marketplace icon, absent when none is published.
+   */
+  logo: string | null;
 };
 
 /**
@@ -64,6 +68,14 @@ export type InstalledPlugin =
     main: string;
     agent: InstalledPluginAgent;
     enabled: boolean;
+    /**
+     * Security-validated SVG source for the package icon, absent when the package ships none.
+     *
+     * The icon travels as inline source instead of a filesystem path because the webview cannot
+     * read the plugin directory; surfaces render it from a `data:` URL and fall back to a
+     * generic mark when it is absent.
+     */
+    logo: string | null;
   }
   & ({ "runtime": "stopped" } | { "runtime": "starting" } | {
     "runtime": "running";


### PR DESCRIPTION
## 背景

插件图标一直没有接上：`AvailablePlugin` 和 `InstalledPlugin` 都没有图标字段，所以市场列表和已安装管理器都硬编码了通用的插头图标。但素材其实早就有了——每个已安装包和注册表条目都在 `orax.toml` 旁边放着 `logo.svg`；`ora-utils::svg` 也早已实现了图标安全策略，只是一个调用方都没有。

## 改动

### 后端

- `ora_utils::svg::read_validated` 按该策略读取单个 SVG，带读取上限并返回源文本，调用方不会持有未经校验的标记。
- `ora-plugin-manager` 按约定读取包根目录的 `logo.svg`。没有图标是正常情况；图标存在但不可读或不安全时记为 `UnusableLogo` 发现问题，插件本身仍然会被发现，只是没有图标。
- `ora-plugin-registry` 把每个清单旁边的图标内联进 `registry_index.json`，消费方直接从缓存索引渲染市场列表，无需回到源仓库读取。该字段是 `serde(default)`，本次改动之前构建的索引仍可加载，只是在下一次市场同步之前没有图标。
- `logo` 在 contracts 中以内联 SVG 源文本传递，而不是文件系统路径，因为 webview 读不到插件目录。

### 前端

- `PluginLogo` 通过 `<img>` 的 data URL 绘制图标，而不是把 SVG 内联进 DOM。以 image 引用的 SVG 不执行脚本、不加载外部资源，在后端校验之外提供纵深防御。没有 logo 的插件回退到通用插头图标，保持行高一致。

## 设计取舍

图标保持为目录约定，而不是清单字段：包可以在不改 schema 的情况下增删素材，宿主也不需要解析作者提供的、可能逃逸出包根目录的路径。
