### PR TITLE
fix(composer): 修复第二次文件引用报错，并让聊天历史保留引用 chip 样式

### DIFF
--- a/docs/task-workspace-files.md
+++ b/docs/task-workspace-files.md
@@ -22,7 +22,10 @@ The layers remain narrow:
   resolution, and the command/channel boundary.
 - `packages/app-shell/src/features/files` owns the file tree, viewer, search UI,
   cache invalidation, and gutter `+` line quotes into the composer (with eager
-  snippet text). The same
+  snippet text). A quote stays a compact chip on both sides of send: the prompt
+  carries the snippet as a fenced payload for the agent, and chat history reads
+  that payload back into the same chip instead of replaying the source. The
+  same
   Files panel hosts the Specs sub-view; see [Specification management](spec-management.md).
   Chat inline artifact links open this panel through `openWorkspaceFile` and a
   `WorkspaceFileRequest` (`path` + `requestId` + optional line/column) so a

--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -51,6 +51,15 @@ function composerText(element: HTMLElement): string {
   return element.dataset.composerText ?? "";
 }
 
+/**
+ * A quote that fails to insert is reported as an alert banner, never thrown, so
+ * "the chip is in the document" is not proof the insert succeeded — a partially
+ * applied insert produces both. Every quote test asserts the banner is absent.
+ */
+function expectNoComposerInjectError(): void {
+  expect(screen.queryByRole("alert")).toBeNull();
+}
+
 /** Flushes conversation hydrate / chip-inject microtasks scheduled from effects. */
 async function flushComposerEffects(): Promise<void> {
   await act(async () => {
@@ -1123,6 +1132,7 @@ describe("Composer", () => {
     expect(
       useComposerFileContextStore.getState().pendingByConversation["session-a"],
     ).toBeUndefined();
+    expectNoComposerInjectError();
 
     act(() => {
       useWorkspaceSelectionStore
@@ -1189,6 +1199,7 @@ describe("Composer", () => {
     expect(
       useComposerFileContextStore.getState().pendingByConversation["session-a"],
     ).toBeUndefined();
+    expectNoComposerInjectError();
   });
 
   it("does not replay a prior quote when a second range is queued", async () => {
@@ -1239,6 +1250,7 @@ describe("Composer", () => {
     expect(
       textarea.querySelectorAll("[data-composer-file='src/second.ts']"),
     ).toHaveLength(1);
+    expectNoComposerInjectError();
   });
 
   it("does not restore an abandoned send over a newer submit on the same surface", async () => {

--- a/packages/app-shell/src/features/chat/markdown-message.test.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { AppI18nProvider } from "../../i18n/i18n";
+import { composerFilePlainText } from "@ora/editor/composer";
 import { PlatformProvider } from "../../platform";
 import { createStubPlatform } from "../../test/stub-platform";
 import { MarkdownDocument, MarkdownMessage } from "./markdown-message";
@@ -54,6 +55,117 @@ describe("MarkdownDocument", () => {
     // same openExternalUrl command assistant messages and the prompt box use.
     await user.click(screen.getByRole("link", { name: "Docs" }));
     expect(openExternalUrl).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("renders a sent file quote as the chip the composer showed", () => {
+    // The exact text the composer sends: chips flatten through
+    // composerFilePlainText, so history has to read that payload back.
+    const content = composerFilePlainText({
+      path: "src/main.py",
+      startLine: 9,
+      endLine: 14,
+      snippet: "import os\nimport sys",
+    });
+    render(
+      <AppI18nProvider>
+        <MarkdownDocument density="compact" content={content} />
+      </AppI18nProvider>,
+    );
+
+    const chip = document.querySelector("[data-composer-file='src/main.py']");
+    expect(chip).not.toBeNull();
+    expect(chip).toHaveAttribute("data-start-line", "9");
+    expect(chip).toHaveAttribute("data-end-line", "14");
+    expect(chip).toHaveClass("composer-file-ref");
+    expect(chip?.textContent).toBe("main.pyL9-14");
+    // The fence must not also render as a code block beside the chip.
+    expect(document.querySelector("pre")).toBeNull();
+    expect(screen.queryByText(/import os/)).toBeNull();
+  });
+
+  it("renders a sent diff quote as a chip carrying the dragged line span", () => {
+    const content = composerFilePlainText({
+      path: "src/example.ts",
+      startLine: 2,
+      endLine: 40,
+      snippet: " keep\n+added",
+      origin: "diff",
+      diffSide: "new",
+    });
+    render(
+      <AppI18nProvider>
+        <MarkdownDocument density="compact" content={content} />
+      </AppI18nProvider>,
+    );
+
+    const chip = document.querySelector(
+      "[data-composer-file='src/example.ts']",
+    );
+    expect(chip?.textContent).toBe("example.tsL2-40");
+    expect(document.querySelector("pre")).toBeNull();
+  });
+
+  it("keeps quotes that were adjacent in the composer on one line", () => {
+    const content = [
+      composerFilePlainText({
+        path: "src/main.py",
+        startLine: 9,
+        endLine: 14,
+        snippet: "import os",
+      }),
+      composerFilePlainText({
+        path: "src/agents.py",
+        startLine: 1,
+        endLine: 2,
+        snippet: "import sys",
+      }),
+    ].join("");
+    render(
+      <AppI18nProvider>
+        <MarkdownDocument density="compact" content={content} />
+      </AppI18nProvider>,
+    );
+
+    const chips = [...document.querySelectorAll("[data-composer-file]")];
+    expect(chips.map((chip) => chip.textContent)).toEqual([
+      "main.pyL9-14",
+      "agents.pyL1-2",
+    ]);
+    expect(chips[0]?.parentElement).toBe(chips[1]?.parentElement);
+  });
+
+  it("renders a quote whose snippet contains a fence line", () => {
+    // codeFenceMarker widens the payload's own fence past the snippet's
+    // backticks; the chip has to survive that longer marker.
+    const content = composerFilePlainText({
+      path: "docs/guide.md",
+      startLine: 3,
+      endLine: 5,
+      snippet: "```\nconst a = 1;\n```",
+    });
+    render(
+      <AppI18nProvider>
+        <MarkdownDocument density="compact" content={content} />
+      </AppI18nProvider>,
+    );
+
+    const chip = document.querySelector("[data-composer-file='docs/guide.md']");
+    expect(chip?.textContent).toBe("guide.mdL3-5");
+    expect(document.querySelector("pre")).toBeNull();
+  });
+
+  it("still renders ordinary fenced code in a user message as a code block", () => {
+    render(
+      <AppI18nProvider>
+        <MarkdownDocument
+          density="compact"
+          content={"```ts\nconst a = 1;\n```"}
+        />
+      </AppI18nProvider>,
+    );
+
+    expect(document.querySelector("[data-composer-file]")).toBeNull();
+    expect(screen.getByText(/const a = 1;/)).toBeInTheDocument();
   });
 
   it("renders compact headings 1-6, strike, highlight, and lists", () => {

--- a/packages/app-shell/src/features/chat/markdown-message.tsx
+++ b/packages/app-shell/src/features/chat/markdown-message.tsx
@@ -42,6 +42,10 @@ import {
   prepareUserMessageMarkdown,
   remarkComposerHighlight,
 } from "./user-message-markdown";
+import {
+  fileQuoteMarkdownComponents,
+  remarkComposerFileQuote,
+} from "./user-message-file-quotes";
 
 interface MarkdownMessageProps {
   content: string;
@@ -318,7 +322,17 @@ function createMarkdownComponents(density: MarkdownDensity): Components {
 }
 
 const markdownComponents = createMarkdownComponents("default");
-const compactMarkdownComponents = createMarkdownComponents("compact");
+// Only the compact surface renders sent prompts, so only it turns quote fences
+// back into chips.
+const compactMarkdownComponents = {
+  ...createMarkdownComponents("compact"),
+  ...fileQuoteMarkdownComponents,
+};
+const compactRemarkPlugins = [
+  ...markdownRemarkPlugins,
+  remarkComposerHighlight,
+  remarkComposerFileQuote,
+];
 
 /** Stable `pre` override so index updates do not remount CodeBlock state. */
 function ChatMarkdownPreOverride({
@@ -351,13 +365,8 @@ export function MarkdownDocument({
         : { ...baseComponents, ...components },
     [baseComponents, components],
   );
-  const remarkPlugins = useMemo(
-    () =>
-      density === "compact"
-        ? [...markdownRemarkPlugins, remarkComposerHighlight]
-        : markdownRemarkPlugins,
-    [density],
-  );
+  const remarkPlugins =
+    density === "compact" ? compactRemarkPlugins : markdownRemarkPlugins;
   const parseable =
     density === "compact" ? prepareUserMessageMarkdown(content) : content;
   return (

--- a/packages/app-shell/src/features/chat/user-message-file-quotes.tsx
+++ b/packages/app-shell/src/features/chat/user-message-file-quotes.tsx
@@ -1,0 +1,83 @@
+import {
+  composerFileAttrsFromUnknown,
+  parseComposerFileQuote,
+  type ComposerFileAttrs,
+} from "@ora/editor/composer";
+import type { Components } from "react-markdown";
+import { FileRefChip } from "../file-ref-chip";
+
+/** Element name the remark pass emits; only this module maps it to a chip. */
+const FILE_QUOTE_TAG = "ora-file-quote";
+
+interface MdastNode {
+  type: string;
+  lang?: string | null;
+  meta?: string | null;
+  value?: string;
+  children?: MdastNode[];
+  data?: { hName?: string; hProperties?: Record<string, unknown> };
+}
+
+/**
+ * Renders the fenced quote payloads inside a sent prompt as the chips the
+ * composer showed while it was being written.
+ *
+ * Sending flattens chips to Markdown (`composerFilePlainText`) because that is
+ * what the agent reads, but the same text is what history replays — so without
+ * this the user's own quote comes back as a wall of source. Quotes that were
+ * adjacent in the composer serialize as back-to-back fences and are folded into
+ * one paragraph again, keeping them on a single line.
+ */
+export function remarkComposerFileQuote() {
+  return (tree: MdastNode) => {
+    const next: MdastNode[] = [];
+    let openChipLine: MdastNode | null = null;
+    for (const child of tree.children ?? []) {
+      const attrs = fileQuoteAttrs(child);
+      if (attrs === null) {
+        openChipLine = null;
+        next.push(child);
+        continue;
+      }
+      if (openChipLine !== null) {
+        openChipLine.children?.push(chipNode(attrs));
+        continue;
+      }
+      openChipLine = { type: "paragraph", children: [chipNode(attrs)] };
+      next.push(openChipLine);
+    }
+    tree.children = next;
+  };
+}
+
+/**
+ * Maps the chip element onto React. The cast is unavoidable: react-markdown
+ * types `components` against known HTML tag names, and a custom name is the
+ * only way to carry parsed attrs to the renderer without re-parsing the fence.
+ */
+export const fileQuoteMarkdownComponents = {
+  [FILE_QUOTE_TAG]: (props: Record<string, unknown>) => (
+    <FileRefChip attrs={composerFileAttrsFromUnknown(props)} />
+  ),
+} as unknown as Components;
+
+/** Chip attrs for a fenced quote block, or null for any other node. */
+function fileQuoteAttrs(node: MdastNode): ComposerFileAttrs | null {
+  if (node.type !== "code") return null;
+  // A path with a space lands in `meta`; the info string is both halves.
+  const info = [node.lang ?? "", node.meta ?? ""].filter(Boolean).join(" ");
+  return parseComposerFileQuote(info, node.value ?? "");
+}
+
+function chipNode(attrs: ComposerFileAttrs): MdastNode {
+  // hast walks every property it is given, so absent quote metadata is dropped
+  // rather than handed over as `undefined`.
+  const hProperties = Object.fromEntries(
+    Object.entries(attrs).filter(([, value]) => value !== undefined),
+  );
+  return {
+    type: "text",
+    value: "",
+    data: { hName: FILE_QUOTE_TAG, hProperties },
+  };
+}

--- a/packages/app-shell/src/features/diff/README.md
+++ b/packages/app-shell/src/features/diff/README.md
@@ -33,8 +33,11 @@ Task Changes panel: parsed worktree patches, file tree, and git commit/push acti
   On send the chip stays basename + `L12-14`, but the agent payload is a mini
   `diff --git` patch (`--- a/` / `+++ b/` / `@@` / unified `+/-/ ` body, with
   a hunk header `quoted from git diff`, plus `(old|new side)` when the chip
-  is a single side) so a follow-up comment is clearly about the existing git
-  change, not current file contents.
+  is a single side, and the quoted file lines as `lines 12-14`) so a follow-up
+  comment is clearly about the existing git change, not current file contents.
+  The line note is what chat history reads back to redraw the same chip label:
+  the hunk counts only cover the body, which is shorter than the span whenever
+  the drag crossed a collapsed hunk.
 - Own commit/push UI for the same task worktree.
 
 ## Non-responsibilities

--- a/packages/app-shell/src/features/editor/README.md
+++ b/packages/app-shell/src/features/editor/README.md
@@ -48,7 +48,13 @@ App-shell wrapper around `@ora/editor` for prompt boxes.
   no neon glow).
 - Sent user messages stay `documentPlainText` in the store and render read-only
   via chat `MarkdownDocument` (`density="compact"`). Compact mode expands
-  TipTap single newlines outside fences and maps `==highlight==` to `<mark>`.
+  TipTap single newlines outside fences, maps `==highlight==` to `<mark>`, and
+  reads quote fences back into chips through `parseComposerFileQuote` so a sent
+  quote keeps the composer's compact look instead of unfolding into its source.
+  Both surfaces render the chip from `FileRefChipContent` against one unscoped
+  stylesheet (`features/file-ref-chip.css`), so the prompt box and the message
+  bubble cannot drift apart; the editor scope only adds editing behaviour
+  (drag, node selection, `user-select`).
   Future edit remounts `ComposerEditor` on that same string; history rows do
   not keep a TipTap instance.
 

--- a/packages/app-shell/src/features/editor/composer-editor.css
+++ b/packages/app-shell/src/features/editor/composer-editor.css
@@ -344,61 +344,14 @@
 }
 
 /*
- * Cursor-style @ file mention: type icon keeps its own hue; basename uses a
- * bright teal ink — higher L / soft chroma for a clear, airy feel.
+ * Editing behaviour only. The chip's colours and layout live in the shared
+ * features/file-ref-chip.css so chat history renders the identical visual.
  */
 .composer-editor-shell .composer-file-ref {
-  --composer-file-ink: oklch(0.55 0.09 195);
-  display: inline-flex;
-  max-width: 14rem;
-  align-items: center;
-  gap: 0.28em;
-  /* Gap without a selectable text space (those paint as thin selection bars). */
-  margin: 0 0.2em;
-  vertical-align: baseline;
-  color: var(--composer-file-ink);
-  font-size: inherit;
-  font-weight: 500;
-  line-height: inherit;
   cursor: default;
   user-select: none;
   -webkit-user-select: none;
   -webkit-user-drag: none;
-}
-
-.dark .composer-editor-shell .composer-file-ref {
-  /* Bright aqua on dark chrome; stays readable without neon glow. */
-  --composer-file-ink: oklch(0.82 0.1 195);
-}
-
-.composer-editor-shell .composer-file-ref-icon {
-  width: 0.95em;
-  height: 0.95em;
-  flex-shrink: 0;
-}
-
-.composer-editor-shell .composer-file-ref-label {
-  display: inline-flex;
-  min-width: 0;
-  align-items: baseline;
-  gap: 0.35em;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.composer-editor-shell .composer-file-ref-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.composer-editor-shell .composer-file-ref-range {
-  flex-shrink: 0;
-  color: color-mix(
-    in oklch,
-    var(--composer-file-ink) 55%,
-    var(--muted-foreground)
-  );
-  font-weight: 400;
 }
 
 .composer-editor-shell .composer-file-ref::selection,

--- a/packages/app-shell/src/features/editor/composer-editor.test.tsx
+++ b/packages/app-shell/src/features/editor/composer-editor.test.tsx
@@ -373,6 +373,58 @@ describe("ComposerEditor", () => {
     editor.destroy();
   });
 
+  it("collapses the separator space when a later quote is its own command", () => {
+    const editor = new Editor({
+      extensions: createComposerExtensions({ placeholder: "Type" }),
+      content: {
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      },
+    });
+
+    // Every gutter click arrives as a separate insertComposerFiles call with the
+    // caret parked at the end, which is the only way to reach the
+    // separator-collapse branch. Doing that work on a nested chain dispatched a
+    // second transaction mid-command and left the outer one stale, so this call
+    // threw *after* the chip had landed.
+    editor.commands.insertComposerFiles([{ path: "first.ts" }]);
+    editor.commands.focus("end");
+    expect(() =>
+      editor.commands.insertComposerFiles([{ path: "second.ts" }]),
+    ).not.toThrow();
+
+    const paragraph = editor.state.doc.firstChild;
+    expect(paragraph?.childCount).toBe(3);
+    expect(paragraph?.child(0).attrs.path).toBe("first.ts");
+    expect(paragraph?.child(1).attrs.path).toBe("second.ts");
+    expect(paragraph?.child(2).text).toBe(" ");
+    expect(documentPlainText(editor.state.doc)).toBe("`first.ts` `second.ts` ");
+    editor.destroy();
+  });
+
+  it("collapses the separator space when a quote follows a prompt token", () => {
+    const editor = new Editor({
+      extensions: createComposerExtensions({ placeholder: "Type" }),
+      content: {
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      },
+    });
+
+    editor.commands.setPromptToken("command", "review");
+    editor.commands.focus("end");
+    expect(() =>
+      editor.commands.insertComposerFiles([{ path: "after-token.ts" }]),
+    ).not.toThrow();
+
+    const paragraph = editor.state.doc.firstChild;
+    expect(paragraph?.childCount).toBe(3);
+    expect(paragraph?.child(0).type.name).toBe("promptToken");
+    expect(paragraph?.child(1).attrs.path).toBe("after-token.ts");
+    expect(paragraph?.child(2).text).toBe(" ");
+    editor.destroy();
+  });
+
   it("restores documentPlainText as formatted nodes instead of leftover markers", () => {
     render(
       <ComposerEditor

--- a/packages/app-shell/src/features/editor/composer-file-chip-view.tsx
+++ b/packages/app-shell/src/features/editor/composer-file-chip-view.tsx
@@ -1,15 +1,13 @@
 import {
   composerFileAttrsFromUnknown,
   composerFileChipTitle,
-  composerFileLabel,
-  composerFileLineRangeLabel,
 } from "@ora/editor/composer";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import type {
   DragEvent as ReactDragEvent,
   MouseEvent as ReactMouseEvent,
 } from "react";
-import { WorkspaceFileIcon } from "../files/workspace-file-visuals";
+import { FileRefChipContent } from "../file-ref-chip";
 
 /**
  * Inline path mention chip: type/folder icon + basename, Cursor-style (no pill).
@@ -18,7 +16,6 @@ import { WorkspaceFileIcon } from "../files/workspace-file-visuals";
 export function ComposerFileChipView({ node, editor, getPos }: NodeViewProps) {
   const attrs = composerFileAttrsFromUnknown(node.attrs);
   const kind = attrs.kind === "directory" ? "directory" : "file";
-  const rangeLabel = composerFileLineRangeLabel(attrs);
   const title = composerFileChipTitle(attrs);
 
   const selectOnlyThisChip = (event: ReactMouseEvent<HTMLElement>): void => {
@@ -55,19 +52,7 @@ export function ComposerFileChipView({ node, editor, getPos }: NodeViewProps) {
       }}
       onDoubleClick={selectOnlyThisChip}
     >
-      <WorkspaceFileIcon
-        path={attrs.path}
-        kind={kind}
-        className="composer-file-ref-icon"
-      />
-      <span className="composer-file-ref-label">
-        <span className="composer-file-ref-name">
-          {composerFileLabel(attrs)}
-        </span>
-        {rangeLabel !== null && (
-          <span className="composer-file-ref-range">{rangeLabel}</span>
-        )}
-      </span>
+      <FileRefChipContent attrs={attrs} />
     </NodeViewWrapper>
   );
 }

--- a/packages/app-shell/src/features/file-ref-chip.css
+++ b/packages/app-shell/src/features/file-ref-chip.css
@@ -1,0 +1,58 @@
+/*
+ * Shared visual for a workspace file reference chip: type icon keeps its own
+ * hue, the basename uses a bright teal ink (higher L / soft chroma for a clear,
+ * airy feel), and the line range trails in a muted mix of the two.
+ *
+ * Unscoped on purpose. The composer renders these as TipTap atoms and chat
+ * history renders the same chip from the sent quote payload, so one definition
+ * keeps the prompt box and the message bubble visually identical.
+ */
+.composer-file-ref {
+  --composer-file-ink: oklch(0.55 0.09 195);
+  display: inline-flex;
+  max-width: 14rem;
+  align-items: center;
+  gap: 0.28em;
+  /* Gap without a selectable text space (those paint as thin selection bars). */
+  margin: 0 0.2em;
+  vertical-align: baseline;
+  color: var(--composer-file-ink);
+  font-size: inherit;
+  font-weight: 500;
+  line-height: inherit;
+}
+
+.dark .composer-file-ref {
+  /* Bright aqua on dark chrome; stays readable without neon glow. */
+  --composer-file-ink: oklch(0.82 0.1 195);
+}
+
+.composer-file-ref-icon {
+  width: 0.95em;
+  height: 0.95em;
+  flex-shrink: 0;
+}
+
+.composer-file-ref-label {
+  display: inline-flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 0.35em;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.composer-file-ref-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.composer-file-ref-range {
+  flex-shrink: 0;
+  color: color-mix(
+    in oklch,
+    var(--composer-file-ink) 55%,
+    var(--muted-foreground)
+  );
+  font-weight: 400;
+}

--- a/packages/app-shell/src/features/file-ref-chip.tsx
+++ b/packages/app-shell/src/features/file-ref-chip.tsx
@@ -1,0 +1,61 @@
+import {
+  composerFileChipTitle,
+  composerFileLabel,
+  composerFileLineRangeLabel,
+  type ComposerFileAttrs,
+} from "@ora/editor/composer";
+import { WorkspaceFileIcon } from "./files/workspace-file-visuals";
+import "./file-ref-chip.css";
+
+/**
+ * Icon + basename + optional `L12-34` range: the inside of a workspace file
+ * reference chip. Split from the wrappers so the composer's TipTap node view
+ * and read-only chat history render byte-identical chip innards instead of two
+ * drifting copies.
+ */
+export function FileRefChipContent({ attrs }: { attrs: ComposerFileAttrs }) {
+  const kind = attrs.kind === "directory" ? "directory" : "file";
+  const rangeLabel = composerFileLineRangeLabel(attrs);
+  return (
+    <>
+      <WorkspaceFileIcon
+        path={attrs.path}
+        kind={kind}
+        className="composer-file-ref-icon"
+      />
+      <span className="composer-file-ref-label">
+        <span className="composer-file-ref-name">
+          {composerFileLabel(attrs)}
+        </span>
+        {rangeLabel !== null && (
+          <span className="composer-file-ref-range">{rangeLabel}</span>
+        )}
+      </span>
+    </>
+  );
+}
+
+/**
+ * Read-only chip for surfaces that only hold the sent prompt text. The composer
+ * wraps the same content in a `NodeViewWrapper` instead, because an editable
+ * chip also carries drag and node-selection behaviour.
+ */
+export function FileRefChip({ attrs }: { attrs: ComposerFileAttrs }) {
+  const kind = attrs.kind === "directory" ? "directory" : "file";
+  return (
+    <span
+      className="composer-file-ref"
+      data-composer-file={attrs.path}
+      data-kind={kind}
+      {...(attrs.startLine === undefined
+        ? {}
+        : { "data-start-line": String(attrs.startLine) })}
+      {...(attrs.endLine === undefined
+        ? {}
+        : { "data-end-line": String(attrs.endLine) })}
+      title={composerFileChipTitle(attrs)}
+    >
+      <FileRefChipContent attrs={attrs} />
+    </span>
+  );
+}

--- a/packages/editor/src/composer/README.md
+++ b/packages/editor/src/composer/README.md
@@ -49,6 +49,15 @@ Tiptap preset and plain-text helpers for prompt boxes (chat composer, HITL).
   empty quote lifts the quote instead of inserting another paragraph inside it.
   A trailing space after a fence info string also
   opens the fence.
+- Custom commands (`insertComposerFiles`, `setPromptToken`) compose through the
+  `commands.*` given to them so every step lands on the one transaction TipTap
+  opened for the call. A nested `editor.chain()…run()` inside a command commits
+  a second transaction while the outer one is still open; the outer transaction
+  is then applied to a state it was never built from and ProseMirror throws
+  `Applying a mismatched transaction` _after_ the content has already been
+  inserted. `insertComposerFiles` needs two steps whenever a quote lands right
+  behind an existing chip or token — it drops the separator space first so a
+  range selection cannot paint a caret-thin bar between adjacent atoms.
 - Prompt links open on pointerdown (not mouseup/`click`) so the first press
   leaves the editor instead of placing a caret. Desktop still routes through
   the host browser command; this preset only calls `window.open` when no

--- a/packages/editor/src/composer/README.md
+++ b/packages/editor/src/composer/README.md
@@ -27,7 +27,12 @@ Tiptap preset and plain-text helpers for prompt boxes (chat composer, HITL).
   `start:end:path` citation fence; Diff-gutter quotes also set `origin: "diff"`
   and expand to a mini `diff --git` patch with unified markers. A mixed
   add/delete range is still one chip; `diffSide` is omitted and the body
-  carries `+/-/ `.
+  carries `+/-/ `. The patch's hunk note names the quoted file lines
+  (`lines 2-40`) because the hunk counts describe the body, which is shorter
+  whenever a drag crossed a collapsed hunk. `parseComposerFileQuote` is the
+  inverse of both payloads: read-only surfaces only hold the sent text, so it
+  is what lets them rebuild the chip — including its label — from the fence
+  alone. Any other fence parses to null and stays a code block.
   Path-only `@` mentions stay backtick paths.
   Inline code that contains backticks, and fenced blocks that contain a ` ``` `
   line, serialize with a longer CommonMark fence so parse cannot close early.

--- a/packages/editor/src/composer/composer-file-quote.ts
+++ b/packages/editor/src/composer/composer-file-quote.ts
@@ -1,0 +1,79 @@
+import type { ComposerFileAttrs } from "./composer-file";
+
+/** `start:end:path` info string of a file-preview citation fence. */
+const CITATION_INFO = /^(\d+):(\d+):(.+)$/;
+/** First line of the mini patch a diff-gutter quote expands to. */
+const DIFF_FILE_HEADER = /^diff --git a\/(.+) b\/(.+)$/;
+/** Hunk header note; the side is absent when one chip spans add and delete. */
+const DIFF_HUNK_HEADER =
+  /^@@ -\d+,\d+ \+\d+,\d+ @@ quoted from git diff(?: \((old|new) side\))?, lines (\d+)-(\d+)$/;
+
+/**
+ * Reads a fenced quote payload back into the chip attrs it was expanded from.
+ *
+ * Sending a prompt flattens chips through `composerFilePlainText`, so surfaces
+ * that only hold the sent text — chat history — need the inverse to show the
+ * same chip the composer did. Returns null for every other fence so ordinary
+ * code blocks keep rendering as code.
+ *
+ * @param info Fence info string (language plus meta, joined by a space).
+ * @param body Fence contents without the surrounding markers.
+ */
+export function parseComposerFileQuote(
+  info: string,
+  body: string,
+): ComposerFileAttrs | null {
+  const citation = CITATION_INFO.exec(info);
+  if (citation !== null) {
+    const [, startLine, endLine, path] = citation;
+    if (
+      startLine === undefined ||
+      endLine === undefined ||
+      path === undefined
+    ) {
+      return null;
+    }
+    return {
+      path,
+      startLine: Number(startLine),
+      endLine: Number(endLine),
+      snippet: body,
+      kind: "file",
+      // Explicit so both branches return the same shape as
+      // `composerFileAttrsFromUnknown`, which chip surfaces compare against.
+      origin: undefined,
+      diffSide: undefined,
+    };
+  }
+  return info === "diff" ? parseDiffQuote(body) : null;
+}
+
+/**
+ * The patch is only a quote when all four header lines are the ones
+ * `diffQuotePlainText` writes; a hand-pasted diff stays a code block.
+ */
+function parseDiffQuote(body: string): ComposerFileAttrs | null {
+  const lines = body.split("\n");
+  const header = DIFF_FILE_HEADER.exec(lines[0] ?? "");
+  if (header === null) return null;
+  const [, oldPath, newPath] = header;
+  if (oldPath === undefined || newPath === undefined || oldPath !== newPath) {
+    return null;
+  }
+  if (lines[1] !== `--- a/${oldPath}` || lines[2] !== `+++ b/${newPath}`) {
+    return null;
+  }
+  const hunk = DIFF_HUNK_HEADER.exec(lines[3] ?? "");
+  if (hunk === null) return null;
+  const [, diffSide, startLine, endLine] = hunk;
+  if (startLine === undefined || endLine === undefined) return null;
+  return {
+    path: newPath,
+    startLine: Number(startLine),
+    endLine: Number(endLine),
+    snippet: lines.slice(4).join("\n"),
+    kind: "file",
+    origin: "diff",
+    diffSide: diffSide === "old" || diffSide === "new" ? diffSide : undefined,
+  };
+}

--- a/packages/editor/src/composer/composer-file.ts
+++ b/packages/editor/src/composer/composer-file.ts
@@ -65,6 +65,7 @@ export function composerFilePlainText(attrs: ComposerFileAttrs): string {
       return diffQuotePlainText(
         attrs.path,
         attrs.startLine,
+        end,
         attrs.snippet,
         attrs.diffSide,
         fence,
@@ -133,16 +134,20 @@ function optionalString(value: unknown): string | undefined {
 function diffQuotePlainText(
   path: string,
   startLine: number,
+  endLine: number,
   snippet: string,
   diffSide: "old" | "new" | undefined,
   fence: string,
 ): string {
   const { oldCount, newCount } = unifiedHunkCounts(snippet);
-  const sideNote =
-    diffSide === "old" || diffSide === "new"
-      ? ` quoted from git diff (${diffSide} side)`
-      : " quoted from git diff";
-  const hunk = `@@ -${startLine},${oldCount} +${startLine},${newCount} @@${sideNote}`;
+  const side =
+    diffSide === "old" || diffSide === "new" ? ` (${diffSide} side)` : "";
+  // The hunk counts describe the quoted lines, not the span they came from: a
+  // drag across a collapsed hunk quotes lines 2 and 40 as a two-line body. The
+  // range note keeps the real span for the agent, and lets chat history rebuild
+  // the chip label from the payload alone.
+  const note = ` quoted from git diff${side}, lines ${startLine}-${endLine}`;
+  const hunk = `@@ -${startLine},${oldCount} +${startLine},${newCount} @@${note}`;
   const body = [
     `diff --git a/${path} b/${path}`,
     `--- a/${path}`,

--- a/packages/editor/src/composer/composer-file.ts
+++ b/packages/editor/src/composer/composer-file.ts
@@ -342,11 +342,16 @@ export const ComposerFile = Node.create({
               (maybeAtom.type.name === "composerFile" ||
                 maybeAtom.type.name === "promptToken")
             ) {
-              return editor
-                .chain()
-                .deleteRange({ from: $from.pos - 1, to: $from.pos })
-                .insertContent(content)
-                .run();
+              // Both steps go through `commands`, which share this command's
+              // own transaction. A nested `editor.chain().run()` would dispatch
+              // a second transaction while this one is still open, so the outer
+              // (now stale) transaction is applied to a state it was not built
+              // from and ProseMirror throws "Applying a mismatched
+              // transaction" after the chips have already landed.
+              return (
+                commands.deleteRange({ from: $from.pos - 1, to: $from.pos }) &&
+                commands.insertContent(content)
+              );
             }
           }
           return commands.insertContent(content);

--- a/packages/editor/src/composer/index.ts
+++ b/packages/editor/src/composer/index.ts
@@ -71,3 +71,4 @@ export {
   composerFilePlainText,
 } from "./composer-file";
 export type { ComposerFileAttrs } from "./composer-file";
+export { parseComposerFileQuote } from "./composer-file-quote";

--- a/packages/editor/tests/composer.test.ts
+++ b/packages/editor/tests/composer.test.ts
@@ -15,6 +15,7 @@ import {
   composerFileLabel,
   composerFilePlainText,
 } from "../src/composer/composer-file.ts";
+import { parseComposerFileQuote } from "../src/composer/composer-file-quote.ts";
 import { parseFenceOpener } from "../src/composer/composer-code-fence.ts";
 import { highlightInputMatch } from "../src/composer/composer-highlight.ts";
 import { isComposerOpenableUrl } from "../src/composer/composer-link.ts";
@@ -172,7 +173,7 @@ test("diff-gutter quotes serialize as a git patch so the agent sees an existing 
       "diff --git a/src/example.ts b/src/example.ts",
       "--- a/src/example.ts",
       "+++ b/src/example.ts",
-      "@@ -1,1 +1,2 @@ quoted from git diff (new side)",
+      "@@ -1,1 +1,2 @@ quoted from git diff (new side), lines 1-2",
       " keep",
       "+new line",
       "```",
@@ -194,7 +195,7 @@ test("diff-gutter quotes serialize as a git patch so the agent sees an existing 
       "diff --git a/src/example.ts b/src/example.ts",
       "--- a/src/example.ts",
       "+++ b/src/example.ts",
-      "@@ -2,1 +2,0 @@ quoted from git diff (old side)",
+      "@@ -2,1 +2,0 @@ quoted from git diff (old side), lines 2-2",
       "-old line",
       "```",
       "",
@@ -214,13 +215,95 @@ test("diff-gutter quotes serialize as a git patch so the agent sees an existing 
       "diff --git a/src/example.ts b/src/example.ts",
       "--- a/src/example.ts",
       "+++ b/src/example.ts",
-      "@@ -1,2 +1,2 @@ quoted from git diff",
+      "@@ -1,2 +1,2 @@ quoted from git diff, lines 1-3",
       " keep",
       "-old line",
       "+new line",
       "```",
       "",
     ].join("\n"),
+  );
+});
+
+/** Splits a serialized quote back into the fence info string and its body. */
+function fencedQuoteParts(payload: string): { info: string; body: string } {
+  const lines = payload.replace(/^\n/, "").replace(/\n$/, "").split("\n");
+  const opener = lines[0] ?? "";
+  return {
+    info: opener.replace(/^`+/, ""),
+    body: lines.slice(1, -1).join("\n"),
+  };
+}
+
+test("parseComposerFileQuote round-trips every payload composerFilePlainText writes", () => {
+  const quotes = [
+    {
+      path: "src/app.ts",
+      startLine: 4,
+      endLine: 5,
+      snippet: "const a = 1;\nconst b = 2;",
+      kind: "file" as const,
+      origin: undefined,
+      diffSide: undefined,
+    },
+    {
+      path: "src/example.ts",
+      startLine: 1,
+      endLine: 2,
+      snippet: " keep\n+new line",
+      kind: "file" as const,
+      origin: "diff" as const,
+      diffSide: "new" as const,
+    },
+    {
+      path: "src/example.ts",
+      startLine: 2,
+      endLine: 2,
+      snippet: "-old line",
+      kind: "file" as const,
+      origin: "diff" as const,
+      diffSide: "old" as const,
+    },
+    {
+      // A drag across a collapsed hunk quotes a wider span than the body has
+      // lines, so only the range note can carry the label history rebuilds.
+      path: "src/example.ts",
+      startLine: 2,
+      endLine: 40,
+      snippet: " keep\n-old line\n+new line",
+      kind: "file" as const,
+      origin: "diff" as const,
+      diffSide: undefined,
+    },
+  ];
+
+  for (const quote of quotes) {
+    const { info, body } = fencedQuoteParts(composerFilePlainText(quote));
+    assert.deepEqual(parseComposerFileQuote(info, body), quote);
+  }
+});
+
+test("parseComposerFileQuote leaves ordinary fenced code alone", () => {
+  assert.equal(parseComposerFileQuote("ts", "const a = 1;"), null);
+  assert.equal(parseComposerFileQuote("", "plain text"), null);
+  // Renamed file: a quote always patches one path against itself.
+  assert.equal(
+    parseComposerFileQuote("diff", "diff --git a/a.ts b/b.ts\n+added"),
+    null,
+  );
+  // A hand-written patch without the quote note stays a diff code block.
+  assert.equal(
+    parseComposerFileQuote(
+      "diff",
+      [
+        "diff --git a/a.ts b/a.ts",
+        "--- a/a.ts",
+        "+++ b/a.ts",
+        "@@ -1,1 +1,1 @@",
+        "+added",
+      ].join("\n"),
+    ),
+    null,
   );
 });
 


### PR DESCRIPTION
修两个文件行引用（gutter `+` 引用）的问题。

## 1. 第二次引用会报「无法把文件选区加入提示词」

`insertComposerFiles` 在命令内部嵌套了 `editor.chain().…run()`。TipTap 调用命令时先开一个事务、命令跑完再 dispatch；内层 chain 会立刻 dispatch 第二个事务让 editor state 前进，等外层那个基于旧 state 建的事务再 dispatch 时，ProseMirror 抛 `RangeError: Applying a mismatched transaction`。

- 第一次引用不报错：编辑器是空的，走 `editor.isEmpty` 分支，全程一个事务。
- 第二次报错：光标停在「chip + 分隔空格」后面，才命中「删掉分隔空格」那条嵌套 chain 的分支。
- chip 却又插进去了：内层事务先成功，异常发生在之后的外层 dispatch。

引入者是 `cfa4fe6c fix(composer): highlight chips inside spanning text selections`。

改为 `commands.deleteRange(...) && commands.insertContent(...)`，两步都落在命令自己的事务上。

**为什么测试没拦住**：这条分支此前零单测覆盖（已有的相邻 chip 测试是一次调用插两个，进不去分支）；集成测试确实触发了，但只断言 chip 存在——失败既不抛出也不写 stderr，被 composer 和 store 两层 `catch` 吃掉，所以 clean-stderr 门也不会响，套件全绿照样发布。

对应地补了：两个单测直接覆盖该分支的两种 atom（前面是 chip / 是 `/command` token），以及给三个 quote 集成测试都加上 `expectNoComposerInjectError()`——以后「chip 进去了但插入其实失败」会直接测挂。

## 2. 回车发送后引用变成源代码

发送时 `composerFilePlainText` 把 chip 摊平成带 snippet 的代码围栏（agent 需要读这个），而聊天历史直接回放这段文本，所以用户自己的引用在气泡里变成一大块源码，和输入框里的紧凑 chip 完全不一样。

- 新增 `parseComposerFileQuote`，`composerFilePlainText` 的逆运算，和格式放在同一个模块里；其它围栏返回 null，仍按代码块渲染。
- 新增只作用于 compact（用户消息）层的 remark pass，把围栏还原成 chip。在输入框里相邻的引用会序列化成连续围栏，这里重新合并进同一个段落，所以还是一行显示。
- chip 的内部结构和样式收敛成一份：输入框的 TipTap node view 和聊天历史都渲染 `FileRefChipContent`，共用一份不带作用域的样式表，编辑器样式表只保留编辑行为（拖拽、节点选中、`user-select`）。两边不可能再走样。

**有一处发送内容的改动**：diff 引用原本无法还原标签——`@@` 的行数统计描述的是引用正文，而拖选跨过折叠 hunk 时正文比真实跨度短（`L2-40` 只引了两行）。现在 hunk 注释会带上真实行号：`@@ -2,2 +2,2 @@ quoted from git diff (new side), lines 2-40`。这对 agent 也是更完整的信息。

## 测试

新增测试都已验证在修复前会失败。

- `packages/editor/tests/composer.test.ts`：对 `composerFilePlainText` 产出的每种形态做整对象往返比较，外加反例（重命名的 patch、没有引用注释的手写 patch、普通 `ts` 围栏）。
- `markdown-message.test.tsx`：五个测试跑真实发送载荷——文件引用渲染成带正确行号范围的 chip 且无 `<pre>`；diff 引用保留拖选跨度；相邻引用共享同一个父节点；snippet 自身含围栏（加长标记的情况）；普通围栏代码仍是代码块。
- `composer-editor.test.tsx`、`chat-view.test.tsx`：见上面第 1 节。

`@ora/editor` 55 个测试全过；`@ora/app-shell` lint（tsc + eslint）通过，改动涉及的 7 个测试文件共 229 个测试全过。

`composer`、`editor`、`diff` 的 README 和 `docs/task-workspace-files.md` 已同步更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
