### PR TITLE
修复聊天多行文本与 Markdown 显示

### DIFF
--- a/packages/app-shell/src/features/chat/assistant-message-markdown.ts
+++ b/packages/app-shell/src/features/chat/assistant-message-markdown.ts
@@ -1,0 +1,65 @@
+const FENCE_SPLIT = /(```[\s\S]*?```)/;
+
+interface MdastNode {
+  type: string;
+  value?: string;
+  children?: MdastNode[];
+}
+
+/** Keeps blank lines beyond Markdown's normal paragraph separator visible. */
+export function prepareAssistantMessageMarkdown(content: string): string {
+  return content
+    .replace(/\r\n?/g, "\n")
+    .split(FENCE_SPLIT)
+    .map((part) => {
+      if (part.startsWith("```")) {
+        return part;
+      }
+      return part.replace(
+        /([^\n])(\n{3,})(?=[^\n])/g,
+        (_match, preceding: string, lineBreaks: string) =>
+          `${preceding}\n\n${"\u00a0\n\n".repeat(lineBreaks.length - 2)}`,
+      );
+    })
+    .join("");
+}
+
+/** Preserves ordinary response newlines instead of letting GFM render them as spaces. */
+export function remarkSoftBreaks() {
+  return (tree: MdastNode) => {
+    replaceSoftBreaks(tree);
+  };
+}
+
+/** Replaces newlines in prose text with mdast break nodes while leaving code untouched. */
+function replaceSoftBreaks(node: MdastNode): void {
+  if (node.type === "code" || node.type === "inlineCode") {
+    return;
+  }
+  if (node.children === undefined) {
+    return;
+  }
+
+  const children: MdastNode[] = [];
+  for (const child of node.children) {
+    if (
+      child.type === "text" &&
+      typeof child.value === "string" &&
+      child.value.includes("\n")
+    ) {
+      const lines = child.value.split("\n");
+      lines.forEach((line, index) => {
+        if (index > 0) {
+          children.push({ type: "break" });
+        }
+        if (line.length > 0) {
+          children.push({ type: "text", value: line });
+        }
+      });
+      continue;
+    }
+    replaceSoftBreaks(child);
+    children.push(child);
+  }
+  node.children = children;
+}

--- a/packages/app-shell/src/features/chat/markdown-message.test.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.test.tsx
@@ -51,9 +51,10 @@ describe("MarkdownDocument", () => {
       </AppI18nProvider>,
     );
 
-    expect(
-      screen.getByRole("heading", { level: 1, name: "H1" }),
-    ).not.toBeNull();
+    expect(screen.getByRole("heading", { level: 1, name: "H1" })).toHaveClass(
+      "text-xl",
+      "leading-7",
+    );
     expect(
       screen.getByRole("heading", { level: 6, name: "H6" }),
     ).not.toBeNull();
@@ -73,6 +74,18 @@ describe("MarkdownDocument", () => {
     expect(paragraphs).toHaveLength(2);
     expect(paragraphs[0]?.tagName).toBe("P");
     expect(paragraphs[1]?.tagName).toBe("P");
+  });
+
+  it("keeps consecutive empty composer blocks visible", () => {
+    const view = render(
+      <AppI18nProvider>
+        <MarkdownDocument density="compact" content={"first\n\n\nlast"} />
+      </AppI18nProvider>,
+    );
+
+    expect(
+      [...view.container.querySelectorAll("p")].map((node) => node.textContent),
+    ).toEqual(["first", "\u00a0", "\u00a0", "last"]);
   });
 
   it("does not expand newlines inside fenced code", async () => {
@@ -109,6 +122,20 @@ describe("MarkdownDocument", () => {
 });
 
 describe("MarkdownMessage", () => {
+  it("renders ordinary assistant newlines as visible line breaks", () => {
+    const view = renderMarkdown("first\nsecond\nthird");
+
+    expect(view.container.querySelectorAll("br")).toHaveLength(2);
+  });
+
+  it("keeps additional blank lines in assistant replies visible", () => {
+    const view = renderMarkdown("first\n\n\nsecond\n\n\n\nthird");
+
+    expect(
+      [...view.container.querySelectorAll("p")].map((node) => node.textContent),
+    ).toEqual(["first", "\u00a0", "second", "\u00a0", "\u00a0", "third"]);
+  });
+
   it("renders GitHub-flavored Markdown with semantic elements", () => {
     render(
       <MarkdownMessage

--- a/packages/app-shell/src/features/chat/markdown-message.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.tsx
@@ -22,6 +22,10 @@ import ReactMarkdown from "react-markdown";
 import { useTranslation } from "react-i18next";
 import remarkGfm from "remark-gfm";
 import type { BundledLanguage, ThemedTokenWithVariants } from "shiki";
+import {
+  prepareAssistantMessageMarkdown,
+  remarkSoftBreaks,
+} from "./assistant-message-markdown";
 import { unwrapMarkdownDocument } from "./markdown-document";
 import { prepareStreamingMarkdown } from "./streaming-markdown";
 import {
@@ -54,6 +58,7 @@ interface MarkdownDocumentProps {
 
 const LANGUAGE_CLASS_PATTERN = /(?:^|\s)language-([^\s]+)/;
 const markdownRemarkPlugins = [remarkGfm];
+const messageRemarkPlugins = [remarkGfm, remarkSoftBreaks];
 const highlightedCodeCache = new Map<
   string,
   Promise<ThemedTokenWithVariants[][] | null>
@@ -137,7 +142,7 @@ function createMarkdownComponents(density: MarkdownDensity): Components {
       <h1
         className={
           compact
-            ? "mb-1 mt-2 text-base font-semibold leading-6 first:mt-0"
+            ? "mb-2 mt-3 text-xl font-semibold leading-7 first:mt-0"
             : "mb-3 mt-6 text-2xl font-semibold leading-8 first:mt-0"
         }
         {...props}
@@ -397,11 +402,12 @@ export function MarkdownMessage({
     [chatLink],
   );
   const renderedMarkdown = useFrameBatchedMarkdown(markdown, streaming);
-  const parseableMarkdown = useMemo(
-    () =>
-      streaming ? prepareStreamingMarkdown(renderedMarkdown) : renderedMarkdown,
-    [renderedMarkdown, streaming],
-  );
+  const parseableMarkdown = useMemo(() => {
+    const completeMarkdown = streaming
+      ? prepareStreamingMarkdown(renderedMarkdown)
+      : renderedMarkdown;
+    return prepareAssistantMessageMarkdown(completeMarkdown);
+  }, [renderedMarkdown, streaming]);
   const [storedRevealState, setStoredRevealState] =
     useState<StreamingRevealState>(() => ({
       renderedLength: renderedMarkdown.length,
@@ -446,7 +452,7 @@ export function MarkdownMessage({
   const markdownBody = useMemo(
     () => (
       <ReactMarkdown
-        remarkPlugins={markdownRemarkPlugins}
+        remarkPlugins={messageRemarkPlugins}
         rehypePlugins={rehypePlugins}
         components={streaming ? streamingMarkdownComponents : markdownWithLinks}
       >

--- a/packages/app-shell/src/features/chat/user-message-markdown.test.ts
+++ b/packages/app-shell/src/features/chat/user-message-markdown.test.ts
@@ -11,8 +11,11 @@ describe("prepareUserMessageMarkdown", () => {
     expect(prepareUserMessageMarkdown("# Title\nbody")).toBe("# Title\n\nbody");
   });
 
-  it("leaves blank lines and fence interiors alone", () => {
-    expect(prepareUserMessageMarkdown("a\n\nb")).toBe("a\n\nb");
+  it("materializes empty composer blocks and leaves fence interiors alone", () => {
+    expect(prepareUserMessageMarkdown("a\n\nb")).toBe("a\n\n\u00a0\n\nb");
+    expect(prepareUserMessageMarkdown("a\n\n\nb")).toBe(
+      "a\n\n\u00a0\n\n\u00a0\n\nb",
+    );
     expect(prepareUserMessageMarkdown("```ts\nline1\nline2\n```")).toBe(
       "```ts\nline1\nline2\n```",
     );

--- a/packages/app-shell/src/features/chat/user-message-markdown.ts
+++ b/packages/app-shell/src/features/chat/user-message-markdown.ts
@@ -6,14 +6,18 @@ const FENCE_SPLIT = /(```[\s\S]*?```)/;
  * before read-only Markdown render.
  */
 export function prepareUserMessageMarkdown(content: string): string {
-  const normalized = content.replace(/\r\n/g, "\n");
+  const normalized = content.replace(/\r\n?/g, "\n");
   return normalized
     .split(FENCE_SPLIT)
     .map((part) => {
       if (part.startsWith("```")) {
         return part;
       }
-      return part.replace(/([^\n])\n(?=[^\n])/g, "$1\n\n");
+      return part.replace(
+        /([^\n])(\n+)(?=[^\n])/g,
+        (_match, preceding: string, lineBreaks: string) =>
+          `${preceding}\n\n${"\u00a0\n\n".repeat(lineBreaks.length - 1)}`,
+      );
     })
     .join("");
 }

--- a/packages/app-shell/src/features/editor/composer-editor.test.tsx
+++ b/packages/app-shell/src/features/editor/composer-editor.test.tsx
@@ -42,6 +42,36 @@ describe("ComposerEditor", () => {
     expect(composerText(textbox)).toMatch(/second/);
   });
 
+  it("moves the caret forward across consecutive Shift+Enter newlines", async () => {
+    const user = userEvent.setup();
+    render(<ComposerEditor ariaLabel="Message" onSubmit={vi.fn()} />);
+    const textbox = screen.getByRole("textbox", { name: "Message" });
+
+    await user.click(textbox);
+    await user.keyboard("first");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    await user.keyboard("last");
+
+    expect(composerText(textbox)).toBe("first\n\n\nlast");
+  });
+
+  it("preserves line breaks when plain multiline text is pasted", async () => {
+    const user = userEvent.setup();
+    render(<ComposerEditor ariaLabel="Message" onSubmit={vi.fn()} />);
+    const textbox = screen.getByRole("textbox", { name: "Message" });
+
+    await user.click(textbox);
+    await user.paste(
+      "first plain line\nsecond plain line\n\n\nthird plain line",
+    );
+
+    expect(composerText(textbox)).toBe(
+      "first plain line\nsecond plain line\n\n\nthird plain line",
+    );
+  });
+
   it("turns a markdown heading prefix into a heading node", async () => {
     const user = userEvent.setup();
     render(<ComposerEditor ariaLabel="Message" onSubmit={vi.fn()} />);

--- a/packages/app-shell/src/features/workspace/chat-interaction.test.tsx
+++ b/packages/app-shell/src/features/workspace/chat-interaction.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createChatStore } from "@ora/chat";
+import type { PromptSessionEvent } from "@ora/contracts";
+import { TooltipProvider } from "@ora/ui";
+import { beforeEach, describe, expect, it } from "vitest";
+import { AppI18nProvider } from "../../i18n/i18n";
+import { PlatformProvider } from "../../platform";
+import {
+  createHookWrapper,
+  createTestQueryClient,
+} from "../../test/hook-harness";
+import { createScriptedChatSession } from "../../test/chat-session-harness";
+import { createStubPlatform } from "../../test/stub-platform";
+import {
+  createMockClient,
+  createMockClientState,
+} from "../../test/mock-client";
+import { useComposerInputStore } from "../../state/stores/composer-input-store";
+import { useDraftSessionsStore } from "../../state/stores/draft-sessions-store";
+import { usePendingAgentStore } from "../../state/stores/pending-agent-store";
+import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
+import { WorkspaceView } from "./workspace-view";
+
+/** Builds one assistant text frame in the same shape as the generated ACP client. */
+function assistantText(
+  text: string,
+  messageId = "assistant-1",
+): PromptSessionEvent {
+  return {
+    type: "session_update",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      messageId,
+      content: { type: "text", text },
+    },
+  };
+}
+
+/** Creates a promise whose completion is controlled by the test. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  useWorkspaceSelectionStore.getState().clearSelection();
+  useDraftSessionsStore.getState().clear();
+  useComposerInputStore.getState().reset();
+  usePendingAgentStore.setState({ selections: {}, switches: {} });
+});
+
+describe("chat interaction MVP", () => {
+  it("sends an Enter-submitted message and renders a controlled streaming reply", async () => {
+    const user = userEvent.setup();
+    const state = createMockClientState();
+    state.projects = [{ id: "p1", name: "Ora", rootPath: "/ora" }];
+    state.tasks = [
+      {
+        id: "t1",
+        projectId: "p1",
+        title: "Chat interaction",
+        workspaceMode: "worktree",
+        type: "default",
+        workflowRunId: null,
+      },
+    ];
+    state.sessions = [
+      {
+        id: "s1",
+        taskId: "t1",
+        agentRef: "ora-space.opencode",
+        status: "running",
+        title: null,
+        historyState: { type: "writable" },
+      },
+    ];
+
+    const secondChunk = deferred();
+    const scriptedSession = createScriptedChatSession(async function* () {
+      yield assistantText("第一段");
+      await secondChunk.promise;
+      yield assistantText("第二段");
+      yield { type: "completed", stopReason: "end_turn" };
+    });
+    const baseClient = createMockClient(state);
+    const client = {
+      ...baseClient,
+      session: { ...baseClient.session, ...scriptedSession },
+    };
+    const chatStore = createChatStore(client.session);
+    const Wrapper = createHookWrapper(
+      client,
+      createTestQueryClient(),
+      chatStore,
+    );
+    useWorkspaceSelectionStore.getState().selectSession("s1", "t1", "p1");
+
+    const view = render(
+      <Wrapper>
+        <AppI18nProvider>
+          <PlatformProvider adapter={createStubPlatform()}>
+            <TooltipProvider>
+              <WorkspaceView userName="Tester" />
+            </TooltipProvider>
+          </PlatformProvider>
+        </AppI18nProvider>
+      </Wrapper>,
+    );
+
+    const composer = await screen.findByRole("textbox");
+    await waitFor(() => expect(composer).toBeEnabled());
+    await user.click(composer);
+    await user.paste("第一行普通文本\n第二行普通文本\n\n\n第四行普通文本");
+    await waitFor(() =>
+      expect(composer.dataset.composerText).toBe(
+        "第一行普通文本\n第二行普通文本\n\n\n第四行普通文本",
+      ),
+    );
+    await user.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expect(scriptedSession.promptRequests).toEqual([
+        {
+          sessionId: "s1",
+          prompt: [
+            {
+              type: "text",
+              text: "第一行普通文本\n第二行普通文本\n\n\n第四行普通文本",
+            },
+          ],
+        },
+      ]),
+    );
+    expect(screen.getByText("第一行普通文本")).toBeInTheDocument();
+    expect(screen.getByText("第四行普通文本")).toBeInTheDocument();
+
+    const response = () => view.container.querySelector("[data-turn-response]");
+    await waitFor(() => expect(response()).toHaveTextContent("第一段"));
+    expect(screen.getByRole("button", { name: /停止|Stop/ })).toBeEnabled();
+
+    secondChunk.resolve();
+
+    await waitFor(() => expect(response()).toHaveTextContent("第一段第二段"));
+    await waitFor(() => expect(composer).toBeEnabled());
+    expect(
+      screen.getByRole("button", { name: /发送消息|Send message/ }),
+    ).toBeDisabled();
+  });
+});

--- a/packages/app-shell/src/test/chat-session-harness.ts
+++ b/packages/app-shell/src/test/chat-session-harness.ts
@@ -1,0 +1,33 @@
+import type { ChatSessionClient } from "@ora/chat";
+import type { PromptSessionEvent, PromptSessionRequest } from "@ora/contracts";
+
+/** A chat client whose prompt stream is supplied by a deterministic test script. */
+export interface ScriptedChatSession extends ChatSessionClient {
+  readonly promptRequests: PromptSessionRequest[];
+}
+
+/**
+ * Creates the smallest fake session boundary needed by interaction tests.
+ *
+ * History completes immediately, while each prompt is recorded before its scripted
+ * events are yielded. Tests can therefore pause a response at an exact event boundary
+ * and exercise the UI while the turn is genuinely streaming.
+ */
+export function createScriptedChatSession(
+  script: (request: PromptSessionRequest) => AsyncIterable<PromptSessionEvent>,
+): ScriptedChatSession {
+  const promptRequests: PromptSessionRequest[] = [];
+
+  return {
+    promptRequests,
+    load: async function* () {
+      yield { type: "completed" as const };
+    },
+    prompt: async function* (request) {
+      promptRequests.push(request);
+      yield* script(request);
+    },
+    respondToPermission: async () => ({}),
+    setConfig: async () => ({ configOptions: [] }),
+  };
+}

--- a/packages/editor/src/composer/composer-markdown.ts
+++ b/packages/editor/src/composer/composer-markdown.ts
@@ -2,6 +2,7 @@ import type { JSONContent } from "@tiptap/core";
 import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { isDangerousComposerHref } from "./composer-link";
+import { plainTextToComposerContent } from "./composer-plain-text";
 
 type MarkSpec = { type: string; attrs?: Record<string, string | null> };
 
@@ -79,10 +80,13 @@ export const ComposerMarkdownPaste = Extension.create({
               return false;
             }
             const text = event.clipboardData.getData("text/plain");
-            if (!looksLikeComposerMarkdown(text)) {
+            const isMarkdown = looksLikeComposerMarkdown(text);
+            if (!isMarkdown && !/[\r\n]/.test(text)) {
               return false;
             }
-            const doc = markdownToComposerContent(text);
+            const doc = isMarkdown
+              ? markdownToComposerContent(text)
+              : plainTextToComposerContent(text.replace(/\r\n?/g, "\n"));
             return this.editor.commands.insertContent(doc.content ?? []);
           },
         },

--- a/packages/editor/src/composer/composer-newline.ts
+++ b/packages/editor/src/composer/composer-newline.ts
@@ -46,7 +46,11 @@ function splitComposerBlock(editor: Editor): boolean {
   if (editor.isActive("blockquote") && $from.parent.content.size === 0) {
     return editor.commands.liftEmptyBlock();
   }
-  if ($from.parentOffset === 0 && $from.parent.type.isTextblock) {
+  if (
+    $from.parentOffset === 0 &&
+    $from.parent.content.size > 0 &&
+    $from.parent.type.isTextblock
+  ) {
     return insertEmptyBlockBefore(editor);
   }
   return editor.commands.splitBlock();


### PR DESCRIPTION
## 变更说明

- 修复连续按 Shift+Enter 时光标停留在首次换行位置的问题
- 保留普通多行文本粘贴中的换行和连续空行，并确保提交 payload 不丢失
- 保留用户消息与 AI 回复中的可见换行、额外空行，同时避开 fenced code block
- 调整用户消息 Markdown 一级标题的字号与间距
- 增加覆盖真实 Enter 提交、流式回复和多行文本的交互测试

## 测试

- `pnpm --filter @ora/editor test`：53 个测试通过
- `pnpm --filter @ora/app-shell exec vitest run src/features/editor/composer-editor.test.tsx`：43 个测试通过
- Markdown 与聊天交互定向测试通过
- `pnpm --filter @ora/app-shell lint` 通过
- `pnpm --filter @ora/editor lint` 通过
- app-shell 全量并发测试中 1015/1018 通过，3 个既有用例因 5 秒超时/并发时序失败；相关测试单独重跑均通过