### PR TITLE
修复工作流节点模型跟随其他会话变化

### DIFF
--- a/packages/app-shell/src/features/chat/chat-view.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.tsx
@@ -31,6 +31,10 @@ interface ChatViewProps {
   error: string | null;
   pendingPermissions?: SessionPermissionRequest[];
   disabled?: boolean;
+  /** Keeps the current model visible while preventing model changes on this surface. */
+  modelSelectorDisabled?: boolean;
+  /** Session whose model configuration the selector should display. */
+  modelSelectorSessionId?: string;
   /** Hides message composition while retaining the ordinary transcript and trailing actions. */
   composerVisible?: boolean;
   onSend: (text: string, images?: acp.ImageContent[]) => void;
@@ -90,6 +94,8 @@ export function ChatView({
   error,
   pendingPermissions = [],
   disabled = false,
+  modelSelectorDisabled = false,
+  modelSelectorSessionId,
   composerVisible = true,
   onSend,
   onEmptySubmit,
@@ -278,6 +284,8 @@ export function ChatView({
                   isResponding={isResponding}
                   isStreaming={isStreaming}
                   disabled={disabled}
+                  modelSelectorDisabled={modelSelectorDisabled}
+                  modelSelectorSessionId={modelSelectorSessionId}
                   skills={skills}
                   availableCommands={availableCommands}
                 />

--- a/packages/app-shell/src/features/chat/composer.tsx
+++ b/packages/app-shell/src/features/chat/composer.tsx
@@ -96,6 +96,10 @@ interface ComposerProps {
    */
   isStreaming?: boolean;
   disabled?: boolean;
+  /** Keeps the current model visible while preventing model changes on this surface. */
+  modelSelectorDisabled?: boolean;
+  /** Session whose model configuration the selector should display. */
+  modelSelectorSessionId?: string;
   placeholder?: string;
   autoFocus?: boolean;
   skills?: Skill[];
@@ -134,6 +138,8 @@ export function Composer({
   isResponding,
   isStreaming = false,
   disabled = false,
+  modelSelectorDisabled = false,
+  modelSelectorSessionId,
   placeholder,
   autoFocus = false,
   skills = [],
@@ -982,7 +988,12 @@ export function Composer({
             ref={rightControlsRef}
             className="flex shrink-0 items-center gap-2"
           >
-            {showModelSelector && <ModelSelector disabled={disabled} />}
+            {showModelSelector && (
+              <ModelSelector
+                disabled={disabled || modelSelectorDisabled}
+                sessionId={modelSelectorSessionId}
+              />
+            )}
             <Button
               size="icon"
               // A live turn always stops on click, whether it is still starting up

--- a/packages/app-shell/src/features/chat/model-selector.tsx
+++ b/packages/app-shell/src/features/chat/model-selector.tsx
@@ -50,13 +50,24 @@ import { ProviderLogo } from "./provider-logos";
  * anything is committed. Choosing a CLI therefore leaves the menu open: picking
  * one of those models is the other half of the same decision.
  */
-export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
+export function ModelSelector({
+  disabled = false,
+  sessionId,
+}: {
+  disabled?: boolean;
+  /** Session whose model configuration should be displayed instead of workspace selection. */
+  sessionId?: string;
+}) {
   const { t } = useTranslation();
   const updateSettings = useSettingsStore((state) => state.updateSettings);
   const selection = useWorkspaceSelectionStore((state) => state.selection);
   const chatStore = useChatStore();
   const setSessionConfig = useSetSessionConfig();
   const { data: sessions = [] } = useSessions();
+  // Workflow node sessions live inside the run workspace without becoming the global workspace
+  // selection. Binding the picker explicitly keeps its read-only label attached to that node.
+  const modelSelection =
+    sessionId === undefined ? selection : { ...selection, sessionId };
 
   // Having a binding is what makes a session persisted, and only a persisted one
   // can be rebound; a warm session has no row to move. The bound CLI is also what
@@ -64,9 +75,9 @@ export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
   // at all — the resolved agent below cannot answer that, since it already
   // reports whatever move is pending.
   const boundSession = sessions.find(
-    (session) => session.id === selection.sessionId,
+    (session) => session.id === modelSelection.sessionId,
   );
-  const targetKey = warmTargetKey(selection);
+  const targetKey = warmTargetKey(modelSelection);
   const setPickedForTarget = usePendingAgentStore(
     (state) => state.setPendingAgent,
   );
@@ -76,10 +87,10 @@ export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
   const clearPendingSwitch = usePendingAgentStore(
     (state) => state.clearPendingSwitch,
   );
-  const pendingSwitch = usePendingSwitch(selection.sessionId);
+  const pendingSwitch = usePendingSwitch(modelSelection.sessionId);
   // Resolved centrally so this and the composer cannot disagree: they share one
   // warm-session query key, and the CLI is part of that key.
-  const agentCli = useTargetAgentCli(selection);
+  const agentCli = useTargetAgentCli(modelSelection);
   // Which agents the runtime actually reports reaching here. An agent whose CLI
   // is absent, or whose plugin package was disabled or uninstalled, drops out of
   // the list rather than being offered and then failing on the first message.
@@ -87,7 +98,7 @@ export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
 
   // Shares the workspace's warm-session query key, so this is a cache read
   // rather than a second provider session.
-  const warmSession = useWarmSession(selection, agentCli);
+  const warmSession = useWarmSession(modelSelection, agentCli);
   // A warm session, when there is one, always describes the CLI on screen —
   // including the one a pending move is heading for, whose models and model
   // choice live on it rather than on the session being moved. While that
@@ -96,7 +107,7 @@ export function ModelSelector({ disabled = false }: { disabled?: boolean }) {
   // incoming agent's.
   const activeSessionId =
     warmSession.sessionId ??
-    (pendingSwitch === undefined ? selection.sessionId : null);
+    (pendingSwitch === undefined ? modelSelection.sessionId : null);
   // Selected narrowly rather than as one conversation object, so a streaming
   // turn does not re-render the picker on every token.
   const liveOptions = useStore(chatStore, (state) =>

--- a/packages/app-shell/src/features/workflow-run/run-node-session-chat.test.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-node-session-chat.test.tsx
@@ -1,10 +1,13 @@
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as acp from "@agentclientprotocol/sdk";
 import type { ChatTurn, SessionConversation } from "@ora/chat";
 import { createChatStore } from "@ora/chat";
 import type { GraphWorkflowNodeStatus } from "@ora/workflow-runtime";
+import { appI18n } from "../../i18n/i18n-instance";
+import { useAgentModelStore } from "../../state/stores/agent-model-store";
 import {
   createTestQueryClient,
   createHookWrapper,
@@ -19,13 +22,18 @@ const sessionId = "session-1";
 const runId = "run-1";
 const nodeId = "node-a";
 
+beforeEach(() => {
+  useAgentModelStore.setState({ known: {} });
+});
+
 /** A loaded, quiet conversation so the dock does not stream anything during the test. */
 function seededConversation(
   isResponding: boolean,
   turns: ChatTurn[] = [],
+  configOptions: acp.SessionConfigOption[] = [],
 ): SessionConversation {
   return {
-    configOptions: [],
+    configOptions,
     modelChanges: [],
     historyNotices: [],
     turns,
@@ -46,11 +54,14 @@ function renderDock(
   turns: ChatTurn[] = [],
   sessionActions?: ReactNode,
   onNodeCompleted?: (nodeId: string) => void,
+  configOptions: acp.SessionConfigOption[] = [],
 ) {
   const client = createMockClient(createMockClientState());
   const chatStore = createChatStore(client.session);
   chatStore.setState({
-    conversations: { [sessionId]: seededConversation(isResponding, turns) },
+    conversations: {
+      [sessionId]: seededConversation(isResponding, turns, configOptions),
+    },
   });
   render(
     <RunNodeSessionChat
@@ -97,6 +108,60 @@ describe("RunNodeSessionChat", () => {
         .querySelector("[data-placeholder]")
         ?.getAttribute("data-placeholder"),
     ).toMatch(/描述一个任务/);
+  });
+
+  it("keeps the node model visible when another session changes models", async () => {
+    const otherSessionOptions = createMockClientState().configOptions;
+    const nodeSessionOptions: acp.SessionConfigOption[] = [
+      {
+        id: "model",
+        name: "Model",
+        category: "model",
+        type: "select",
+        currentValue: "workflow/node-model",
+        options: [{ value: "workflow/node-model", name: "Workflow Model" }],
+      },
+    ];
+    useAgentModelStore.setState({
+      known: { "ora-space.opencode": otherSessionOptions },
+    });
+    renderDock(
+      "awaiting_input",
+      false,
+      [],
+      undefined,
+      undefined,
+      nodeSessionOptions,
+    );
+
+    const modelPicker = screen.getByRole("button", {
+      name: appI18n.t("chat.modelSelector.label"),
+    });
+    expect(modelPicker).toBeDisabled();
+    expect(modelPicker).toHaveTextContent("Workflow Model");
+
+    act(() =>
+      useAgentModelStore.setState({
+        known: {
+          "ora-space.opencode": [
+            {
+              id: "model",
+              name: "Model",
+              category: "model",
+              type: "select",
+              currentValue: "other/new-model",
+              options: [
+                { value: "other/new-model", name: "Other Session Model" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+    expect(modelPicker).toHaveTextContent("Workflow Model");
+
+    await userEvent.click(modelPicker);
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("places the shared conversation navigator inside the node session", () => {

--- a/packages/app-shell/src/features/workflow-run/run-node-session-chat.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-node-session-chat.tsx
@@ -150,6 +150,8 @@ export function RunNodeSessionChat({
         availableCommands={conversation?.availableCommands ?? []}
         conversationNavigation={NODE_SESSION_CONVERSATION_NAVIGATION}
         disabled={composerDisabled}
+        modelSelectorDisabled
+        modelSelectorSessionId={sessionId}
         composerVisible={interactive}
         composerActions={
           active || sessionActions != null ? (


### PR DESCRIPTION
## 变更说明

- 保留工作流节点模型选择器的当前模型展示，但禁用点击和下拉交互。
- 将模型展示绑定到工作流节点自身的 sessionId，避免普通会话切换模型时联动变化。
- 增加回归测试，验证节点模型不受其他会话模型缓存更新影响。

## 验证结果

- 工作流节点会话测试：13/13 通过
- TypeScript / ESLint：通过
- Prettier：通过