### PR TITLE
fix(chat): 修复禁用再启用 agent 插件后会话无法继续对话

### DIFF
--- a/packages/app-shell/src/features/chat/session-agent-banner.test.tsx
+++ b/packages/app-shell/src/features/chat/session-agent-banner.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ContractsClient, InstalledPlugin, Session } from "@ora/contracts";
+import { createChatStore } from "@ora/chat";
+import { describe, expect, it } from "vitest";
+import {
+  createHookWrapper,
+  createTestQueryClient,
+} from "../../test/hook-harness";
+import {
+  createMockClient,
+  createMockClientState,
+} from "../../test/mock-client";
+import { useAgentRuntimeStatus } from "../../state/hooks/use-agent-runtime-status";
+import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
+import { SessionAgentBanner } from "./session-agent-banner";
+
+/**
+ * The runtime half of an installed package.
+ *
+ * Spelled out rather than derived: the contract models it as a tagged union on
+ * the whole plugin, so `Pick` cannot isolate the arm that carries a reason.
+ */
+type PluginRuntime =
+  | { runtime: "stopped" }
+  | { runtime: "starting" }
+  | { runtime: "running" }
+  | { runtime: "failed"; failureReason: string };
+
+/** Builds one installed agent package whose eligibility the test controls. */
+function agentPlugin(
+  enabled: boolean,
+  runtime: PluginRuntime = { runtime: "running" },
+): InstalledPlugin {
+  return {
+    id: "ora-space.reviewer",
+    packageName: "ora-space.reviewer",
+    displayName: "Code Reviewer",
+    version: "0.1.0",
+    kind: "agent",
+    main: "dist/index.js",
+    agent: { displayName: "Review Agent", contractVersion: 1 },
+    enabled,
+    logo: null,
+    ...runtime,
+  };
+}
+
+/** Builds one running session bound to the given agent identity. */
+function session(agentRef: string): Session {
+  return {
+    id: "session-1",
+    taskId: "task-1",
+    title: "Review",
+    agentRef,
+    status: "running",
+    historyState: { type: "writable" },
+  };
+}
+
+/**
+ * Marks the point at which both availability queries have answered.
+ *
+ * A banner that renders nothing is only meaningful once the data it reads has
+ * arrived, so the negative assertions wait for this rather than for a timeout.
+ */
+function SettleProbe() {
+  const plugins = useInstalledPlugins();
+  const supervised = useAgentRuntimeStatus();
+  if (!plugins.isSuccess || !supervised.isSuccess) return null;
+  return <span data-testid="availability-settled" />;
+}
+
+/** Renders the banner over a mock backend seeded with the given packages. */
+function renderBanner(plugins: InstalledPlugin[], bound: Session) {
+  const state = createMockClientState();
+  state.installedPlugins = plugins;
+  const backend = createMockClient(state);
+  // The mock flips eligibility on the very objects it later hands back, which no
+  // IPC boundary would do: react-query would see one unchanged reference and
+  // skip the render that clears the banner. Copying restores the real contract
+  // that every response is fresh data.
+  const client: ContractsClient = {
+    ...backend,
+    plugin: {
+      ...backend.plugin,
+      listInstalled: async (request) => ({
+        plugins: (await backend.plugin.listInstalled(request)).plugins.map(
+          (plugin) => ({ ...plugin }),
+        ),
+      }),
+    },
+  };
+  const Wrapper = createHookWrapper(
+    client,
+    createTestQueryClient(),
+    createChatStore(client.session),
+  );
+  render(
+    <Wrapper>
+      <SessionAgentBanner session={bound} />
+      <SettleProbe />
+    </Wrapper>,
+  );
+  return state;
+}
+
+describe("SessionAgentBanner", () => {
+  it("warns and offers repair when the session's plugin is disabled", async () => {
+    const state = renderBanner(
+      [agentPlugin(false, { runtime: "stopped" })],
+      session("ora-space.reviewer"),
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveAttribute("data-agent-availability", "disabled");
+    expect(alert).toHaveTextContent("Code Reviewer");
+
+    await userEvent.click(within(alert).getByRole("button"));
+
+    expect(state.installedPlugins[0]?.enabled).toBe(true);
+    // The repaired plugin makes the agent servable again, so the warning clears
+    // itself once the invalidated query answers rather than waiting for the
+    // next navigation.
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+  });
+
+  it("reports an agent whose package is gone as uninstalled", async () => {
+    renderBanner([], session("ora-space.reviewer"));
+
+    expect(await screen.findByRole("alert")).toHaveAttribute(
+      "data-agent-availability",
+      "uninstalled",
+    );
+  });
+
+  it("stays silent for a built-in CLI, which has no plugin package", async () => {
+    renderBanner([], session("ora-space.nga"));
+
+    await screen.findByTestId("availability-settled");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("stays silent while an enabled plugin is serving the session", async () => {
+    renderBanner([agentPlugin(true)], session("ora-space.reviewer"));
+
+    await screen.findByTestId("availability-settled");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("surfaces the backend's reason when the plugin failed to start", async () => {
+    renderBanner(
+      [
+        agentPlugin(true, {
+          runtime: "failed",
+          failureReason: "deno exited with 1",
+        }),
+      ],
+      session("ora-space.reviewer"),
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveAttribute("data-agent-availability", "failed");
+    // The backend's reason is the only description of what actually broke.
+    expect(alert).toHaveTextContent("deno exited with 1");
+  });
+});

--- a/packages/app-shell/src/features/chat/session-agent-banner.tsx
+++ b/packages/app-shell/src/features/chat/session-agent-banner.tsx
@@ -1,0 +1,176 @@
+import { useTranslation } from "react-i18next";
+import type { InstalledPlugin, Session } from "@ora/contracts";
+import { Button } from "@ora/ui";
+import { IconAlertTriangle, IconLoader2 } from "@tabler/icons-react";
+import { localizeContractError } from "../../i18n/contract-error";
+import { useAgentRuntimeStatus } from "../../state/hooks/use-agent-runtime-status";
+import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
+import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
+
+/** Why the agent a session is bound to cannot serve it right now. */
+type AgentAvailability =
+  | { kind: "available" }
+  | { kind: "disabled"; plugin: InstalledPlugin }
+  | { kind: "failed"; plugin: InstalledPlugin; reason: string }
+  | { kind: "uninstalled" };
+
+/**
+ * Warns when the plugin behind a session's agent was disabled or uninstalled.
+ *
+ * A session keeps its agent binding for its whole life, so turning the plugin
+ * off leaves a conversation that looks ordinary but cannot be answered. Saying
+ * so up front is what separates "your agent is switched off" from the generic
+ * failure a send would otherwise produce, and the enable action makes the fix
+ * reachable without a detour through settings.
+ *
+ * Eligibility is read from the installed-plugin list rather than the agent
+ * runtime status: disabling publishes the plugin change immediately, while the
+ * supervisor only reports `unavailable` once its connection has actually
+ * dropped, so the runtime view can still say `ready` for a moment afterwards.
+ *
+ * Rendering nothing while the agent is fine keeps callers free to mount this
+ * unconditionally beside the conversation it belongs to.
+ */
+export function SessionAgentBanner({
+  session,
+}: {
+  session: Session | undefined;
+}) {
+  const { t } = useTranslation();
+  const plugins = useInstalledPlugins();
+  const supervised = useAgentRuntimeStatus();
+  const availability = resolveAvailability(
+    session,
+    plugins.data,
+    supervised.data?.map((status) => status.agentRef),
+  );
+
+  if (availability.kind === "available") return null;
+  return <AgentUnavailableBanner availability={availability} t={t} />;
+}
+
+/**
+ * Renders one unavailability reason, with the repair action the reason allows.
+ *
+ * Split from the resolver so the message stays a pure function of availability;
+ * the enable mutation lives in its own component because a hook keyed by plugin
+ * id must not run for the case that has no plugin to name.
+ */
+function AgentUnavailableBanner({
+  availability,
+  t,
+}: {
+  availability: Exclude<AgentAvailability, { kind: "available" }>;
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
+  return (
+    <div
+      role="alert"
+      // Names the reason without depending on the localized sentence, which is
+      // what lets a test — or a bug report — tell the three cases apart.
+      data-agent-availability={availability.kind}
+      className="mx-3 mb-2 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs sm:mx-4"
+    >
+      <IconAlertTriangle
+        className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400"
+        aria-hidden="true"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="font-medium text-amber-700 dark:text-amber-300">
+          {t("chat.agentUnavailable.title")}
+        </p>
+        <p className="mt-0.5 break-words text-muted-foreground">
+          {availability.kind === "disabled" &&
+            t("chat.agentUnavailable.disabled", {
+              plugin: availability.plugin.displayName,
+            })}
+          {availability.kind === "uninstalled" &&
+            t("chat.agentUnavailable.uninstalled")}
+          {/* The backend's reason is the only description of what actually broke,
+              so it is shown verbatim rather than flattened into one sentence. */}
+          {availability.kind === "failed" &&
+            t("chat.agentUnavailable.failed", {
+              plugin: availability.plugin.displayName,
+              reason: availability.reason,
+            })}
+        </p>
+      </div>
+      {availability.kind === "disabled" && (
+        <EnablePluginAction pluginId={availability.plugin.id} t={t} />
+      )}
+    </div>
+  );
+}
+
+/** Offers the one repair a disabled plugin needs, reporting a refused enable in place. */
+function EnablePluginAction({
+  pluginId,
+  t,
+}: {
+  pluginId: string;
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
+  const { enable } = usePluginMutations(pluginId);
+
+  return (
+    <div className="flex shrink-0 flex-col items-end gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-7 text-xs"
+        disabled={enable.isPending}
+        onClick={() => enable.mutate()}
+      >
+        {enable.isPending && (
+          <IconLoader2 className="size-3 animate-spin" aria-hidden="true" />
+        )}
+        {t("chat.agentUnavailable.enable")}
+      </Button>
+      {enable.isError && (
+        <p className="text-destructive">
+          {localizeContractError(enable.error, t)}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Decides whether a session's agent is currently servable, and why it is not.
+ *
+ * A package supplies exactly one agent under its package name, which is the
+ * same value a session persists as its binding, so the two are matched directly.
+ * An identity no plugin claims is only reported as uninstalled when the runtime
+ * does not supervise it either — a built-in CLI has no plugin row and must not
+ * be mistaken for a package that was removed.
+ *
+ * Both queries answer `undefined` until they resolve; treating that as available
+ * keeps the banner from flashing on every mount before anything is known.
+ */
+function resolveAvailability(
+  session: Session | undefined,
+  plugins: InstalledPlugin[] | undefined,
+  supervisedAgentRefs: string[] | undefined,
+): AgentAvailability {
+  if (session === undefined || plugins === undefined) {
+    return { kind: "available" };
+  }
+  const plugin = plugins.find(
+    (installed) => installed.packageName === session.agentRef,
+  );
+  if (plugin === undefined) {
+    if (
+      supervisedAgentRefs === undefined ||
+      supervisedAgentRefs.includes(session.agentRef)
+    ) {
+      return { kind: "available" };
+    }
+    return { kind: "uninstalled" };
+  }
+  if (!plugin.enabled) return { kind: "disabled", plugin };
+  if (plugin.runtime === "failed") {
+    return { kind: "failed", plugin, reason: plugin.failureReason };
+  }
+  return { kind: "available" };
+}

--- a/packages/app-shell/src/features/workspace/workspace-view.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-view.tsx
@@ -50,6 +50,7 @@ import { DragRegion } from "../../components/drag-region";
 import { WindowControls } from "../../components/window-controls";
 import { ChatView } from "../chat/chat-view";
 import { ComposerContextBar } from "../chat/composer-context-bar";
+import { SessionAgentBanner } from "../chat/session-agent-banner";
 import { SessionHistoryBanner } from "../chat/session-history-banner";
 import { WorkflowStepper } from "../workflow/workflow-stepper";
 import { useWorkflowDetection } from "../workflow/use-workflow-detection";
@@ -670,6 +671,7 @@ export function WorkspaceView({ userName }: WorkspaceViewProps) {
           </Button>
           <WindowControls />
         </div>
+        <SessionAgentBanner session={session} />
         <SessionHistoryBanner
           session={session}
           notices={conversation?.historyNotices ?? []}

--- a/packages/app-shell/src/i18n/i18n-instance.ts
+++ b/packages/app-shell/src/i18n/i18n-instance.ts
@@ -1206,6 +1206,13 @@ export const translationResources = {
     "chat.modelSelector.model": "模型",
     "chat.modelSelector.updating": "更新中…",
     "chat.modelSelector.empty": "该 Agent 未提供可选模型",
+    "chat.agentUnavailable.title": "当前 Agent 不可用",
+    "chat.agentUnavailable.disabled":
+      "{{plugin}} 插件已被禁用，启用后即可继续这段对话。",
+    "chat.agentUnavailable.uninstalled":
+      "提供该 Agent 的插件已被卸载，重新安装后才能继续这段对话。",
+    "chat.agentUnavailable.failed": "{{plugin}} 插件启动失败：{{reason}}",
+    "chat.agentUnavailable.enable": "启用插件",
     "chat.historyDegraded.title": "会话记录已中断",
     "chat.historyDegraded.resume": "恢复记录",
     "chat.historyNotice.title": "会话历史不完整",
@@ -2751,6 +2758,14 @@ export const translationResources = {
     "chat.modelSelector.model": "Model",
     "chat.modelSelector.updating": "Updating…",
     "chat.modelSelector.empty": "This agent offers no model choice",
+    "chat.agentUnavailable.title": "This session's agent is unavailable",
+    "chat.agentUnavailable.disabled":
+      "The {{plugin}} plugin is disabled. Enable it to continue this conversation.",
+    "chat.agentUnavailable.uninstalled":
+      "The plugin that provided this agent was uninstalled. Reinstall it to continue this conversation.",
+    "chat.agentUnavailable.failed":
+      "The {{plugin}} plugin failed to start: {{reason}}",
+    "chat.agentUnavailable.enable": "Enable plugin",
     "chat.historyDegraded.title": "This session's history stopped recording",
     "chat.historyDegraded.resume": "Resume history",
     "chat.historyNotice.title": "This session's history is incomplete",

--- a/packages/chat/src/store.ts
+++ b/packages/chat/src/store.ts
@@ -1,8 +1,10 @@
 import type * as acp from "@agentclientprotocol/sdk";
-import type {
-  ContractsClient,
-  SessionHistoryNotice,
-  SessionPermissionRequest,
+import {
+  type ContractsClient,
+  type PromptSessionEvent,
+  RemoteContractError,
+  type SessionHistoryNotice,
+  type SessionPermissionRequest,
 } from "@ora/contracts";
 import { createStore, type StoreApi } from "zustand/vanilla";
 import type {
@@ -512,9 +514,11 @@ export function createChatStore(
       }
 
       try {
-        for await (const event of client.prompt(
-          { sessionId: key, prompt },
-          { signal: controller.signal },
+        for await (const event of promptWithReattach(
+          client,
+          key,
+          prompt,
+          controller.signal,
         )) {
           if (event.type === "session_update") {
             // The user turn is already materialized, so the echoed prompt chunk
@@ -1307,6 +1311,51 @@ function sessionScopedConfigOptions(
   return update.sessionUpdate === "config_option_update"
     ? update.configOptions
     : null;
+}
+
+/**
+ * Streams one prompt, rebuilding a route that died under a still-open session.
+ *
+ * `sessionStopped` before the first event means the connection generation this
+ * session was routed on is gone — an agent provider that restarted, not a
+ * conversation the user ended. Ora's load path already knows how to re-attach
+ * and restore the agent's context, so the send borrows it once instead of
+ * surfacing a failure that the very next message would have repaired anyway.
+ *
+ * The reload is streamed and discarded: the caller's transcript is already the
+ * session's history, so applying the replay would only repaint what is on
+ * screen. Nothing is retried once an event has been delivered — a stream that
+ * broke midway has already shown the user part of a turn, and sending the same
+ * prompt again would duplicate it.
+ */
+async function* promptWithReattach(
+  client: ChatSessionClient,
+  sessionId: string,
+  prompt: acp.ContentBlock[],
+  signal: AbortSignal,
+): AsyncGenerator<PromptSessionEvent> {
+  let delivered = false;
+  try {
+    for await (const event of client.prompt(
+      { sessionId, prompt },
+      { signal },
+    )) {
+      delivered = true;
+      yield event;
+    }
+    return;
+  } catch (error) {
+    if (delivered || !isSessionStoppedError(error)) throw error;
+  }
+  await loadSessionConversation(client, sessionId, signal);
+  yield* client.prompt({ sessionId, prompt }, { signal });
+}
+
+/** Reports whether a failure is the backend refusing a session that holds no live route. */
+function isSessionStoppedError(error: unknown): boolean {
+  return (
+    error instanceof RemoteContractError && error.code === "session_stopped"
+  );
 }
 
 /**

--- a/packages/chat/tests/store.test.ts
+++ b/packages/chat/tests/store.test.ts
@@ -1,10 +1,11 @@
 import type * as acp from "@agentclientprotocol/sdk";
 import assert from "node:assert/strict";
 import test from "node:test";
-import type {
-  LoadSessionEvent,
-  PromptSessionEvent,
-  PromptSessionRequest,
+import {
+  type LoadSessionEvent,
+  type PromptSessionEvent,
+  type PromptSessionRequest,
+  RemoteContractError,
 } from "@ora/contracts";
 import { createChatStore, type ChatSessionClient } from "../src/index.js";
 
@@ -1426,4 +1427,136 @@ test("keeps one marker per point in the thread while the model is cycled", async
   assert.deepEqual(store.getState().conversations["ora-1"]?.modelChanges, [
     { id: "local-4", afterTurnCount: 1, modelName: "Fast", createdAt: 42 },
   ]);
+});
+
+/** Builds the backend's refusal of a session that currently holds no live route. */
+function sessionStoppedError(): RemoteContractError {
+  return new RemoteContractError(
+    {
+      code: "session_stopped",
+      params: {},
+      requestId: "00000000-0000-4000-8000-000000000000",
+    },
+    null,
+  );
+}
+
+test("re-attaches and retries once when the route died before the prompt was accepted", async () => {
+  let loads = 0;
+  let prompts = 0;
+  const client: ChatSessionClient = {
+    load: () => {
+      loads += 1;
+      return events<LoadSessionEvent>([{ type: "completed" }]);
+    },
+    // The provider process restarted between turns, so the first send is refused
+    // before a single event exists; the second runs against the rebuilt route.
+    prompt: () => {
+      prompts += 1;
+      if (prompts === 1) throw sessionStoppedError();
+      return events<PromptSessionEvent>([
+        textEvent(
+          "agent_message_chunk",
+          "back online",
+          "agent-1",
+        ) as PromptSessionEvent,
+        { type: "completed", stopReason: "end_turn" },
+      ]);
+    },
+    respondToPermission: async () => ({}),
+    setConfig: async () => ({ configOptions: [] }),
+  };
+  let nextId = 0;
+  const store = createChatStore(client, {
+    createId: () => `local-${++nextId}`,
+    now: () => 42,
+  });
+
+  await store.getState().loadSession("ora-1");
+  await store.getState().sendMessage({ oraSessionId: "ora-1", text: "hello" });
+
+  // One load opened the conversation and one rebuilt the route the send needed.
+  assert.equal(loads, 2);
+  assert.equal(prompts, 2);
+  const conversation = store.getState().conversations["ora-1"]!;
+  // The reconnect never reaches the user: the optimistic turn streams straight
+  // through and the conversation carries no error.
+  assert.equal(conversation.error, null);
+  assert.equal(conversation.turns.length, 1);
+  const [turn] = conversation.turns;
+  assert.equal(turn?.status, "completed");
+  assert.deepEqual(
+    turn?.items.map((item) => item.kind === "message" && item.content),
+    ["back online"],
+  );
+});
+
+test("does not retry a stopped session once the prompt has streamed anything", async () => {
+  let loads = 0;
+  let prompts = 0;
+  const client: ChatSessionClient = {
+    load: () => {
+      loads += 1;
+      return events<LoadSessionEvent>([{ type: "completed" }]);
+    },
+    prompt: async function* () {
+      prompts += 1;
+      yield textEvent(
+        "agent_message_chunk",
+        "partial",
+        "agent-1",
+      ) as PromptSessionEvent;
+      throw sessionStoppedError();
+    },
+    respondToPermission: async () => ({}),
+    setConfig: async () => ({ configOptions: [] }),
+  };
+  let nextId = 0;
+  const store = createChatStore(client, {
+    createId: () => `local-${++nextId}`,
+    now: () => 42,
+  });
+
+  await store.getState().loadSession("ora-1");
+  await assert.rejects(
+    store.getState().sendMessage({ oraSessionId: "ora-1", text: "hello" }),
+  );
+
+  // Half a turn is already on screen, so resending would duplicate it.
+  assert.equal(loads, 1);
+  assert.equal(prompts, 1);
+  assert.equal(
+    store.getState().conversations["ora-1"]?.turns[0]?.status,
+    "failed",
+  );
+});
+
+test("does not re-attach for a failure that is not a stopped session", async () => {
+  let loads = 0;
+  let prompts = 0;
+  const client: ChatSessionClient = {
+    load: () => {
+      loads += 1;
+      return events<LoadSessionEvent>([{ type: "completed" }]);
+    },
+    prompt: () => {
+      prompts += 1;
+      throw new Error("agent runtime is unavailable");
+    },
+    respondToPermission: async () => ({}),
+    setConfig: async () => ({ configOptions: [] }),
+  };
+  let nextId = 0;
+  const store = createChatStore(client, {
+    createId: () => `local-${++nextId}`,
+    now: () => 42,
+  });
+
+  await store.getState().loadSession("ora-1");
+  await assert.rejects(
+    store.getState().sendMessage({ oraSessionId: "ora-1", text: "hello" }),
+  );
+
+  assert.equal(loads, 1);
+  assert.equal(prompts, 1);
 });


### PR DESCRIPTION
## 问题

聊天过程中禁用正在使用的 agent 插件，再重新启用，该会话仍然无法继续对话，必须重启 Ora 才恢复。

复现：

1. 用某个 agent 插件正常聊天
2. 在设置里禁用该插件
3. 回到会话发消息 → 报错（符合预期）
4. 重新启用该插件，再发消息 → **仍然报错**（不符合预期）
5. 重启 Ora 后进入同一会话 → 一切正常

## 原因

禁用插件会杀掉插件进程，该 agent 的连接 generation 随之结束，会话被持久化成 `Stopped`。之后每一次发送都在 `AgentRuntimeManager::prompt` 的状态闸门处被拒（`crates/backend/src/agent_runtime/mod.rs:837`），**根本走不到 session actor**。

重新启用插件其实是有效的——supervisor 会被唤醒并重新 attach，后端恢复能力完好。断的是前端这一环：chat store 在第一轮对话结束后就把 `isLoaded` 置为 `true`，而自动加载的 effect 只在 `isLoaded !== true` 时触发，于是**再也没有人请求后端重新接上路由**。

重启 Ora 之所以有效，是因为 store 被重建、`isLoaded` 回到 `false`，进入会话时触发一次 `loadSession` → 后端重开 channel 并通过 `session/load` 恢复 agent 上下文。

**换句话说：恢复路径一直存在且被验证可用，只是不可达。**

## 改动

### 1. 发送时自愈，且用户无感

`packages/chat/src/store.ts` 新增 `promptWithReattach`。当一次 prompt 在**尚未产出任何事件**时收到 `sessionStopped`，就调用已有的 `loadSessionConversation` 重建后端路由（返回值直接丢弃，因为前端的 transcript 已经是这个会话的历史），然后重发一次。

用户看到的只是思考指示器多转了一下，乐观 turn 全程保持 `streaming`，**不会有失败消息闪过**。

重试范围刻意收窄：

- 只针对 `sessionStopped`；插件仍处于禁用状态时错误是 `agent_runtime_unavailable`，如实失败
- 只在一个事件都还没送出时重试；流到一半断开不重发，否则会重复半个 turn
- 只重试一次

### 2. Agent 不可用时给出明确警告

会话的 agent 绑定终生不变——这是有意的，因为对话确实跑在那个 agent 上，#434 也明确了「会话自身的绑定不让位」。但这也意味着插件被禁用或卸载后，会话看起来一切正常却无法作答，而 picker 把条目摘掉这件事**并不会告诉已经绑定在它上面的那个会话**。

新增 `SessionAgentBanner`，挂在 `SessionHistoryBanner` 旁边，沿用其结构与样式，就地说明原因：

| 情况 | 表现 |
| --- | --- |
| 插件被禁用 | 警告 + 「启用插件」按钮，启用后自动消失 |
| 插件已卸载 | 警告，提示重新安装 |
| 插件启动失败 | 警告 + 后端原样的 `failureReason` |
| 内置 CLI / 一切正常 | 不渲染任何内容 |

判定依据是**已安装插件列表**而非 agent 运行时状态：禁用时生命周期立即发布变更，而 supervisor 要等连接真正断开才会转为 `unavailable`，用后者会读到抢跑的 `ready`。运行时状态仅用于区分「内置 CLI」（没有插件记录但仍被 supervise）与「确实已卸载」。

## 与 #434 的关系

本 PR 原本还包含一处「让前端响应 `plugin_status_changed` 事件」的改动。#434 已经落地了同一件事，且做得更准（我那版额外失效了 `queryKeys.agents`，那是「可配置 agent」查询，与插件 agent 无关）。rebase 时该文件的冲突**整段采用上游版本**，本 PR 不再包含这部分。

横幅所依赖的实时刷新因此直接受益于 #434 的失效逻辑：禁用、启用、卸载插件时横幅会实时出现与消失。二者是互补的——#434 负责「不要提供够不到的 agent」，本 PR 负责「已经绑定上去的会话怎么办」。

## 验证

已 rebase 到 `c4e311ce`（#434 之后）。

```bash
pnpm --filter @ora/chat test
pnpm --filter @ora/app-shell test
```

- `@ora/chat` 29/29 通过（新增 3 个用例覆盖重连与两条不重试的边界）
- `@ora/app-shell` 910/910 通过（新增 5 个用例覆盖横幅四种状态与启用后的自动消失）
- 两个包 lint 干净，`task format` 已执行

## 范围说明

- **后端零改动**，全部集中在前端两个包
- **未覆盖**：workflow run 在 Rust 侧直接调用 `prompt_session`（`crates/backend/src/workflow/run/executor.rs:428`），撞的是同一道状态闸门，前端这层够不到。彻底解决需要在 actor 层区分「连接断了」与「会话结束了」——目前二者共用 `channel: Option<SessionChannel>` 与同一个 `SessionStatus`。那是一笔独立的技术债，建议等内置 CLI 全部插件化、断连成为常态时再单独处理，不与本次修复捆绑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
