### PR TITLE
feat(app-shell): persist workspace and review UI state

### DIFF
--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -564,6 +564,32 @@ describe("Composer", () => {
     expect(composerText(textarea)).toBe("on B");
   });
 
+  it("does not park the leaving session's editor onto the next session key before hydrate", async () => {
+    const user = userEvent.setup();
+    useComposerInputStore.getState().reset();
+    useWorkspaceSelectionStore
+      .getState()
+      .selectSession("session-a", "task-1", "project-1");
+
+    renderWithI18n(<Composer onSend={vi.fn()} isResponding={false} />);
+    const textarea = screen.getByRole("textbox");
+    await user.type(textarea, "content on A");
+
+    act(() => {
+      useWorkspaceSelectionStore
+        .getState()
+        .selectSession("session-b", "task-1", "project-1");
+    });
+
+    expect(useComposerInputStore.getState().byKey["session-a"]?.text).toBe(
+      "content on A",
+    );
+    expect(useComposerInputStore.getState().byKey["session-b"]).toBeUndefined();
+
+    await flushComposerEffects();
+    expect(composerText(textarea)).toBe("");
+  });
+
   it("restores file and skill chips (not inline code) when switching sessions", async () => {
     useComposerInputStore.getState().reset();
     const parkedDoc = {

--- a/packages/app-shell/src/features/chat/composer.tsx
+++ b/packages/app-shell/src/features/chat/composer.tsx
@@ -279,6 +279,21 @@ export function Composer({
    */
   const syncedSurfaceRef = useRef<string | null>(null);
   if (syncedSurfaceRef.current !== conversationKey) {
+    const previousKey = syncedSurfaceRef.current;
+    // Park the surface we are leaving before adopting the new key. The editor
+    // still shows the old session until hydrate's microtask runs; without this,
+    // onTextChange would write that stale document onto the new session id.
+    if (previousKey !== null) {
+      const editor = editorRef.current;
+      if (editor !== null) {
+        useComposerInputStore.getState().setInput(previousKey, {
+          text: editor.getText(),
+          images: [...attachmentsRef.current],
+          doc: editor.getJSON(),
+        });
+      }
+    }
+    suppressPersistRef.current = true;
     syncedSurfaceRef.current = conversationKey;
     const parked = useComposerInputStore.getState().byKey[conversationKey];
     const draft =
@@ -365,19 +380,26 @@ export function Composer({
     // microtask and would wipe them.
     if (emptyPayload && previousKey === null) {
       hydratedConversationKey.current = key;
+      suppressPersistRef.current = false;
       return;
     }
 
     const generation = (hydrateGenerationRef.current += 1);
     pendingHydrateKeyRef.current = key;
     queueMicrotask(() => {
-      if (pendingHydrateKeyRef.current === key) {
-        pendingHydrateKeyRef.current = null;
+      try {
+        if (pendingHydrateKeyRef.current === key) {
+          pendingHydrateKeyRef.current = null;
+        }
+        if (hydrateGenerationRef.current !== generation) return;
+        if (conversationKeyRef.current !== key) return;
+        hydratedConversationKey.current = key;
+        applyComposerContent(text, images, doc);
+      } finally {
+        if (conversationKeyRef.current === key) {
+          suppressPersistRef.current = false;
+        }
       }
-      if (hydrateGenerationRef.current !== generation) return;
-      if (conversationKeyRef.current !== key) return;
-      hydratedConversationKey.current = key;
-      applyComposerContent(text, images, doc);
     });
   }, [applyComposerContent, conversationKey, draftId, selectedSessionId]);
 

--- a/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
+++ b/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
@@ -72,6 +72,7 @@ vi.mock("../files/workspace-review-files-panel", () => ({
           ? ""
           : `${fileRequest.path}:${fileRequest.line ?? ""}`}
       </span>
+      <span data-testid="files-request-id">{fileRequest?.requestId ?? ""}</span>
       <button
         type="button"
         data-testid="simulate-files-preview"
@@ -157,6 +158,31 @@ async function clickFilesTab(user: ReturnType<typeof userEvent.setup>) {
         name: /工作区审查面板|Workspace review panels/,
       }),
     ).getByRole("button", { name: /^文件$|^Files$/ }),
+  );
+}
+
+/**
+ * Rebuilds the `context` prop as a fresh object literal on every render, the way
+ * `workspace-view` / `workflow-run-workspace` derive it. The button lets a test
+ * force a parent render without touching the review layout's own state.
+ */
+function RerenderHarness() {
+  const [tick, setTick] = useState(0);
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="force-parent-render"
+        onClick={() => setTick((current) => current + 1)}
+      >
+        rerender {tick}
+      </button>
+      <WorkspaceReviewLayout
+        context={{ kind: "task", taskId: "task-1", projectId: "project-1" }}
+      >
+        <main>Workspace</main>
+      </WorkspaceReviewLayout>
+    </>
   );
 }
 
@@ -534,7 +560,7 @@ describe("WorkspaceReviewLayout", () => {
               open: true,
               panel: "changes",
               width: 720,
-              file: { path: "src/main.ts", line: 4 },
+              files: { changes: { path: "src/main.ts", line: 4 } },
             },
           },
         },
@@ -570,7 +596,7 @@ describe("WorkspaceReviewLayout", () => {
       open: true,
       panel: "files",
       width: 640,
-      file: { path: "src/a.ts" },
+      files: { files: { path: "src/a.ts" } },
     });
     useReviewStore.getState().upsertContext("task:task-2", {
       open: false,
@@ -636,7 +662,7 @@ describe("WorkspaceReviewLayout", () => {
       open: true,
       panel: "changes",
       width: 640,
-      file: { path: "README.md", line: 2 },
+      files: { files: { path: "README.md", line: 2 } },
     });
 
     await act(async () => {
@@ -669,7 +695,7 @@ describe("WorkspaceReviewLayout", () => {
       open: true,
       panel: "files",
       width: 640,
-      file: { path: "src/b.ts" },
+      files: { files: { path: "src/b.ts" } },
     });
 
     await act(async () => {
@@ -692,9 +718,9 @@ describe("WorkspaceReviewLayout", () => {
     await clickChangesTab(user);
     flushDebouncedPersistStorage();
 
-    expect(useReviewStore.getState().byContext["task:task-1"]?.file?.path).toBe(
-      "src/b.ts",
-    );
+    expect(useReviewStore.getState().byContext["task:task-1"]?.files).toEqual({
+      files: { path: "src/b.ts" },
+    });
   });
 
   it("reopens the last previewed file after the panel was closed on the prior session", async () => {
@@ -702,7 +728,7 @@ describe("WorkspaceReviewLayout", () => {
       open: false,
       panel: "files",
       width: 640,
-      file: { path: "src/closed.ts" },
+      files: { files: { path: "src/closed.ts" } },
     });
 
     await act(async () => {
@@ -755,7 +781,7 @@ describe("WorkspaceReviewLayout", () => {
     });
 
     expect(useReviewStore.getState().byContext["task:task-1"]).toMatchObject({
-      file: { path: "src/tree-picked.ts" },
+      files: { files: { path: "src/tree-picked.ts" } },
     });
   });
 
@@ -788,7 +814,86 @@ describe("WorkspaceReviewLayout", () => {
 
     expect(useReviewStore.getState().byContext["task:task-1"]).toMatchObject({
       panel: "changes",
-      file: { path: "src/diff-picked.ts" },
+      files: { changes: { path: "src/diff-picked.ts" } },
     });
+  });
+
+  it("restores once per scope even when the parent re-renders", async () => {
+    useReviewStore.getState().upsertContext("task:task-1", {
+      open: true,
+      panel: "files",
+      width: 640,
+      files: { files: { path: "src/a.ts" } },
+    });
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    const user = userEvent.setup();
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <RerenderHarness />
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    expect(screen.getByTestId("files-request")).toHaveTextContent("src/a.ts:");
+    const restoredRequestId =
+      screen.getByTestId("files-request-id").textContent;
+
+    // Each parent render hands down a brand new context object. Restore must
+    // stay one-shot per scope: re-running it bumps the request id, and a fresh
+    // id makes the files panel re-read and re-scroll the same file — once per
+    // streaming token in production.
+    await user.click(screen.getByTestId("force-parent-render"));
+    await user.click(screen.getByTestId("force-parent-render"));
+
+    expect(screen.getByTestId("files-request-id")).toHaveTextContent(
+      restoredRequestId ?? "",
+    );
+    expect(screen.getByTestId("files-request")).toHaveTextContent("src/a.ts:");
+  });
+
+  it("never adopts a Changes path as the Files panel selection", async () => {
+    useReviewStore.getState().upsertContext("task:task-1", {
+      open: true,
+      panel: "files",
+      width: 640,
+      files: { files: { path: "src/a.ts" } },
+    });
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    const user = userEvent.setup();
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext}>
+            <main>Workspace</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    await clickChangesTab(user);
+    await user.click(screen.getByTestId("simulate-diff-preview"));
+    await clickFilesTab(user);
+    await act(async () => {
+      flushDebouncedPersistStorage();
+    });
+
+    // The diff-only path stays under `changes`; Files keeps its own selection.
+    expect(useReviewStore.getState().byContext["task:task-1"]).toMatchObject({
+      panel: "files",
+      files: {
+        files: { path: "src/a.ts" },
+        changes: { path: "src/diff-picked.ts" },
+      },
+    });
+    expect(screen.getByTestId("files-request")).toHaveTextContent("src/a.ts:");
   });
 });

--- a/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
+++ b/packages/app-shell/src/features/diff/task-changes-layout.test.tsx
@@ -1,23 +1,30 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PlatformProvider } from "../../platform";
 import { useState, type ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppI18nProvider } from "../../i18n/i18n";
 import { createStubPlatform } from "../../test/stub-platform";
 import { useTaskChangesNavigation } from "./task-changes-navigation-context";
 import { WorkspaceReviewLayout } from "../workspace/workspace-review-layout";
 import { responsiveReviewWidth } from "../workspace/workspace-review-layout-utils";
+import { flushDebouncedPersistStorage } from "../../state/stores/debounced-json-storage";
+import {
+  REVIEW_STORAGE_KEY,
+  useReviewStore,
+} from "../../state/stores/review-store";
 
 vi.mock("./task-diff-view", () => ({
   TaskDiffView: ({
     toolbar,
     fileRequest,
     onFileNotFound,
+    onPreviewPathChange,
   }: {
     toolbar?: ReactNode;
     fileRequest?: { path: string; requestId: number; line?: number };
     onFileNotFound?: (path: string, line?: number) => void;
+    onPreviewPathChange?: (path: string) => void;
   }) => (
     <section aria-label="Task diff">
       <header data-diff-toolbar>
@@ -33,6 +40,13 @@ vi.mock("./task-diff-view", () => ({
       >
         Simulate Not Found
       </button>
+      <button
+        type="button"
+        data-testid="simulate-diff-preview"
+        onClick={() => onPreviewPathChange?.("src/diff-picked.ts")}
+      >
+        Simulate diff tree pick
+      </button>
     </section>
   ),
 }));
@@ -43,11 +57,13 @@ vi.mock("../files/workspace-review-files-panel", () => ({
     taskId,
     projectId,
     fileRequest,
+    onPreviewPathChange,
   }: {
     toolbar?: ReactNode;
     taskId?: string;
     projectId: string;
     fileRequest?: { path: string; requestId: number; line?: number };
+    onPreviewPathChange?: (path: string) => void;
   }) => (
     <section aria-label="Files panel" data-testid="files-panel">
       <span data-testid="files-target">{taskId ?? projectId}</span>
@@ -56,6 +72,13 @@ vi.mock("../files/workspace-review-files-panel", () => ({
           ? ""
           : `${fileRequest.path}:${fileRequest.line ?? ""}`}
       </span>
+      <button
+        type="button"
+        data-testid="simulate-files-preview"
+        onClick={() => onPreviewPathChange?.("src/tree-picked.ts")}
+      >
+        Simulate tree pick
+      </button>
       {toolbar}
     </section>
   ),
@@ -106,6 +129,36 @@ const taskContext = {
   taskId: "task-1",
   projectId: "project-1",
 };
+
+beforeEach(() => {
+  flushDebouncedPersistStorage();
+  window.localStorage.clear();
+  useReviewStore.setState({ byContext: {} });
+  flushDebouncedPersistStorage();
+  window.localStorage.clear();
+});
+
+/** Clicks the Changes tab in the review toolbar. */
+async function clickChangesTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    within(
+      screen.getByRole("group", {
+        name: /工作区审查面板|Workspace review panels/,
+      }),
+    ).getByRole("button", { name: /^变更$|^Changes$/ }),
+  );
+}
+
+/** Clicks the Files tab in the review toolbar. */
+async function clickFilesTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    within(
+      screen.getByRole("group", {
+        name: /工作区审查面板|Workspace review panels/,
+      }),
+    ).getByRole("button", { name: /^文件$|^Files$/ }),
+  );
+}
 
 describe("responsiveReviewWidth", () => {
   it("narrows the opening panel on small windows", () => {
@@ -469,5 +522,273 @@ describe("WorkspaceReviewLayout", () => {
 
     expect(screen.getByTestId("files-target")).toHaveTextContent("task-2");
     expect(screen.getByTestId("files-request").textContent).toBe("");
+  });
+
+  it("restores an open Changes panel and file after review storage hydrates", async () => {
+    window.localStorage.setItem(
+      REVIEW_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          byContext: {
+            "task:task-1": {
+              open: true,
+              panel: "changes",
+              width: 720,
+              file: { path: "src/main.ts", line: 4 },
+            },
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext}>
+            <main>Workspace</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    expect(
+      screen.getByRole("region", { name: "Task diff" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("requested-file")).toHaveTextContent(
+      "src/main.ts",
+    );
+    expect(screen.getByTestId("requested-line")).toHaveTextContent("4");
+  });
+
+  it("re-applies per-context open state when switching tasks", async () => {
+    useReviewStore.getState().upsertContext("task:task-1", {
+      open: true,
+      panel: "files",
+      width: 640,
+      file: { path: "src/a.ts" },
+    });
+    useReviewStore.getState().upsertContext("task:task-2", {
+      open: false,
+      panel: "files",
+      width: 640,
+    });
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    const { rerender } = render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext}>
+            <main>Task 1</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    expect(
+      screen.getByRole("region", { name: "Files panel" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("files-request")).toHaveTextContent("src/a.ts:");
+
+    rerender(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout
+            context={{
+              kind: "task",
+              taskId: "task-2",
+              projectId: "project-1",
+            }}
+          >
+            <main>Task 2</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    expect(screen.queryByRole("region", { name: "Files panel" })).toBeNull();
+
+    rerender(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext}>
+            <main>Task 1</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    expect(
+      screen.getByRole("region", { name: "Files panel" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("files-request")).toHaveTextContent("src/a.ts:");
+  });
+
+  it("opens the Files panel for a project when persisted Changes is invalid", async () => {
+    useReviewStore.getState().upsertContext("project:project-1", {
+      open: true,
+      panel: "changes",
+      width: 640,
+      file: { path: "README.md", line: 2 },
+    });
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout
+            context={{ kind: "project", projectId: "project-1" }}
+          >
+            <main>Project</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    expect(screen.getByTestId("files-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("files-request")).toHaveTextContent(
+      "README.md:2",
+    );
+    expect(
+      screen.queryByRole("region", { name: "Task diff" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not replace a Files preview path when switching to Changes without a selection", async () => {
+    useReviewStore.getState().upsertContext("task:task-1", {
+      open: true,
+      panel: "files",
+      width: 640,
+      file: { path: "src/b.ts" },
+    });
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    const user = userEvent.setup();
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext}>
+            <main>Workspace</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    expect(screen.getByTestId("files-request")).toHaveTextContent("src/b.ts:");
+
+    await clickChangesTab(user);
+    flushDebouncedPersistStorage();
+
+    expect(useReviewStore.getState().byContext["task:task-1"]?.file?.path).toBe(
+      "src/b.ts",
+    );
+  });
+
+  it("reopens the last previewed file after the panel was closed on the prior session", async () => {
+    useReviewStore.getState().upsertContext("task:task-1", {
+      open: false,
+      panel: "files",
+      width: 640,
+      file: { path: "src/closed.ts" },
+    });
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    const user = userEvent.setup();
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext}>
+            <main>Workspace</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    await clickFilesTab(user);
+
+    expect(screen.getByTestId("files-request")).toHaveTextContent(
+      "src/closed.ts:",
+    );
+  });
+
+  it("persists a file chosen from the tree via onPreviewPathChange", async () => {
+    useReviewStore.getState().upsertContext("task:task-1", {
+      open: true,
+      panel: "files",
+      width: 640,
+    });
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    const user = userEvent.setup();
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext}>
+            <main>Workspace</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    await user.click(screen.getByTestId("simulate-files-preview"));
+    await act(async () => {
+      flushDebouncedPersistStorage();
+    });
+
+    expect(useReviewStore.getState().byContext["task:task-1"]).toMatchObject({
+      file: { path: "src/tree-picked.ts" },
+    });
+  });
+
+  it("persists a diff file chosen from the tree via onPreviewPathChange", async () => {
+    useReviewStore.getState().upsertContext("task:task-1", {
+      open: true,
+      panel: "changes",
+      width: 640,
+    });
+
+    await act(async () => {
+      await useReviewStore.persist.rehydrate();
+    });
+
+    const user = userEvent.setup();
+    render(
+      <PlatformProvider adapter={createStubPlatform()}>
+        <AppI18nProvider>
+          <WorkspaceReviewLayout context={taskContext}>
+            <main>Workspace</main>
+          </WorkspaceReviewLayout>
+        </AppI18nProvider>
+      </PlatformProvider>,
+    );
+
+    await user.click(screen.getByTestId("simulate-diff-preview"));
+    await act(async () => {
+      flushDebouncedPersistStorage();
+    });
+
+    expect(useReviewStore.getState().byContext["task:task-1"]).toMatchObject({
+      panel: "changes",
+      file: { path: "src/diff-picked.ts" },
+    });
   });
 });

--- a/packages/app-shell/src/features/diff/task-diff-view.tsx
+++ b/packages/app-shell/src/features/diff/task-diff-view.tsx
@@ -83,6 +83,8 @@ interface TaskDiffViewProps {
   toolbar?: ReactNode;
   onFileTreeOpenChange: (open: boolean) => void;
   onFileNotFound?: (path: string, line?: number) => void;
+  /** Reports the file currently shown so review layout can persist it. */
+  onPreviewPathChange?: (path: string) => void;
 }
 
 export type TaskDiffViewType = "unified" | "split";
@@ -102,6 +104,7 @@ export function TaskDiffView({
   toolbar,
   onFileTreeOpenChange,
   onFileNotFound,
+  onPreviewPathChange,
 }: TaskDiffViewProps) {
   const { i18n, t } = useTranslation();
   const client = useContractsClient();
@@ -124,6 +127,11 @@ export function TaskDiffView({
   // Programmatic jumps (chat links, tree clicks) must not be overwritten by the
   // scroll spy: on mount it treats an empty viewport as "scrolled to the end".
   const suppressScrollSyncRef = useRef(false);
+  const onPreviewPathChangeRef = useRef(onPreviewPathChange);
+
+  useEffect(() => {
+    onPreviewPathChangeRef.current = onPreviewPathChange;
+  });
 
   const files = useMemo(
     () =>
@@ -159,6 +167,17 @@ export function TaskDiffView({
     }
   }
 
+  useLayoutEffect(() => {
+    if (fileRequest === undefined || diffQuery.isLoading) return;
+    if (fileRequest.requestId !== appliedFileRequestId) return;
+    const matchingPath = filePaths.find((path) =>
+      pathsMatchForWorkspace(fileRequest.path, path),
+    );
+    if (matchingPath !== undefined) {
+      onPreviewPathChangeRef.current?.(matchingPath);
+    }
+  }, [appliedFileRequestId, diffQuery.isLoading, filePaths, fileRequest]);
+
   /**
    * Scrolls the Diff viewport so `path` sits near the top.
    * Returns false when the panel has not laid out yet so callers can retry
@@ -185,6 +204,7 @@ export function TaskDiffView({
     (path: string, behavior: ScrollBehavior = "smooth") => {
       suppressScrollSyncRef.current = true;
       setSelectedFilePath(path);
+      onPreviewPathChangeRef.current?.(path);
       if (scrollToPath(path, behavior)) return;
       requestAnimationFrame(() => {
         if (!scrollToPath(path, behavior))
@@ -324,9 +344,11 @@ export function TaskDiffView({
             activePath = path;
           }
         }
-        setSelectedFilePath((currentPath) =>
-          currentPath === activePath ? currentPath : activePath,
-        );
+        setSelectedFilePath((currentPath) => {
+          if (currentPath === activePath) return currentPath;
+          onPreviewPathChangeRef.current?.(activePath);
+          return activePath;
+        });
       });
     };
 

--- a/packages/app-shell/src/features/diff/task-diff-view.tsx
+++ b/packages/app-shell/src/features/diff/task-diff-view.tsx
@@ -128,10 +128,25 @@ export function TaskDiffView({
   // scroll spy: on mount it treats an empty viewport as "scrolled to the end".
   const suppressScrollSyncRef = useRef(false);
   const onPreviewPathChangeRef = useRef(onPreviewPathChange);
+  /** Last path reported upward, so repeat notifications collapse to one call. */
+  const notifiedPreviewPathRef = useRef<string | null>(null);
 
   useEffect(() => {
     onPreviewPathChangeRef.current = onPreviewPathChange;
   });
+
+  /**
+   * Reports the previewed file to the review layout.
+   *
+   * Must stay callable from plain event/effect code only — never from a
+   * `setState` updater, which React may re-run and which must not touch another
+   * component's state.
+   */
+  const notifyPreviewPath = useCallback((path: string) => {
+    if (notifiedPreviewPathRef.current === path) return;
+    notifiedPreviewPathRef.current = path;
+    onPreviewPathChangeRef.current?.(path);
+  }, []);
 
   const files = useMemo(
     () =>
@@ -174,9 +189,15 @@ export function TaskDiffView({
       pathsMatchForWorkspace(fileRequest.path, path),
     );
     if (matchingPath !== undefined) {
-      onPreviewPathChangeRef.current?.(matchingPath);
+      notifyPreviewPath(matchingPath);
     }
-  }, [appliedFileRequestId, diffQuery.isLoading, filePaths, fileRequest]);
+  }, [
+    appliedFileRequestId,
+    diffQuery.isLoading,
+    filePaths,
+    fileRequest,
+    notifyPreviewPath,
+  ]);
 
   /**
    * Scrolls the Diff viewport so `path` sits near the top.
@@ -204,14 +225,14 @@ export function TaskDiffView({
     (path: string, behavior: ScrollBehavior = "smooth") => {
       suppressScrollSyncRef.current = true;
       setSelectedFilePath(path);
-      onPreviewPathChangeRef.current?.(path);
+      notifyPreviewPath(path);
       if (scrollToPath(path, behavior)) return;
       requestAnimationFrame(() => {
         if (!scrollToPath(path, behavior))
           suppressScrollSyncRef.current = false;
       });
     },
-    [scrollToPath],
+    [notifyPreviewPath, scrollToPath],
   );
 
   useLayoutEffect(() => {
@@ -344,11 +365,12 @@ export function TaskDiffView({
             activePath = path;
           }
         }
-        setSelectedFilePath((currentPath) => {
-          if (currentPath === activePath) return currentPath;
-          onPreviewPathChangeRef.current?.(activePath);
-          return activePath;
-        });
+        // Notify outside the updater: updaters must be pure, and this one
+        // would otherwise setState on the parent review layout.
+        notifyPreviewPath(activePath);
+        setSelectedFilePath((currentPath) =>
+          currentPath === activePath ? currentPath : activePath,
+        );
       });
     };
 
@@ -357,7 +379,7 @@ export function TaskDiffView({
       root.removeEventListener("scroll", updateActiveFile);
       if (frame !== null) cancelAnimationFrame(frame);
     };
-  }, [filePaths]);
+  }, [filePaths, notifyPreviewPath]);
 
   const commitChanges = useMutation({
     mutationFn: (message: string) =>

--- a/packages/app-shell/src/features/files/workspace-files-view.tsx
+++ b/packages/app-shell/src/features/files/workspace-files-view.tsx
@@ -67,6 +67,8 @@ interface WorkspaceFilesViewProps {
   surface?: "explorer" | "search";
   onSurfaceChange?: (surface: "explorer" | "search") => void;
   fileRequest?: WorkspaceFileRequest;
+  /** Reports the file currently previewed so review layout can persist it. */
+  onPreviewPathChange?: (path: string) => void;
 }
 
 /** External Files-panel open request. requestId must change to re-apply the same path. */
@@ -100,6 +102,7 @@ export function WorkspaceFilesView({
   surface: controlledSurface,
   onSurfaceChange,
   fileRequest,
+  onPreviewPathChange,
 }: WorkspaceFilesViewProps) {
   const { t } = useTranslation();
   const client = useContractsClient();
@@ -202,6 +205,11 @@ export function WorkspaceFilesView({
     );
     return () => clearTimeout(timer);
   }, [fileFilterText]);
+
+  useEffect(() => {
+    if (selectedPath === null) return;
+    onPreviewPathChange?.(selectedPath);
+  }, [onPreviewPathChange, selectedPath]);
 
   // A new chat requestId must re-read even when the path is unchanged. Otherwise
   // a file the user deleted after an earlier preview stays on screen from cache.

--- a/packages/app-shell/src/features/files/workspace-review-files-panel.tsx
+++ b/packages/app-shell/src/features/files/workspace-review-files-panel.tsx
@@ -22,6 +22,7 @@ interface WorkspaceReviewFilesPanelProps {
   taskId?: string;
   toolbar?: ReactNode;
   fileRequest?: WorkspaceFileRequest;
+  onPreviewPathChange?: (path: string) => void;
 }
 
 /** Hosts project/task file browsing and the read-only Spec catalog in one review panel. */
@@ -30,6 +31,7 @@ export function WorkspaceReviewFilesPanel({
   taskId,
   toolbar,
   fileRequest,
+  onPreviewPathChange,
 }: WorkspaceReviewFilesPanelProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -133,6 +135,7 @@ export function WorkspaceReviewFilesPanel({
             surface={surface}
             hideHeader
             fileRequest={fileRequest}
+            onPreviewPathChange={onPreviewPathChange}
           />
         )}
       </div>

--- a/packages/app-shell/src/features/workflow-run/workflow-run-workspace.tsx
+++ b/packages/app-shell/src/features/workflow-run/workflow-run-workspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertDialog,
@@ -368,14 +368,19 @@ export function WorkflowRunWorkspace({ runId }: WorkflowRunWorkspaceProps) {
     startRun.isPending || cancelRun.isPending || rerun.isPending;
 
   // Run-task worktree Diff / Files — same surface as chat Task Changes.
-  const reviewContext: WorkspaceReviewContext =
-    runTaskId !== null && projectId !== null && project !== undefined
-      ? {
-          kind: "task",
-          taskId: runTaskId,
-          projectId,
-        }
-      : { kind: "none" };
+  // Memoized for the same reason as in workspace-view: the review layout keys
+  // its one-shot restore off this object's identity.
+  const reviewContext = useMemo<WorkspaceReviewContext>(
+    () =>
+      runTaskId !== null && projectId !== null && project !== undefined
+        ? {
+            kind: "task",
+            taskId: runTaskId,
+            projectId,
+          }
+        : { kind: "none" },
+    [project, projectId, runTaskId],
+  );
 
   // If the run finishes while the stop dialog is open, dismiss it so Confirm
   // (which preventDefault + early-returns when !canStop) cannot leave a stuck modal.

--- a/packages/app-shell/src/features/workspace/draft-session-tree-row.tsx
+++ b/packages/app-shell/src/features/workspace/draft-session-tree-row.tsx
@@ -1,5 +1,6 @@
 import { memo, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useStoreWithEqualityFn } from "zustand/traditional";
 import { Button } from "@ora/ui";
 import { IconMessageCircle, IconX } from "@tabler/icons-react";
 import {
@@ -18,6 +19,32 @@ interface DraftSessionTreeRowProps {
   depth: 0 | 1 | 2;
 }
 
+type DraftRowSnapshot = {
+  id: string;
+  text: string;
+  projectId: string;
+  taskId: string | null;
+  pendingSessionId: string | null;
+  sendInFlight: boolean;
+};
+
+/** Limits re-renders to rows whose own draft fields changed. */
+function draftRowSnapshotEqual(
+  left: DraftRowSnapshot | null,
+  right: DraftRowSnapshot | null,
+): boolean {
+  if (left === right) return true;
+  if (left === null || right === null) return false;
+  return (
+    left.id === right.id &&
+    left.text === right.text &&
+    left.projectId === right.projectId &&
+    left.taskId === right.taskId &&
+    left.pendingSessionId === right.pendingSessionId &&
+    left.sendInFlight === right.sendInFlight
+  );
+}
+
 /**
  * Muted new-chat leaf. It stays visually quiet until attach turns it into a
  * real session. Bound rows open that session; unbound ones restore the
@@ -30,8 +57,21 @@ export const DraftSessionTreeRow = memo(function DraftSessionTreeRow({
 }: DraftSessionTreeRowProps) {
   const { t } = useTranslation();
   const rowRef = useRef<HTMLDivElement>(null);
-  const draft = useDraftSessionsStore((s) =>
-    s.drafts.find((candidate) => candidate.id === draftId),
+  const draft = useStoreWithEqualityFn(
+    useDraftSessionsStore,
+    (s) => {
+      const candidate = s.drafts.find((entry) => entry.id === draftId);
+      if (candidate === undefined) return null;
+      return {
+        id: candidate.id,
+        text: candidate.text,
+        projectId: candidate.projectId,
+        taskId: candidate.taskId,
+        pendingSessionId: candidate.pendingSessionId,
+        sendInFlight: candidate.sendInFlight,
+      };
+    },
+    draftRowSnapshotEqual,
   );
   const pendingSessionId = draft?.pendingSessionId ?? null;
   // O(1) compare so selection changes do not scan the drafts array per row.
@@ -41,11 +81,10 @@ export const DraftSessionTreeRow = memo(function DraftSessionTreeRow({
       s.selection.draftId === draftId ||
       (pendingSessionId !== null && s.selection.sessionId === pendingSessionId),
   );
-  if (draft === undefined) return null;
+  if (draft === null) return null;
 
   const bound = pendingSessionId !== null;
   const title = draftSidebarTitle(draft.text, t("sidebar.newSession"));
-  // Capture after the undefined guard — nested handlers do not retain the narrow.
   const current = draft;
 
   /** Bound drafts jump to the live session; others restore the parked composer. */

--- a/packages/app-shell/src/features/workspace/workspace-dialogs.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-dialogs.tsx
@@ -104,7 +104,10 @@ function DeleteEntityDialog({
         // Project deletion has the same running-session guard as task deletion.
         // Stop and remove every descendant session before cascading the project.
         for (const sessionId of target.sessionIds) {
-          await deleteSession.mutateAsync({ sessionId });
+          await deleteSession.mutateAsync({
+            sessionId,
+            listSync: "defer",
+          });
         }
         await deleteProject.mutateAsync({ projectId: target.id });
       }
@@ -112,7 +115,10 @@ function DeleteEntityDialog({
         // The backend protects every task with a running provider session.
         // Stop and remove each child session before deleting either task mode.
         for (const sessionId of target.sessionIds) {
-          await deleteSession.mutateAsync({ sessionId });
+          await deleteSession.mutateAsync({
+            sessionId,
+            listSync: "defer",
+          });
         }
         await deleteTask.mutateAsync({ taskId: target.id });
       }

--- a/packages/app-shell/src/features/workspace/workspace-project-tree-node.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-project-tree-node.tsx
@@ -1,0 +1,402 @@
+import { memo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  IconFolder,
+  IconFolderOpen,
+  IconGitBranch,
+  IconMessageCircle,
+  IconTrash,
+} from "@tabler/icons-react";
+import type { Project, Session, Task } from "@ora/contracts";
+import type { DraftPlacement } from "../../state/stores/draft-sessions-store";
+import { useUiStore } from "../../state/stores/ui-store";
+import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
+import { startSessionDraft } from "../../state/session-drafts";
+import {
+  useUpdateProject,
+  useUpdateTask,
+} from "../../state/hooks/use-workspace-mutations";
+import { DraftSessionTreeRow } from "./draft-session-tree-row";
+import { SessionTreeRow } from "./session-tree-row";
+import { SidebarCreateMenu } from "./sidebar-create-menu";
+import {
+  NewSessionButton,
+  ProjectWorkflowRunRows,
+  TreeBranch,
+  TreeRow,
+} from "./workspace-tree-row";
+
+const EMPTY_SESSIONS: Session[] = [];
+const EMPTY_DRAFTS: DraftPlacement[] = [];
+
+interface ProjectTreeNodeProps {
+  project: Project;
+  tasks: readonly Task[];
+  sessionsByTaskId: ReadonlyMap<string, readonly Session[]>;
+  directDrafts: readonly DraftPlacement[];
+  worktreeDraftsByTaskId: ReadonlyMap<string, readonly DraftPlacement[]>;
+  /** Search forces branches open without mutating persisted expand sets. */
+  forceExpanded: boolean;
+}
+
+/**
+ * True when this project's visible tree props are referentially unchanged.
+ *
+ * The parent rebuilds the sessions/tasks Maps on any list write; only the
+ * buckets for *this* project's tasks matter for memoization.
+ */
+function projectTreeNodePropsEqual(
+  prev: ProjectTreeNodeProps,
+  next: ProjectTreeNodeProps,
+): boolean {
+  if (prev.project !== next.project) return false;
+  if (prev.tasks !== next.tasks) return false;
+  if (prev.forceExpanded !== next.forceExpanded) return false;
+  if (prev.directDrafts !== next.directDrafts) return false;
+  for (const task of next.tasks) {
+    if (
+      prev.sessionsByTaskId.get(task.id) !== next.sessionsByTaskId.get(task.id)
+    ) {
+      return false;
+    }
+    if (
+      prev.worktreeDraftsByTaskId.get(task.id) !==
+      next.worktreeDraftsByTaskId.get(task.id)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * One project row and its descendants. Expand state is subscribed per id so
+ * toggling another project does not reconcile this subtree.
+ */
+export const ProjectTreeNode = memo(function ProjectTreeNode({
+  project,
+  tasks,
+  sessionsByTaskId,
+  directDrafts,
+  worktreeDraftsByTaskId,
+  forceExpanded,
+}: ProjectTreeNodeProps) {
+  const { t } = useTranslation();
+  const updateProject = useUpdateProject();
+  const projectOpen =
+    useUiStore((s) => s.expandedProjects.has(project.id)) || forceExpanded;
+
+  const projectSelected = useWorkspaceSelectionStore(
+    (s) =>
+      s.selection.projectId === project.id &&
+      s.selection.taskId === null &&
+      s.selection.sessionId === null &&
+      s.selection.draftId === null &&
+      s.selection.workflowRunId === null,
+  );
+  const projectContainsSelection = useWorkspaceSelectionStore((s) => {
+    const { selection } = s;
+    return (
+      selection.projectId === project.id &&
+      (selection.taskId !== null ||
+        selection.sessionId !== null ||
+        selection.draftId !== null ||
+        selection.workflowRunId !== null)
+    );
+  });
+  const projectCreateFocused = useWorkspaceSelectionStore((s) => {
+    const { createFocus, selection } = s;
+    return (
+      createFocus !== null &&
+      createFocus.projectId === project.id &&
+      createFocus.taskId === null &&
+      !(
+        selection.projectId === createFocus.projectId &&
+        selection.taskId === createFocus.taskId
+      )
+    );
+  });
+  const activeRunId = useWorkspaceSelectionStore((s) =>
+    s.selection.projectId === project.id ? s.selection.workflowRunId : null,
+  );
+
+  const projectSessionIds = tasks.flatMap((task) =>
+    (sessionsByTaskId.get(task.id) ?? EMPTY_SESSIONS).map(
+      (session) => session.id,
+    ),
+  );
+
+  return (
+    <div>
+      <TreeRow
+        depth={0}
+        active={projectSelected}
+        containsSelection={!projectOpen && projectContainsSelection}
+        createFocused={projectCreateFocused}
+        icon={
+          projectOpen ? (
+            <IconFolderOpen className="size-[18px] text-muted-foreground" />
+          ) : (
+            <IconFolder className="size-[18px] text-muted-foreground" />
+          )
+        }
+        label={project.name}
+        expanded={projectOpen}
+        onClick={() => {
+          useWorkspaceSelectionStore
+            .getState()
+            .setCreateFocus({ projectId: project.id, taskId: null });
+          useUiStore.getState().toggleProjectExpand(project.id);
+        }}
+        action={
+          <SidebarCreateMenu
+            projectId={project.id}
+            onNewTask={(projectId) => {
+              startSessionDraft({ projectId, taskId: null });
+            }}
+          />
+        }
+        onRename={(name) => updateProject.mutateAsync({ project, name })}
+        commands={[
+          {
+            label: t("common.delete"),
+            icon: <IconTrash />,
+            variant: "destructive",
+            onSelect: () =>
+              useUiStore.getState().setDeleteTarget({
+                kind: "project",
+                id: project.id,
+                name: project.name,
+                sessionIds: projectSessionIds,
+              }),
+          },
+        ]}
+      />
+      <TreeBranch expanded={projectOpen} retainWhenCollapsed={!forceExpanded}>
+        <ProjectWorkflowRunRows
+          projectId={project.id}
+          listEnabled={projectOpen}
+          activeRunId={activeRunId}
+          onSelectRun={(runId) =>
+            useWorkspaceSelectionStore
+              .getState()
+              .selectWorkflowRun(runId, project.id)
+          }
+          onDeleteRun={(run) =>
+            useUiStore.getState().setDeleteTarget({
+              kind: "workflowRun",
+              id: run.id,
+              name: run.name,
+              projectId: project.id,
+            })
+          }
+        />
+        {directDrafts.map((draft) => (
+          <DraftSessionTreeRow key={draft.id} draftId={draft.id} depth={1} />
+        ))}
+        {tasks.map((task) => {
+          const taskSessions = sessionsByTaskId.get(task.id) ?? EMPTY_SESSIONS;
+          if (task.workspaceMode === "project_root") {
+            return (
+              <ProjectRootTaskRow
+                key={task.id}
+                task={task}
+                projectId={project.id}
+                sessions={taskSessions}
+              />
+            );
+          }
+          return (
+            <WorktreeTaskNode
+              key={task.id}
+              task={task}
+              projectId={project.id}
+              sessions={taskSessions}
+              drafts={worktreeDraftsByTaskId.get(task.id) ?? EMPTY_DRAFTS}
+              forceExpanded={forceExpanded}
+            />
+          );
+        })}
+      </TreeBranch>
+    </div>
+  );
+}, projectTreeNodePropsEqual);
+
+/** Direct-chat task: one session leaf, or an empty task row before the first send. */
+const ProjectRootTaskRow = memo(function ProjectRootTaskRow({
+  task,
+  projectId,
+  sessions,
+}: {
+  task: Task;
+  projectId: string;
+  sessions: readonly Session[];
+}) {
+  const { t } = useTranslation();
+  const updateTask = useUpdateTask();
+  const directSession = sessions[0];
+  const taskActive = useWorkspaceSelectionStore(
+    (s) => s.selection.taskId === task.id,
+  );
+
+  if (directSession) {
+    return (
+      <SessionTreeRow
+        sessionId={directSession.id}
+        taskId={task.id}
+        projectId={projectId}
+        depth={1}
+        title={directSession.title ?? t("sidebar.newSession")}
+        deleteAs="task"
+        workspaceMode={task.workspaceMode}
+      />
+    );
+  }
+
+  return (
+    <TreeRow
+      depth={1}
+      active={taskActive}
+      icon={
+        <IconMessageCircle
+          className="size-4 text-muted-foreground"
+          aria-label={t("sidebar.directChatTask")}
+        />
+      }
+      label={task.title}
+      onClick={() =>
+        useWorkspaceSelectionStore.getState().selectTask(task.id, projectId)
+      }
+      onRename={(name) => updateTask.mutateAsync({ task, title: name })}
+      commands={[
+        {
+          label: t("common.delete"),
+          icon: <IconTrash />,
+          variant: "destructive",
+          onSelect: () =>
+            useUiStore.getState().setDeleteTarget({
+              kind: "task",
+              id: task.id,
+              name: task.title,
+              workspaceMode: task.workspaceMode,
+              sessionIds: [],
+            }),
+        },
+      ]}
+    />
+  );
+});
+
+interface WorktreeTaskNodeProps {
+  task: Task;
+  projectId: string;
+  sessions: readonly Session[];
+  drafts: readonly DraftPlacement[];
+  forceExpanded: boolean;
+}
+
+/**
+ * Worktree task row with its own expand subscription so collapsing one task
+ * does not rebuild sibling task session lists.
+ */
+const WorktreeTaskNode = memo(function WorktreeTaskNode({
+  task,
+  projectId,
+  sessions,
+  drafts,
+  forceExpanded,
+}: WorktreeTaskNodeProps) {
+  const { t } = useTranslation();
+  const updateTask = useUpdateTask();
+  const taskOpen =
+    useUiStore((s) => s.expandedTasks.has(task.id)) || forceExpanded;
+
+  const taskSelected = useWorkspaceSelectionStore(
+    (s) =>
+      s.selection.taskId === task.id &&
+      s.selection.sessionId === null &&
+      s.selection.draftId === null,
+  );
+  const taskContainsSelection = useWorkspaceSelectionStore(
+    (s) =>
+      s.selection.taskId === task.id &&
+      (s.selection.sessionId !== null || s.selection.draftId !== null),
+  );
+  const taskCreateFocused = useWorkspaceSelectionStore((s) => {
+    const { createFocus, selection } = s;
+    return (
+      createFocus?.taskId === task.id &&
+      !(
+        selection.projectId === createFocus.projectId &&
+        selection.taskId === createFocus.taskId
+      )
+    );
+  });
+
+  return (
+    <div>
+      <TreeRow
+        depth={1}
+        active={taskSelected}
+        containsSelection={!taskOpen && taskContainsSelection}
+        createFocused={taskCreateFocused}
+        icon={
+          <IconGitBranch
+            className="size-4 text-muted-foreground"
+            aria-label={t("sidebar.worktreeTask")}
+          />
+        }
+        label={task.title}
+        expanded={taskOpen}
+        onClick={() => {
+          useWorkspaceSelectionStore
+            .getState()
+            .setCreateFocus({ projectId, taskId: task.id });
+          useUiStore.getState().toggleTaskExpand(task.id);
+        }}
+        action={
+          <NewSessionButton
+            onClick={() =>
+              startSessionDraft({
+                projectId: task.projectId,
+                taskId: task.id,
+              })
+            }
+          />
+        }
+        onRename={(name) => updateTask.mutateAsync({ task, title: name })}
+        commands={[
+          {
+            label: t("common.delete"),
+            icon: <IconTrash />,
+            variant: "destructive",
+            onSelect: () =>
+              useUiStore.getState().setDeleteTarget({
+                kind: "task",
+                id: task.id,
+                name: task.title,
+                workspaceMode: task.workspaceMode,
+                sessionIds: sessions.map((session) => session.id),
+              }),
+          },
+        ]}
+      />
+      <TreeBranch expanded={taskOpen} retainWhenCollapsed={!forceExpanded}>
+        {drafts.map((draft) => (
+          <DraftSessionTreeRow key={draft.id} draftId={draft.id} depth={2} />
+        ))}
+        {sessions.map((session) => (
+          <SessionTreeRow
+            key={session.id}
+            sessionId={session.id}
+            taskId={task.id}
+            projectId={projectId}
+            depth={2}
+            title={session.title ?? t("sidebar.newSession")}
+            deleteAs="session"
+          />
+        ))}
+      </TreeBranch>
+    </div>
+  );
+});

--- a/packages/app-shell/src/features/workspace/workspace-review-layout.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-review-layout.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -34,6 +35,12 @@ import {
   animatePanelWidth,
   cancelPanelWidthAnimation,
 } from "../../lib/panel-motion";
+import { usePersistHydrated } from "../../state/hooks/use-persist-hydrated";
+import {
+  buildReviewFilePersist,
+  reviewContextKey,
+  useReviewStore,
+} from "../../state/stores/review-store";
 import {
   DEFAULT_REVIEW_WIDTH,
   MAX_REVIEW_WIDTH,
@@ -83,6 +90,7 @@ export function WorkspaceReviewLayout({
   const [workspaceFileRequest, setWorkspaceFileRequest] = useState<
     WorkspaceFileRequest | undefined
   >();
+  const [reviewFilePath, setReviewFilePath] = useState<string | undefined>();
   const [previousContextKind, setPreviousContextKind] = useState(context.kind);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileRequestSequence = useRef(0);
@@ -100,13 +108,17 @@ export function WorkspaceReviewLayout({
   /** Host whose width drives the responsive opening width. */
   const contentRef = useRef<HTMLDivElement | null>(null);
   const taskId = context.kind === "task" ? context.taskId : undefined;
-  const contextKey =
-    context.kind === "none"
-      ? "none"
-      : context.kind === "project"
-        ? `project:${context.projectId}`
-        : `task:${context.taskId}`;
+  const contextKey = reviewContextKey(context) ?? "none";
   const [previousContextKey, setPreviousContextKey] = useState(contextKey);
+  const [restoredForContextKey, setRestoredForContextKey] = useState<
+    string | null
+  >(null);
+  const reviewHydrated = usePersistHydrated(useReviewStore.persist);
+  const reviewHydratedRef = useRef(reviewHydrated);
+
+  useEffect(() => {
+    reviewHydratedRef.current = reviewHydrated;
+  }, [reviewHydrated]);
 
   // Keep the latest open-change listener for effect notifications.
   useEffect(() => {
@@ -116,6 +128,112 @@ export function WorkspaceReviewLayout({
   const setReviewOpen = useCallback((next: boolean) => {
     setOpen((current) => (current === next ? current : next));
   }, []);
+
+  const rememberReviewFile = useCallback((path: string) => {
+    setReviewFilePath(path);
+  }, []);
+
+  const applyStoredPreviewForPanel = useCallback(
+    (panelToOpen: ReviewPanel) => {
+      if (context.kind === "none") return;
+      const saved = useReviewStore.getState().byContext[contextKey];
+      if (saved?.file === undefined) return;
+      const savedPanel =
+        context.kind === "project" && saved.panel === "changes"
+          ? "files"
+          : saved.panel;
+      const openPanel =
+        context.kind === "project" && panelToOpen === "changes"
+          ? "files"
+          : panelToOpen;
+      if (savedPanel !== openPanel) return;
+
+      setReviewFilePath(saved.file.path);
+      if (openPanel === "changes" && context.kind === "task") {
+        fileRequestSequence.current += 1;
+        setFileRequest({
+          path: saved.file.path,
+          requestId: fileRequestSequence.current,
+          line: saved.file.line,
+        });
+      } else {
+        workspaceFileRequestSequence.current += 1;
+        setWorkspaceFileRequest({
+          path: saved.file.path,
+          requestId: workspaceFileRequestSequence.current,
+          line: saved.file.line,
+          column: saved.file.column,
+        });
+      }
+    },
+    [context, contextKey],
+  );
+
+  const persistReviewLayout = useCallback(() => {
+    if (context.kind === "none" || !reviewHydratedRef.current) return;
+    if (restoredForContextKey !== contextKey) return;
+    const file = buildReviewFilePersist({
+      open,
+      panel,
+      reviewFilePath,
+      fileRequest,
+      workspaceFileRequest,
+    });
+    useReviewStore.getState().upsertContext(contextKey, {
+      open,
+      panel,
+      width: panelWidthRef.current,
+      ...(file !== undefined ? { file } : {}),
+    });
+  }, [
+    context.kind,
+    contextKey,
+    fileRequest,
+    open,
+    panel,
+    restoredForContextKey,
+    reviewFilePath,
+    workspaceFileRequest,
+  ]);
+
+  useEffect(() => {
+    persistReviewLayout();
+  }, [persistReviewLayout]);
+
+  /* eslint-disable react-hooks/set-state-in-effect -- apply persisted review snapshot before paint so persist cannot clobber disk with the previous context's open state */
+  useLayoutEffect(() => {
+    if (!reviewHydrated || context.kind === "none") return;
+
+    setRestoredForContextKey(contextKey);
+
+    const saved = useReviewStore.getState().byContext[contextKey];
+    if (saved === undefined) return;
+
+    if (!saved.open) {
+      setReviewOpen(false);
+      return;
+    }
+
+    const panelToOpen =
+      context.kind === "project" && saved.panel === "changes"
+        ? "files"
+        : saved.panel;
+
+    panelWidthRef.current = saved.width;
+    panelCurrentWidthRef.current = saved.width;
+    panelWidthTouchedRef.current = true;
+
+    setPanel(panelToOpen);
+    setReviewOpen(true);
+    applyStoredPreviewForPanel(panelToOpen);
+  }, [
+    applyStoredPreviewForPanel,
+    context.kind,
+    contextKey,
+    reviewHydrated,
+    setReviewOpen,
+  ]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Notify the parent after paint so we never setState on the parent during this
   // layout's render (React forbids updating WorkflowRunWorkspace from here).
@@ -202,6 +320,13 @@ export function WorkspaceReviewLayout({
     // selected project or task changes so paths from the previous root vanish.
     setFileRequest(undefined);
     setWorkspaceFileRequest(undefined);
+    setReviewFilePath(undefined);
+    setExpanded(false);
+    setClosing(false);
+    const savedForContext = useReviewStore.getState().byContext[contextKey];
+    if (savedForContext !== undefined && !savedForContext.open) {
+      setOpen(false);
+    }
     // Project review has no Changes surface; coerce so Files chrome matches content.
     if (context.kind === "project") setPanel("files");
   }
@@ -216,6 +341,7 @@ export function WorkspaceReviewLayout({
         line,
         column,
       });
+      setReviewFilePath(path);
       setPanel("files");
       setReviewOpen(true);
       if (panelAnimationRef.current !== null) slidePanelOpen();
@@ -236,6 +362,7 @@ export function WorkspaceReviewLayout({
         requestId: fileRequestSequence.current,
         line,
       });
+      setReviewFilePath(path);
       setPanel("changes");
       setReviewOpen(true);
       // A close slide may still be in flight; switch it back to opening.
@@ -296,8 +423,15 @@ export function WorkspaceReviewLayout({
   const selectPanel = (next: ReviewPanel) => {
     if (open && panel === next) close();
     else {
+      const switching = panel !== next;
+      if (switching) {
+        setReviewFilePath(undefined);
+        setFileRequest(undefined);
+        setWorkspaceFileRequest(undefined);
+      }
       setPanel(next);
       setReviewOpen(true);
+      applyStoredPreviewForPanel(next);
       // A close slide may still be in flight; switch it back to opening.
       if (panelAnimationRef.current !== null) slidePanelOpen();
     }
@@ -396,6 +530,7 @@ export function WorkspaceReviewLayout({
         toolbar={controls}
         onFileTreeOpenChange={setFileTreeOpen}
         onFileNotFound={openWorkspaceFile}
+        onPreviewPathChange={rememberReviewFile}
       />
     ) : (
       <WorkspaceReviewFilesPanel
@@ -404,6 +539,7 @@ export function WorkspaceReviewLayout({
         taskId={context.kind === "task" ? context.taskId : undefined}
         toolbar={controls}
         fileRequest={workspaceFileRequest}
+        onPreviewPathChange={rememberReviewFile}
       />
     );
 
@@ -452,6 +588,11 @@ export function WorkspaceReviewLayout({
             else if (size.inPixels >= MIN_REVIEW_WIDTH) {
               panelWidthTouchedRef.current = true;
               panelWidthRef.current = size.inPixels;
+              if (reviewHydratedRef.current) {
+                useReviewStore.getState().upsertContext(contextKey, {
+                  width: size.inPixels,
+                });
+              }
             }
           }}
         >

--- a/packages/app-shell/src/features/workspace/workspace-review-layout.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-review-layout.tsx
@@ -133,44 +133,42 @@ export function WorkspaceReviewLayout({
     setReviewFilePath(path);
   }, []);
 
+  const contextKind = context.kind;
   const applyStoredPreviewForPanel = useCallback(
     (panelToOpen: ReviewPanel) => {
-      if (context.kind === "none") return;
-      const saved = useReviewStore.getState().byContext[contextKey];
-      if (saved?.file === undefined) return;
-      const savedPanel =
-        context.kind === "project" && saved.panel === "changes"
-          ? "files"
-          : saved.panel;
+      if (contextKind === "none") return;
+      // Project review has no Changes surface; its file always lives under Files.
       const openPanel =
-        context.kind === "project" && panelToOpen === "changes"
+        contextKind === "project" && panelToOpen === "changes"
           ? "files"
           : panelToOpen;
-      if (savedPanel !== openPanel) return;
+      const saved = useReviewStore.getState().byContext[contextKey];
+      const savedFile = saved?.files[openPanel];
+      if (savedFile === undefined) return;
 
-      setReviewFilePath(saved.file.path);
-      if (openPanel === "changes" && context.kind === "task") {
+      setReviewFilePath(savedFile.path);
+      if (openPanel === "changes" && contextKind === "task") {
         fileRequestSequence.current += 1;
         setFileRequest({
-          path: saved.file.path,
+          path: savedFile.path,
           requestId: fileRequestSequence.current,
-          line: saved.file.line,
+          line: savedFile.line,
         });
       } else {
         workspaceFileRequestSequence.current += 1;
         setWorkspaceFileRequest({
-          path: saved.file.path,
+          path: savedFile.path,
           requestId: workspaceFileRequestSequence.current,
-          line: saved.file.line,
-          column: saved.file.column,
+          line: savedFile.line,
+          column: savedFile.column,
         });
       }
     },
-    [context, contextKey],
+    [contextKey, contextKind],
   );
 
   const persistReviewLayout = useCallback(() => {
-    if (context.kind === "none" || !reviewHydratedRef.current) return;
+    if (contextKind === "none" || !reviewHydratedRef.current) return;
     if (restoredForContextKey !== contextKey) return;
     const file = buildReviewFilePersist({
       open,
@@ -183,11 +181,12 @@ export function WorkspaceReviewLayout({
       open,
       panel,
       width: panelWidthRef.current,
-      ...(file !== undefined ? { file } : {}),
+      // Store under the live panel so the other tab keeps its own selection.
+      ...(file !== undefined ? { files: { [panel]: file } } : {}),
     });
   }, [
-    context.kind,
     contextKey,
+    contextKind,
     fileRequest,
     open,
     panel,
@@ -202,7 +201,11 @@ export function WorkspaceReviewLayout({
 
   /* eslint-disable react-hooks/set-state-in-effect -- apply persisted review snapshot before paint so persist cannot clobber disk with the previous context's open state */
   useLayoutEffect(() => {
-    if (!reviewHydrated || context.kind === "none") return;
+    if (!reviewHydrated || contextKind === "none") return;
+    // Restore is a one-shot per scope. Re-running would re-issue the stored file
+    // request on every parent render and revert open/tab gestures the user made
+    // after restore (layout effects observe the pre-commit store snapshot).
+    if (restoredForContextKey === contextKey) return;
 
     setRestoredForContextKey(contextKey);
 
@@ -215,7 +218,7 @@ export function WorkspaceReviewLayout({
     }
 
     const panelToOpen =
-      context.kind === "project" && saved.panel === "changes"
+      contextKind === "project" && saved.panel === "changes"
         ? "files"
         : saved.panel;
 
@@ -228,8 +231,9 @@ export function WorkspaceReviewLayout({
     applyStoredPreviewForPanel(panelToOpen);
   }, [
     applyStoredPreviewForPanel,
-    context.kind,
     contextKey,
+    contextKind,
+    restoredForContextKey,
     reviewHydrated,
     setReviewOpen,
   ]);
@@ -588,7 +592,13 @@ export function WorkspaceReviewLayout({
             else if (size.inPixels >= MIN_REVIEW_WIDTH) {
               panelWidthTouchedRef.current = true;
               panelWidthRef.current = size.inPixels;
-              if (reviewHydratedRef.current) {
+              // Same gate as persistReviewLayout: before this scope has been
+              // restored, upsertContext would seed a fresh entry from defaults
+              // (open: false) for a panel the user currently has open.
+              if (
+                reviewHydratedRef.current &&
+                restoredForContextKey === contextKey
+              ) {
                 useReviewStore.getState().upsertContext(contextKey, {
                   width: size.inPixels,
                 });

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
@@ -202,8 +202,10 @@ beforeEach(() => {
   });
   useDraftSessionsStore.getState().clear();
   useUiStore.setState({
+    sidebarCollapsed: false,
     expandedProjects: new Set(),
     expandedTasks: new Set(),
+    treeExpansionBootstrapped: false,
     dialog: null,
     deleteTarget: null,
   });
@@ -1205,17 +1207,185 @@ describe("WorkspaceSidebar", () => {
     expect(treeRow(TASK.title)).not.toBeNull();
   });
 
-  // The Collapsible holds the panel just long enough to animate out, then drops
-  // it, so a collapsed branch costs nothing once the close has finished.
-  it("unmounts a collapsed branch instead of leaving it hidden in the DOM", async () => {
+  // First collapse unmounts; after a reopen, collapse hides instead of remounting.
+  it("unmounts on the first collapse and retains after a reopen", async () => {
     const user = userEvent.setup();
     renderSidebar(workspaceWithOneSession());
 
     await waitFor(() => expect(treeRow(TASK.title)).not.toBeNull());
 
     await user.click(screen.getByText(PROJECT.name));
+    expect(treeRow(TASK.title)).toBeNull();
+    expect(screen.queryByText(TASK.title)).toBeNull();
 
-    await waitFor(() => expect(screen.queryByText(TASK.title)).toBeNull());
+    await user.click(screen.getByText(PROJECT.name));
+    await waitFor(() => expect(treeRow(TASK.title)).not.toBeNull());
+
+    await user.click(screen.getByText(PROJECT.name));
+    expect(treeRow(TASK.title)).toBeNull();
+    expect(screen.getByText(TASK.title).closest("[hidden]")).not.toBeNull();
+  });
+
+  it("keeps a previously collapsed project collapsed after hydrate", async () => {
+    useUiStore.setState({
+      expandedProjects: new Set(),
+      expandedTasks: new Set(),
+      treeExpansionBootstrapped: true,
+    });
+    renderSidebar(workspaceWithOneSession());
+
+    await waitFor(() => expect(treeRow(PROJECT.name)).not.toBeNull());
+    expect(treeRow(TASK.title)).toBeNull();
+    expect(useUiStore.getState().expandedProjects.has(PROJECT.id)).toBe(false);
+  });
+
+  it("does not re-expand a collapsed project when restoring its selected session", async () => {
+    useUiStore.setState({
+      expandedProjects: new Set(),
+      expandedTasks: new Set(),
+      treeExpansionBootstrapped: true,
+    });
+    useWorkspaceSelectionStore.setState({
+      selection: {
+        projectId: null,
+        taskId: null,
+        sessionId: null,
+        workflowRunId: null,
+        draftId: null,
+      },
+      pendingRestore: {
+        projectId: PROJECT.id,
+        taskId: TASK.id,
+        sessionId: SESSION.id,
+        workflowRunId: null,
+        draftId: null,
+      },
+      createFocus: null,
+    });
+    renderSidebar(workspaceWithOneSession());
+
+    await waitFor(() =>
+      expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+        SESSION.id,
+      ),
+    );
+    expect(treeRow(TASK.title)).toBeNull();
+    expect(useUiStore.getState().expandedProjects.has(PROJECT.id)).toBe(false);
+    expect(treeRowShell(PROJECT.name).dataset.selectionHint).toBe("true");
+  });
+
+  it("bubbles selection hint to collapsed ancestors and clears it on expand", async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({
+      expandedProjects: new Set([PROJECT.id]),
+      expandedTasks: new Set([TASK.id]),
+      treeExpansionBootstrapped: true,
+    });
+    useWorkspaceSelectionStore
+      .getState()
+      .selectSession(SESSION.id, TASK.id, PROJECT.id);
+    renderSidebar(workspaceWithOneSession());
+
+    await waitFor(() => expect(treeRow(NEW_SESSION_LABEL)).not.toBeNull());
+    expect(treeRowShell(PROJECT.name).dataset.selectionHint).toBeUndefined();
+    expect(treeRowShell(TASK.title).dataset.selectionHint).toBeUndefined();
+
+    await user.click(screen.getByText(TASK.title));
+    expect(useUiStore.getState().expandedTasks.has(TASK.id)).toBe(false);
+    expect(treeRow(NEW_SESSION_LABEL)).toBeNull();
+    expect(treeRowShell(TASK.title).dataset.selectionHint).toBe("true");
+    expect(treeRowShell(PROJECT.name).dataset.selectionHint).toBeUndefined();
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      SESSION.id,
+    );
+
+    await user.click(screen.getByText(PROJECT.name));
+    expect(useUiStore.getState().expandedProjects.has(PROJECT.id)).toBe(false);
+    expect(treeRow(TASK.title)).toBeNull();
+    expect(treeRowShell(PROJECT.name).dataset.selectionHint).toBe("true");
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      SESSION.id,
+    );
+
+    await user.click(screen.getByText(PROJECT.name));
+    await waitFor(() => expect(treeRow(TASK.title)).not.toBeNull());
+    expect(treeRowShell(PROJECT.name).dataset.selectionHint).toBeUndefined();
+    expect(treeRowShell(TASK.title).dataset.selectionHint).toBe("true");
+
+    await user.click(screen.getByText(TASK.title));
+    await waitFor(() => expect(treeRow(NEW_SESSION_LABEL)).not.toBeNull());
+    expect(treeRowShell(TASK.title).dataset.selectionHint).toBeUndefined();
+  });
+
+  it("does not show a selection hint when the project itself is selected", async () => {
+    useUiStore.setState({
+      expandedProjects: new Set(),
+      expandedTasks: new Set(),
+      treeExpansionBootstrapped: true,
+    });
+    useWorkspaceSelectionStore.getState().selectProject(PROJECT.id);
+    renderSidebar(workspaceWithOneSession());
+
+    await waitFor(() => expect(treeRow(PROJECT.name)).not.toBeNull());
+    expect(treeRowShell(PROJECT.name).dataset.selectionHint).toBeUndefined();
+    expect(
+      treeRowShell(PROJECT.name).className.includes("bg-sidebar-accent "),
+    ).toBe(true);
+  });
+
+  it("does not seal first-run bootstrap when the tree query fails", async () => {
+    const state = workspaceWithOneSession();
+    const client = createMockClient(state);
+    vi.spyOn(client.project, "list").mockRejectedValue(
+      new LocalTransportError("tauri_invoke_failure", "projects unavailable"),
+    );
+    renderSidebar(state, undefined, client);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/projects unavailable|调用失败|tauri/i),
+      ).toBeTruthy(),
+    );
+    expect(useUiStore.getState().treeExpansionBootstrapped).toBe(false);
+    expect(useUiStore.getState().expandedProjects.size).toBe(0);
+  });
+
+  it("keeps a staged session restore when the sessions query fails", async () => {
+    useWorkspaceSelectionStore.setState({
+      selection: {
+        projectId: null,
+        taskId: null,
+        sessionId: null,
+        workflowRunId: null,
+        draftId: null,
+      },
+      pendingRestore: {
+        projectId: PROJECT.id,
+        taskId: TASK.id,
+        sessionId: SESSION.id,
+        workflowRunId: null,
+        draftId: null,
+      },
+      createFocus: null,
+    });
+    const state = workspaceWithOneSession();
+    const client = createMockClient(state);
+    vi.spyOn(client.session, "list").mockRejectedValue(
+      new LocalTransportError("tauri_invoke_failure", "sessions unavailable"),
+    );
+    renderSidebar(state, undefined, client);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/sessions unavailable|调用失败|tauri/i),
+      ).toBeTruthy(),
+    );
+    expect(
+      useWorkspaceSelectionStore.getState().pendingRestore?.sessionId,
+    ).toBe(SESSION.id);
+    expect(
+      useWorkspaceSelectionStore.getState().selection.sessionId,
+    ).toBeNull();
   });
 
   // Matches the working-indicator aria-label in either shipped locale.

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
@@ -1,5 +1,4 @@
 import {
-  Fragment,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -10,35 +9,16 @@ import {
 import { useTranslation } from "react-i18next";
 import {
   Button,
-  Collapsible,
-  CollapsibleContent,
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger,
   Input,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-  cn,
-  toast,
 } from "@ora/ui";
 import {
-  IconArchive,
-  IconChevronDown,
-  IconChevronRight,
-  IconFolder,
-  IconFolderOpen,
-  IconGitBranch,
   IconLayoutSidebarLeftCollapse,
-  IconMessageCircle,
   IconMessageCirclePlus,
-  IconPencil,
   IconPlus,
-  IconRoute,
   IconSearch,
-  IconTrash,
   IconX,
 } from "@tabler/icons-react";
 import type { Session, Task } from "@ora/contracts";
@@ -49,21 +29,15 @@ import { useProjects } from "../../state/hooks/use-projects";
 import { useTasks } from "../../state/hooks/use-tasks";
 import { useSessions } from "../../state/hooks/use-sessions";
 import { useRestoreWorkspaceSelection } from "../../state/hooks/use-restore-workspace-selection";
-import {
-  useRenameWorkflowRun,
-  useWorkflowRunsByProject,
-} from "../../state/hooks/use-workflow-runs";
-import {
-  useUpdateProject,
-  useUpdateTask,
-} from "../../state/hooks/use-workspace-mutations";
 import { useStoreWithEqualityFn } from "zustand/traditional";
+import { usePersistHydrated } from "../../state/hooks/use-persist-hydrated";
 import { useUiStore } from "../../state/stores/ui-store";
 import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
 import {
   draftPlacements,
   draftPlacementsEqual,
   draftSidebarTitle,
+  type DraftPlacement,
   type SessionDraft,
   useDraftSessionsStore,
 } from "../../state/stores/draft-sessions-store";
@@ -74,19 +48,30 @@ import {
 } from "../../state/session-drafts";
 import { OraMark } from "../../components/ora-mark";
 import { DragRegion } from "../../components/drag-region";
-import type { GraphWorkflowRunStatus } from "@ora/workflow-runtime";
-import { SidebarCreateMenu } from "./sidebar-create-menu";
-import { DraftSessionTreeRow } from "./draft-session-tree-row";
-import { SessionTreeRow } from "./session-tree-row";
-import { useInlineTreeRename } from "./use-inline-tree-rename";
+import { useStableGroupBy } from "../../lib/use-stable-group-by";
+import { ProjectTreeNode } from "./workspace-project-tree-node";
 
 const EMPTY_TASKS: Task[] = [];
 const EMPTY_SESSIONS: Session[] = [];
+const EMPTY_DRAFTS: DraftPlacement[] = [];
 type DraftSearchEntry = Pick<
   SessionDraft,
   "id" | "projectId" | "taskId" | "text"
 >;
 const EMPTY_DRAFT_SEARCH_ENTRIES: DraftSearchEntry[] = [];
+
+function projectIdOfTask(task: Task): string {
+  return task.projectId;
+}
+function taskIdOfSession(session: Session): string {
+  return session.taskId;
+}
+function projectIdOfDraft(draft: DraftPlacement): string {
+  return draft.projectId;
+}
+function taskIdOfDraft(draft: DraftPlacement): string {
+  return draft.taskId!;
+}
 
 /** Compares only draft fields that can change sidebar search results. */
 function draftSearchEntriesEqual(
@@ -116,6 +101,7 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
   const [query, setQuery] = useState("");
   const needle = query.trim().toLowerCase();
   const initializedTreeExpansion = useRef(false);
+  const uiHydrated = usePersistHydrated(useUiStore.persist);
 
   const projectsQuery = useProjects();
   const tasksQuery = useTasks();
@@ -176,76 +162,56 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
   }, [persistedSessionIds]);
   const loading =
     projectsQuery.isPending || tasksQuery.isPending || sessionsQuery.isPending;
+  // Bootstrap and restore both need a successful tree. `!isPending` alone would
+  // let a failed/empty fetch miss-clear `pendingRestore` and persist that wipe
+  // so the next launch has nothing to restore (flaky "sometimes works").
+  const treeReady =
+    projectsQuery.isSuccess && tasksQuery.isSuccess && sessionsQuery.isSuccess;
   const error = projectsQuery.error ?? tasksQuery.error ?? sessionsQuery.error;
+
+  const expandTreeKey = useMemo(
+    () =>
+      JSON.stringify({
+        p: projects.map((project) => project.id),
+        t: tasks.map((task) => task.id),
+      }),
+    [projects, tasks],
+  );
 
   useRestoreWorkspaceSelection({
     projects,
     tasks,
     sessions,
-    // Restore must wait not only while the tree queries are pending but also
-    // while any has errored: a settled-but-failed query yields an empty list,
-    // which would make the resolver discard a valid candidate as a miss and
-    // overwrite the disk selection. Keep the loading indicator on isPending.
-    treePending: loading || error !== null,
+    treePending: !treeReady,
   });
 
-  const tasksByProjectId = useMemo(() => {
-    const grouped = new Map<string, Task[]>();
-    for (const task of tasks) {
-      if (task.type === "workflow") continue;
-      const list = grouped.get(task.projectId);
-      if (list) list.push(task);
-      else grouped.set(task.projectId, [task]);
-    }
-    return grouped;
-  }, [tasks]);
+  const nonWorkflowTasks = useMemo(
+    () => tasks.filter((task) => task.type !== "workflow"),
+    [tasks],
+  );
+  const tasksByProjectId = useStableGroupBy(nonWorkflowTasks, projectIdOfTask);
+  const sessionsByTaskId = useStableGroupBy(sessions, taskIdOfSession);
 
-  const sessionsByTaskId = useMemo(() => {
-    const grouped = new Map<string, Session[]>();
-    for (const session of sessions) {
-      const list = grouped.get(session.taskId);
-      if (list) list.push(session);
-      else grouped.set(session.taskId, [session]);
-    }
-    return grouped;
-  }, [sessions]);
-
-  const { directDraftsByProjectId, worktreeDraftsByTaskId } = useMemo(() => {
-    const direct = new Map<string, typeof visiblePlacements>();
-    const worktree = new Map<string, typeof visiblePlacements>();
-    for (const draft of visiblePlacements) {
-      const grouped =
-        draft.taskId === null
-          ? { map: direct, key: draft.projectId }
-          : { map: worktree, key: draft.taskId };
-      const list = grouped.map.get(grouped.key);
-      if (list) list.push(draft);
-      else grouped.map.set(grouped.key, [draft]);
-    }
-    return {
-      directDraftsByProjectId: direct,
-      worktreeDraftsByTaskId: worktree,
-    };
-  }, [visiblePlacements]);
-
-  const selection = useWorkspaceSelectionStore((s) => s.selection);
-  const createFocus = useWorkspaceSelectionStore((s) => s.createFocus);
-  const setCreateFocus = useWorkspaceSelectionStore((s) => s.setCreateFocus);
-  const selectTask = useWorkspaceSelectionStore((s) => s.selectTask);
-  const selectWorkflowRun = useWorkspaceSelectionStore(
-    (s) => s.selectWorkflowRun,
+  const directDraftSource = useMemo(
+    () => visiblePlacements.filter((draft) => draft.taskId === null),
+    [visiblePlacements],
+  );
+  const worktreeDraftSource = useMemo(
+    () => visiblePlacements.filter((draft) => draft.taskId !== null),
+    [visiblePlacements],
+  );
+  const directDraftsByProjectId = useStableGroupBy(
+    directDraftSource,
+    projectIdOfDraft,
+  );
+  const worktreeDraftsByTaskId = useStableGroupBy(
+    worktreeDraftSource,
+    taskIdOfDraft,
   );
 
-  const expandedProjects = useUiStore((s) => s.expandedProjects);
-  const expandedTasks = useUiStore((s) => s.expandedTasks);
-  const toggleProjectExpand = useUiStore((s) => s.toggleProjectExpand);
-  const toggleTaskExpand = useUiStore((s) => s.toggleTaskExpand);
   const setSidebarCollapsed = useUiStore((s) => s.setSidebarCollapsed);
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
   const setDialog = useUiStore((s) => s.setDialog);
-  const setDeleteTarget = useUiStore((s) => s.setDeleteTarget);
-  const updateProject = useUpdateProject();
-  const updateTask = useUpdateTask();
 
   // Subscribe to structured search data only while filtering. Equality ignores
   // attachment and timestamp churn that cannot change a title match.
@@ -308,33 +274,25 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
     tasksByProjectId,
   ]);
 
-  // Expand the initial workspace tree once while preserving later manual collapse choices.
+  // First install only: open the whole tree once. After that, trust localStorage
+  // (and wait for hydrate so a sync expand-all cannot wipe a restored collapse).
+  // Prune whenever the live tree changes so deleted ids do not linger on disk.
   useEffect(() => {
-    if (loading || initializedTreeExpansion.current) return;
-    initializedTreeExpansion.current = true;
-    useUiStore.setState((state) => ({
-      expandedProjects: new Set([
-        ...state.expandedProjects,
-        ...projects.map((project) => project.id),
-      ]),
-      expandedTasks: new Set([
-        ...state.expandedTasks,
-        ...tasks.map((task) => task.id),
-      ]),
-    }));
-  }, [loading, projects, tasks]);
-
-  const openProject = (projectId: string) => {
-    // Remember create target without selecting — composer stays on the current chat.
-    setCreateFocus({ projectId, taskId: null });
-    toggleProjectExpand(projectId);
-  };
-
-  /** Same as projects: row click only toggles; New chat follows createFocus. */
-  const openTask = (taskId: string, projectId: string) => {
-    setCreateFocus({ projectId, taskId });
-    toggleTaskExpand(taskId);
-  };
+    if (!treeReady || !uiHydrated) return;
+    const projectIds = projects.map((project) => project.id);
+    const taskIds = tasks.map((task) => task.id);
+    const ui = useUiStore.getState();
+    if (!ui.treeExpansionBootstrapped) {
+      if (initializedTreeExpansion.current) return;
+      initializedTreeExpansion.current = true;
+      ui.bootstrapTreeExpansion(projectIds, taskIds);
+      return;
+    }
+    ui.pruneTreeExpansion(projectIds, taskIds);
+    // `expandTreeKey` gates re-runs so query refetches with the same ids do not
+    // rebuild expand sets or churn subscribers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ids captured in expandTreeKey
+  }, [treeReady, uiHydrated, expandTreeKey]);
 
   /** Starts a blank chat under create focus, selection, or the first project. */
   const startNewChat = useCallback(() => {
@@ -457,249 +415,19 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
               {t("sidebar.empty")}
             </p>
           )}
-          {visibleProjects.map((project) => {
-            const projectTasks =
-              tasksByProjectId.get(project.id) ?? EMPTY_TASKS;
-            const projectSessionIds = projectTasks.flatMap((task) =>
-              (sessionsByTaskId.get(task.id) ?? EMPTY_SESSIONS).map(
-                (session) => session.id,
-              ),
-            );
-            const projectOpen =
-              expandedProjects.has(project.id) || Boolean(needle);
-            return (
-              <div key={project.id}>
-                <TreeRow
-                  depth={0}
-                  active={
-                    selection.projectId === project.id &&
-                    selection.taskId === null &&
-                    selection.sessionId === null &&
-                    selection.draftId === null &&
-                    selection.workflowRunId === null
-                  }
-                  createFocused={
-                    createFocus !== null &&
-                    createFocus.projectId === project.id &&
-                    createFocus.taskId === null &&
-                    !(
-                      selection.projectId === createFocus.projectId &&
-                      selection.taskId === createFocus.taskId
-                    )
-                  }
-                  icon={
-                    projectOpen ? (
-                      <IconFolderOpen className="size-[18px] text-muted-foreground" />
-                    ) : (
-                      <IconFolder className="size-[18px] text-muted-foreground" />
-                    )
-                  }
-                  label={project.name}
-                  expanded={projectOpen}
-                  onClick={() => openProject(project.id)}
-                  action={
-                    <SidebarCreateMenu
-                      projectId={project.id}
-                      onNewTask={(projectId) => {
-                        startSessionDraft({ projectId, taskId: null });
-                      }}
-                    />
-                  }
-                  onRename={(name) =>
-                    updateProject.mutateAsync({ project, name })
-                  }
-                  commands={[
-                    {
-                      label: t("common.delete"),
-                      icon: <IconTrash />,
-                      variant: "destructive",
-                      onSelect: () =>
-                        setDeleteTarget({
-                          kind: "project",
-                          id: project.id,
-                          name: project.name,
-                          sessionIds: projectSessionIds,
-                        }),
-                    },
-                  ]}
-                />
-                <TreeBranch expanded={projectOpen}>
-                  <ProjectWorkflowRunRows
-                    projectId={project.id}
-                    activeRunId={
-                      selection.projectId === project.id
-                        ? selection.workflowRunId
-                        : null
-                    }
-                    onSelectRun={(runId) =>
-                      selectWorkflowRun(runId, project.id)
-                    }
-                    onDeleteRun={(run) =>
-                      setDeleteTarget({
-                        kind: "workflowRun",
-                        id: run.id,
-                        name: run.name,
-                        projectId: project.id,
-                      })
-                    }
-                  />
-                  {(directDraftsByProjectId.get(project.id) ?? []).map(
-                    (draft) => (
-                      <DraftSessionTreeRow
-                        key={draft.id}
-                        draftId={draft.id}
-                        depth={1}
-                      />
-                    ),
-                  )}
-                  {projectTasks.map((task) => {
-                    const taskSessions =
-                      sessionsByTaskId.get(task.id) ?? EMPTY_SESSIONS;
-                    const taskOpen =
-                      expandedTasks.has(task.id) || Boolean(needle);
-                    if (task.workspaceMode === "project_root") {
-                      const directSession = taskSessions[0];
-                      if (directSession) {
-                        return (
-                          <SessionTreeRow
-                            key={task.id}
-                            sessionId={directSession.id}
-                            taskId={task.id}
-                            projectId={project.id}
-                            depth={1}
-                            title={
-                              directSession.title ?? t("sidebar.newSession")
-                            }
-                            deleteAs="task"
-                            workspaceMode={task.workspaceMode}
-                          />
-                        );
-                      }
-                      return (
-                        <TreeRow
-                          key={task.id}
-                          depth={1}
-                          active={selection.taskId === task.id}
-                          icon={
-                            <IconMessageCircle
-                              className="size-4 text-muted-foreground"
-                              aria-label={t("sidebar.directChatTask")}
-                            />
-                          }
-                          label={task.title}
-                          onClick={() => selectTask(task.id, task.projectId)}
-                          onRename={(name) =>
-                            updateTask.mutateAsync({
-                              task,
-                              title: name,
-                            })
-                          }
-                          commands={[
-                            {
-                              label: t("common.delete"),
-                              icon: <IconTrash />,
-                              variant: "destructive",
-                              onSelect: () =>
-                                setDeleteTarget({
-                                  kind: "task",
-                                  id: task.id,
-                                  name: task.title,
-                                  workspaceMode: task.workspaceMode,
-                                  sessionIds: [],
-                                }),
-                            },
-                          ]}
-                        />
-                      );
-                    }
-                    return (
-                      <div key={task.id}>
-                        <TreeRow
-                          depth={1}
-                          active={
-                            selection.taskId === task.id &&
-                            selection.sessionId === null &&
-                            selection.draftId === null
-                          }
-                          createFocused={
-                            createFocus?.taskId === task.id &&
-                            !(
-                              selection.projectId === createFocus.projectId &&
-                              selection.taskId === createFocus.taskId
-                            )
-                          }
-                          icon={
-                            <IconGitBranch
-                              className="size-4 text-muted-foreground"
-                              aria-label={t("sidebar.worktreeTask")}
-                            />
-                          }
-                          label={task.title}
-                          expanded={taskOpen}
-                          onClick={() => openTask(task.id, task.projectId)}
-                          action={
-                            <NewSessionButton
-                              onClick={() =>
-                                startSessionDraft({
-                                  projectId: task.projectId,
-                                  taskId: task.id,
-                                })
-                              }
-                            />
-                          }
-                          onRename={(name) =>
-                            updateTask.mutateAsync({
-                              task,
-                              title: name,
-                            })
-                          }
-                          commands={[
-                            {
-                              label: t("common.delete"),
-                              icon: <IconTrash />,
-                              variant: "destructive",
-                              onSelect: () =>
-                                setDeleteTarget({
-                                  kind: "task",
-                                  id: task.id,
-                                  name: task.title,
-                                  workspaceMode: task.workspaceMode,
-                                  sessionIds: taskSessions.map(
-                                    (session) => session.id,
-                                  ),
-                                }),
-                            },
-                          ]}
-                        />
-                        <TreeBranch expanded={taskOpen}>
-                          {(worktreeDraftsByTaskId.get(task.id) ?? []).map(
-                            (draft) => (
-                              <DraftSessionTreeRow
-                                key={draft.id}
-                                draftId={draft.id}
-                                depth={2}
-                              />
-                            ),
-                          )}
-                          {taskSessions.map((session) => (
-                            <SessionTreeRow
-                              key={session.id}
-                              sessionId={session.id}
-                              taskId={task.id}
-                              projectId={project.id}
-                              depth={2}
-                              title={session.title ?? t("sidebar.newSession")}
-                              deleteAs="session"
-                            />
-                          ))}
-                        </TreeBranch>
-                      </div>
-                    );
-                  })}
-                </TreeBranch>
-              </div>
-            );
-          })}
+          {visibleProjects.map((project) => (
+            <ProjectTreeNode
+              key={project.id}
+              project={project}
+              tasks={tasksByProjectId.get(project.id) ?? EMPTY_TASKS}
+              sessionsByTaskId={sessionsByTaskId}
+              directDrafts={
+                directDraftsByProjectId.get(project.id) ?? EMPTY_DRAFTS
+              }
+              worktreeDraftsByTaskId={worktreeDraftsByTaskId}
+              forceExpanded={Boolean(needle)}
+            />
+          ))}
         </nav>
 
         {error && (
@@ -718,351 +446,6 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
           />
         </div>
       </aside>
-    </>
-  );
-}
-
-/**
- * Animates a level of the tree open and closed.
- *
- * Driven by the shared Collapsible rather than a hand-rolled height, because the
- * same sidebar ships to the desktop shell and the browser: both put it on WebKit,
- * where animating a `0fr`/`1fr` grid track is far less dependable than the pixel
- * height Base UI measures into `--collapsible-panel-height`.
- *
- * The rows carry their own selection state, so the row button stays the control
- * and this stays a controlled panel with no Trigger of its own.
- *
- * Follows the height pattern established by the shared Accordion. Note that
- * tw-animate-css's `animate-collapsible-*` classes cannot stand in here: their
- * keyframes read Radix/Bits/Reka/Kobalte height variables, none of which Base UI
- * sets, so they would silently fall back to `height: auto` and never animate.
- */
-function TreeBranch({
-  expanded,
-  children,
-}: {
-  expanded: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <Collapsible open={expanded}>
-      <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height,opacity] duration-200 ease-out data-ending-style:h-0 data-ending-style:opacity-0 data-starting-style:h-0 data-starting-style:opacity-0">
-        {children}
-      </CollapsibleContent>
-    </Collapsible>
-  );
-}
-
-interface TreeRowCommand {
-  label: string;
-  icon: React.ReactNode;
-  variant?: "destructive";
-  /** Renders a divider above this item, matching session-row delete placement. */
-  separatorBefore?: boolean;
-  onSelect: () => void;
-}
-
-interface TreeRowProps {
-  depth: 0 | 1 | 2;
-  active: boolean;
-  /**
-   * Soft highlight for create-focus rows that are not the live selection — shows
-   * where New chat will land without implying the composer already switched.
-   */
-  createFocused?: boolean;
-  icon: React.ReactNode;
-  label: string;
-  meta?: string;
-  expanded?: boolean;
-  onClick: () => void;
-  /** Hover-only plus (create under a project or a new session under a worktree). */
-  action?: React.ReactNode;
-  /** Persists the inline rename; same editor as session rows. */
-  onRename: (name: string) => Promise<unknown>;
-  /** Right-click actions after Rename; overflow `···` menus are intentionally not used. */
-  commands: TreeRowCommand[];
-}
-
-/**
- * One navigation row: click selects/toggles, right-click opens commands.
- *
- * The context-menu trigger wraps only the label so the hover plus can host its
- * own dropdown without nesting menus. A nested native button inside Base UI's
- * default trigger would swallow `contextmenu` in the Tauri WebKit/WebView2 shells.
- */
-function TreeRow({
-  depth,
-  active,
-  createFocused = false,
-  icon,
-  label,
-  meta,
-  expanded,
-  onClick,
-  action,
-  onRename,
-  commands,
-}: TreeRowProps) {
-  const { t } = useTranslation();
-  const {
-    renaming,
-    draft,
-    setDraft,
-    inputRef,
-    restoreMenuFocus,
-    beginRename,
-    onInputKeyDown,
-    onInputBlur,
-    maxLength,
-  } = useInlineTreeRename({ value: label, onCommit: onRename });
-
-  // Conditional class names are composed with `cn` instead of a nested ternary
-  // so each branch reads as a standalone predicate, matching the rest of the UI.
-  const rowTone = cn(
-    "group/tree flex h-9 items-center rounded-md transition-colors",
-    active && "bg-sidebar-accent text-sidebar-accent-foreground",
-    !active &&
-      createFocused &&
-      "bg-sidebar-accent/45 text-sidebar-foreground ring-1 ring-inset ring-sidebar-accent/60",
-    !active && !createFocused && "hover:bg-sidebar-accent/70",
-  );
-
-  return (
-    <div
-      className={rowTone}
-      data-create-focus={createFocused && !active ? "true" : undefined}
-    >
-      <ContextMenu>
-        <ContextMenuTrigger
-          render={
-            <div
-              className="flex h-full min-w-0 flex-1 items-center"
-              onContextMenu={(event) => event.preventDefault()}
-            />
-          }
-        >
-          {renaming ? (
-            <div
-              className="flex h-full min-w-0 flex-1 items-center gap-2"
-              style={{ paddingLeft: `${8 + depth * 18}px` }}
-            >
-              <span className="flex size-[18px] shrink-0 items-center justify-center">
-                {icon}
-              </span>
-              <Input
-                ref={inputRef}
-                value={draft}
-                maxLength={maxLength}
-                aria-label={t("sidebar.rename")}
-                className="h-7 flex-1 border-transparent bg-background px-1.5 text-[13px] shadow-none"
-                onChange={(event) => setDraft(event.target.value)}
-                onClick={(event) => event.stopPropagation()}
-                onKeyDown={onInputKeyDown}
-                onBlur={onInputBlur}
-              />
-            </div>
-          ) : (
-            <div
-              role="button"
-              tabIndex={0}
-              onClick={onClick}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter" && event.key !== " ") return;
-                event.preventDefault();
-                onClick();
-              }}
-              aria-expanded={expanded}
-              className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md text-left text-[13px] outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              style={{ paddingLeft: `${8 + depth * 18}px` }}
-            >
-              <span className="relative flex size-[18px] shrink-0 items-center justify-center">
-                <span
-                  className={`flex items-center justify-center transition-opacity duration-100 ${expanded === undefined ? "" : "group-hover/tree:opacity-0"}`}
-                >
-                  {icon}
-                </span>
-                {expanded !== undefined &&
-                  (expanded ? (
-                    <IconChevronDown className="absolute size-4 opacity-0 transition-opacity duration-100 group-hover/tree:opacity-100" />
-                  ) : (
-                    <IconChevronRight className="absolute size-4 opacity-0 transition-opacity duration-100 group-hover/tree:opacity-100" />
-                  ))}
-              </span>
-              <span className="min-w-0 flex-1 truncate font-medium">
-                {label}
-              </span>
-              {meta && (
-                <span
-                  className={`truncate text-[11px] ${active ? "text-sidebar-accent-foreground/80" : "text-amber-700 dark:text-amber-300"}`}
-                >
-                  {meta}
-                </span>
-              )}
-            </div>
-          )}
-        </ContextMenuTrigger>
-        {/* Rename suppresses restore so the editor keeps focus; other actions still return it. */}
-        <ContextMenuContent
-          className="w-44"
-          finalFocus={() => restoreMenuFocus.current}
-        >
-          <ContextMenuItem onClick={beginRename}>
-            <IconPencil />
-            {t("sidebar.rename")}
-          </ContextMenuItem>
-          {commands.map((command) => (
-            <Fragment key={command.label}>
-              {command.separatorBefore ? <ContextMenuSeparator /> : null}
-              <ContextMenuItem
-                variant={command.variant}
-                onClick={command.onSelect}
-              >
-                {command.icon}
-                {command.label}
-              </ContextMenuItem>
-            </Fragment>
-          ))}
-        </ContextMenuContent>
-      </ContextMenu>
-      {action && !renaming && (
-        <div className="mr-1 flex items-center opacity-0 transition-opacity duration-100 group-hover/tree:opacity-100 group-focus-within/tree:opacity-100">
-          {action}
-        </div>
-      )}
-    </div>
-  );
-}
-
-/**
- * Placeholder archive control until persistence ships.
- * Same toast as session rows so every tree leaf exposes the same control.
- */
-function ArchiveButton() {
-  const { t } = useTranslation();
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      aria-label={t("sidebar.archive")}
-      onClick={(event) => {
-        event.stopPropagation();
-        toast(t("sidebar.archiveSoon"));
-      }}
-    >
-      <IconArchive />
-    </Button>
-  );
-}
-
-/**
- * Hover plus on a worktree: mint/focus a draft under that branch without
- * toggling the row's expand state.
- */
-function NewSessionButton({ onClick }: { onClick: () => void }) {
-  const { t } = useTranslation();
-  return (
-    <Button
-      variant="ghost"
-      size="icon-sm"
-      aria-label={t("sidebar.newSession")}
-      onClick={(event) => {
-        // The row underneath toggles expansion; opening the composer should not.
-        event.stopPropagation();
-        onClick();
-      }}
-    >
-      <IconPlus />
-    </Button>
-  );
-}
-
-/** Status dot color for sidebar GraphWorkflowRun rows. */
-function runStatusClass(status: GraphWorkflowRunStatus): string {
-  switch (status) {
-    case "running":
-      return "bg-sky-500";
-    case "awaiting_input":
-      return "bg-amber-500";
-    case "succeeded":
-      return "bg-emerald-500";
-    case "failed":
-      return "bg-rose-500";
-    case "cancelled":
-      return "bg-zinc-400";
-    case "pending":
-      return "bg-amber-400";
-  }
-}
-
-/** Per-project run list so each row can call useGraphWorkflowRuns without hook-in-loop. */
-function ProjectWorkflowRunRows({
-  projectId,
-  activeRunId,
-  onSelectRun,
-  onDeleteRun,
-}: {
-  projectId: string;
-  activeRunId: string | null;
-  onSelectRun: (runId: string) => void;
-  onDeleteRun: (run: { id: string; name: string }) => void;
-}) {
-  const { t } = useTranslation();
-  const runsQuery = useWorkflowRunsByProject(projectId);
-  const renameWorkflowRun = useRenameWorkflowRun();
-  const runs = runsQuery.data ?? [];
-  return (
-    <>
-      {runs.map((run) => {
-        // The backend derives `awaitingInput` on the wire while the display model spells it
-        // `awaiting_input`; normalize so the sidebar dot and label match the run detail.
-        const displayStatus: GraphWorkflowRunStatus =
-          run.status === "awaitingInput" ? "awaiting_input" : run.status;
-        return (
-          <TreeRow
-            key={run.id}
-            depth={1}
-            active={activeRunId === run.id}
-            icon={
-              <span className="relative flex size-[18px] items-center justify-center">
-                <IconRoute
-                  className="size-4 text-muted-foreground"
-                  aria-hidden
-                />
-                <span
-                  className={`absolute -right-0.5 -top-0.5 size-1.5 rounded-full ${runStatusClass(displayStatus)}`}
-                  aria-label={t(`workflowRun.status.${displayStatus}`)}
-                />
-              </span>
-            }
-            label={run.name}
-            onClick={() => onSelectRun(run.id)}
-            action={<ArchiveButton />}
-            onRename={(name) =>
-              renameWorkflowRun.mutateAsync({
-                runId: run.id,
-                name,
-                projectId,
-              })
-            }
-            commands={[
-              {
-                label: t("sidebar.archive"),
-                icon: <IconArchive />,
-                onSelect: () => toast(t("sidebar.archiveSoon")),
-              },
-              {
-                label: t("common.delete"),
-                icon: <IconTrash />,
-                variant: "destructive",
-                separatorBefore: true,
-                onSelect: () => onDeleteRun({ id: run.id, name: run.name }),
-              },
-            ]}
-          />
-        );
-      })}
     </>
   );
 }

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.tsx
@@ -32,6 +32,7 @@ import { useRestoreWorkspaceSelection } from "../../state/hooks/use-restore-work
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { usePersistHydrated } from "../../state/hooks/use-persist-hydrated";
 import { useUiStore } from "../../state/stores/ui-store";
+import { useReviewStore } from "../../state/stores/review-store";
 import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
 import {
   draftPlacements,
@@ -289,6 +290,9 @@ export function WorkspaceSidebar({ user, onSignOut }: WorkspaceSidebarProps) {
       return;
     }
     ui.pruneTreeExpansion(projectIds, taskIds);
+    // Same lifetime for the per-scope review layout: a deleted project or task
+    // must not keep its open/tab/width/preview entry on disk forever.
+    useReviewStore.getState().pruneContexts(projectIds, taskIds);
     // `expandTreeKey` gates re-runs so query refetches with the same ids do not
     // rebuild expand sets or churn subscribers.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- ids captured in expandTreeKey

--- a/packages/app-shell/src/features/workspace/workspace-tree-row.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-tree-row.tsx
@@ -1,0 +1,410 @@
+import {
+  Fragment,
+  memo,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  Input,
+  toast,
+} from "@ora/ui";
+import {
+  IconArchive,
+  IconChevronDown,
+  IconChevronRight,
+  IconPencil,
+  IconPlus,
+  IconRoute,
+  IconTrash,
+} from "@tabler/icons-react";
+import type { GraphWorkflowRunStatus } from "@ora/workflow-runtime";
+import {
+  useRenameWorkflowRun,
+  useWorkflowRunsByProject,
+} from "../../state/hooks/use-workflow-runs";
+import { useInlineTreeRename } from "./use-inline-tree-rename";
+
+/**
+ * Mounts branch children while open; after the user reopens once, keeps them
+ * mounted (hidden) on collapse so session rows and workflow queries do not
+ * remount and flash.
+ *
+ * The first open→collapse cycle still unmounts so first-run expand-all does
+ * not pin every subtree in memory. Search-forced expansion passes
+ * `retainWhenCollapsed={false}` so clearing the query drops matching branches.
+ */
+export function TreeBranch({
+  expanded,
+  children,
+  retainWhenCollapsed = true,
+}: {
+  expanded: boolean;
+  children: ReactNode;
+  /** When false, collapse always unmounts (search-forced expansion). */
+  retainWhenCollapsed?: boolean;
+}) {
+  const [sticky, setSticky] = useState(false);
+  const wasExpandedRef = useRef(expanded);
+  const hadOpenBeforeRef = useRef(false);
+
+  useEffect(() => {
+    if (!retainWhenCollapsed) {
+      wasExpandedRef.current = expanded;
+      if (expanded) hadOpenBeforeRef.current = true;
+      return;
+    }
+    if (expanded) {
+      if (!wasExpandedRef.current && hadOpenBeforeRef.current) {
+        setSticky(true);
+      }
+      hadOpenBeforeRef.current = true;
+    }
+    wasExpandedRef.current = expanded;
+  }, [expanded, retainWhenCollapsed]);
+
+  if (!retainWhenCollapsed) {
+    if (!expanded) return null;
+    return <>{children}</>;
+  }
+
+  if (expanded) return <>{children}</>;
+  if (!sticky) return null;
+  return (
+    <div hidden inert>
+      {children}
+    </div>
+  );
+}
+
+interface TreeRowCommand {
+  label: string;
+  icon: ReactNode;
+  variant?: "destructive";
+  /** Renders a divider above this item, matching session-row delete placement. */
+  separatorBefore?: boolean;
+  onSelect: () => void;
+}
+
+interface TreeRowProps {
+  depth: 0 | 1 | 2;
+  active: boolean;
+  /**
+   * Soft highlight when a descendant leaf is selected but this branch is
+   * collapsed — keeps the open chat discoverable without changing expand state
+   * or the real selection.
+   */
+  containsSelection?: boolean;
+  /**
+   * Soft highlight for create-focus rows that are not the live selection — shows
+   * where New chat will land without implying the composer already switched.
+   */
+  createFocused?: boolean;
+  icon: ReactNode;
+  label: string;
+  meta?: string;
+  expanded?: boolean;
+  onClick: () => void;
+  /** Hover-only plus (create under a project or a new session under a worktree). */
+  action?: ReactNode;
+  /** Persists the inline rename; same editor as session rows. */
+  onRename: (name: string) => Promise<unknown>;
+  /** Right-click actions after Rename; overflow `···` menus are intentionally not used. */
+  commands: TreeRowCommand[];
+}
+
+/**
+ * One navigation row: click selects/toggles, right-click opens commands.
+ *
+ * The context-menu trigger wraps only the label so the hover plus can host its
+ * own dropdown without nesting menus. A nested native button inside Base UI's
+ * default trigger would swallow `contextmenu` in the Tauri WebKit/WebView2 shells.
+ */
+export function TreeRow({
+  depth,
+  active,
+  containsSelection = false,
+  createFocused = false,
+  icon,
+  label,
+  meta,
+  expanded,
+  onClick,
+  action,
+  onRename,
+  commands,
+}: TreeRowProps) {
+  const { t } = useTranslation();
+  const {
+    renaming,
+    draft,
+    setDraft,
+    inputRef,
+    restoreMenuFocus,
+    beginRename,
+    onInputKeyDown,
+    onInputBlur,
+    maxLength,
+  } = useInlineTreeRename({ value: label, onCommit: onRename });
+
+  // True leaf selection and collapsed-ancestor hint share the same selected
+  // chrome; create-focus stays softer so New-chat targeting never looks live.
+  const selected = active || containsSelection;
+  const rowTone = selected
+    ? "bg-sidebar-accent text-sidebar-accent-foreground"
+    : createFocused
+      ? "bg-sidebar-accent/45 text-sidebar-foreground ring-1 ring-inset ring-sidebar-accent/60"
+      : "hover:bg-sidebar-accent/70";
+
+  return (
+    <div
+      className={`group/tree flex h-9 items-center rounded-md transition-colors ${rowTone}`}
+      data-selection-hint={containsSelection && !active ? "true" : undefined}
+      data-create-focus={createFocused && !selected ? "true" : undefined}
+    >
+      <ContextMenu>
+        <ContextMenuTrigger
+          render={
+            <div
+              className="flex h-full min-w-0 flex-1 items-center"
+              onContextMenu={(event) => event.preventDefault()}
+            />
+          }
+        >
+          {renaming ? (
+            <div
+              className="flex h-full min-w-0 flex-1 items-center gap-2"
+              style={{ paddingLeft: `${8 + depth * 18}px` }}
+            >
+              <span className="flex size-[18px] shrink-0 items-center justify-center">
+                {icon}
+              </span>
+              <Input
+                ref={inputRef}
+                value={draft}
+                maxLength={maxLength}
+                aria-label={t("sidebar.rename")}
+                className="h-7 flex-1 border-transparent bg-background px-1.5 text-[13px] shadow-none"
+                onChange={(event) => setDraft(event.target.value)}
+                onClick={(event) => event.stopPropagation()}
+                onKeyDown={onInputKeyDown}
+                onBlur={onInputBlur}
+              />
+            </div>
+          ) : (
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={onClick}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter" && event.key !== " ") return;
+                event.preventDefault();
+                onClick();
+              }}
+              aria-expanded={expanded}
+              className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md text-left text-[13px] outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              style={{ paddingLeft: `${8 + depth * 18}px` }}
+            >
+              <span className="relative flex size-[18px] shrink-0 items-center justify-center">
+                <span
+                  className={`flex items-center justify-center transition-opacity duration-100 ${expanded === undefined ? "" : "group-hover/tree:opacity-0"}`}
+                >
+                  {icon}
+                </span>
+                {expanded !== undefined &&
+                  (expanded ? (
+                    <IconChevronDown className="absolute size-4 opacity-0 transition-opacity duration-100 group-hover/tree:opacity-100" />
+                  ) : (
+                    <IconChevronRight className="absolute size-4 opacity-0 transition-opacity duration-100 group-hover/tree:opacity-100" />
+                  ))}
+              </span>
+              <span className="min-w-0 flex-1 truncate font-medium">
+                {label}
+              </span>
+              {meta && (
+                <span
+                  className={`truncate text-[11px] ${active ? "text-sidebar-accent-foreground/80" : "text-amber-700 dark:text-amber-300"}`}
+                >
+                  {meta}
+                </span>
+              )}
+            </div>
+          )}
+        </ContextMenuTrigger>
+        {/* Rename suppresses restore so the editor keeps focus; other actions still return it. */}
+        <ContextMenuContent
+          className="w-44"
+          finalFocus={() => restoreMenuFocus.current}
+        >
+          <ContextMenuItem onClick={beginRename}>
+            <IconPencil />
+            {t("sidebar.rename")}
+          </ContextMenuItem>
+          {commands.map((command) => (
+            <Fragment key={command.label}>
+              {command.separatorBefore ? <ContextMenuSeparator /> : null}
+              <ContextMenuItem
+                variant={command.variant}
+                onClick={command.onSelect}
+              >
+                {command.icon}
+                {command.label}
+              </ContextMenuItem>
+            </Fragment>
+          ))}
+        </ContextMenuContent>
+      </ContextMenu>
+      {action && !renaming && (
+        <div className="mr-1 flex items-center opacity-0 transition-opacity duration-100 group-hover/tree:opacity-100 group-focus-within/tree:opacity-100">
+          {action}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Placeholder archive control until persistence ships.
+ * Same toast as session rows so every tree leaf exposes the same control.
+ */
+function ArchiveButton() {
+  const { t } = useTranslation();
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      aria-label={t("sidebar.archive")}
+      onClick={(event) => {
+        event.stopPropagation();
+        toast(t("sidebar.archiveSoon"));
+      }}
+    >
+      <IconArchive />
+    </Button>
+  );
+}
+
+/**
+ * Hover plus on a worktree: mint/focus a draft under that branch without
+ * toggling the row's expand state.
+ */
+export function NewSessionButton({ onClick }: { onClick: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      aria-label={t("sidebar.newSession")}
+      onClick={(event) => {
+        // The row underneath toggles expansion; opening the composer should not.
+        event.stopPropagation();
+        onClick();
+      }}
+    >
+      <IconPlus />
+    </Button>
+  );
+}
+
+/** Status dot color for sidebar GraphWorkflowRun rows. */
+function runStatusClass(status: GraphWorkflowRunStatus): string {
+  switch (status) {
+    case "running":
+      return "bg-sky-500";
+    case "awaiting_input":
+      return "bg-amber-500";
+    case "succeeded":
+      return "bg-emerald-500";
+    case "failed":
+      return "bg-rose-500";
+    case "cancelled":
+      return "bg-zinc-400";
+    case "pending":
+      return "bg-amber-400";
+  }
+}
+
+/** Per-project run list so each row can call useGraphWorkflowRuns without hook-in-loop. */
+export const ProjectWorkflowRunRows = memo(function ProjectWorkflowRunRows({
+  projectId,
+  activeRunId,
+  onSelectRun,
+  onDeleteRun,
+  listEnabled = true,
+}: {
+  projectId: string;
+  activeRunId: string | null;
+  onSelectRun: (runId: string) => void;
+  onDeleteRun: (run: { id: string; name: string }) => void;
+  /** False while the branch is collapsed so sticky keep-mount does not keep polling. */
+  listEnabled?: boolean;
+}) {
+  const { t } = useTranslation();
+  const runsQuery = useWorkflowRunsByProject(projectId, {
+    enabled: listEnabled,
+  });
+  const renameWorkflowRun = useRenameWorkflowRun();
+  const runs = runsQuery.data ?? [];
+  return (
+    <>
+      {runs.map((run) => {
+        // The backend derives `awaitingInput` on the wire while the display model spells it
+        // `awaiting_input`; normalize so the sidebar dot and label match the run detail.
+        const displayStatus: GraphWorkflowRunStatus =
+          run.status === "awaitingInput" ? "awaiting_input" : run.status;
+        return (
+          <TreeRow
+            key={run.id}
+            depth={1}
+            active={activeRunId === run.id}
+            icon={
+              <span className="relative flex size-[18px] items-center justify-center">
+                <IconRoute
+                  className="size-4 text-muted-foreground"
+                  aria-hidden
+                />
+                <span
+                  className={`absolute -right-0.5 -top-0.5 size-1.5 rounded-full ${runStatusClass(displayStatus)}`}
+                  aria-label={t(`workflowRun.status.${displayStatus}`)}
+                />
+              </span>
+            }
+            label={run.name}
+            onClick={() => onSelectRun(run.id)}
+            action={<ArchiveButton />}
+            onRename={(name) =>
+              renameWorkflowRun.mutateAsync({
+                runId: run.id,
+                name,
+                projectId,
+              })
+            }
+            commands={[
+              {
+                label: t("sidebar.archive"),
+                icon: <IconArchive />,
+                onSelect: () => toast(t("sidebar.archiveSoon")),
+              },
+              {
+                label: t("common.delete"),
+                icon: <IconTrash />,
+                variant: "destructive",
+                separatorBefore: true,
+                onSelect: () => onDeleteRun({ id: run.id, name: run.name }),
+              },
+            ]}
+          />
+        );
+      })}
+    </>
+  );
+});

--- a/packages/app-shell/src/features/workspace/workspace-view.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-view.tsx
@@ -1,5 +1,5 @@
 import type * as acp from "@agentclientprotocol/sdk";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@ora/ui";
 import type { AttachSessionResponse, Session, Task } from "@ora/contracts";
 import { useTranslation } from "react-i18next";
@@ -191,12 +191,17 @@ export function WorkspaceView({ userName }: WorkspaceViewProps) {
   // model picker act on. Resolving it the same way here is what lets anything
   // reported before that first send reach the screen.
   const conversationSessionId = selection.sessionId ?? warmSessionId;
-  const reviewContext: WorkspaceReviewContext =
-    task !== undefined && project !== undefined
-      ? { kind: "task", taskId: task.id, projectId: project.id }
-      : project !== undefined
-        ? { kind: "project", projectId: project.id }
-        : { kind: "none" };
+  // Memoized: WorkspaceReviewLayout keys per-scope restore off this object's
+  // identity, and this component re-renders on every streaming chat update.
+  const reviewContext = useMemo<WorkspaceReviewContext>(
+    () =>
+      task !== undefined && project !== undefined
+        ? { kind: "task", taskId: task.id, projectId: project.id }
+        : project !== undefined
+          ? { kind: "project", projectId: project.id }
+          : { kind: "none" },
+    [project, task],
+  );
   const conversation = useStore(chatStore, (state) =>
     conversationSessionId === null
       ? undefined

--- a/packages/app-shell/src/lib/group-by-stable.test.ts
+++ b/packages/app-shell/src/lib/group-by-stable.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { groupByStable } from "./group-by-stable";
+
+describe("groupByStable", () => {
+  it("reuses bucket arrays when membership and item identities are unchanged", () => {
+    const a = { id: "a", g: "1" };
+    const b = { id: "b", g: "1" };
+    const c = { id: "c", g: "2" };
+    const first = groupByStable([a, b, c], (item) => item.g);
+    const second = groupByStable([a, b, c], (item) => item.g, first);
+
+    expect(second.get("1")).toBe(first.get("1"));
+    expect(second.get("2")).toBe(first.get("2"));
+  });
+
+  it("rebuilds only the bucket whose item identity changed", () => {
+    const a = { id: "a", g: "1", title: "old" };
+    const b = { id: "b", g: "2" };
+    const first = groupByStable([a, b], (item) => item.g);
+    const a2 = { ...a, title: "new" };
+    const second = groupByStable([a2, b], (item) => item.g, first);
+
+    expect(second.get("1")).not.toBe(first.get("1"));
+    expect(second.get("2")).toBe(first.get("2"));
+  });
+});

--- a/packages/app-shell/src/lib/group-by-stable.ts
+++ b/packages/app-shell/src/lib/group-by-stable.ts
@@ -1,0 +1,35 @@
+/**
+ * Groups items by key while reusing prior bucket array identities when the
+ * bucket's item references are unchanged. Memoized tree nodes can then keep
+ * stable props across unrelated list patches (rename/delete of another branch).
+ */
+export function groupByStable<T>(
+  items: readonly T[],
+  keyOf: (item: T) => string,
+  previous?: ReadonlyMap<string, readonly T[]>,
+): Map<string, readonly T[]> {
+  const drafted = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyOf(item);
+    const bucket = drafted.get(key);
+    if (bucket) bucket.push(item);
+    else drafted.set(key, [item]);
+  }
+
+  if (previous === undefined) return drafted;
+
+  const next = new Map<string, readonly T[]>();
+  for (const [key, bucket] of drafted) {
+    const prior = previous.get(key);
+    if (
+      prior !== undefined &&
+      prior.length === bucket.length &&
+      prior.every((item, index) => item === bucket[index])
+    ) {
+      next.set(key, prior);
+    } else {
+      next.set(key, bucket);
+    }
+  }
+  return next;
+}

--- a/packages/app-shell/src/lib/use-stable-group-by.ts
+++ b/packages/app-shell/src/lib/use-stable-group-by.ts
@@ -1,0 +1,26 @@
+import { useMemo, useRef } from "react";
+import { groupByStable } from "./group-by-stable";
+
+/**
+ * Groups `items` with bucket-identity reuse across updates.
+ *
+ * The previous map is read/written inside `useMemo` (not during the broad
+ * render body) so unchanged project/task buckets keep stable array identities
+ * for memoized tree nodes. Callers must pass a stable `items` reference
+ * (e.g. from `useMemo`) — inline filters would defeat both memo layers.
+ */
+export function useStableGroupBy<T>(
+  items: readonly T[],
+  keyOf: (item: T) => string,
+): Map<string, readonly T[]> {
+  const previousRef = useRef<Map<string, readonly T[]>>(new Map());
+  return useMemo(() => {
+    // react-hooks/refs: intentional cache across memoized recalculations only.
+    // eslint-disable-next-line react-hooks/refs -- previous map is a memo input, not render state
+    const previous = previousRef.current;
+    const next = groupByStable(items, keyOf, previous);
+    // eslint-disable-next-line react-hooks/refs -- store for the next items identity change
+    previousRef.current = next;
+    return next;
+  }, [items, keyOf]);
+}

--- a/packages/app-shell/src/state/hooks/use-persist-hydrated.ts
+++ b/packages/app-shell/src/state/hooks/use-persist-hydrated.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Subscribes to a zustand persist store's hydration so callers can wait for
+ * disk state before applying first-run defaults that would overwrite it.
+ */
+export function usePersistHydrated(persistApi: {
+  hasHydrated: () => boolean;
+  onFinishHydration: (fn: (state: unknown) => void) => () => void;
+}): boolean {
+  return useSyncExternalStore(
+    (onStoreChange) => persistApi.onFinishHydration(onStoreChange),
+    () => persistApi.hasHydrated(),
+    () => false,
+  );
+}

--- a/packages/app-shell/src/state/hooks/use-projects.ts
+++ b/packages/app-shell/src/state/hooks/use-projects.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useContractsClient } from "../../contracts-client-context";
 import { queryKeys } from "./query-keys";
+import { WORKSPACE_LIST_NOTIFY_PROPS } from "./workspace-list-query";
 
 /** Loads the visible project list through the contracts client and caches it. */
 export function useProjects(options?: { enabled?: boolean }) {
@@ -10,5 +11,6 @@ export function useProjects(options?: { enabled?: boolean }) {
     queryFn: () =>
       client.project.list({}).then((response) => response.projects),
     enabled: options?.enabled ?? true,
+    notifyOnChangeProps: [...WORKSPACE_LIST_NOTIFY_PROPS],
   });
 }

--- a/packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts
+++ b/packages/app-shell/src/state/hooks/use-restore-workspace-selection.ts
@@ -1,48 +1,43 @@
-import { useEffect, useMemo, useSyncExternalStore } from "react";
+import { useEffect, useMemo } from "react";
 import type { Project, Session, Task } from "@ora/contracts";
 import { useDraftSessionsStore } from "../stores/draft-sessions-store";
-import { useUiStore } from "../stores/ui-store";
 import { useWorkspaceSelectionStore } from "../stores/workspace-selection-store";
-import { isWorkspaceSelectionEmpty } from "../stores/sanitize-workspace-selection";
 import { resolveRestoredWorkspaceSelection } from "../resolve-restored-workspace-selection";
+import { usePersistHydrated } from "./use-persist-hydrated";
 import { useWorkflowRunsByProject } from "./use-workflow-runs";
-
-/**
- * Subscribes to a zustand persist store's hydration so restore can wait for
- * disk drafts before treating a missing draft id as deleted.
- */
-function usePersistHydrated(persistApi: {
-  hasHydrated: () => boolean;
-  onFinishHydration: (fn: (state: unknown) => void) => () => void;
-}): boolean {
-  return useSyncExternalStore(
-    (onStoreChange) => persistApi.onFinishHydration(onStoreChange),
-    () => persistApi.hasHydrated(),
-    () => false,
-  );
-}
 
 /**
  * Applies a validated disk selection once the workspace tree has settled.
  *
- * Must not run before projects/tasks/sessions finish their first fetch: putting
- * a session id into live selection while the sessions list is still empty would
- * look "unpersisted" to warm and open a stray provider session.
+ * Must not run before projects/tasks/sessions have **successfully** loaded:
+ * treating a failed or still-empty fetch as "session gone" would clear
+ * `pendingRestore` and persist that wipe, so the next launch has nothing left
+ * to restore (intermittent cold-start misses).
  *
  * Draft candidates also wait for `draft-sessions-store` rehydration — otherwise
  * a still-empty in-memory draft list would look like "draft deleted" and clear
  * a perfectly valid restore.
+ *
+ * Selection-store hydration is required too: until `pendingRestore` is seeded
+ * from disk, treating "null pending" as "nothing to restore" would skip the
+ * saved session entirely.
  */
 export function useRestoreWorkspaceSelection(input: {
   projects: readonly Project[];
   tasks: readonly Task[];
   sessions: readonly Session[];
-  /** True while any of the three tree queries is still pending or has errored. */
+  /**
+   * True until every tree query has `isSuccess`. Callers must not pass mere
+   * `isPending` — error/empty interim states must keep the candidate staged.
+   */
   treePending: boolean;
 }): void {
   const { projects, tasks, sessions, treePending } = input;
   const pendingRestore = useWorkspaceSelectionStore((s) => s.pendingRestore);
   const draftsHydrated = usePersistHydrated(useDraftSessionsStore.persist);
+  const selectionHydrated = usePersistHydrated(
+    useWorkspaceSelectionStore.persist,
+  );
 
   const needsWorkflowRuns =
     pendingRestore !== null && pendingRestore.workflowRunId !== null;
@@ -57,30 +52,27 @@ export function useRestoreWorkspaceSelection(input: {
     // Sanitized candidates always carry a projectId with a run id. Without one
     // the by-project query stays disabled and would never leave pending.
     if (workflowProjectId === null) return [];
-    // Treat an errored run list like a still-pending one: return null so the
-    // effect keeps waiting instead of resolving against an empty error list,
-    // which would discard a valid restore candidate as a miss. A later refetch
-    // that succeeds re-runs the effect with the real list.
-    if (runsQuery.isPending || runsQuery.isError) return null;
+    // Mirror the tree gate: wait for success. An error/`data` miss must not
+    // become `[]` → resolve miss → clearPendingRestore and wipe disk.
+    if (!runsQuery.isSuccess) return null;
     return runsQuery.data ?? [];
   }, [
     needsWorkflowRuns,
     runsQuery.data,
-    runsQuery.isError,
-    runsQuery.isPending,
+    runsQuery.isSuccess,
     workflowProjectId,
   ]);
 
   useEffect(() => {
-    if (treePending || pendingRestore === null || !draftsHydrated) return;
-    if (needsWorkflowRuns && workflowRuns === null) return;
-
-    const live = useWorkspaceSelectionStore.getState().selection;
-    if (!isWorkspaceSelectionEmpty(live)) {
-      // User already navigated; keep their choice and stop retrying disk.
-      useWorkspaceSelectionStore.getState().clearPendingRestore();
+    if (
+      treePending ||
+      !draftsHydrated ||
+      !selectionHydrated ||
+      pendingRestore === null
+    ) {
       return;
     }
+    if (needsWorkflowRuns && workflowRuns === null) return;
 
     // Read drafts at apply time so keystroke updates do not re-trigger restore,
     // while still seeing the post-rehydrate list once `draftsHydrated` flips.
@@ -106,6 +98,7 @@ export function useRestoreWorkspaceSelection(input: {
     needsWorkflowRuns,
     pendingRestore,
     projects,
+    selectionHydrated,
     sessions,
     tasks,
     treePending,
@@ -113,7 +106,7 @@ export function useRestoreWorkspaceSelection(input: {
   ]);
 }
 
-/** Routes a validated selection through the store APIs and expands ancestors. */
+/** Commits a validated selection without touching expand/collapse state. */
 function applyRestoredSelection(selection: {
   projectId: string | null;
   taskId: string | null;
@@ -129,31 +122,10 @@ function applyRestoredSelection(selection: {
 
   // A tree click during restore only sets createFocus (selection stays empty).
   // Preserve that gesture so New chat still follows the row the user pointed at
-  // instead of being overwritten when select* syncs focus from the restored leaf.
+  // instead of being overwritten when restore syncs focus from the restored leaf.
   const createFocusBefore = store.createFocus;
-
-  if (selection.sessionId !== null && selection.taskId !== null) {
-    store.selectSession(
-      selection.sessionId,
-      selection.taskId,
-      selection.projectId,
-    );
-  } else if (selection.draftId !== null) {
-    store.selectDraft(selection.draftId, selection.taskId, selection.projectId);
-  } else if (selection.workflowRunId !== null) {
-    store.selectWorkflowRun(selection.workflowRunId, selection.projectId);
-  } else if (selection.taskId !== null) {
-    store.selectTask(selection.taskId, selection.projectId);
-  } else {
-    store.selectProject(selection.projectId);
-  }
-
+  store.commitRestoredSelection(selection);
   if (createFocusBefore !== null) {
     store.setCreateFocus(createFocusBefore);
-  }
-
-  useUiStore.getState().expandProject(selection.projectId);
-  if (selection.taskId !== null) {
-    useUiStore.getState().expandTask(selection.taskId);
   }
 }

--- a/packages/app-shell/src/state/hooks/use-sessions.ts
+++ b/packages/app-shell/src/state/hooks/use-sessions.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useContractsClient } from "../../contracts-client-context";
 import { queryKeys } from "./query-keys";
+import { WORKSPACE_LIST_NOTIFY_PROPS } from "./workspace-list-query";
 
 /** Loads the visible agent session list through the contracts client and caches it. */
 export function useSessions() {
@@ -9,5 +10,6 @@ export function useSessions() {
     queryKey: queryKeys.sessions,
     queryFn: () =>
       client.session.list({}).then((response) => response.sessions),
+    notifyOnChangeProps: [...WORKSPACE_LIST_NOTIFY_PROPS],
   });
 }

--- a/packages/app-shell/src/state/hooks/use-tasks.ts
+++ b/packages/app-shell/src/state/hooks/use-tasks.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useContractsClient } from "../../contracts-client-context";
 import { queryKeys } from "./query-keys";
+import { WORKSPACE_LIST_NOTIFY_PROPS } from "./workspace-list-query";
 
 /** Loads the visible task list through the contracts client and caches it. */
 export function useTasks() {
@@ -8,5 +9,6 @@ export function useTasks() {
   return useQuery({
     queryKey: queryKeys.tasks,
     queryFn: () => client.task.list({}).then((response) => response.tasks),
+    notifyOnChangeProps: [...WORKSPACE_LIST_NOTIFY_PROPS],
   });
 }

--- a/packages/app-shell/src/state/hooks/use-workflow-runs.ts
+++ b/packages/app-shell/src/state/hooks/use-workflow-runs.ts
@@ -50,15 +50,21 @@ export function useWorkflowRunsByWorkflow(
 }
 
 /** Lists the persisted workflow runs of one project. */
-export function useWorkflowRunsByProject(projectId: string | null | undefined) {
+export function useWorkflowRunsByProject(
+  projectId: string | null | undefined,
+  options?: { enabled?: boolean },
+) {
   const client = useContractsClient();
+  const enabled =
+    projectId != null && projectId !== "" && (options?.enabled ?? true);
   return useQuery({
     queryKey: runsByProjectKey(projectId ?? ""),
     queryFn: async () =>
       (await client.workflowRun.list({ projectId: projectId! })).runs,
-    enabled: projectId != null && projectId !== "",
+    enabled,
     // Completion is backend-driven with no frontend event, so poll while any run is active.
-    refetchInterval: (query) => (hasActiveRun(query.state.data) ? 4000 : false),
+    refetchInterval: (query) =>
+      enabled && hasActiveRun(query.state.data) ? 4000 : false,
   });
 }
 

--- a/packages/app-shell/src/state/hooks/use-workspace-mutations.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-workspace-mutations.test.tsx
@@ -40,10 +40,12 @@ describe("useRenameSession", () => {
       },
     ];
     const client = createMockClient(state);
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(queryKeys.sessions, state.sessions);
     const { result } = renderHookWithClient(
       () => useRenameSession(),
       client,
-      createTestQueryClient(),
+      queryClient,
     );
 
     await act(async () => {
@@ -51,10 +53,52 @@ describe("useRenameSession", () => {
     });
 
     expect(state.sessions[0]?.title).toBe("New title");
+    expect(queryClient.getQueryData(queryKeys.sessions)).toEqual([
+      expect.objectContaining({ id: "s1", title: "New title" }),
+    ]);
+    // Patch-only: do not force an active list refetch that rebuilds every row.
+    expect(queryClient.isFetching({ queryKey: queryKeys.sessions })).toBe(0);
   });
 });
 
 describe("delete mutations clear parked composer state", () => {
+  it("optimistically removes a session from the list cache", async () => {
+    const state = createMockClientState();
+    state.sessions = [
+      {
+        id: "s1",
+        taskId: "t1",
+        agentCli: "open_code",
+        status: "running",
+        title: null,
+        historyState: { type: "writable" },
+      },
+      {
+        id: "s2",
+        taskId: "t1",
+        agentCli: "open_code",
+        status: "running",
+        title: null,
+        historyState: { type: "writable" },
+      },
+    ];
+    const client = createMockClient(state);
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(queryKeys.sessions, state.sessions);
+    const { result } = renderHookWithClient(
+      () => useDeleteSession(),
+      client,
+      queryClient,
+    );
+    await act(async () => {
+      await result.current.mutateAsync({ sessionId: "s1", listSync: "defer" });
+    });
+    expect(queryClient.getQueryData(queryKeys.sessions)).toEqual([
+      expect.objectContaining({ id: "s2" }),
+    ]);
+    expect(queryClient.isFetching({ queryKey: queryKeys.sessions })).toBe(0);
+  });
+
   it("clears composer input and bound drafts when a session is deleted", async () => {
     const state = createMockClientState();
     state.sessions = [

--- a/packages/app-shell/src/state/hooks/use-workspace-mutations.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-workspace-mutations.test.tsx
@@ -68,7 +68,7 @@ describe("delete mutations clear parked composer state", () => {
       {
         id: "s1",
         taskId: "t1",
-        agentCli: "open_code",
+        agentRef: "ora-space.opencode",
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -76,7 +76,7 @@ describe("delete mutations clear parked composer state", () => {
       {
         id: "s2",
         taskId: "t1",
-        agentCli: "open_code",
+        agentRef: "ora-space.opencode",
         status: "running",
         title: null,
         historyState: { type: "writable" },

--- a/packages/app-shell/src/state/hooks/use-workspace-mutations.ts
+++ b/packages/app-shell/src/state/hooks/use-workspace-mutations.ts
@@ -12,9 +12,30 @@ import { useChatStore } from "../../chat-store-context";
 
 type QueryClient = ReturnType<typeof useQueryClient>;
 
+/**
+ * How list caches should sync after a mutation.
+ *
+ * - `immediate`: patch and mark the list stale with an active refetch — use for
+ *   standalone deletes the user just confirmed.
+ * - `defer`: patch only; a parent cascade will invalidate once at the end so
+ *   N child deletes do not thrash the sidebar N times.
+ */
+export type WorkspaceListSync = "immediate" | "defer";
+
 /** Reads the cached projects, tasks, or sessions, returning [] while data is absent. */
 function readCache<T>(queryClient: QueryClient, key: readonly string[]): T[] {
   return (queryClient.getQueryData(key) as T[] | undefined) ?? [];
+}
+
+/** Marks list queries stale; `none` skips the active refetch that rebuilds every subscriber. */
+function invalidateWorkspaceLists(
+  queryClient: QueryClient,
+  keys: readonly (readonly string[])[],
+  refetchType: "active" | "none" = "active",
+): void {
+  for (const queryKey of keys) {
+    void queryClient.invalidateQueries({ queryKey, refetchType });
+  }
 }
 
 /** Creates a project and selects it once the backend confirms the id. */
@@ -52,7 +73,12 @@ export function useUpdateProject() {
           candidate.id === project.id ? { ...project } : candidate,
         ),
       );
-      queryClient.invalidateQueries({ queryKey: queryKeys.projects });
+      // Response already applied; mark stale without refetching every subscriber.
+      invalidateWorkspaceLists(
+        queryClient,
+        [queryKeys.projects],
+        /*refetchType*/ "none",
+      );
     },
   });
 }
@@ -65,9 +91,6 @@ export function useDeleteProject() {
     mutationFn: ({ projectId }: { projectId: string }) =>
       client.project.delete({ projectId }),
     onSuccess: (_void, { projectId }) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.projects });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tasks });
-      queryClient.invalidateQueries({ queryKey: queryKeys.sessions });
       const tasks = readCache<Task>(queryClient, queryKeys.tasks);
       const taskIds = new Set(
         tasks
@@ -78,6 +101,23 @@ export function useDeleteProject() {
       const sessionIds = sessions
         .filter((session) => taskIds.has(session.taskId))
         .map((session) => session.id);
+
+      // Optimistic scrub so the sidebar drops the branch before refetch settles.
+      queryClient.setQueryData<Project[]>(queryKeys.projects, (current) =>
+        (current ?? []).filter((project) => project.id !== projectId),
+      );
+      queryClient.setQueryData<Task[]>(queryKeys.tasks, (current) =>
+        (current ?? []).filter((task) => task.projectId !== projectId),
+      );
+      queryClient.setQueryData<Session[]>(queryKeys.sessions, (current) =>
+        (current ?? []).filter((session) => !taskIds.has(session.taskId)),
+      );
+      invalidateWorkspaceLists(queryClient, [
+        queryKeys.projects,
+        queryKeys.tasks,
+        queryKeys.sessions,
+      ]);
+
       useComposerInputStore
         .getState()
         .clearKeys([
@@ -89,7 +129,6 @@ export function useDeleteProject() {
       const store = useWorkspaceSelectionStore.getState();
       const selection = store.selection;
       if (selection.projectId === projectId) {
-        // Pick the next surviving project from the stale cache; invalidate already triggered refetch.
         const projects = readCache<Project>(queryClient, queryKeys.projects);
         const next = projects.find((project) => project.id !== projectId);
         // setProject resyncs createFocus to the new selection. Preserve a
@@ -161,7 +200,11 @@ export function useUpdateTask() {
           candidate.id === task.id ? { ...task } : candidate,
         ),
       );
-      queryClient.invalidateQueries({ queryKey: queryKeys.tasks });
+      invalidateWorkspaceLists(
+        queryClient,
+        [queryKeys.tasks],
+        /*refetchType*/ "none",
+      );
     },
   });
 }
@@ -174,12 +217,22 @@ export function useDeleteTask() {
     mutationFn: ({ taskId }: { taskId: string }) =>
       client.task.delete({ taskId }),
     onSuccess: (_void, { taskId }) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.tasks });
-      queryClient.invalidateQueries({ queryKey: queryKeys.sessions });
       const sessions = readCache<Session>(queryClient, queryKeys.sessions);
       const sessionIds = sessions
         .filter((session) => session.taskId === taskId)
         .map((session) => session.id);
+
+      queryClient.setQueryData<Task[]>(queryKeys.tasks, (current) =>
+        (current ?? []).filter((task) => task.id !== taskId),
+      );
+      queryClient.setQueryData<Session[]>(queryKeys.sessions, (current) =>
+        (current ?? []).filter((session) => session.taskId !== taskId),
+      );
+      invalidateWorkspaceLists(queryClient, [
+        queryKeys.tasks,
+        queryKeys.sessions,
+      ]);
+
       useComposerInputStore
         .getState()
         .clearKeys([...sessionIds, `task:${taskId}`]);
@@ -290,10 +343,20 @@ export function useDeleteSession() {
   const client = useContractsClient();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ sessionId }: { sessionId: string }) =>
-      client.session.delete({ sessionId }),
-    onSuccess: (_void, { sessionId }) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.sessions });
+    mutationFn: ({
+      sessionId,
+    }: {
+      sessionId: string;
+      /** Parent project/task cascades pass `defer` to avoid N list refetches. */
+      listSync?: WorkspaceListSync;
+    }) => client.session.delete({ sessionId }),
+    onSuccess: (_void, { sessionId, listSync = "immediate" }) => {
+      queryClient.setQueryData<Session[]>(queryKeys.sessions, (current) =>
+        (current ?? []).filter((session) => session.id !== sessionId),
+      );
+      if (listSync === "immediate") {
+        invalidateWorkspaceLists(queryClient, [queryKeys.sessions]);
+      }
       useComposerInputStore.getState().clear(sessionId);
       useDraftSessionsStore.getState().clearReturnToForSessions([sessionId]);
       useDraftSessionsStore.getState().removeForSessions([sessionId]);
@@ -322,7 +385,11 @@ export function useRenameSession() {
           candidate.id === session.id ? { ...session } : candidate,
         ),
       );
-      void queryClient.invalidateQueries({ queryKey: queryKeys.sessions });
+      invalidateWorkspaceLists(
+        queryClient,
+        [queryKeys.sessions],
+        /*refetchType*/ "none",
+      );
     },
   });
 }

--- a/packages/app-shell/src/state/hooks/workspace-list-query.ts
+++ b/packages/app-shell/src/state/hooks/workspace-list-query.ts
@@ -3,6 +3,12 @@
  *
  * Omits fetch-status flags so a background invalidate/refetch does not wake
  * every sidebar subscriber until `data` (or error/status) actually changes.
+ *
+ * Consumers of `useProjects` / `useTasks` / `useSessions` may therefore only
+ * rely on `data`, `error`, `isPending`, `isSuccess`, `status`, and anything
+ * derived from `status` (`isError`, `isLoading`). Reading `isFetching`,
+ * `isRefetching`, `isStale`, or `fetchStatus` compiles and runs but silently
+ * stops updating — add the prop here first if a caller needs one.
  */
 export const WORKSPACE_LIST_NOTIFY_PROPS = [
   "data",

--- a/packages/app-shell/src/state/hooks/workspace-list-query.ts
+++ b/packages/app-shell/src/state/hooks/workspace-list-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared `notifyOnChangeProps` for workspace list queries.
+ *
+ * Omits fetch-status flags so a background invalidate/refetch does not wake
+ * every sidebar subscriber until `data` (or error/status) actually changes.
+ */
+export const WORKSPACE_LIST_NOTIFY_PROPS = [
+  "data",
+  "error",
+  "isPending",
+  "isSuccess",
+  "status",
+] as const;

--- a/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
@@ -21,7 +21,7 @@ const TASK: Task = {
 const SESSION: Session = {
   id: "s1",
   taskId: "t1",
-  agentCli: "open_code",
+  agentRef: "ora-space.opencode",
   status: "running",
   title: null,
   historyState: { type: "writable" },

--- a/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/resolve-restored-workspace-selection.test.ts
@@ -21,7 +21,7 @@ const TASK: Task = {
 const SESSION: Session = {
   id: "s1",
   taskId: "t1",
-  agentRef: "ora-space.opencode",
+  agentCli: "open_code",
   status: "running",
   title: null,
   historyState: { type: "writable" },

--- a/packages/app-shell/src/state/session-drafts.test.ts
+++ b/packages/app-shell/src/state/session-drafts.test.ts
@@ -25,6 +25,7 @@ beforeEach(() => {
   useUiStore.setState({
     expandedProjects: new Set(),
     expandedTasks: new Set(),
+    treeExpansionBootstrapped: false,
   });
 });
 

--- a/packages/app-shell/src/state/session-drafts.ts
+++ b/packages/app-shell/src/state/session-drafts.ts
@@ -66,6 +66,9 @@ function base64ByteLength(data: string): number {
 
 /** Expands the ancestors needed to keep a project-root or worktree draft visible. */
 function expandDraftScope(scope: DraftScope): void {
+  // A staged session restore owns layout until it commits; expanding here would
+  // reopen rows the user had collapsed before quit.
+  if (useWorkspaceSelectionStore.getState().pendingRestore !== null) return;
   useUiStore.getState().expandProject(scope.projectId);
   if (scope.taskId !== null) useUiStore.getState().expandTask(scope.taskId);
 }

--- a/packages/app-shell/src/state/session-drafts.ts
+++ b/packages/app-shell/src/state/session-drafts.ts
@@ -64,11 +64,14 @@ function base64ByteLength(data: string): number {
   return Math.max(0, Math.floor((compact.length * 3) / 4) - padding);
 }
 
-/** Expands the ancestors needed to keep a project-root or worktree draft visible. */
+/**
+ * Expands the ancestors needed to keep a project-root or worktree draft visible.
+ *
+ * Every caller runs a `select*` action first, and those clear `pendingRestore`,
+ * so by this point the user has explicitly navigated and owns the layout — no
+ * staged-restore guard is possible (or needed) here.
+ */
 function expandDraftScope(scope: DraftScope): void {
-  // A staged session restore owns layout until it commits; expanding here would
-  // reopen rows the user had collapsed before quit.
-  if (useWorkspaceSelectionStore.getState().pendingRestore !== null) return;
   useUiStore.getState().expandProject(scope.projectId);
   if (scope.taskId !== null) useUiStore.getState().expandTask(scope.taskId);
 }

--- a/packages/app-shell/src/state/stores/debounced-json-storage.test.ts
+++ b/packages/app-shell/src/state/stores/debounced-json-storage.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createDebouncedStateStorage,
+  createSafeJSONStorage,
   DEBOUNCED_PERSIST_MS,
   flushDebouncedPersistStorage,
 } from "./debounced-json-storage";
@@ -126,5 +127,37 @@ describe("createDebouncedStateStorage", () => {
 
     expect(() => window.dispatchEvent(new Event("pagehide"))).not.toThrow();
     expect(window.localStorage.getItem("healthy")).toBe("saved");
+  });
+});
+
+describe("createSafeJSONStorage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("treats corrupt JSON as a cache miss instead of rejecting", async () => {
+    window.localStorage.setItem("ora.test", "{not json");
+    const storage = createSafeJSONStorage();
+    await expect(storage.getItem("ora.test")).resolves.toBeNull();
+  });
+
+  it("skips setItem when the serialized payload is unchanged", async () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    const storage = createSafeJSONStorage();
+    const payload = { state: { n: 1 }, version: 0 };
+    storage.setItem("ora.elide", payload);
+    const writesAfterFirst = setItem.mock.calls.filter(
+      ([key]) => key === "ora.elide",
+    ).length;
+    storage.setItem("ora.elide", payload);
+    const writesAfterSecond = setItem.mock.calls.filter(
+      ([key]) => key === "ora.elide",
+    ).length;
+    expect(writesAfterSecond).toBe(writesAfterFirst);
+    setItem.mockRestore();
   });
 });

--- a/packages/app-shell/src/state/stores/debounced-json-storage.ts
+++ b/packages/app-shell/src/state/stores/debounced-json-storage.ts
@@ -110,17 +110,73 @@ export function createDebouncedStateStorage(
  * Zustand JSON persist storage that debounces disk writes while keeping memory
  * state immediate. Call `flushDebouncedPersistStorage` in tests before reading
  * `localStorage`, or rely on pagehide / visibility for production durability.
+ *
+ * Corrupt JSON is treated as a cache miss so zustand can still flip
+ * `hasHydrated` — a thrown `JSON.parse` would otherwise stall forever and
+ * block first-run bootstrap / restore gates that wait on hydration.
  */
 export function createDebouncedJSONStorage<S>(
   debounceMs: number = DEBOUNCED_PERSIST_MS,
 ): PersistStorage<S, unknown> {
-  const json = createJSONStorage<S>(() =>
+  return createSafeJSONStorage<S>(() =>
     createDebouncedStateStorage(debounceMs),
   );
+}
+
+/**
+ * `createJSONStorage` whose `getItem` never rejects, and whose `setItem` skips
+ * writes when the serialized payload is unchanged. Corrupt JSON becomes a cache
+ * miss so persist rehydrate can still flip `hasHydrated`; write elision stops
+ * dialog / no-op expand churn from hammering localStorage.
+ */
+export function createSafeJSONStorage<S>(
+  getStorage: () => StateStorage = () => window.localStorage,
+): PersistStorage<S, unknown> {
+  let base: StateStorage;
+  try {
+    base = getStorage();
+  } catch {
+    throw new Error("createJSONStorage storage unavailable");
+  }
+
+  const lastWritten = new Map<string, string>();
+  const elidingStorage: StateStorage = {
+    getItem: (name) => {
+      const value = base.getItem(name);
+      if (typeof value === "string") lastWritten.set(name, value);
+      return value;
+    },
+    setItem: (name, value) => {
+      // Skip only when memory and disk already agree. Tests (and rare host
+      // clears) can empty localStorage while the in-memory last-write cache
+      // still holds the previous payload.
+      if (lastWritten.get(name) === value && base.getItem(name) === value) {
+        return;
+      }
+      lastWritten.set(name, value);
+      base.setItem(name, value);
+    },
+    removeItem: (name) => {
+      lastWritten.delete(name);
+      base.removeItem(name);
+    },
+  };
+
+  const json = createJSONStorage<S>(() => elidingStorage);
   if (json === undefined) {
     throw new Error("createJSONStorage returned undefined");
   }
-  return json;
+  return {
+    getItem: async (name) => {
+      try {
+        return await json.getItem(name);
+      } catch {
+        return null;
+      }
+    },
+    setItem: (name, value) => json.setItem(name, value),
+    removeItem: (name) => json.removeItem(name),
+  };
 }
 
 /** Drains every registered debounced persist queue (tests + rare sync needs). */

--- a/packages/app-shell/src/state/stores/review-store.test.ts
+++ b/packages/app-shell/src/state/stores/review-store.test.ts
@@ -70,19 +70,23 @@ describe("review-store", () => {
       open: false,
       panel: "files",
       width: DEFAULT_REVIEW_WIDTH,
+      files: {},
     });
     expect(
       sanitizeReviewContextPersist({
         open: true,
         panel: "changes",
         width: 99999,
-        file: { path: "", line: "bad" },
+        files: {
+          changes: { path: "", line: "bad" },
+          files: { path: "src/keep.ts", line: 3 },
+        },
       }),
     ).toEqual({
       open: true,
       panel: "changes",
       width: clampReviewWidth(99999),
-      file: undefined,
+      files: { files: { path: "src/keep.ts", line: 3 } },
     });
   });
 
@@ -96,7 +100,7 @@ describe("review-store", () => {
               open: true,
               panel: "changes",
               width: 720,
-              file: { path: "src/main.ts", line: 12 },
+              files: { changes: { path: "src/main.ts", line: 12 } },
             },
           },
         },
@@ -110,7 +114,7 @@ describe("review-store", () => {
       open: true,
       panel: "changes",
       width: 720,
-      file: { path: "src/main.ts", line: 12 },
+      files: { changes: { path: "src/main.ts", line: 12 } },
     });
   });
 
@@ -142,6 +146,45 @@ describe("review-store", () => {
       open: true,
       panel: "changes",
       width: 640,
+      files: {},
     });
+  });
+
+  it("keeps each panel's preview independent", () => {
+    useReviewStore.getState().upsertContext("task:t1", {
+      open: true,
+      panel: "files",
+      files: { files: { path: "src/a.ts" } },
+    });
+    useReviewStore.getState().upsertContext("task:t1", {
+      panel: "changes",
+      files: { changes: { path: "src/b.ts", line: 9 } },
+    });
+    // Switching back to Files must not adopt the Changes-only path.
+    useReviewStore.getState().upsertContext("task:t1", { panel: "files" });
+
+    expect(useReviewStore.getState().byContext["task:t1"]).toEqual({
+      open: true,
+      panel: "files",
+      width: DEFAULT_REVIEW_WIDTH,
+      files: {
+        files: { path: "src/a.ts" },
+        changes: { path: "src/b.ts", line: 9 },
+      },
+    });
+  });
+
+  it("prunes scopes whose project or task no longer exists", () => {
+    useReviewStore.getState().upsertContext("project:p1", { open: true });
+    useReviewStore.getState().upsertContext("project:gone", { open: true });
+    useReviewStore.getState().upsertContext("task:t1", { open: true });
+    useReviewStore.getState().upsertContext("task:gone", { open: true });
+
+    useReviewStore.getState().pruneContexts(["p1"], ["t1"]);
+
+    expect(Object.keys(useReviewStore.getState().byContext).sort()).toEqual([
+      "project:p1",
+      "task:t1",
+    ]);
   });
 });

--- a/packages/app-shell/src/state/stores/review-store.test.ts
+++ b/packages/app-shell/src/state/stores/review-store.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildReviewFilePersist,
+  clampReviewWidth,
+  REVIEW_STORAGE_KEY,
+  reviewContextKey,
+  sanitizeReviewContextPersist,
+  useReviewStore,
+} from "./review-store";
+import { flushDebouncedPersistStorage } from "./debounced-json-storage";
+import { DEFAULT_REVIEW_WIDTH } from "../../features/workspace/workspace-review-layout-utils";
+
+beforeEach(() => {
+  flushDebouncedPersistStorage();
+  window.localStorage.clear();
+  useReviewStore.setState({ byContext: {} });
+  flushDebouncedPersistStorage();
+  window.localStorage.clear();
+});
+
+describe("review-store", () => {
+  it("builds stable keys per checkout scope", () => {
+    expect(reviewContextKey({ kind: "project", projectId: "p1" })).toBe(
+      "project:p1",
+    );
+    expect(
+      reviewContextKey({
+        kind: "task",
+        projectId: "p1",
+        taskId: "t1",
+      }),
+    ).toBe("task:t1");
+    expect(reviewContextKey({ kind: "none" })).toBeNull();
+  });
+
+  it("keeps line metadata when preview and request paths match by suffix", () => {
+    expect(
+      buildReviewFilePersist({
+        open: true,
+        panel: "changes",
+        reviewFilePath: "src/main.ts",
+        fileRequest: { path: "/repo/src/main.ts", line: 12 },
+      }),
+    ).toEqual({ path: "src/main.ts", line: 12 });
+  });
+
+  it("omits line metadata when preview and request paths do not match", () => {
+    expect(
+      buildReviewFilePersist({
+        open: true,
+        panel: "changes",
+        reviewFilePath: "src/other.ts",
+        fileRequest: { path: "src/main.ts", line: 12 },
+      }),
+    ).toEqual({ path: "src/other.ts" });
+  });
+
+  it("returns undefined when the panel is closed", () => {
+    expect(
+      buildReviewFilePersist({
+        open: false,
+        panel: "files",
+        reviewFilePath: "src/main.ts",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("clamps corrupt widths and drops invalid file paths", () => {
+    expect(sanitizeReviewContextPersist(undefined)).toEqual({
+      open: false,
+      panel: "files",
+      width: DEFAULT_REVIEW_WIDTH,
+    });
+    expect(
+      sanitizeReviewContextPersist({
+        open: true,
+        panel: "changes",
+        width: 99999,
+        file: { path: "", line: "bad" },
+      }),
+    ).toEqual({
+      open: true,
+      panel: "changes",
+      width: clampReviewWidth(99999),
+      file: undefined,
+    });
+  });
+
+  it("round-trips one context through localStorage", async () => {
+    window.localStorage.setItem(
+      REVIEW_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          byContext: {
+            "task:t1": {
+              open: true,
+              panel: "changes",
+              width: 720,
+              file: { path: "src/main.ts", line: 12 },
+            },
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    await useReviewStore.persist.rehydrate();
+
+    expect(useReviewStore.getState().byContext["task:t1"]).toEqual({
+      open: true,
+      panel: "changes",
+      width: 720,
+      file: { path: "src/main.ts", line: 12 },
+    });
+  });
+
+  it("keeps in-memory edits when async rehydrate finishes later", async () => {
+    window.localStorage.setItem(
+      REVIEW_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          byContext: {
+            "task:t1": {
+              open: false,
+              panel: "files",
+              width: DEFAULT_REVIEW_WIDTH,
+            },
+          },
+        },
+        version: 0,
+      }),
+    );
+    useReviewStore.getState().upsertContext("task:t1", {
+      open: true,
+      panel: "changes",
+      width: 640,
+    });
+
+    await useReviewStore.persist.rehydrate();
+
+    expect(useReviewStore.getState().byContext["task:t1"]).toEqual({
+      open: true,
+      panel: "changes",
+      width: 640,
+    });
+  });
+});

--- a/packages/app-shell/src/state/stores/review-store.ts
+++ b/packages/app-shell/src/state/stores/review-store.ts
@@ -1,0 +1,201 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import {
+  DEFAULT_REVIEW_WIDTH,
+  MAX_REVIEW_WIDTH,
+  MIN_REVIEW_WIDTH,
+} from "../../features/workspace/workspace-review-layout-utils";
+import { pathsMatchForWorkspace } from "../../lib/workspace-path";
+import { createDebouncedJSONStorage } from "./debounced-json-storage";
+
+export const REVIEW_STORAGE_KEY = "ora.review.v1";
+
+export type ReviewPanelKind = "changes" | "files";
+
+/** Last previewed file while the review panel was open for one checkout scope. */
+export interface ReviewFilePersist {
+  path: string;
+  line?: number;
+  column?: number;
+}
+
+export interface ReviewContextPersist {
+  open: boolean;
+  panel: ReviewPanelKind;
+  width: number;
+  file?: ReviewFilePersist;
+}
+
+interface ReviewState {
+  byContext: Record<string, ReviewContextPersist>;
+  /** Merges one checkout-scoped review snapshot onto disk. */
+  upsertContext: (
+    contextKey: string,
+    patch: Partial<ReviewContextPersist>,
+  ) => void;
+}
+
+/** Clamps a persisted review width into the live drag range. */
+export function clampReviewWidth(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_REVIEW_WIDTH;
+  }
+  return Math.min(
+    MAX_REVIEW_WIDTH,
+    Math.max(MIN_REVIEW_WIDTH, Math.round(value)),
+  );
+}
+
+function sanitizePanel(value: unknown): ReviewPanelKind {
+  return value === "changes" ? "changes" : "files";
+}
+
+function sanitizeFile(value: unknown): ReviewFilePersist | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.path !== "string" || record.path.length === 0) {
+    return undefined;
+  }
+  const line = record.line;
+  const column = record.column;
+  return {
+    path: record.path,
+    ...(typeof line === "number" && Number.isFinite(line) ? { line } : {}),
+    ...(typeof column === "number" && Number.isFinite(column)
+      ? { column }
+      : {}),
+  };
+}
+
+/** Maps an untrusted disk entry onto the review fields the layout owns. */
+export function sanitizeReviewContextPersist(
+  value: unknown,
+): ReviewContextPersist {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { open: false, panel: "files", width: DEFAULT_REVIEW_WIDTH };
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    open: record.open === true,
+    panel: sanitizePanel(record.panel),
+    width: clampReviewWidth(record.width),
+    file: sanitizeFile(record.file),
+  };
+}
+
+function sanitizeByContext(
+  value: unknown,
+): Record<string, ReviewContextPersist> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const next: Record<string, ReviewContextPersist> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof key !== "string" || key.length === 0) continue;
+    next[key] = sanitizeReviewContextPersist(entry);
+  }
+  return next;
+}
+
+/** Stable key for one project checkout or task worktree review scope. */
+export function reviewContextKey(context: {
+  kind: "none" | "project" | "task";
+  projectId?: string;
+  taskId?: string;
+}): string | null {
+  if (context.kind === "none") return null;
+  if (context.kind === "project") return `project:${context.projectId}`;
+  return `task:${context.taskId}`;
+}
+
+/** Builds the file slice written while the review panel is open. */
+export function buildReviewFilePersist(input: {
+  open: boolean;
+  panel: ReviewPanelKind;
+  reviewFilePath?: string;
+  fileRequest?: { path: string; line?: number };
+  workspaceFileRequest?: { path: string; line?: number; column?: number };
+}): ReviewFilePersist | undefined {
+  const { open, panel, reviewFilePath, fileRequest, workspaceFileRequest } =
+    input;
+  if (!open || reviewFilePath === undefined) return undefined;
+  return {
+    path: reviewFilePath,
+    ...(panel === "changes" &&
+    fileRequest?.line !== undefined &&
+    pathsMatchForWorkspace(fileRequest.path, reviewFilePath)
+      ? { line: fileRequest.line }
+      : {}),
+    ...(panel === "files" &&
+    workspaceFileRequest?.line !== undefined &&
+    pathsMatchForWorkspace(workspaceFileRequest.path, reviewFilePath)
+      ? {
+          line: workspaceFileRequest.line,
+          column: workspaceFileRequest.column,
+        }
+      : {}),
+  };
+}
+
+/**
+ * Persists the right review rail per checkout scope: open/tab/width and, when
+ * the panel was open, the last previewed file path.
+ */
+export const useReviewStore = create<ReviewState>()(
+  persist(
+    (set) => ({
+      byContext: {},
+      upsertContext: (contextKey, patch) =>
+        set((state) => {
+          const hasCurrent = contextKey in state.byContext;
+          const current =
+            state.byContext[contextKey] ??
+            sanitizeReviewContextPersist(undefined);
+          const next: ReviewContextPersist = {
+            open: patch.open ?? current.open,
+            panel:
+              patch.panel !== undefined
+                ? sanitizePanel(patch.panel)
+                : current.panel,
+            width:
+              patch.width !== undefined
+                ? clampReviewWidth(patch.width)
+                : current.width,
+            file: patch.file !== undefined ? patch.file : current.file,
+          };
+          if (
+            hasCurrent &&
+            current.open === next.open &&
+            current.panel === next.panel &&
+            current.width === next.width &&
+            current.file?.path === next.file?.path &&
+            current.file?.line === next.file?.line &&
+            current.file?.column === next.file?.column
+          ) {
+            return state;
+          }
+          return {
+            byContext: { ...state.byContext, [contextKey]: next },
+          };
+        }),
+    }),
+    {
+      name: REVIEW_STORAGE_KEY,
+      storage: createDebouncedJSONStorage(),
+      partialize: (state) => ({ byContext: state.byContext }),
+      merge: (persisted, current) => {
+        const slice =
+          typeof persisted === "object" && persisted !== null
+            ? (persisted as { byContext?: unknown })
+            : undefined;
+        const disk = sanitizeByContext(slice?.byContext);
+        return {
+          ...current,
+          byContext: { ...disk, ...current.byContext },
+        };
+      },
+    },
+  ),
+);

--- a/packages/app-shell/src/state/stores/review-store.ts
+++ b/packages/app-shell/src/state/stores/review-store.ts
@@ -19,20 +19,56 @@ export interface ReviewFilePersist {
   column?: number;
 }
 
+/**
+ * Last previewed file per panel. Keyed by panel because the two tabs browse
+ * different path spaces: Changes only knows paths present in the diff, Files
+ * knows the whole checkout. A single shared slot lets a Changes-only path (a
+ * deleted or renamed file) be replayed into the Files panel after a restart.
+ */
+export type ReviewFilesPersist = Partial<
+  Record<ReviewPanelKind, ReviewFilePersist>
+>;
+
 export interface ReviewContextPersist {
   open: boolean;
   panel: ReviewPanelKind;
   width: number;
-  file?: ReviewFilePersist;
+  files: ReviewFilesPersist;
 }
 
 interface ReviewState {
   byContext: Record<string, ReviewContextPersist>;
-  /** Merges one checkout-scoped review snapshot onto disk. */
+  /**
+   * Merges one checkout-scoped review snapshot onto disk. `files` is merged
+   * per panel, so writing the Changes preview never disturbs the Files one.
+   */
   upsertContext: (
     contextKey: string,
     patch: Partial<ReviewContextPersist>,
   ) => void;
+  /**
+   * Drops scopes whose project or task no longer exists so deleted rows do not
+   * accumulate on disk (mirrors `pruneTreeExpansion` in the UI store).
+   */
+  pruneContexts: (
+    projectIds: readonly string[],
+    taskIds: readonly string[],
+  ) => void;
+}
+
+/** True when two per-panel file slices carry the same path/line/column. */
+function reviewFilesEqual(
+  left: ReviewFilesPersist,
+  right: ReviewFilesPersist,
+): boolean {
+  const panels: readonly ReviewPanelKind[] = ["changes", "files"];
+  return panels.every((panel) => {
+    const a = left[panel];
+    const b = right[panel];
+    return (
+      a?.path === b?.path && a?.line === b?.line && a?.column === b?.column
+    );
+  });
 }
 
 /** Clamps a persisted review width into the live drag range. */
@@ -69,19 +105,38 @@ function sanitizeFile(value: unknown): ReviewFilePersist | undefined {
   };
 }
 
+/** Keeps only the per-panel entries that survive `sanitizeFile`. */
+export function sanitizeFiles(value: unknown): ReviewFilesPersist {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const record = value as Record<string, unknown>;
+  const changes = sanitizeFile(record.changes);
+  const files = sanitizeFile(record.files);
+  return {
+    ...(changes !== undefined ? { changes } : {}),
+    ...(files !== undefined ? { files } : {}),
+  };
+}
+
 /** Maps an untrusted disk entry onto the review fields the layout owns. */
 export function sanitizeReviewContextPersist(
   value: unknown,
 ): ReviewContextPersist {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return { open: false, panel: "files", width: DEFAULT_REVIEW_WIDTH };
+    return {
+      open: false,
+      panel: "files",
+      width: DEFAULT_REVIEW_WIDTH,
+      files: {},
+    };
   }
   const record = value as Record<string, unknown>;
   return {
     open: record.open === true,
     panel: sanitizePanel(record.panel),
     width: clampReviewWidth(record.width),
-    file: sanitizeFile(record.file),
+    files: sanitizeFiles(record.files),
   };
 }
 
@@ -110,7 +165,12 @@ export function reviewContextKey(context: {
   return `task:${context.taskId}`;
 }
 
-/** Builds the file slice written while the review panel is open. */
+/**
+ * Builds the file slice written while the review panel is open.
+ *
+ * The caller stores the result under the *live* panel, so a Changes path can
+ * never end up as the Files panel's restored selection.
+ */
 export function buildReviewFilePersist(input: {
   open: boolean;
   panel: ReviewPanelKind;
@@ -163,22 +223,40 @@ export const useReviewStore = create<ReviewState>()(
               patch.width !== undefined
                 ? clampReviewWidth(patch.width)
                 : current.width,
-            file: patch.file !== undefined ? patch.file : current.file,
+            // Sanitize here too: `upsertContext` is the single write door, so
+            // everything in `byContext` stays sanitized by construction rather
+            // than by convention at each call site.
+            files:
+              patch.files !== undefined
+                ? { ...current.files, ...sanitizeFiles(patch.files) }
+                : current.files,
           };
           if (
             hasCurrent &&
             current.open === next.open &&
             current.panel === next.panel &&
             current.width === next.width &&
-            current.file?.path === next.file?.path &&
-            current.file?.line === next.file?.line &&
-            current.file?.column === next.file?.column
+            reviewFilesEqual(current.files, next.files)
           ) {
             return state;
           }
           return {
             byContext: { ...state.byContext, [contextKey]: next },
           };
+        }),
+      pruneContexts: (projectIds, taskIds) =>
+        set((state) => {
+          const live = new Set([
+            ...projectIds.map((id) => `project:${id}`),
+            ...taskIds.map((id) => `task:${id}`),
+          ]);
+          const entries = Object.entries(state.byContext).filter(([key]) =>
+            live.has(key),
+          );
+          if (entries.length === Object.keys(state.byContext).length) {
+            return state;
+          }
+          return { byContext: Object.fromEntries(entries) };
         }),
     }),
     {

--- a/packages/app-shell/src/state/stores/ui-store.test.ts
+++ b/packages/app-shell/src/state/stores/ui-store.test.ts
@@ -1,16 +1,31 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useUiStore } from "./ui-store";
+import {
+  useUiStore,
+  UI_STORAGE_KEY,
+  DEFAULT_DASHBOARD_WIDTH,
+} from "./ui-store";
+import { flushDebouncedPersistStorage } from "./debounced-json-storage";
 import type { Session } from "@ora/contracts";
 
 beforeEach(() => {
+  flushDebouncedPersistStorage();
+  window.localStorage.clear();
   useUiStore.setState({
     sidebarCollapsed: false,
     settingsOpen: false,
+    dashboardOpen: false,
+    dashboardMode: "trace",
+    dashboardWidth: DEFAULT_DASHBOARD_WIDTH,
     expandedProjects: new Set<string>(),
     expandedTasks: new Set<string>(),
+    treeExpansionBootstrapped: false,
     dialog: null,
     deleteTarget: null,
   });
+  // setState enqueues a persist write; drain and clear so rehydrate tests seed
+  // localStorage without losing to a pending default snapshot.
+  flushDebouncedPersistStorage();
+  window.localStorage.clear();
 });
 
 describe("useUiStore", () => {
@@ -51,6 +66,172 @@ describe("useUiStore", () => {
     useUiStore.getState().expandTask("t1");
     useUiStore.getState().expandTask("t1");
     expect(useUiStore.getState().expandedTasks).toEqual(new Set(["t1"]));
+  });
+
+  it("bootstrapTreeExpansion seeds once and then no-ops", () => {
+    useUiStore.getState().bootstrapTreeExpansion(["p1"], ["t1"]);
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set(["p1"]));
+    expect(useUiStore.getState().expandedTasks).toEqual(new Set(["t1"]));
+    expect(useUiStore.getState().treeExpansionBootstrapped).toBe(true);
+
+    useUiStore.getState().toggleProjectExpand("p1");
+    useUiStore.getState().bootstrapTreeExpansion(["p1", "p2"], ["t1", "t2"]);
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set());
+    expect(useUiStore.getState().expandedTasks).toEqual(new Set(["t1"]));
+  });
+
+  it("marks treeExpansionBootstrapped when the user toggles a row", () => {
+    expect(useUiStore.getState().treeExpansionBootstrapped).toBe(false);
+    useUiStore.getState().toggleProjectExpand("p1");
+    expect(useUiStore.getState().treeExpansionBootstrapped).toBe(true);
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set(["p1"]));
+  });
+
+  it("pruneTreeExpansion drops ids that are no longer in the live tree", () => {
+    useUiStore.setState({
+      expandedProjects: new Set(["p1", "gone"]),
+      expandedTasks: new Set(["t1", "gone-task"]),
+      treeExpansionBootstrapped: true,
+    });
+    useUiStore.getState().pruneTreeExpansion(["p1"], ["t1"]);
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set(["p1"]));
+    expect(useUiStore.getState().expandedTasks).toEqual(new Set(["t1"]));
+  });
+
+  it("round-trips a collapsed tree through localStorage without re-expanding", async () => {
+    useUiStore.getState().bootstrapTreeExpansion(["p1", "p2"], ["t1"]);
+    useUiStore.getState().toggleProjectExpand("p1");
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set(["p2"]));
+    flushDebouncedPersistStorage();
+
+    await useUiStore.persist.rehydrate();
+    expect(useUiStore.getState().treeExpansionBootstrapped).toBe(true);
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set(["p2"]));
+    expect(useUiStore.getState().expandedTasks).toEqual(new Set(["t1"]));
+
+    useUiStore.getState().bootstrapTreeExpansion(["p1", "p2"], ["t1"]);
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set(["p2"]));
+  });
+
+  it("persists layout preferences to localStorage under the v1 key", () => {
+    useUiStore.getState().setSidebarCollapsed(true);
+    useUiStore.getState().setDashboardWidth(640);
+    useUiStore.getState().toggleProjectExpand("p1");
+    useUiStore.getState().toggleTaskExpand("t1");
+    useUiStore.getState().bootstrapTreeExpansion([], []);
+    flushDebouncedPersistStorage();
+
+    const raw = window.localStorage.getItem(UI_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as {
+      state: {
+        sidebarCollapsed: boolean;
+        dashboardWidth: number;
+        expandedProjects: string[];
+        expandedTasks: string[];
+        treeExpansionBootstrapped: boolean;
+      };
+    };
+    expect(parsed.state).toEqual({
+      sidebarCollapsed: true,
+      dashboardWidth: 640,
+      expandedProjects: ["p1"],
+      expandedTasks: ["t1"],
+      treeExpansionBootstrapped: true,
+    });
+    expect(raw!).not.toContain("settingsOpen");
+    expect(raw!).not.toContain("dialog");
+  });
+
+  it("rehydrates layout preferences and rebuilds expand Sets", async () => {
+    window.localStorage.setItem(
+      UI_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          sidebarCollapsed: true,
+          dashboardWidth: 900,
+          expandedProjects: ["p1", "p2"],
+          expandedTasks: ["t1"],
+          treeExpansionBootstrapped: true,
+        },
+        version: 0,
+      }),
+    );
+    await useUiStore.persist.rehydrate();
+    expect(useUiStore.getState().sidebarCollapsed).toBe(true);
+    expect(useUiStore.getState().dashboardWidth).toBe(900);
+    expect(useUiStore.getState().expandedProjects).toEqual(
+      new Set(["p1", "p2"]),
+    );
+    expect(useUiStore.getState().expandedTasks).toEqual(new Set(["t1"]));
+    expect(useUiStore.getState().treeExpansionBootstrapped).toBe(true);
+  });
+
+  it("keeps pre-hydration expand toggles when async rehydrate completes", async () => {
+    window.localStorage.setItem(
+      UI_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          sidebarCollapsed: false,
+          dashboardWidth: DEFAULT_DASHBOARD_WIDTH,
+          expandedProjects: ["p1"],
+          expandedTasks: [],
+          treeExpansionBootstrapped: true,
+        },
+        version: 0,
+      }),
+    );
+    useUiStore.setState({
+      sidebarCollapsed: false,
+      dashboardOpen: false,
+      dashboardMode: "trace",
+      dashboardWidth: DEFAULT_DASHBOARD_WIDTH,
+      expandedProjects: new Set(["p1"]),
+      expandedTasks: new Set(),
+      treeExpansionBootstrapped: true,
+      settingsOpen: false,
+      dialog: null,
+      deleteTarget: null,
+    });
+    useUiStore.getState().toggleProjectExpand("p1");
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set());
+
+    await useUiStore.persist.rehydrate();
+
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set());
+  });
+
+  it("clamps corrupt dashboard widths and drops non-string expand ids", async () => {
+    window.localStorage.setItem(
+      UI_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          sidebarCollapsed: "yes",
+          dashboardWidth: 99999,
+          expandedProjects: ["p1", 42, null, ""],
+          expandedTasks: "t1",
+          treeExpansionBootstrapped: 1,
+        },
+        version: 0,
+      }),
+    );
+    await useUiStore.persist.rehydrate();
+    expect(useUiStore.getState().sidebarCollapsed).toBe(false);
+    expect(useUiStore.getState().dashboardWidth).toBe(1400);
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set(["p1"]));
+    expect(useUiStore.getState().expandedTasks).toEqual(new Set());
+    expect(useUiStore.getState().treeExpansionBootstrapped).toBe(false);
+  });
+
+  it("falls back to defaults when persisted JSON is corrupt", async () => {
+    window.localStorage.setItem(UI_STORAGE_KEY, "{not json");
+    await useUiStore.persist.rehydrate();
+    expect(useUiStore.persist.hasHydrated()).toBe(true);
+    expect(useUiStore.getState().sidebarCollapsed).toBe(false);
+    expect(useUiStore.getState().dashboardWidth).toBe(DEFAULT_DASHBOARD_WIDTH);
+    expect(useUiStore.getState().expandedProjects).toEqual(new Set());
+    expect(useUiStore.getState().expandedTasks).toEqual(new Set());
+    expect(useUiStore.getState().treeExpansionBootstrapped).toBe(false);
   });
 
   it("stores the active dialog and delete target verbatim", () => {

--- a/packages/app-shell/src/state/stores/ui-store.ts
+++ b/packages/app-shell/src/state/stores/ui-store.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import type { Session, Task } from "@ora/contracts";
+import { createDebouncedJSONStorage } from "./debounced-json-storage";
 
 /** Shape of the create dialog currently driven from the workspace tree. */
 export type DialogState =
@@ -28,6 +30,13 @@ export type DeleteTarget =
 
 export type DashboardPanelMode = "trace" | "compare";
 
+export const UI_STORAGE_KEY = "ora.ui.v1";
+
+/** Matches the trace dashboard panel's drag clamp so disk values stay usable. */
+export const DEFAULT_DASHBOARD_WIDTH = 800;
+const MIN_DASHBOARD_WIDTH = 420;
+const MAX_DASHBOARD_WIDTH = 1400;
+
 interface UiState {
   sidebarCollapsed: boolean;
   settingsOpen: boolean;
@@ -37,6 +46,11 @@ interface UiState {
   dashboardWidth: number;
   expandedProjects: Set<string>;
   expandedTasks: Set<string>;
+  /**
+   * True after the first-run expand-all seed, or after the user toggles a row.
+   * Returning sessions must trust the persisted expand sets verbatim.
+   */
+  treeExpansionBootstrapped: boolean;
   dialog: DialogState | null;
   deleteTarget: DeleteTarget | null;
   setSidebarCollapsed: (collapsed: boolean) => void;
@@ -50,53 +64,233 @@ interface UiState {
   expandProject: (projectId: string) => void;
   /** Expands a task without toggling it closed (used after mutations select a child). */
   expandTask: (taskId: string) => void;
+  /**
+   * First-run only: expands every known project/task and marks expansion seeded
+   * so later restarts trust the persisted sets instead of opening the whole tree.
+   */
+  bootstrapTreeExpansion: (
+    projectIds: readonly string[],
+    taskIds: readonly string[],
+  ) => void;
+  /**
+   * Drops expand ids that no longer exist in the live tree so deleted rows do
+   * not accumulate forever on disk.
+   */
+  pruneTreeExpansion: (
+    projectIds: readonly string[],
+    taskIds: readonly string[],
+  ) => void;
   setDialog: (dialog: DialogState | null) => void;
   setDeleteTarget: (target: DeleteTarget | null) => void;
 }
 
-/** Global UI state for the app shell: sidebar folding, tree expansion, and dialog switches. */
-export const useUiStore = create<UiState>((set) => ({
-  sidebarCollapsed: false,
-  settingsOpen: false,
-  dashboardOpen: false,
-  dashboardMode: "trace",
-  dashboardWidth: 800,
-  expandedProjects: new Set<string>(),
-  expandedTasks: new Set<string>(),
-  dialog: null,
-  deleteTarget: null,
-  setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
-  setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
-  setDashboardOpen: (dashboardOpen) => set({ dashboardOpen }),
-  openDashboardPanel: (dashboardMode) =>
-    set({ dashboardMode, dashboardOpen: true }),
-  setDashboardWidth: (dashboardWidth) => set({ dashboardWidth }),
-  toggleProjectExpand: (projectId) =>
-    set((state) => {
-      const next = new Set(state.expandedProjects);
-      if (next.has(projectId)) next.delete(projectId);
-      else next.add(projectId);
-      return { expandedProjects: next };
+/** Disk shape for the UI slice — Sets become string arrays for JSON. */
+interface UiPersistSlice {
+  sidebarCollapsed?: unknown;
+  dashboardWidth?: unknown;
+  expandedProjects?: unknown;
+  expandedTasks?: unknown;
+  treeExpansionBootstrapped?: unknown;
+}
+
+/** Layout fields restored from disk (or defaults when missing/corrupt). */
+export interface UiPersistFields {
+  sidebarCollapsed: boolean;
+  dashboardWidth: number;
+  expandedProjects: Set<string>;
+  expandedTasks: Set<string>;
+  treeExpansionBootstrapped: boolean;
+}
+
+/** Keeps only non-empty string ids so corrupt disk payloads cannot poison the tree. */
+function sanitizeIdSet(value: unknown): Set<string> {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(
+    value.filter((id): id is string => typeof id === "string" && id.length > 0),
+  );
+}
+
+/** Clamps a persisted dashboard width into the panel's live drag range. */
+function sanitizeDashboardWidth(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_DASHBOARD_WIDTH;
+  }
+  return Math.min(
+    MAX_DASHBOARD_WIDTH,
+    Math.max(MIN_DASHBOARD_WIDTH, Math.round(value)),
+  );
+}
+
+/** Maps an untrusted persist slice onto the layout fields the store owns. */
+export function sanitizeUiPersistSlice(
+  slice: UiPersistSlice | undefined,
+): UiPersistFields {
+  if (slice === undefined) {
+    return {
+      sidebarCollapsed: false,
+      dashboardWidth: DEFAULT_DASHBOARD_WIDTH,
+      expandedProjects: new Set(),
+      expandedTasks: new Set(),
+      treeExpansionBootstrapped: false,
+    };
+  }
+  return {
+    sidebarCollapsed: slice.sidebarCollapsed === true,
+    dashboardWidth: sanitizeDashboardWidth(slice.dashboardWidth),
+    expandedProjects: sanitizeIdSet(slice.expandedProjects),
+    expandedTasks: sanitizeIdSet(slice.expandedTasks),
+    treeExpansionBootstrapped: slice.treeExpansionBootstrapped === true,
+  };
+}
+
+/**
+ * Reads `ora.ui.v1` synchronously so the first paint already matches the last
+ * closed layout. Async rehydrate still runs afterward and must agree.
+ */
+export function readUiPersistFromDisk(): UiPersistFields {
+  if (typeof window === "undefined") return sanitizeUiPersistSlice(undefined);
+  try {
+    const raw = window.localStorage.getItem(UI_STORAGE_KEY);
+    if (raw === null) return sanitizeUiPersistSlice(undefined);
+    const parsed = JSON.parse(raw) as { state?: UiPersistSlice };
+    return sanitizeUiPersistSlice(
+      typeof parsed.state === "object" && parsed.state !== null
+        ? parsed.state
+        : undefined,
+    );
+  } catch {
+    return sanitizeUiPersistSlice(undefined);
+  }
+}
+
+const initialPersist = readUiPersistFromDisk();
+
+/**
+ * Global UI state for the app shell: sidebar folding, tree expansion, and dialog
+ * switches. Layout preferences that should survive restart are mirrored to
+ * localStorage; transient dialogs and open panels stay memory-only.
+ */
+export const useUiStore = create<UiState>()(
+  persist(
+    (set, get) => ({
+      sidebarCollapsed: initialPersist.sidebarCollapsed,
+      settingsOpen: false,
+      dashboardOpen: false,
+      dashboardMode: "trace",
+      dashboardWidth: initialPersist.dashboardWidth,
+      expandedProjects: initialPersist.expandedProjects,
+      expandedTasks: initialPersist.expandedTasks,
+      treeExpansionBootstrapped: initialPersist.treeExpansionBootstrapped,
+      dialog: null,
+      deleteTarget: null,
+      setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
+      setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
+      setDashboardOpen: (dashboardOpen) => set({ dashboardOpen }),
+      openDashboardPanel: (dashboardMode) =>
+        set({ dashboardMode, dashboardOpen: true }),
+      setDashboardWidth: (dashboardWidth) =>
+        set({ dashboardWidth: sanitizeDashboardWidth(dashboardWidth) }),
+      toggleProjectExpand: (projectId) =>
+        set((state) => {
+          const next = new Set(state.expandedProjects);
+          if (next.has(projectId)) next.delete(projectId);
+          else next.add(projectId);
+          // A manual toggle leaves first-run defaults; never expand-all after this.
+          return {
+            expandedProjects: next,
+            treeExpansionBootstrapped: true,
+          };
+        }),
+      toggleTaskExpand: (taskId) =>
+        set((state) => {
+          const next = new Set(state.expandedTasks);
+          if (next.has(taskId)) next.delete(taskId);
+          else next.add(taskId);
+          return { expandedTasks: next, treeExpansionBootstrapped: true };
+        }),
+      expandProject: (projectId) =>
+        set((state) =>
+          state.expandedProjects.has(projectId)
+            ? state
+            : {
+                expandedProjects: new Set(state.expandedProjects).add(
+                  projectId,
+                ),
+              },
+        ),
+      expandTask: (taskId) =>
+        set((state) =>
+          state.expandedTasks.has(taskId)
+            ? state
+            : { expandedTasks: new Set(state.expandedTasks).add(taskId) },
+        ),
+      bootstrapTreeExpansion: (projectIds, taskIds) => {
+        if (get().treeExpansionBootstrapped) return;
+        set((state) => ({
+          expandedProjects: new Set([...state.expandedProjects, ...projectIds]),
+          expandedTasks: new Set([...state.expandedTasks, ...taskIds]),
+          treeExpansionBootstrapped: true,
+        }));
+      },
+      pruneTreeExpansion: (projectIds, taskIds) =>
+        set((state) => {
+          const liveProjects = new Set(projectIds);
+          const liveTasks = new Set(taskIds);
+          const expandedProjects = new Set(
+            [...state.expandedProjects].filter((id) => liveProjects.has(id)),
+          );
+          const expandedTasks = new Set(
+            [...state.expandedTasks].filter((id) => liveTasks.has(id)),
+          );
+          if (
+            expandedProjects.size === state.expandedProjects.size &&
+            expandedTasks.size === state.expandedTasks.size
+          ) {
+            return state;
+          }
+          return { expandedProjects, expandedTasks };
+        }),
+      setDialog: (dialog) => set({ dialog }),
+      setDeleteTarget: (deleteTarget) => set({ deleteTarget }),
     }),
-  toggleTaskExpand: (taskId) =>
-    set((state) => {
-      const next = new Set(state.expandedTasks);
-      if (next.has(taskId)) next.delete(taskId);
-      else next.add(taskId);
-      return { expandedTasks: next };
-    }),
-  expandProject: (projectId) =>
-    set((state) =>
-      state.expandedProjects.has(projectId)
-        ? state
-        : { expandedProjects: new Set(state.expandedProjects).add(projectId) },
-    ),
-  expandTask: (taskId) =>
-    set((state) =>
-      state.expandedTasks.has(taskId)
-        ? state
-        : { expandedTasks: new Set(state.expandedTasks).add(taskId) },
-    ),
-  setDialog: (dialog) => set({ dialog }),
-  setDeleteTarget: (deleteTarget) => set({ deleteTarget }),
-}));
+    {
+      name: UI_STORAGE_KEY,
+      storage: createDebouncedJSONStorage(),
+      partialize: (state) => ({
+        sidebarCollapsed: state.sidebarCollapsed,
+        dashboardWidth: state.dashboardWidth,
+        expandedProjects: [...state.expandedProjects],
+        expandedTasks: [...state.expandedTasks],
+        treeExpansionBootstrapped: state.treeExpansionBootstrapped,
+      }),
+      merge: (persisted, current) => {
+        const slice =
+          typeof persisted === "object" && persisted !== null
+            ? (persisted as UiPersistSlice)
+            : undefined;
+        const restored = sanitizeUiPersistSlice(slice);
+        return {
+          ...current,
+          ...restored,
+          expandedProjects: current.treeExpansionBootstrapped
+            ? current.expandedProjects
+            : restored.expandedProjects,
+          expandedTasks: current.treeExpansionBootstrapped
+            ? current.expandedTasks
+            : restored.expandedTasks,
+          treeExpansionBootstrapped:
+            current.treeExpansionBootstrapped ||
+            restored.treeExpansionBootstrapped,
+          sidebarCollapsed:
+            current.sidebarCollapsed !== initialPersist.sidebarCollapsed
+              ? current.sidebarCollapsed
+              : restored.sidebarCollapsed,
+          dashboardWidth:
+            current.dashboardWidth !== initialPersist.dashboardWidth
+              ? current.dashboardWidth
+              : restored.dashboardWidth,
+        };
+      },
+    },
+  ),
+);

--- a/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
@@ -477,7 +477,7 @@ describe("useWorkspaceSelectionStore", () => {
     });
   });
 
-  it("does not persist createFocus across rehydrate", async () => {
+  it("never writes createFocus to disk", async () => {
     useWorkspaceSelectionStore
       .getState()
       .setCreateFocus({ projectId: "p1", taskId: "t1" });
@@ -485,13 +485,30 @@ describe("useWorkspaceSelectionStore", () => {
     expect(raw).not.toBeNull();
     expect(raw!).not.toContain("createFocus");
 
+    // Rehydrate must not resurrect a focus from disk — there is none to read.
+    useWorkspaceSelectionStore.setState({
+      selection: empty,
+      pendingRestore: null,
+      createFocus: null,
+    });
+    await useWorkspaceSelectionStore.persist.rehydrate();
+    expect(useWorkspaceSelectionStore.getState().createFocus).toBeNull();
+  });
+
+  it("keeps a pre-hydration tree click's createFocus", async () => {
+    // A tree row click before hydration sets only createFocus; selection stays
+    // empty. Async rehydrate must not discard that gesture — restore relies on
+    // it still being there when it commits.
     useWorkspaceSelectionStore.setState({
       selection: empty,
       pendingRestore: null,
       createFocus: { projectId: "p1", taskId: "t1" },
     });
     await useWorkspaceSelectionStore.persist.rehydrate();
-    expect(useWorkspaceSelectionStore.getState().createFocus).toBeNull();
+    expect(useWorkspaceSelectionStore.getState().createFocus).toEqual({
+      projectId: "p1",
+      taskId: "t1",
+    });
   });
 
   it("setCreateFocus is a no-op when the focus is unchanged", () => {

--- a/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.test.ts
@@ -281,6 +281,44 @@ describe("useWorkspaceSelectionStore", () => {
     ).toBe("s1");
   });
 
+  it("keeps pre-hydration navigation when async rehydrate completes", async () => {
+    window.localStorage.setItem(
+      WORKSPACE_SELECTION_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          selection: {
+            projectId: "p1",
+            taskId: "t1",
+            sessionId: "s-old",
+            workflowRunId: null,
+            draftId: null,
+          },
+          pendingRestore: null,
+        },
+        version: 0,
+      }),
+    );
+    useWorkspaceSelectionStore.setState({
+      selection: empty,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s-old",
+        workflowRunId: null,
+        draftId: null,
+      },
+      createFocus: null,
+    });
+    useWorkspaceSelectionStore.getState().selectSession("s-new", "t1", "p1");
+
+    await useWorkspaceSelectionStore.persist.rehydrate();
+
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      "s-new",
+    );
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+  });
+
   it("sanitizes illegal session+draft combos on rehydrate", async () => {
     window.localStorage.setItem(
       WORKSPACE_SELECTION_STORAGE_KEY,
@@ -311,7 +349,50 @@ describe("useWorkspaceSelectionStore", () => {
   it("falls back to empty pendingRestore when persisted JSON is corrupt", async () => {
     window.localStorage.setItem(WORKSPACE_SELECTION_STORAGE_KEY, "{not json");
     await useWorkspaceSelectionStore.persist.rehydrate();
+    expect(useWorkspaceSelectionStore.persist.hasHydrated()).toBe(true);
     expect(useWorkspaceSelectionStore.getState().selection).toEqual(empty);
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+  });
+
+  it("lets navigation cancel a staged restore candidate", () => {
+    useWorkspaceSelectionStore.setState({
+      selection: empty,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    useWorkspaceSelectionStore.getState().selectSession("s-new", "t1", "p1");
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      "s-new",
+    );
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+  });
+
+  it("commitRestoredSelection applies the candidate and clears pendingRestore", () => {
+    useWorkspaceSelectionStore.setState({
+      selection: empty,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    useWorkspaceSelectionStore.getState().commitRestoredSelection({
+      projectId: "p1",
+      taskId: "t1",
+      sessionId: "s1",
+      workflowRunId: null,
+      draftId: null,
+    });
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      "s1",
+    );
     expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
   });
 

--- a/packages/app-shell/src/state/stores/workspace-selection-store.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.ts
@@ -300,20 +300,7 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
                 },
           );
         },
-        commitRestoredSelection: (selection) => {
-          const previousDraftId = get().selection.draftId;
-          set({
-            selection,
-            pendingRestore: null,
-            createFocus: createFocusFromSelection(selection),
-          });
-          if (
-            previousDraftId !== null &&
-            previousDraftId !== selection.draftId
-          ) {
-            useDraftSessionsStore.getState().discardIfEmpty(previousDraftId);
-          }
-        },
+        commitRestoredSelection: (selection) => replaceSelection(selection),
         clearPendingRestore: () => set({ pendingRestore: null }),
       };
     },
@@ -345,7 +332,10 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
           ...current,
           selection: EMPTY_WORKSPACE_SELECTION,
           pendingRestore: diskPending,
-          createFocus: null,
+          // A tree click before hydration sets only createFocus (selection stays
+          // empty). Clearing it here would undo the very gesture restore takes
+          // care to preserve when it commits.
+          createFocus: current.createFocus,
         };
       },
     },

--- a/packages/app-shell/src/state/stores/workspace-selection-store.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
+import { persist } from "zustand/middleware";
 import { useDraftSessionsStore } from "./draft-sessions-store";
+import { createSafeJSONStorage } from "./debounced-json-storage";
 import {
   EMPTY_WORKSPACE_SELECTION,
   isWorkspaceSelectionEmpty,
@@ -81,6 +82,11 @@ interface WorkspaceSelectionState {
   /** Replaces the project leg, clearing task/session/run (used after the selected project is deleted). */
   setProject: (projectId: string | null) => void;
   /**
+   * Applies a tree-validated restore candidate. The only path allowed to move
+   * live selection while `pendingRestore` is staged.
+   */
+  commitRestoredSelection: (selection: WorkspaceSelection) => void;
+  /**
    * Drops a consumed or abandoned restore candidate. Clears without touching
    * live selection so a user who already navigated keeps their choice.
    */
@@ -94,6 +100,47 @@ function createFocusFromSelection(
   if (selection.projectId === null) return null;
   return { projectId: selection.projectId, taskId: selection.taskId };
 }
+
+/** Builds the staged restore candidate from an untrusted disk slice. */
+export function pendingRestoreFromPersistSlice(
+  slice: Record<string, unknown> | undefined,
+): WorkspaceSelection | null {
+  const fromPending = sanitizeWorkspaceSelection(slice?.pendingRestore);
+  const fromSelection = sanitizeWorkspaceSelection(slice?.selection);
+  // Prefer an in-flight candidate (crash mid-restore) over the last live
+  // selection so a half-applied restore does not lose its intent.
+  const candidate = isWorkspaceSelectionEmpty(fromPending)
+    ? fromSelection
+    : fromPending;
+  return isWorkspaceSelectionEmpty(candidate) ? null : candidate;
+}
+
+/**
+ * Reads the selection persist key synchronously so `pendingRestore` exists on
+ * the first paint. Async rehydrate must agree; without this seed, startup
+ * chatter can select another session before the disk candidate arrives.
+ */
+export function readWorkspaceSelectionPersistFromDisk(): {
+  pendingRestore: WorkspaceSelection | null;
+} {
+  if (typeof window === "undefined") return { pendingRestore: null };
+  try {
+    const raw = window.localStorage.getItem(WORKSPACE_SELECTION_STORAGE_KEY);
+    if (raw === null) return { pendingRestore: null };
+    const parsed = JSON.parse(raw) as { state?: Record<string, unknown> };
+    return {
+      pendingRestore: pendingRestoreFromPersistSlice(
+        typeof parsed.state === "object" && parsed.state !== null
+          ? parsed.state
+          : undefined,
+      ),
+    };
+  } catch {
+    return { pendingRestore: null };
+  }
+}
+
+const initialPersist = readWorkspaceSelectionPersistFromDisk();
 
 /**
  * Owns the workspace tree selection without coupling to query data. Callers pass
@@ -113,10 +160,14 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
        * Navigation must remain responsive even if draft persistence cleanup fails.
        * Create focus follows the new selection so New chat stays coherent after
        * opening a leaf; empty selection clears focus.
+       *
+       * Explicit navigation cancels a staged disk restore. Keep `select*`
+       * responsive while restore waits on a successful tree fetch — do not
+       * hard-block here (a failed fetch would otherwise freeze the sidebar).
+       * False miss-clears are prevented by gating restore on `isSuccess`.
        */
       const replaceSelection = (selection: WorkspaceSelection): void => {
         const previousDraftId = get().selection.draftId;
-        // User navigation cancels any outstanding restore candidate.
         set({
           selection,
           pendingRestore: null,
@@ -129,7 +180,7 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
 
       return {
         selection: EMPTY_WORKSPACE_SELECTION,
-        pendingRestore: null,
+        pendingRestore: initialPersist.pendingRestore,
         createFocus: null,
         setCreateFocus: (focus) => {
           const current = get().createFocus;
@@ -249,12 +300,26 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
                 },
           );
         },
+        commitRestoredSelection: (selection) => {
+          const previousDraftId = get().selection.draftId;
+          set({
+            selection,
+            pendingRestore: null,
+            createFocus: createFocusFromSelection(selection),
+          });
+          if (
+            previousDraftId !== null &&
+            previousDraftId !== selection.draftId
+          ) {
+            useDraftSessionsStore.getState().discardIfEmpty(previousDraftId);
+          }
+        },
         clearPendingRestore: () => set({ pendingRestore: null }),
       };
     },
     {
       name: WORKSPACE_SELECTION_STORAGE_KEY,
-      storage: createJSONStorage(() => window.localStorage),
+      storage: createSafeJSONStorage(),
       // createFocus is intentionally omitted — it is a session gesture, not a restore target.
       partialize: (state) => ({
         selection: state.selection,
@@ -265,19 +330,21 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
           typeof persisted === "object" && persisted !== null
             ? (persisted as Record<string, unknown>)
             : undefined;
-        const fromPending = sanitizeWorkspaceSelection(slice?.pendingRestore);
-        const fromSelection = sanitizeWorkspaceSelection(slice?.selection);
-        // Prefer an in-flight candidate (crash mid-restore) over the last live
-        // selection so a half-applied restore does not lose its intent.
-        const candidate = isWorkspaceSelectionEmpty(fromPending)
-          ? fromSelection
-          : fromPending;
+        const diskPending = pendingRestoreFromPersistSlice(slice);
+
+        // Async rehydrate must not undo explicit navigation that happened after
+        // the sync disk seed but before `onFinishHydration`.
+        if (!isWorkspaceSelectionEmpty(current.selection)) {
+          return {
+            ...current,
+            pendingRestore: null,
+          };
+        }
+
         return {
           ...current,
           selection: EMPTY_WORKSPACE_SELECTION,
-          pendingRestore: isWorkspaceSelectionEmpty(candidate)
-            ? null
-            : candidate,
+          pendingRestore: diskPending,
           createFocus: null,
         };
       },

--- a/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
@@ -23,7 +23,7 @@ const TASK: Task = {
 const SESSION: Session = {
   id: "s1",
   taskId: "t1",
-  agentCli: "open_code",
+  agentRef: "ora-space.opencode",
   status: "running",
   title: null,
   historyState: { type: "writable" },
@@ -468,7 +468,7 @@ describe("useRestoreWorkspaceSelection", () => {
       ).toBe("run-1");
     });
     expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
-    expect(useUiStore.getState().expandedProjects.has("p1")).toBe(true);
+    expect(useUiStore.getState().expandedProjects.has("p1")).toBe(false);
   });
 
   it("waits while the workflow-run query has errored instead of discarding the candidate", async () => {
@@ -598,7 +598,7 @@ describe("useWarmSession restore gate", () => {
             taskId: "t1",
             sessionId: null,
           },
-          "open_code",
+          "ora-space.opencode",
         ),
       client,
       undefined,

--- a/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
+++ b/packages/app-shell/src/state/use-restore-workspace-selection.test.ts
@@ -23,7 +23,7 @@ const TASK: Task = {
 const SESSION: Session = {
   id: "s1",
   taskId: "t1",
-  agentRef: "ora-space.opencode",
+  agentCli: "open_code",
   status: "running",
   title: null,
   historyState: { type: "writable" },
@@ -40,6 +40,7 @@ beforeEach(() => {
   useUiStore.setState({
     expandedProjects: new Set(),
     expandedTasks: new Set(),
+    treeExpansionBootstrapped: false,
   });
   vi.restoreAllMocks();
 });
@@ -83,8 +84,51 @@ describe("useRestoreWorkspaceSelection", () => {
       });
     });
     expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
-    expect(useUiStore.getState().expandedProjects.has("p1")).toBe(true);
-    expect(useUiStore.getState().expandedTasks.has("t1")).toBe(true);
+    // Selection restore must not force-expand; expand state is owned by ui-store.
+    expect(useUiStore.getState().expandedProjects.has("p1")).toBe(false);
+    expect(useUiStore.getState().expandedTasks.has("t1")).toBe(false);
+  });
+
+  it("keeps a collapsed project collapsed when restoring its session", async () => {
+    useUiStore.setState({
+      expandedProjects: new Set(),
+      expandedTasks: new Set(),
+      treeExpansionBootstrapped: true,
+    });
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [SESSION];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: false,
+        }),
+      client,
+    );
+
+    await waitFor(() => {
+      expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+        "s1",
+      );
+    });
+    expect(useUiStore.getState().expandedProjects.has("p1")).toBe(false);
+    expect(useUiStore.getState().expandedTasks.has("t1")).toBe(false);
   });
 
   it("clears a stale session candidate without applying it", async () => {
@@ -123,7 +167,9 @@ describe("useRestoreWorkspaceSelection", () => {
     );
   });
 
-  it("does not overwrite a live selection the user already made", async () => {
+  it("applies the staged restore even if live selection was set before commit", async () => {
+    // Direct setState simulates a stale in-memory selection; pendingRestore must
+    // still win so startup chatter cannot keep a wrong leaf.
     useWorkspaceSelectionStore.setState({
       selection: {
         projectId: "p1",
@@ -158,15 +204,33 @@ describe("useRestoreWorkspaceSelection", () => {
     );
 
     await waitFor(() => {
-      expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+      expect(useWorkspaceSelectionStore.getState().selection).toEqual({
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      });
     });
-    expect(useWorkspaceSelectionStore.getState().selection).toEqual({
-      projectId: "p1",
-      taskId: null,
-      sessionId: null,
-      workflowRunId: null,
-      draftId: null,
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
+  });
+
+  it("lets an explicit selectSession cancel a staged restore", () => {
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
     });
+    useWorkspaceSelectionStore.getState().selectSession("s-newest", "t1", "p1");
+    expect(useWorkspaceSelectionStore.getState().selection.sessionId).toBe(
+      "s-newest",
+    );
+    expect(useWorkspaceSelectionStore.getState().pendingRestore).toBeNull();
   });
 
   it("waits while the tree is still pending", async () => {
@@ -204,6 +268,44 @@ describe("useRestoreWorkspaceSelection", () => {
       EMPTY_WORKSPACE_SELECTION,
     );
     expect(useWorkspaceSelectionStore.getState().pendingRestore).not.toBeNull();
+  });
+
+  it("does not miss-clear when the sessions list is empty before the tree is ready", async () => {
+    // Regression: gating on `!isPending` alone let a failed/empty interim list
+    // clear pendingRestore and persist the wipe — next launch then restored nothing.
+    useWorkspaceSelectionStore.setState({
+      selection: EMPTY_WORKSPACE_SELECTION,
+      pendingRestore: {
+        projectId: "p1",
+        taskId: "t1",
+        sessionId: "s1",
+        workflowRunId: null,
+        draftId: null,
+      },
+    });
+    const state = createMockClientState();
+    state.projects = [PROJECT];
+    state.tasks = [TASK];
+    state.sessions = [];
+    const client = createMockClient(state);
+
+    renderHookWithClient(
+      () =>
+        useRestoreWorkspaceSelection({
+          projects: state.projects,
+          tasks: state.tasks,
+          sessions: state.sessions,
+          treePending: true,
+        }),
+      client,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(
+      useWorkspaceSelectionStore.getState().pendingRestore?.sessionId,
+    ).toBe("s1");
   });
 
   it("waits for draft rehydration before treating a draft candidate as missing", async () => {
@@ -496,7 +598,7 @@ describe("useWarmSession restore gate", () => {
             taskId: "t1",
             sessionId: null,
           },
-          "ora-space.opencode",
+          "open_code",
         ),
       client,
       undefined,


### PR DESCRIPTION
## Summary

Persist workspace navigation and review panel state across restarts while making session restoration safer.

## Changes

- Persist sidebar collapse state, expanded projects and tasks, and dashboard width.
- Restore workspace selection only after all required queries and persisted stores are ready.
- Preserve collapsed branches during restoration and indicate selections within collapsed branches.
- Refactor the workspace tree into memoized nodes with stable grouping and scoped subscriptions.
- Prevent deferred TipTap hydration from parking stale editor content under a newly selected session.
- Persist review panel state per project/task scope, including:
  - Open or closed state
  - Changes or Files tab
  - Panel width
  - Last previewed file and optional line
- Prevent hydration and context switches from overwriting persisted state.
- Update restore tests to use current agent references and expansion-state behavior.

## Testing

- `task test`
- Frontend lint and type checking
- Workspace restoration and sidebar tests
- Composer session-switch tests
- Review store and task changes layout tests
- Rust workspace and documentation tests

Closes #400