### PR TITLE
fix(app-shell): offer only the agents this installation can actually reach

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -150,11 +150,20 @@ two stores held the _older_, pre-namespaced spellings and are worth knowing abou
 
 Two limits are deliberate rather than incidental:
 
-- **The chat model picker still offers only the five built-in CLIs.** A plugin-provided agent is
-  supervised, bindable by id, and reported by the runtime status endpoint, but the picker does not
-  enumerate it: rendering one needs a label and a logo, which are product decisions rather than
-  runtime ones. The frontend keeps a closed `KnownAgentCli` subset so this boundary is visible in
-  the types instead of implied.
+- **The chat model picker offers only the agents it has a label and a logo for.** A plugin-provided
+  agent is supervised, bindable by id, and reported by the runtime status endpoint, but the picker
+  does not enumerate arbitrary ones: rendering one needs a label and a logo, which are product
+  decisions rather than runtime ones. The frontend keeps a closed `KnownAgentCli` subset so this
+  boundary is visible in the types instead of implied. Within that subset an entry is offered only
+  while `getAgentRuntimeStatus` reports it `Ready` or `Starting`. That one answer already covers
+  every way an agent can be out of reach — a built-in CLI missing from this machine, a plugin
+  package that was never installed and so has no supervisor, and one the user disabled, which the
+  supervisor reports exactly like a missing CLI — so the client models none of them separately.
+  `Unavailable` is polled on at a slow cadence because it is expected configuration that can
+  resolve itself; `Failing` is not, because the restart circuit is open for the rest of the
+  process. A stored default naming an agent that is no longer reachable yields to the first one
+  that is, but a session's own binding is still reported as written — the conversation genuinely
+  runs on that agent.
 - **`agent_cli_not_found` keeps its name.** The code is part of the public error contract and its
   translations; renaming it is unrelated to how identity is modelled, and what an uninstalled agent
   should look like in the UI is still an open question.

--- a/packages/app-shell/src/features/chat/model-selector.test.tsx
+++ b/packages/app-shell/src/features/chat/model-selector.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TooltipProvider } from "@ora/ui";
 import { PlatformProvider } from "../../platform";
@@ -13,6 +13,7 @@ import { createChatStore } from "@ora/chat";
 import {
   createMockClient,
   createMockClientState,
+  type MockClientState,
 } from "../../test/mock-client";
 import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
 import {
@@ -20,6 +21,7 @@ import {
   DEFAULT_SETTINGS,
 } from "../../state/stores/settings-store";
 import { usePendingAgentStore } from "../../state/stores/pending-agent-store";
+import type { AgentStatus } from "@ora/contracts";
 import { ModelSelector } from "./model-selector";
 
 beforeEach(() => {
@@ -28,8 +30,21 @@ beforeEach(() => {
   usePendingAgentStore.setState({ selections: {} });
 });
 
-function renderModelSelector() {
+/** Replaces what the runtime reports about OpenCode, leaving every other agent detected. */
+function reportOpenCode(status: AgentStatus) {
+  return (state: MockClientState) => {
+    const entry = state.agentRuntimeStatuses.find(
+      (candidate) => candidate.agentRef === "ora-space.opencode",
+    );
+    entry!.status = status;
+  };
+}
+
+function renderModelSelector(
+  seed: (state: MockClientState) => void = () => {},
+) {
   const state = createMockClientState();
+  seed(state);
   const client = createMockClient(state);
   const chatStore = createChatStore(client.session);
   const Wrapper = createHookWrapper(client, createTestQueryClient(), chatStore);
@@ -89,5 +104,72 @@ describe("ModelSelector agent isolation across not-yet-started chats", () => {
 
     act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
     expect(within(picker()).getByText("Claude Code")).not.toBeNull();
+  });
+});
+
+/**
+ * Opens the picker and returns its agent list, which keeps re-rendering as queries settle.
+ *
+ * Assertions are made against this element rather than by reopening the menu: which agents are
+ * offered depends on the installed-plugin snapshot, and the loading answer is the whole catalog.
+ */
+async function openAgentList(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(picker());
+  return await screen.findByRole("menu");
+}
+
+describe("ModelSelector agent availability", () => {
+  it("offers every agent the runtime reports reaching", async () => {
+    const user = userEvent.setup();
+    renderModelSelector();
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    const menu = await openAgentList(user);
+
+    await waitFor(() =>
+      expect(within(menu).queryByText("OpenCode")).not.toBeNull(),
+    );
+    expect(within(menu).queryByText("Claude Code")).not.toBeNull();
+  });
+
+  it("withholds an agent whose runtime nothing answered for", async () => {
+    const user = userEvent.setup();
+    renderModelSelector(reportOpenCode("unavailable"));
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    const menu = await openAgentList(user);
+
+    await waitFor(() =>
+      expect(within(menu).queryByText("OpenCode")).toBeNull(),
+    );
+    expect(within(menu).queryByText("Claude Code")).not.toBeNull();
+  });
+
+  it("withholds an agent nothing supervises at all", async () => {
+    const user = userEvent.setup();
+    renderModelSelector((state) => {
+      state.agentRuntimeStatuses = state.agentRuntimeStatuses.filter(
+        (status) => status.agentRef !== "ora-space.opencode",
+      );
+    });
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    const menu = await openAgentList(user);
+
+    await waitFor(() =>
+      expect(within(menu).queryByText("OpenCode")).toBeNull(),
+    );
+  });
+
+  it("moves a surface off a stored default the installation can no longer reach", async () => {
+    renderModelSelector(reportOpenCode("unavailable"));
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+
+    // The stored default names OpenCode, which the runtime cannot reach here, so
+    // the surface must settle on the first agent that is genuinely available.
+    await waitFor(() =>
+      expect(within(picker()).queryByText("NGA")).not.toBeNull(),
+    );
   });
 });

--- a/packages/app-shell/src/features/chat/model-selector.tsx
+++ b/packages/app-shell/src/features/chat/model-selector.tsx
@@ -21,22 +21,24 @@ import {
   warmTargetKey,
 } from "../../state/hooks/use-warm-session";
 import { useTargetAgentCli } from "../../state/hooks/use-target-agent-cli";
+import { useAvailableAgentClis } from "../../state/hooks/use-available-agent-clis";
 import {
   usePendingAgentStore,
   usePendingSwitch,
 } from "../../state/stores/pending-agent-store";
 import { useAgentModelStore } from "../../state/stores/agent-model-store";
 import { currentValueName, findModelOption, selectableValues } from "@ora/chat";
-import { AGENT_CLI_LABELS, AGENT_CLI_ORDER } from "./model-catalog";
+import { AGENT_CLI_LABELS } from "./model-catalog";
 import { ProviderLogo } from "./provider-logos";
 
 /**
  * The composer's agent and model picker.
  *
- * Both lists describe the session the composer will send into. Which CLIs exist
- * is static; which models are available is whatever that CLI reported for this
- * session, so the model list has three states rather than two — still arriving,
- * genuinely offering no choice, or a real set to pick from.
+ * Both lists describe the session the composer will send into. Which agents exist
+ * is whatever this installation can actually reach; which models are available is
+ * whatever the chosen agent reported for this session, so the model list has three
+ * states rather than two — still arriving, genuinely offering no choice, or a real
+ * set to pick from.
  *
  * With a session selected, choosing a different CLI moves that conversation onto
  * it rather than only changing the default for the next one. Ora owns the
@@ -78,6 +80,10 @@ export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
   // Resolved centrally so this and the composer cannot disagree: they share one
   // warm-session query key, and the CLI is part of that key.
   const agentCli = useTargetAgentCli(selection);
+  // Which agents the runtime actually reports reaching here. An agent whose CLI
+  // is absent, or whose plugin package was disabled or uninstalled, drops out of
+  // the list rather than being offered and then failing on the first message.
+  const availableAgentClis = useAvailableAgentClis();
 
   // Shares the workspace's warm-session query key, so this is a cache read
   // rather than a second provider session.
@@ -235,7 +241,7 @@ export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
           <DropdownMenuLabel className="px-2 py-1.5 text-xs font-normal text-muted-foreground">
             {t("chat.modelSelector.agent")}
           </DropdownMenuLabel>
-          {AGENT_CLI_ORDER.map((candidate) => (
+          {availableAgentClis.map((candidate) => (
             <DropdownMenuItem
               key={candidate}
               className="gap-1.5 rounded-sm px-2 py-1.5 text-xs"

--- a/packages/app-shell/src/state/hooks/use-agent-runtime-status.ts
+++ b/packages/app-shell/src/state/hooks/use-agent-runtime-status.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { AgentRuntimeStatus } from "@ora/contracts";
 import { useContractsClient } from "../../contracts-client-context";
 import { queryKeys } from "./query-keys";
 
@@ -6,9 +7,35 @@ import { queryKeys } from "./query-keys";
 const STARTING_POLL_INTERVAL_MS = 1500;
 
 /**
- * Loads the live per-CLI detection status (ready/starting/unavailable/failing) used to drive the
- * plugin settings pane's installed indicator. Polls at a short interval only while some CLI
- * is still starting; once every CLI has settled into ready, unavailable, or failing, polling stops.
+ * Slow cadence used while some agent is merely missing, so one that appears is eventually noticed.
+ *
+ * An unavailable agent is expected configuration rather than a fault, and it can become usable
+ * without anything telling this client: a CLI installed into `PATH`, or a plugin whose supervisor
+ * is most of a backoff interval away from retrying it. Polling on is what lets it come back.
+ */
+const UNAVAILABLE_POLL_INTERVAL_MS = 15_000;
+
+/** Chooses how often to ask again, or `false` once nothing is expected to change on its own. */
+function pollInterval(statuses: AgentRuntimeStatus[] | undefined) {
+  if (statuses === undefined) return false as const;
+  if (statuses.some((status) => status.status === "starting"))
+    return STARTING_POLL_INTERVAL_MS;
+  // `failing` is deliberately excluded: the supervisor has opened that agent's restart circuit and
+  // will not retry it for the rest of the process, so asking again cannot change the answer.
+  if (statuses.some((status) => status.status === "unavailable"))
+    return UNAVAILABLE_POLL_INTERVAL_MS;
+  return false as const;
+}
+
+/**
+ * Loads the live per-agent detection status (ready/starting/unavailable/failing) that decides
+ * which agents the pickers offer.
+ *
+ * The set is whatever this installation actually supervises: a built-in CLI is always supervised
+ * and reports whether its executable was found, while a plugin-supplied agent is only supervised
+ * while its package is installed and only reaches `ready` once the lifecycle agrees to start it.
+ * That makes one answer cover "not installed on this machine", "package uninstalled", and
+ * "package disabled" without the client having to model any of them separately.
  */
 export function useAgentRuntimeStatus() {
   const client = useContractsClient();
@@ -16,9 +43,6 @@ export function useAgentRuntimeStatus() {
     queryKey: queryKeys.agentRuntimeStatus,
     queryFn: () =>
       client.agentRuntime.getStatus({}).then((response) => response.statuses),
-    refetchInterval: (query) =>
-      query.state.data?.some((status) => status.status === "starting")
-        ? STARTING_POLL_INTERVAL_MS
-        : false,
+    refetchInterval: (query) => pollInterval(query.state.data),
   });
 }

--- a/packages/app-shell/src/state/hooks/use-app-events.test.ts
+++ b/packages/app-shell/src/state/hooks/use-app-events.test.ts
@@ -46,4 +46,43 @@ describe("useAppEvents", () => {
 
     unmount();
   });
+
+  it("invalidates the plugin snapshot and agent detection for lifecycle events", async () => {
+    const client = createMockClient(createMockClientState());
+    client.appEvents.watch = async function* (
+      _request,
+      options,
+    ): AsyncGenerator<AppEvent> {
+      yield { type: "ready" };
+      yield { type: "plugin_status_changed", plugin_id: "official/example" };
+      await new Promise<void>((resolve) => {
+        const signal = options?.signal;
+        if (signal === undefined || signal.aborted) {
+          resolve();
+          return;
+        }
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    };
+    const queryClient = createTestQueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result, unmount } = renderHookWithClient(
+      () => useAppEvents(client),
+      client,
+      queryClient,
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    await waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: queryKeys.installedPlugins,
+      }),
+    );
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: queryKeys.agentRuntimeStatus,
+    });
+
+    unmount();
+  });
 });

--- a/packages/app-shell/src/state/hooks/use-app-events.ts
+++ b/packages/app-shell/src/state/hooks/use-app-events.ts
@@ -23,6 +23,19 @@ export function useAppEvents(client: ContractsClient) {
     const invalidateSessions = () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.sessions });
     };
+    // A plugin's eligibility decides whether the agent it supplies can be reached
+    // at all, and the lifecycle changes it from places no mutation on this client
+    // passes through — a background launch settling, a scan, a crash. Both the
+    // settings snapshot and the agent detection the pickers read from are asked
+    // again, because enabling or removing a package moves them together.
+    const invalidatePluginState = () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.installedPlugins,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.agentRuntimeStatus,
+      });
+    };
     const scheduleReconnect = () => {
       if (disposed) return;
       reconnectTimer = setTimeout(() => {
@@ -52,6 +65,8 @@ export function useAppEvents(client: ContractsClient) {
             refetchSessions();
           } else if (event.type === "session_title_updated") {
             invalidateSessions();
+          } else if (event.type === "plugin_status_changed") {
+            invalidatePluginState();
           }
         }
         handleDisconnect();

--- a/packages/app-shell/src/state/hooks/use-available-agent-clis.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-available-agent-clis.test.tsx
@@ -1,0 +1,104 @@
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { AgentStatus } from "@ora/contracts";
+import {
+  createMockClient,
+  createMockClientState,
+  type MockClientState,
+} from "../../test/mock-client";
+import { renderHookWithClient } from "../../test/hook-harness";
+import { AGENT_CLI_ORDER } from "../../features/chat/model-catalog";
+import { useAgentRuntimeStatus } from "./use-agent-runtime-status";
+import { useAvailableAgentClis } from "./use-available-agent-clis";
+
+/** The catalog without OpenCode, which every "one agent is missing" case here drops. */
+const WITHOUT_OPENCODE = AGENT_CLI_ORDER.filter(
+  (agentCli) => agentCli !== "ora-space.opencode",
+);
+
+/** Replaces what the runtime reports about one agent, leaving the rest detected. */
+function reportOpenCode(status: AgentStatus) {
+  return (state: MockClientState) => {
+    const entry = state.agentRuntimeStatuses.find(
+      (candidate) => candidate.agentRef === "ora-space.opencode",
+    );
+    entry!.status = status;
+  };
+}
+
+/**
+ * Renders the hook against a settled detection status and returns what it offers.
+ *
+ * The status is awaited through the same query the hook reads, because the loading answer is the
+ * whole catalog: asserting before it settles would pass for reasons the test is not about.
+ */
+async function offeredAgentClis(
+  seed: (state: MockClientState) => void,
+): Promise<string[]> {
+  const state = createMockClientState();
+  seed(state);
+  const { result } = renderHookWithClient(
+    () => ({
+      offered: useAvailableAgentClis(),
+      statuses: useAgentRuntimeStatus(),
+    }),
+    createMockClient(state),
+  );
+  await waitFor(() => expect(result.current.statuses.isSuccess).toBe(true));
+  return result.current.offered;
+}
+
+describe("useAvailableAgentClis", () => {
+  it("offers every agent the runtime reports reaching", async () => {
+    expect(await offeredAgentClis(() => {})).toEqual(AGENT_CLI_ORDER);
+  });
+
+  it("offers an agent still completing its handshake", async () => {
+    expect(await offeredAgentClis(reportOpenCode("starting"))).toEqual(
+      AGENT_CLI_ORDER,
+    );
+  });
+
+  it("withholds an agent nothing answered for", async () => {
+    expect(await offeredAgentClis(reportOpenCode("unavailable"))).toEqual(
+      WITHOUT_OPENCODE,
+    );
+  });
+
+  it("withholds an agent the supervisor has given up on", async () => {
+    expect(await offeredAgentClis(reportOpenCode("failing"))).toEqual(
+      WITHOUT_OPENCODE,
+    );
+  });
+
+  it("withholds an agent nothing supervises at all", async () => {
+    expect(
+      await offeredAgentClis((state) => {
+        state.agentRuntimeStatuses = state.agentRuntimeStatuses.filter(
+          (status) => status.agentRef !== "ora-space.opencode",
+        );
+      }),
+    ).toEqual(WITHOUT_OPENCODE);
+  });
+
+  it("withholds a built-in CLI that is missing from this machine", async () => {
+    expect(
+      await offeredAgentClis((state) => {
+        state.agentRuntimeStatuses = state.agentRuntimeStatuses.filter(
+          (status) => status.agentRef !== "ora-space.claude",
+        );
+      }),
+    ).toEqual(
+      AGENT_CLI_ORDER.filter((agentCli) => agentCli !== "ora-space.claude"),
+    );
+  });
+
+  it("offers the whole catalog while the detection status is still loading", () => {
+    const { result } = renderHookWithClient(
+      () => useAvailableAgentClis(),
+      createMockClient(createMockClientState()),
+    );
+
+    expect(result.current).toEqual(AGENT_CLI_ORDER);
+  });
+});

--- a/packages/app-shell/src/state/hooks/use-available-agent-clis.ts
+++ b/packages/app-shell/src/state/hooks/use-available-agent-clis.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import {
+  AGENT_CLI_ORDER,
+  type KnownAgentCli,
+} from "../../features/chat/model-catalog";
+import { useAgentRuntimeStatus } from "./use-agent-runtime-status";
+
+/**
+ * Resolves which agents the pickers may offer on this installation, in the catalog's order.
+ *
+ * Which agents exist is no longer knowable at build time. A built-in CLI ships with every build
+ * but its executable may be absent from this machine; an agent supplied by a plugin does not exist
+ * here at all unless its package is installed, and the user can revoke it at any time by disabling
+ * that package. Offering an agent in either of those states advertises something no session could
+ * be opened on, so the list is the agents the runtime actually reports reaching.
+ *
+ * `starting` counts alongside `ready` because an agent still completing its handshake is on its
+ * way to being usable, and an entry that vanished for the first second of every launch would take
+ * the surfaces pointing at it along with it. `unavailable` and `failing` do not: the first means
+ * nothing answered — a missing executable, an uninstalled or disabled package — and the second
+ * means the supervisor has given up on it for the rest of the process.
+ *
+ * While the status is still loading the full catalog is offered. "Not answered yet" is not "not
+ * detected", and answering it as such would move every surface onto a different agent for as long
+ * as that query is in flight.
+ */
+export function useAvailableAgentClis(): KnownAgentCli[] {
+  const { data: statuses } = useAgentRuntimeStatus();
+  return useMemo(() => {
+    if (statuses === undefined) return AGENT_CLI_ORDER;
+    const detected = new Set(
+      statuses
+        .filter(
+          (status) => status.status === "ready" || status.status === "starting",
+        )
+        .map((status) => status.agentRef),
+    );
+    return AGENT_CLI_ORDER.filter((agentCli) => detected.has(agentCli));
+  }, [statuses]);
+}

--- a/packages/app-shell/src/state/hooks/use-target-agent-cli.ts
+++ b/packages/app-shell/src/state/hooks/use-target-agent-cli.ts
@@ -3,6 +3,7 @@ import { useSettingsStore } from "../stores/settings-store";
 import { usePendingAgentStore } from "../stores/pending-agent-store";
 import { warmTargetKey } from "./use-warm-session";
 import { useSessions } from "./use-sessions";
+import { useAvailableAgentClis } from "./use-available-agent-clis";
 
 /** The selection legs that decide which agent a chat surface is pointing at. */
 interface AgentSelection {
@@ -32,6 +33,14 @@ interface AgentSelection {
  * bound, so the pick recorded for this exact target answers instead; reading the
  * shared default directly would let picking an agent for one not-yet-started chat
  * repaint every other one the moment it is visited.
+ *
+ * A binding is reported as written even when that agent can no longer be reached:
+ * the conversation genuinely runs on it, and naming a different one would claim a
+ * move that never happened. A preference is not a binding — both the shared
+ * default and a per-target pick outlive whatever supplied the agent they name — so
+ * one the runtime no longer reports reaching yields to the first agent this
+ * installation can actually open a session on, rather than sending every
+ * not-yet-started chat at an agent that is not there.
  */
 export function useTargetAgentCli(selection: AgentSelection): KnownAgentCli {
   const defaultAgentCli = useSettingsStore((state) => state.settings.agentCli);
@@ -45,12 +54,21 @@ export function useTargetAgentCli(selection: AgentSelection): KnownAgentCli {
   const pickedForTarget = usePendingAgentStore((state) =>
     targetKey === null ? undefined : state.selections[targetKey],
   );
+  const availableAgentClis = useAvailableAgentClis();
   // The wire carries any installed agent's identity as a plain string, but the picker this
-  // hook drives only ever offers Ora's bundled CLIs today, so a bound session is assumed to be
-  // one of them. A session bound to a plugin agent the picker cannot yet render falls back to
-  // the stored default rather than surfacing an identity nothing here knows how to label.
+  // hook drives only labels the closed set it knows, so a bound session is assumed to name one
+  // of them. A binding onto an agent outside that set is still reported here — it is what the
+  // session actually runs on — and simply has no entry to render against.
   const boundAgentCli = sessions.find(
     (session) => session.id === selection.sessionId,
   )?.agentRef as KnownAgentCli | undefined;
-  return pendingSwitch ?? boundAgentCli ?? pickedForTarget ?? defaultAgentCli;
+  if (pendingSwitch !== undefined) return pendingSwitch;
+  if (boundAgentCli !== undefined) return boundAgentCli;
+  const preferred = pickedForTarget ?? defaultAgentCli;
+  // An installation can genuinely reach no agent at all — nothing detected yet, or
+  // nothing installed. There is no better answer to fall back to then, so the
+  // preference is kept rather than invented away.
+  return availableAgentClis.includes(preferred)
+    ? preferred
+    : (availableAgentClis[0] ?? preferred);
 }

--- a/packages/app-shell/src/test/mock-client.ts
+++ b/packages/app-shell/src/test/mock-client.ts
@@ -1,6 +1,7 @@
 import type * as acp from "@agentclientprotocol/sdk";
 import type {
   Agent,
+  AgentRuntimeStatus,
   AvailablePlugin,
   ContractsClient,
   InstalledPlugin,
@@ -63,6 +64,12 @@ export interface MockClientState {
   agents: Agent[];
   skills: Skill[];
   installedPlugins: InstalledPlugin[];
+  /**
+   * What the agent runtime reports reaching, which is what decides the agents the pickers offer.
+   *
+   * An agent missing from this list is one nothing supervises — an uninstalled plugin package.
+   */
+  agentRuntimeStatuses: AgentRuntimeStatus[];
   availablePlugins: AvailablePlugin[];
   availablePluginsUpdatedAt: bigint;
   developerMode: { enabled: boolean };
@@ -81,6 +88,20 @@ export interface MockClientState {
   warmModelsByCli?: Partial<Record<string, acp.SessionConfigOption[] | null>>;
 }
 
+/**
+ * Every agent identity the frontend has a picker entry for, all detected by default.
+ *
+ * A test that needs one to be missing or unreachable overrides `agentRuntimeStatuses` rather than
+ * rebuilding the whole list.
+ */
+const AGENT_REFS = [
+  "ora-space.opencode",
+  "ora-space.nga",
+  "ora-space.codeagentcli",
+  "ora-space.claude",
+  "ora-space.codex",
+];
+
 /** Creates a fresh in-memory mock state with no records. */
 export function createMockClientState(): MockClientState {
   return {
@@ -90,6 +111,10 @@ export function createMockClientState(): MockClientState {
     agents: [],
     skills: [],
     installedPlugins: [],
+    agentRuntimeStatuses: AGENT_REFS.map((agentRef) => ({
+      agentRef,
+      status: "ready",
+    })),
     availablePlugins: [],
     availablePluginsUpdatedAt: 0n,
     developerMode: { enabled: false },
@@ -328,13 +353,7 @@ export function createMockClient(state: MockClientState): ContractsClient {
       },
     },
     agentRuntime: {
-      getStatus: async () => ({
-        statuses: [
-          { agentRef: "ora-space.opencode", status: "ready" },
-          { agentRef: "ora-space.nga", status: "ready" },
-          { agentRef: "ora-space.codeagentcli", status: "ready" },
-        ],
-      }),
+      getStatus: async () => ({ statuses: [...state.agentRuntimeStatuses] }),
     },
     plugin: {
       listInstalled: async () => ({ plugins: [...state.installedPlugins] }),


### PR DESCRIPTION
## 问题

聊天输入框的模型选择器里，agent 列表是写死的五个 CLI（`AGENT_CLI_ORDER`）——**不管这台机器上到底有没有这个 agent，全都照列**。

具体分两类：

| 情况 | 现在的表现 | 应该的表现 |
| --- | --- | --- |
| 没装 OpenCode 插件 | 列表里照样有 OpenCode | 不显示 |
| 在设置里 disable 了插件 | 列表里照样有 OpenCode | 不显示 |
| 卸载了插件 | 列表里照样有 OpenCode | 不显示 |
| 内置 CLI 的可执行文件不在这台机器上 | 列表里照样有（选了之后第一条消息才失败） | 不显示 |

`ora-space.opencode` 早就不是内置 CLI 了，它由一个 agent 插件提供；而它**同时还是默认 agent**（`DEFAULT_SETTINGS.agentCli`）。所以在没装该插件的机器上，一个新聊天会拿着后端根本没有 supervisor 的 agent 身份去 warm session，注定失败。

还有一个隐藏原因让上面几点更难被发现：后端插件生命周期一直在发 `plugin_status_changed` 事件，但前端 `useAppEvents` 从来没处理过它。所以在设置里启用/禁用/卸载插件后，聊天界面不会有任何反应。

## 解决方案

**列表改成从后端的 agent 检测状态推导——检测不到就不显示。**

核心是 `getAgentRuntimeStatus`：它返回本机每个被 supervise 的 agent 的实时状态（`ready` / `starting` / `unavailable` / `failing`）。这一个接口已经天然覆盖了"够不着"的所有形态，前端不需要分别建模：

- 内置 CLI 可执行文件找不到 → `unavailable`
- 插件没装 → 压根没有 supervisor，**不在返回列表里**
- 插件被 disable → 后端"和缺失的 CLI 完全一样地上报"，即 `unavailable`
- 插件已启用且跑起来了 → `ready`

于是规则统一成一句话：**只有 `ready` 或 `starting` 的 agent 才进列表。**

1. 新增 `useAvailableAgentClis()`，按上面的规则过滤 `AGENT_CLI_ORDER`，`ModelSelector` 改用它渲染。
   - 为什么 `starting` 也算：agent 还在握手，马上就能用。否则每次开 App 的头一两秒条目会先消失再出现，指向它的界面会被一起带走。
   - 状态还没加载时先返回完整列表：**"还没查到"不等于"检测不到"**，否则每次打开界面都会先把默认 agent 甩到别的 CLI 上。

2. `useAgentRuntimeStatus` 的轮询策略调整。原来只在有 agent 处于 `starting` 时快轮询（1.5s），settle 之后就停。现在条目会被**隐藏**，"什么时候能回来"就变得重要了，所以只要还有 `unavailable` 就慢轮询（15s）——它属于"预期内的环境配置"，可能自己变好（用户把 CLI 装进 PATH、刚启用的插件 supervisor 还在 backoff 里没重试）。`failing` 不轮询：restart circuit 已经打开，这个进程周期内不会再重试，问了也没用。

3. `useTargetAgentCli` 增加回退：**偏好**（共享默认值、某个 target 上记录的选择——两者都会比提供该 agent 的东西活得久）如果已经够不着，就退到第一个可达的 agent；但**已绑定 session 的 `agentRef` 照原样返回**——那条会话确实跑在那个 agent 上，改名等于谎报一次从未发生的迁移。

4. `useAppEvents` 处理 `plugin_status_changed`，同时失效 `installedPlugins`（设置面板读）和 `agentRuntimeStatus`（选择器读）——启用或移除一个包会同时改变这两者。

## 效果

- agent 可达 → 列表里有它，行为不变。
- 在设置里关掉插件开关 → 进程被停掉、supervisor 转为 `unavailable`，选择器里该 agent 消失，界面自动落到第一个可用 agent。
- 卸载插件 → supervisor 被移除，同上。
- 没装过插件的机器 → 一开始就不列出它，不再拿一个不存在的 agent 去 warm session。
- 内置 CLI 没装 → 同样不列出；之后把它装进 PATH，慢轮询会让它自己回到列表里，不用重启 App。

## 测试

- 新增 `use-available-agent-clis.test.tsx`：覆盖全部可达 / `starting` / `unavailable` / `failing` / 完全不在 supervise 列表里 / 内置 CLI 缺失 / 加载中 七种情况。
- `model-selector.test.tsx` 新增 4 个用例：正常列出、`unavailable` 不列出、未被 supervise 不列出、默认值不可达时落到 NGA。
- `use-app-events.test.ts` 断言插件事件同时失效两个查询。
- `mock-client` 的 `agentRuntime.getStatus` 改为读 state（默认五个 agent 全部 `ready`），测试可以直接声明"这台机器能够到哪些 agent"，不再是写死的三条。

`task lint:frontend` 通过，`@ora/app-shell` 全量 905 个用例通过（stderr gate 干净）。

## 未包含

`workflow-inspector.tsx` 里工作流节点的 agent 选择器仍然无条件列出全部五个，有同样的问题。本次只改聊天界面，没有顺手扩大范围——需要的话换成同一个 hook 即可。

## 文档

`docs/agent-runtime.md` 里"聊天模型选择器只提供五个内置 CLI"这条刻意保留的限制已经更新，写清了条目现在按 `getAgentRuntimeStatus` 过滤、为什么这一个答案就够、以及 `unavailable` 与 `failing` 的轮询差别。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
