### PR TITLE
feat(plugin): support installable skill plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "futures",
  "ora-domain",
  "ora-plugin-manifest",
+ "ora-skill-package",
  "ora-utils",
  "pretty_assertions",
  "semver",

--- a/crates/application/src/error.rs
+++ b/crates/application/src/error.rs
@@ -28,6 +28,8 @@ pub enum ApplicationError {
     SkillNotFound { skill_id: String },
     #[error("skill is referenced by Workspace desired state")]
     SkillInUse,
+    #[error("plugin-provided skills are read-only")]
+    SkillReadOnly,
     #[error("skill repository operation failed")]
     SkillRepository {
         #[source]

--- a/crates/application/src/skill/handlers.rs
+++ b/crates/application/src/skill/handlers.rs
@@ -2,7 +2,7 @@ use crate::skill::mapper::{map_skill, map_skill_details};
 use crate::skill::package_health::{
     claim_untracked_name, commit_existing_package, commit_restored_package,
     commit_unclaimed_package, has_usable_package, manifest_is_usable, package_availability,
-    persist_promoted_package,
+    persist_promoted_package, read_skill_manifest,
 };
 use crate::skill::ports::{
     LocalSkillSourceRevision, SkillDeleteOutcome, SkillIdGenerator, SkillRepository,
@@ -159,10 +159,7 @@ where
             .ok_or_else(|| ApplicationError::SkillNotFound {
                 skill_id: skill_id.to_string(),
             })?;
-        let manifest = self
-            .storage
-            .read_manifest(&skill.name)
-            .map_err(ApplicationError::from_skill_storage_error)?;
+        let manifest = read_skill_manifest(&self.storage, &skill)?;
         let Some(manifest) = manifest else {
             return Ok(GetSkillResponse {
                 skill: map_skill_details(skill, String::new(), SkillAvailability::Unavailable),
@@ -215,7 +212,7 @@ where
             .map_err(ApplicationError::from_skill_repository_error)?;
         let mut mapped = Vec::new();
         for skill in skills {
-            let availability = package_availability(&self.storage, &skill.name)?;
+            let availability = package_availability(&self.storage, &skill)?;
             mapped.push(map_skill(skill, availability));
         }
         Ok(ListSkillsResponse { skills: mapped })
@@ -259,6 +256,9 @@ where
             .ok_or_else(|| ApplicationError::SkillNotFound {
                 skill_id: skill_id.to_string(),
             })?;
+        if existing.is_read_only() {
+            return Err(ApplicationError::SkillReadOnly);
+        }
 
         let name = request.name.trim().to_string();
         reject_conflicting_name(&self.repository, &existing.namespace, &name, &existing.id)?;
@@ -406,6 +406,9 @@ where
             .ok_or_else(|| ApplicationError::SkillNotFound {
                 skill_id: skill_id.to_string(),
             })?;
+        if existing.is_read_only() {
+            return Err(ApplicationError::SkillReadOnly);
+        }
 
         let handle = match self.storage.commit_delete(&existing.name, &skill_id) {
             Ok(handle) => Some(handle),

--- a/crates/application/src/skill/mapper.rs
+++ b/crates/application/src/skill/mapper.rs
@@ -1,5 +1,5 @@
-use ora_contracts::{Skill as ContractSkill, SkillAvailability, SkillDetails};
-use ora_domain::Skill as DomainSkill;
+use ora_contracts::{Skill as ContractSkill, SkillAvailability, SkillDetails, SkillSource};
+use ora_domain::{Skill as DomainSkill, SkillOrigin};
 
 /// Projects a domain skill into its audit-free public contract form.
 pub(crate) fn map_skill(skill: DomainSkill, availability: SkillAvailability) -> ContractSkill {
@@ -8,6 +8,7 @@ pub(crate) fn map_skill(skill: DomainSkill, availability: SkillAvailability) -> 
         namespace: skill.namespace.to_string(),
         name: skill.name,
         description: skill.description,
+        source: map_source(&skill.origin),
         availability,
     }
 }
@@ -24,6 +25,16 @@ pub(crate) fn map_skill_details(
         name: skill.name,
         description: skill.description,
         content,
+        source: map_source(&skill.origin),
         availability,
+    }
+}
+
+fn map_source(origin: &SkillOrigin) -> SkillSource {
+    match origin {
+        SkillOrigin::Local => SkillSource::Local,
+        SkillOrigin::Plugin { plugin_id, .. } => SkillSource::Plugin {
+            plugin_id: plugin_id.canonical(),
+        },
     }
 }

--- a/crates/application/src/skill/package_health.rs
+++ b/crates/application/src/skill/package_health.rs
@@ -1,7 +1,7 @@
 use super::storage::{CreateHandle, JournalOp, SkillStorage, SwapHandle};
 use crate::ApplicationError;
 use ora_contracts::SkillAvailability;
-use ora_domain::{Namespace, SkillId};
+use ora_domain::{Namespace, Skill, SkillId, SkillOrigin};
 use ora_skill_package::Limits;
 use ora_skill_package::manifest::parse_manifest;
 use std::path::Path;
@@ -56,14 +56,24 @@ pub fn has_usable_package<Storage: SkillStorage>(
         .is_some_and(|bytes| manifest_is_usable(&bytes)))
 }
 
-/// Derives catalog availability from the on-disk package. Missing or unreadable files do
-/// not forget the row; the skill stays visible as unavailable until the user deletes it
-/// or restores a package with the same name.
+/// Reads the manifest from either mutable local storage or an immutable plugin package.
+pub(crate) fn read_skill_manifest<Storage: SkillStorage>(
+    storage: &Storage,
+    skill: &Skill,
+) -> Result<Option<Vec<u8>>, ApplicationError> {
+    match &skill.origin {
+        SkillOrigin::Local => storage.read_manifest(&skill.name),
+        SkillOrigin::Plugin { package_root, .. } => storage.read_package_manifest(package_root),
+    }
+    .map_err(ApplicationError::from_skill_storage_error)
+}
+
+/// Derives catalog availability from the package owned by the Skill's source.
 pub(crate) fn package_availability<Storage: SkillStorage>(
     storage: &Storage,
-    name: &str,
+    skill: &Skill,
 ) -> Result<SkillAvailability, ApplicationError> {
-    if has_usable_package(storage, name)? {
+    if read_skill_manifest(storage, skill)?.is_some_and(|bytes| manifest_is_usable(&bytes)) {
         Ok(SkillAvailability::Available)
     } else {
         Ok(SkillAvailability::Unavailable)

--- a/crates/application/src/skill/storage.rs
+++ b/crates/application/src/skill/storage.rs
@@ -193,6 +193,22 @@ pub trait SkillStorage {
     /// Returns whether a formal directory exists for the name.
     fn formal_exists(&self, name: &str) -> bool;
 
+    /// Reads `SKILL.md` from an immutable package root outside local formal storage.
+    fn read_package_manifest(
+        &self,
+        package_root: &Path,
+    ) -> Result<Option<Vec<u8>>, SkillStorageError> {
+        let manifest = package_root.join("SKILL.md");
+        if !manifest.is_file() {
+            return Ok(None);
+        }
+        std::fs::read(&manifest)
+            .map(Some)
+            .map_err(|error| SkillStorageError::OperationFailed {
+                message: format!("failed to read {}: {error}", manifest.display()),
+            })
+    }
+
     /// Reads the formal `SKILL.md` bytes, if the directory exists.
     fn read_manifest(&self, name: &str) -> Result<Option<Vec<u8>>, SkillStorageError>;
 

--- a/crates/application/src/skill/tests.rs
+++ b/crates/application/src/skill/tests.rs
@@ -6,9 +6,10 @@ use super::{
 use crate::skill::storage::{CreateHandle, DeleteHandle, SwapHandle, TransactionJournal};
 use crate::{ApplicationError, Clock, RepositoryError};
 use ora_contracts::{
-    CreateSkillRequest, DeleteSkillRequest, GetSkillRequest, ListSkillsRequest, UpdateSkillRequest,
+    CreateSkillRequest, DeleteSkillRequest, GetSkillRequest, ListSkillsRequest, SkillSource,
+    UpdateSkillRequest,
 };
-use ora_domain::{AuditFields, Namespace, Skill, SkillId};
+use ora_domain::{AuditFields, Namespace, PluginId, Skill, SkillId};
 use ora_skill_package::manifest::{render_manifest, render_minimal_manifest};
 use ora_utils::path::StrictRelativePath;
 use pretty_assertions::assert_eq;
@@ -398,6 +399,60 @@ fn recreates_a_deleted_unavailable_skill_under_the_same_name() {
     assert!(storage.formal_exists("review"));
 }
 
+#[test]
+fn plugin_skills_load_from_their_package_and_reject_user_mutations() {
+    let package = TempDir::new().unwrap();
+    fs::write(
+        package.path().join("SKILL.md"),
+        "---\nname: review\ndescription: Reviews changes\n---\n# Plugin body\n",
+    )
+    .unwrap();
+    let plugin_id = PluginId::new("official", "review-pack").unwrap();
+    let plugin_skill = Skill::new_plugin(
+        SkillId::new("plugin:official/review-pack:review"),
+        Namespace::new(plugin_id.canonical()).unwrap(),
+        "review",
+        "Reviews changes",
+        plugin_id.clone(),
+        package.path().to_path_buf(),
+        AuditFields::new(10, 10, false),
+    )
+    .unwrap();
+    let repository = Rc::new(FakeSkillRepository::with_skills(vec![plugin_skill]));
+    let storage = Rc::new(FakeSkillStorage::default());
+
+    let details = GetSkillHandler::new(repository.clone(), storage.clone())
+        .handle(GetSkillRequest {
+            skill_id: "plugin:official/review-pack:review".to_string(),
+        })
+        .unwrap()
+        .skill;
+    assert_eq!(details.content, "# Plugin body");
+    assert_eq!(
+        details.source,
+        SkillSource::Plugin {
+            plugin_id: plugin_id.canonical(),
+        }
+    );
+
+    assert!(matches!(
+        UpdateSkillHandler::new(repository.clone(), storage.clone(), FixedClock(20)).handle(
+            UpdateSkillRequest {
+                skill_id: details.id.clone(),
+                name: "renamed".to_string(),
+                description: "Changed".to_string(),
+                content: None,
+            }
+        ),
+        Err(ApplicationError::SkillReadOnly)
+    ));
+    assert!(matches!(
+        DeleteSkillHandler::new(repository, storage, FixedClock(20)).handle(DeleteSkillRequest {
+            skill_id: details.id,
+        }),
+        Err(ApplicationError::SkillReadOnly)
+    ));
+}
 #[test]
 fn reports_unavailable_skills_and_restores_them_by_same_name() {
     let repository = Rc::new(FakeSkillRepository::with_skills(vec![

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -71,6 +71,8 @@ pub enum BackendBootstrapError {
     Database(#[source] ora_db::DatabaseError),
     #[error("failed to initialize plugin lifecycle")]
     PluginLifecycle(#[source] ora_plugin_lifecycle::PluginLifecycleError),
+    #[error("failed to synchronize installed plugin Skills")]
+    PluginSkillCatalog(#[source] BackendError),
     #[error("failed to reconcile skill storage")]
     SkillStorage(#[source] ApplicationError),
     #[error("failed to initialize agent runtime")]
@@ -145,6 +147,9 @@ impl Backend {
             )
             .map_err(BackendBootstrapError::PluginLifecycle)?,
         );
+        plugin
+            .sync_installed_skills()
+            .map_err(BackendBootstrapError::PluginSkillCatalog)?;
         let scheduler = Scheduler::new(paths.timezone);
         let worktree_root = Arc::new(RwLock::new(paths.worktree_root));
         let sessions_root = paths.sessions_root;
@@ -337,11 +342,7 @@ impl Backend {
         &self,
         request: UninstallPluginRequest,
     ) -> Result<UninstallPluginResponse, BackendError> {
-        let response = self
-            .plugin
-            .uninstall(request)
-            .await
-            .map_err(BackendError::from)?;
+        let response = self.plugin.uninstall(request).await?;
         self.agent_runtime.sync_plugin_agents();
         Ok(response)
     }
@@ -1674,6 +1675,58 @@ mod tests {
         assert_eq!(error.public_error().code(), "project_not_found");
     }
 
+    /// Verifies startup projects installed Skill plugins into the shared Skill catalog.
+    #[test]
+    fn opens_with_plugin_skills_written_to_the_existing_database_schema() {
+        let temporary = TempDir::new().expect("create temporary backend directory");
+        let package_root = temporary
+            .path()
+            .join("plugins/installed/official/review-pack/1.0.0");
+        let skill_root = package_root.join("assets/skills/review");
+        fs::create_dir_all(&skill_root).expect("create installed Skill tree");
+        fs::write(
+            package_root.join("orax.toml"),
+            "name = \"review-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.0.0\"\ndescription = \"Review skills\"\n",
+        )
+        .expect("write plugin manifest");
+        fs::write(
+            skill_root.join("SKILL.md"),
+            "---\nname: review\ndescription: Reviews changes\n---\n# Review instructions\n",
+        )
+        .expect("write Skill manifest");
+
+        let backend = Backend::open(BackendPaths {
+            database_path: temporary.path().join("ora.sqlite3"),
+            data_directory: temporary.path().to_path_buf(),
+            deno_path: std::path::PathBuf::from("deno"),
+            worktree_root: temporary.path().join("worktrees"),
+            home_directory: temporary.path().to_path_buf(),
+            relative_path_base: temporary.path().to_path_buf(),
+            sessions_root: temporary.path().join("sessions"),
+            skills_root: temporary.path().join("atoms/skills"),
+            ripgrep_path: std::path::PathBuf::from("rg"),
+            timezone: chrono_tz::UTC,
+        })
+        .expect("open shared backend");
+
+        let skills = backend
+            .list_skills(ListSkillsRequest {})
+            .expect("list plugin Skills")
+            .skills;
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].namespace, "official/review-pack");
+        assert_eq!(skills[0].name, "review");
+        assert_eq!(
+            skills[0].source,
+            ora_contracts::SkillSource::Plugin {
+                plugin_id: "official/review-pack".to_string(),
+            }
+        );
+        assert_eq!(
+            skills[0].availability,
+            ora_contracts::SkillAvailability::Available
+        );
+    }
     /// Verifies an update rewrites only the manifest and preserves other package files.
     #[test]
     fn update_preserves_other_package_files() {

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -184,6 +184,11 @@ impl From<ApplicationError> for BackendError {
                 PublicError::ResourceInUse(EmptyErrorParams {}),
                 "skill is referenced by Workspace desired state",
             ),
+            ApplicationError::SkillReadOnly => (
+                ErrorClassification::InvalidRequest,
+                PublicError::InvalidRequest(EmptyErrorParams {}),
+                "plugin-provided skills are read-only",
+            ),
             ApplicationError::SkillStorageInconsistent { .. } => (
                 ErrorClassification::Internal,
                 PublicError::SkillStorageInconsistent(EmptyErrorParams {}),

--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -2,6 +2,7 @@ use crate::app_event::AppEventPublisher;
 use crate::clock::SystemClock;
 use crate::error::{BackendError, ErrorClassification};
 use gitlancer::{BranchName, CliGitRunner, Git};
+use ora_application::Clock;
 use ora_contracts::{
     ActivatePluginRequest, ActivatePluginResponse, DisablePluginRequest, DisablePluginResponse,
     EmptyErrorParams, EnablePluginRequest, EnablePluginResponse, ImportPluginRequest,
@@ -11,15 +12,18 @@ use ora_contracts::{
     SyncAvailablePluginsRequest, SyncAvailablePluginsResponse, UninstallPluginRequest,
     UninstallPluginResponse,
 };
-use ora_db::{RepositoryPool, SqlitePluginStateRepository};
+use ora_db::{
+    PluginSkillProjection, RepositoryPool, SqlitePluginStateRepository, SqliteSkillRepository,
+};
 use ora_domain::PluginId;
+use ora_effect::Digest;
 use ora_logging::{ora_debug, ora_info, ora_warn};
 use ora_plugin_lifecycle::{
     ConnectionError, DenoPluginRuntime, DenoPluginRuntimeLauncher, InboundNotification,
     PluginGenerationKey, PluginGenerationLease, PluginLifecycle, PluginLifecycleConfig,
     PluginLifecycleError, PluginNotificationSink, PluginRuntimeTimeouts,
 };
-use ora_plugin_manager::Installer;
+use ora_plugin_manager::{Installer, PluginContribution, PluginManager};
 use ora_plugin_registry::{
     RegistryEntry, RegistryError, RegistryIndex, RegistrySource, RegistrySync,
 };
@@ -159,6 +163,8 @@ pub(crate) struct PluginApi {
     data_directory: PathBuf,
     installer: Installer<ReqwestDownloader>,
     notifications: BroadcastNotificationSink,
+    skill_repository: SqliteSkillRepository,
+    clock: SystemClock,
 }
 
 impl PluginApi {
@@ -188,7 +194,7 @@ impl PluginApi {
                 data_directory: data_directory.clone(),
                 deno_path,
             },
-            SqlitePluginStateRepository::new(pool),
+            SqlitePluginStateRepository::new(pool.clone()),
             clock,
             DenoPluginRuntimeLauncher::new(PluginRuntimeTimeouts::default()),
             publisher,
@@ -202,9 +208,21 @@ impl PluginApi {
             data_directory,
             installer,
             notifications,
+            skill_repository: SqliteSkillRepository::new(pool),
+            clock,
         })
     }
 
+    /// Rebuilds catalog projections for every Skill plugin already installed on disk.
+    pub(crate) fn sync_installed_skills(&self) -> Result<(), BackendError> {
+        let manager = PluginManager::discover(&self.data_directory);
+        for plugin in manager.installed_plugins() {
+            if matches!(plugin.contributes, PluginContribution::Skill(_)) {
+                self.persist_discovered_plugin_skills(plugin)?;
+            }
+        }
+        Ok(())
+    }
     /// Returns the cached marketplace registry index, or an empty catalog when absent.
     pub(crate) fn list_available_plugins(
         &self,
@@ -336,8 +354,15 @@ impl PluginApi {
     pub(crate) async fn uninstall(
         &self,
         request: UninstallPluginRequest,
-    ) -> Result<UninstallPluginResponse, PluginLifecycleError> {
-        self.lifecycle.uninstall_plugin(request).await
+    ) -> Result<UninstallPluginResponse, BackendError> {
+        let plugin_id = request.plugin_id.clone();
+        let response = self.lifecycle.uninstall_plugin(request).await?;
+        let plugin_id = PluginId::parse(&plugin_id)
+            .map_err(|error| BackendError::internal("uninstalled plugin id is invalid", error))?;
+        self.skill_repository
+            .remove_plugin_skills(&plugin_id, self.clock.now_timestamp_millis())
+            .map_err(|error| BackendError::internal("failed to remove plugin Skills", error))?;
+        Ok(response)
     }
     /// Installs a marketplace plugin by resolving its release manifest from the synced source and
     /// downloading, verifying, and extracting its package through the network-backed installer.
@@ -387,7 +412,7 @@ impl PluginApi {
             )
             .await
             .map_err(|error| BackendError::internal("failed to install plugin", error))?;
-        self.finalize_new_install(&request.plugin_id).await;
+        self.finalize_new_install(&request.plugin_id).await?;
         ora_info!(plugin_id = %request.plugin_id, "installed marketplace plugin");
         Ok(InstallPluginResponse {
             plugin_id: request.plugin_id,
@@ -413,7 +438,7 @@ impl PluginApi {
         .await
         .map_err(|error| BackendError::internal("failed to join plugin import task", error))?
         .map_err(|error| BackendError::internal("failed to import plugin archive", error))?;
-        self.finalize_new_install(&package.id).await;
+        self.finalize_new_install(&package.id).await?;
         ora_info!(plugin_id = %package.id, "imported plugin release from local archive");
         Ok(ImportPluginResponse {
             plugin_id: package.id,
@@ -427,7 +452,8 @@ impl PluginApi {
     /// new package to appear in the installed list without restarting the backend. Enabling is a
     /// best-effort follow-up: a package that fails to launch still reports its failure through the
     /// lifecycle runtime instead of failing the install.
-    async fn finalize_new_install(&self, plugin_id: &str) {
+    async fn finalize_new_install(&self, plugin_id: &str) -> Result<(), BackendError> {
+        self.sync_plugin_skills(plugin_id)?;
         if let Err(error) = self.lifecycle.scan_plugins(ScanPluginsRequest {}).await {
             ora_warn!(plugin_id = %plugin_id, %error, "installed the package but failed to refresh the installed-plugin snapshot");
         }
@@ -440,6 +466,65 @@ impl PluginApi {
         {
             ora_warn!(plugin_id = %plugin_id, %error, "installed plugin could not be enabled by default");
         }
+        Ok(())
+    }
+
+    /// Projects validated static Skill metadata into the shared catalog and Effect source tables.
+    fn sync_plugin_skills(&self, plugin_id: &str) -> Result<(), BackendError> {
+        let manager = PluginManager::discover(&self.data_directory);
+        let plugin = manager
+            .installed_plugins()
+            .iter()
+            .find(|plugin| plugin.id.canonical() == plugin_id)
+            .ok_or_else(|| {
+                BackendError::internal(
+                    "installed plugin was not discoverable for Skill synchronization",
+                    std::io::Error::new(std::io::ErrorKind::NotFound, plugin_id.to_string()),
+                )
+            })?;
+        self.persist_discovered_plugin_skills(plugin)
+    }
+
+    /// Persists one already-discovered Skill plugin without exposing package layout to callers.
+    fn persist_discovered_plugin_skills(
+        &self,
+        plugin: &ora_plugin_manager::InstalledPlugin,
+    ) -> Result<(), BackendError> {
+        let PluginContribution::Skill(descriptor) = &plugin.contributes else {
+            self.skill_repository
+                .remove_plugin_skills(&plugin.id, self.clock.now_timestamp_millis())
+                .map_err(|error| {
+                    BackendError::internal("failed to clear stale plugin Skills", error)
+                })?;
+            return Ok(());
+        };
+        let mut projections = Vec::with_capacity(descriptor.skills.len());
+        for skill in &descriptor.skills {
+            let manifest_path = skill.package_root.join("SKILL.md");
+            let manifest = std::fs::read(&manifest_path).map_err(|error| {
+                BackendError::internal(
+                    "failed to read validated plugin Skill manifest",
+                    std::io::Error::new(
+                        error.kind(),
+                        format!("{}: {error}", manifest_path.display()),
+                    ),
+                )
+            })?;
+            projections.push(PluginSkillProjection {
+                name: skill.name.clone(),
+                description: skill.description.clone(),
+                package_root: skill.package_root.clone(),
+                skill_md_digest: Digest::sha256(&manifest).to_string(),
+            });
+        }
+        self.skill_repository
+            .replace_plugin_skills(
+                &plugin.id,
+                &plugin.version.to_string(),
+                &projections,
+                self.clock.now_timestamp_millis(),
+            )
+            .map_err(|error| BackendError::internal("failed to persist plugin Skills", error))
     }
 }
 

--- a/crates/backend/src/skill_reconciliation.rs
+++ b/crates/backend/src/skill_reconciliation.rs
@@ -46,6 +46,9 @@ pub(crate) fn reconcile_skill_storage(
     let visible = repository.list_skills().map_err(operation_failed)?;
     let mut claimed = BTreeSet::new();
     for skill in visible {
+        if skill.is_read_only() {
+            continue;
+        }
         let has_directory = storage.formal_exists(&skill.name);
         let manifest = storage
             .read_manifest(&skill.name)

--- a/crates/contracts/src/plugin.rs
+++ b/crates/contracts/src/plugin.rs
@@ -28,6 +28,8 @@ pub enum InstalledPluginContribution {
         title: String,
         start_url: String,
     },
+    /// A static package kind whose Skill assets are cataloged without a runtime process.
+    Skill,
 }
 
 /// Represents the process-scoped lifecycle of one installed plugin.
@@ -416,6 +418,32 @@ mod tests {
         );
     }
 
+    /// Verifies the static Skill contribution adds only its kind discriminator.
+    #[test]
+    fn serializes_skill_plugin_contract() {
+        let plugin = InstalledPlugin {
+            id: "official/ora.skill-pack".to_string(),
+            namespace: "official".to_string(),
+            name: "ora.skill-pack".to_string(),
+            display_name: "ora.skill-pack".to_string(),
+            version: "0.1.1".to_string(),
+            description: "Skill plugin test".to_string(),
+            homepage: None,
+            license: None,
+            contribution: InstalledPluginContribution::Skill,
+            enabled: true,
+            logo: None,
+            runtime: PluginRuntimeStatus::Stopped,
+        };
+
+        let value = serde_json::to_value(&plugin).expect("Skill plugin serializes");
+        assert_eq!(value.get("kind"), Some(&json!("skill")));
+        assert_eq!(value.as_object().map(serde_json::Map::len), Some(12));
+        assert_eq!(
+            serde_json::from_value::<InstalledPlugin>(value).expect("Skill plugin round-trips"),
+            plugin
+        );
+    }
     /// Verifies an empty startup snapshot has a stable collection shape.
     #[test]
     fn serializes_empty_installed_plugin_response() {

--- a/crates/contracts/src/skill.rs
+++ b/crates/contracts/src/skill.rs
@@ -10,6 +10,18 @@ pub enum SkillAvailability {
     Unavailable,
 }
 
+/// Identifies whether a Skill is user-owned or supplied by an immutable plugin package.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+#[ts(export_to = "skill.ts")]
+pub enum SkillSource {
+    Local,
+    Plugin { plugin_id: String },
+}
 /// Describes a public skill payload without persistence audit metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -19,6 +31,7 @@ pub struct Skill {
     pub namespace: String,
     pub name: String,
     pub description: String,
+    pub source: SkillSource,
     pub availability: SkillAvailability,
 }
 
@@ -32,6 +45,7 @@ pub struct SkillDetails {
     pub name: String,
     pub description: String,
     pub content: String,
+    pub source: SkillSource,
     pub availability: SkillAvailability,
 }
 
@@ -125,6 +139,7 @@ pub struct DeleteSkillResponse {
 /// Exports every TypeScript binding declared in this module into the target directory.
 pub(crate) fn export(config: &ts_rs::Config) -> Result<(), ts_rs::ExportError> {
     SkillAvailability::export(config)?;
+    SkillSource::export(config)?;
     Skill::export(config)?;
     SkillDetails::export(config)?;
     CreateSkillRequest::export(config)?;
@@ -145,7 +160,7 @@ mod tests {
     use super::{
         CreateSkillRequest, CreateSkillResponse, DeleteSkillRequest, DeleteSkillResponse,
         GetSkillRequest, GetSkillResponse, ListSkillsRequest, ListSkillsResponse, Skill,
-        SkillAvailability, UpdateSkillRequest, UpdateSkillResponse,
+        SkillAvailability, SkillSource, UpdateSkillRequest, UpdateSkillResponse,
     };
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -158,6 +173,7 @@ mod tests {
             namespace: "local".to_string(),
             name: "review".to_string(),
             description: "Reviews implementation changes".to_string(),
+            source: SkillSource::Local,
             availability: SkillAvailability::Available,
         };
 
@@ -168,6 +184,7 @@ mod tests {
                 "namespace": "local",
                 "name": "review",
                 "description": "Reviews implementation changes",
+                "source": { "kind": "local" },
                 "availability": "available",
             })
         );
@@ -181,6 +198,7 @@ mod tests {
             namespace: "local".to_string(),
             name: "review".to_string(),
             description: "Reviews implementation changes".to_string(),
+            source: SkillSource::Local,
             availability: SkillAvailability::Available,
         };
 
@@ -196,7 +214,7 @@ mod tests {
             &CreateSkillResponse {
                 skill: skill.clone(),
             },
-            json!({ "skill": { "id": "skill-1", "namespace": "local", "name": "review", "description": "Reviews implementation changes", "availability": "available" } }),
+            json!({ "skill": { "id": "skill-1", "namespace": "local", "name": "review", "description": "Reviews implementation changes", "source": { "kind": "local" }, "availability": "available" } }),
         );
         assert_serialized_json(
             &GetSkillRequest {
@@ -212,17 +230,18 @@ mod tests {
                     name: skill.name.clone(),
                     description: skill.description.clone(),
                     content: "# Instructions".to_string(),
+                    source: SkillSource::Local,
                     availability: SkillAvailability::Available,
                 },
             },
-            json!({ "skill": { "id": "skill-1", "namespace": "local", "name": "review", "description": "Reviews implementation changes", "content": "# Instructions", "availability": "available" } }),
+            json!({ "skill": { "id": "skill-1", "namespace": "local", "name": "review", "description": "Reviews implementation changes", "content": "# Instructions", "source": { "kind": "local" }, "availability": "available" } }),
         );
         assert_serialized_json(&ListSkillsRequest {}, json!({}));
         assert_serialized_json(
             &ListSkillsResponse {
-                skills: vec![skill.clone()],
+                skills: vec![skill],
             },
-            json!({ "skills": [{ "id": "skill-1", "namespace": "local", "name": "review", "description": "Reviews implementation changes", "availability": "available" }] }),
+            json!({ "skills": [{ "id": "skill-1", "namespace": "local", "name": "review", "description": "Reviews implementation changes", "source": { "kind": "local" }, "availability": "available" }] }),
         );
         assert_serialized_json(
             &UpdateSkillRequest {
@@ -253,10 +272,11 @@ mod tests {
                     namespace: "local".to_string(),
                     name: "code-review".to_string(),
                     description: "Reviews code changes".to_string(),
+                    source: SkillSource::Local,
                     availability: SkillAvailability::Available,
                 },
             },
-            json!({ "skill": { "id": "skill-1", "namespace": "local", "name": "code-review", "description": "Reviews code changes", "availability": "available" } }),
+            json!({ "skill": { "id": "skill-1", "namespace": "local", "name": "code-review", "description": "Reviews code changes", "source": { "kind": "local" }, "availability": "available" } }),
         );
         assert_serialized_json(
             &DeleteSkillRequest {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -21,10 +21,10 @@ pub use error::{DatabaseError, MigrationDirection};
 pub use location::DatabaseLocation;
 pub use migration::{AppliedMigration, Migration, MigrationCatalog, default_migration_catalog};
 pub use repository::{
-    CascadeDeleteOutcome, RepositoryPool, SourceMutationOutcome, SourcePublication,
-    SqliteAgentDefinitionRepository, SqliteCascadeRepository, SqliteEffectRepository,
-    SqliteGitCleanupJobRepository, SqlitePluginStateRepository, SqliteProjectRepository,
-    SqliteSessionRepository, SqliteSkillRepository, SqliteTaskRepository,
+    CascadeDeleteOutcome, PluginSkillProjection, RepositoryPool, SourceMutationOutcome,
+    SourcePublication, SqliteAgentDefinitionRepository, SqliteCascadeRepository,
+    SqliteEffectRepository, SqliteGitCleanupJobRepository, SqlitePluginStateRepository,
+    SqliteProjectRepository, SqliteSessionRepository, SqliteSkillRepository, SqliteTaskRepository,
     SqliteTaskWorkspaceRepository, SqliteUserConfigRepository, SqliteWorkflowRepository,
     SqliteWorkflowRunEngineRepository, SqliteWorkflowRunRepository, SqliteWorkspaceRepository,
     SqliteWorktreeProvisioningLeaseRepository, SqliteWorktreeRepository,

--- a/crates/db/src/repository/mod.rs
+++ b/crates/db/src/repository/mod.rs
@@ -25,7 +25,7 @@ pub use git_cleanup_job::SqliteGitCleanupJobRepository;
 pub use plugin::SqlitePluginStateRepository;
 pub use project::SqliteProjectRepository;
 pub use session::SqliteSessionRepository;
-pub use skill::SqliteSkillRepository;
+pub use skill::{PluginSkillProjection, SqliteSkillRepository};
 pub use task::SqliteTaskRepository;
 pub use task_workspace::SqliteTaskWorkspaceRepository;
 pub use user_config::SqliteUserConfigRepository;

--- a/crates/db/src/repository/skill.rs
+++ b/crates/db/src/repository/skill.rs
@@ -2,10 +2,20 @@ use ora_application::{
     LocalSkillSourceRevision, RepositoryError, SkillDeleteOutcome, SkillRepository,
     SkillUpdateOutcome,
 };
-use ora_domain::{AuditFields, Namespace, Skill, SkillId};
+use ora_domain::{AuditFields, Namespace, PluginId, Skill, SkillId};
 use rusqlite::{OptionalExtension, Row, TransactionBehavior, params};
+use std::path::PathBuf;
 
 use crate::repository::{RepositoryPool, connection::bool_to_sqlite};
+
+/// One validated Skill package projected from an installed plugin.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PluginSkillProjection {
+    pub name: String,
+    pub description: String,
+    pub package_root: PathBuf,
+    pub skill_md_digest: String,
+}
 
 /// Persists reusable skill definitions in SQLite.
 #[derive(Clone, Debug)]
@@ -17,6 +27,115 @@ impl SqliteSkillRepository {
     /// Builds a skill repository from the shared SQLite connection pool.
     pub fn new(pool: RepositoryPool) -> Self {
         Self { pool }
+    }
+
+    /// Replaces the catalog projection owned by one installed Skill plugin.
+    pub fn replace_plugin_skills(
+        &self,
+        plugin_id: &PluginId,
+        plugin_version: &str,
+        skills: &[PluginSkillProjection],
+        updated_at: i64,
+    ) -> Result<(), crate::DatabaseError> {
+        let plugin_id = plugin_id.canonical();
+        self.pool.with_connection_mut(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            transaction.execute(
+                "UPDATE skills SET is_deleted = 1, updated_at = ?2
+                 WHERE namespace = ?1 COLLATE NOCASE AND is_deleted = 0",
+                params![&plugin_id, updated_at],
+            )?;
+            transaction.execute(
+                "UPDATE effect_source_states
+                 SET availability = 'unavailable', unavailable_reason = 'plugin no longer provides this Skill', updated_at = ?2
+                 WHERE source_kind = 'plugin' AND namespace = ?1",
+                params![&plugin_id, updated_at],
+            )?;
+
+            for skill in skills {
+                let canonical_name = skill.name.to_ascii_lowercase();
+                let skill_id = format!("plugin:{plugin_id}:{canonical_name}");
+                transaction.execute(
+                    "INSERT INTO skills (
+                         id, namespace, name, description, created_at, updated_at, is_deleted
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?5, 0)
+                     ON CONFLICT(id) DO UPDATE SET
+                         namespace = excluded.namespace,
+                         name = excluded.name,
+                         description = excluded.description,
+                         updated_at = excluded.updated_at,
+                         is_deleted = 0",
+                    params![
+                        skill_id,
+                        &plugin_id,
+                        &skill.name,
+                        &skill.description,
+                        updated_at,
+                    ],
+                )?;
+                transaction.execute(
+                    "INSERT INTO effect_source_states (
+                         source_kind, namespace, skill_name, display_name, source_version,
+                         skill_md_digest, package_root, availability, unavailable_reason, updated_at
+                     ) VALUES ('plugin', ?1, ?2, ?3, ?4, ?5, ?6, 'available', NULL, ?7)
+                     ON CONFLICT(source_kind, namespace, skill_name) DO UPDATE SET
+                         display_name = excluded.display_name,
+                         source_version = excluded.source_version,
+                         skill_md_digest = excluded.skill_md_digest,
+                         package_root = excluded.package_root,
+                         availability = 'available',
+                         unavailable_reason = NULL,
+                         updated_at = excluded.updated_at",
+                    params![
+                        &plugin_id,
+                        &canonical_name,
+                        &skill.name,
+                        plugin_version,
+                        &skill.skill_md_digest,
+                        skill.package_root.to_string_lossy(),
+                        updated_at,
+                    ],
+                )?;
+                transaction.execute(
+                    "INSERT INTO effect_source_propagation_requests (
+                         source_kind, namespace, skill_name, requested_version, requested_at
+                     ) VALUES ('plugin', ?1, ?2, ?3, ?4)
+                     ON CONFLICT(source_kind, namespace, skill_name) DO UPDATE SET
+                         requested_version = excluded.requested_version,
+                         requested_at = excluded.requested_at",
+                    params![&plugin_id, &canonical_name, plugin_version, updated_at],
+                )?;
+            }
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
+    /// Makes every Skill from an uninstalled plugin disappear from the catalog.
+    pub fn remove_plugin_skills(
+        &self,
+        plugin_id: &PluginId,
+        updated_at: i64,
+    ) -> Result<(), crate::DatabaseError> {
+        let plugin_id = plugin_id.canonical();
+        self.pool.with_connection_mut(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            transaction.execute(
+                "UPDATE skills SET is_deleted = 1, updated_at = ?2
+                 WHERE namespace = ?1 COLLATE NOCASE AND is_deleted = 0",
+                params![&plugin_id, updated_at],
+            )?;
+            transaction.execute(
+                "UPDATE effect_source_states
+                 SET availability = 'unavailable', unavailable_reason = 'source plugin is not installed', updated_at = ?2
+                 WHERE source_kind = 'plugin' AND namespace = ?1",
+                params![&plugin_id, updated_at],
+            )?;
+            transaction.commit()?;
+            Ok(())
+        })
     }
 }
 
@@ -61,7 +180,13 @@ impl SkillRepository for SqliteSkillRepository {
     fn find_skill(&self, skill_id: &SkillId) -> Result<Option<Skill>, RepositoryError> {
         self.pool.with_connection(|connection| {
             let mut statement = connection.prepare(
-                "SELECT id, namespace, name, description, created_at, updated_at, is_deleted FROM skills WHERE id = ?1 AND is_deleted = 0",
+                "SELECT s.id, s.namespace, s.name, s.description, s.created_at, s.updated_at, s.is_deleted,
+                       e.source_kind, e.package_root AS source_package_root
+                FROM skills s
+                LEFT JOIN effect_source_states e
+                  ON e.source_kind = 'plugin'
+                 AND e.namespace = s.namespace COLLATE NOCASE
+                 AND e.skill_name = s.name COLLATE NOCASE WHERE s.id = ?1 AND s.is_deleted = 0",
             )?;
             let mut rows = statement.query(params![skill_id.to_string()])?;
             rows.next()?.map(map_skill_row).transpose()
@@ -75,7 +200,13 @@ impl SkillRepository for SqliteSkillRepository {
     ) -> Result<Option<Skill>, RepositoryError> {
         self.pool.with_connection(|connection| {
             let mut statement = connection.prepare(
-                "SELECT id, namespace, name, description, created_at, updated_at, is_deleted FROM skills WHERE namespace = ?1 COLLATE NOCASE AND name = ?2 COLLATE NOCASE AND is_deleted = 0",
+                "SELECT s.id, s.namespace, s.name, s.description, s.created_at, s.updated_at, s.is_deleted,
+                       e.source_kind, e.package_root AS source_package_root
+                FROM skills s
+                LEFT JOIN effect_source_states e
+                  ON e.source_kind = 'plugin'
+                 AND e.namespace = s.namespace COLLATE NOCASE
+                 AND e.skill_name = s.name COLLATE NOCASE WHERE s.namespace = ?1 COLLATE NOCASE AND s.name = ?2 COLLATE NOCASE AND s.is_deleted = 0",
             )?;
             let mut rows = statement.query(params![namespace.as_ref(), name])?;
             rows.next()?.map(map_skill_row).transpose()
@@ -85,7 +216,13 @@ impl SkillRepository for SqliteSkillRepository {
     fn list_skills(&self) -> Result<Vec<Skill>, RepositoryError> {
         self.pool.with_connection(|connection| {
             let mut statement = connection.prepare(
-                "SELECT id, namespace, name, description, created_at, updated_at, is_deleted FROM skills WHERE is_deleted = 0 ORDER BY created_at ASC, id ASC",
+                "SELECT s.id, s.namespace, s.name, s.description, s.created_at, s.updated_at, s.is_deleted,
+                       e.source_kind, e.package_root AS source_package_root
+                FROM skills s
+                LEFT JOIN effect_source_states e
+                  ON e.source_kind = 'plugin'
+                 AND e.namespace = s.namespace COLLATE NOCASE
+                 AND e.skill_name = s.name COLLATE NOCASE WHERE s.is_deleted = 0 ORDER BY s.created_at ASC, s.id ASC",
             )?;
             let mut rows = statement.query([])?;
             let mut skills = Vec::new();
@@ -334,18 +471,32 @@ fn delete_local_source(
 
 /// Reconstructs a domain skill from a selected SQLite row.
 fn map_skill_row(row: &Row<'_>) -> Result<Skill, crate::DatabaseError> {
-    Skill::new(
-        SkillId::new(row.get::<_, String>("id")?),
-        Namespace::new(row.get::<_, String>("namespace")?)?,
-        row.get::<_, String>("name")?,
-        row.get::<_, String>("description")?,
-        AuditFields::new(
-            row.get("created_at")?,
-            row.get("updated_at")?,
-            row.get::<_, i64>("is_deleted")? != 0,
-        ),
-    )
-    .map_err(Into::into)
+    let id = SkillId::new(row.get::<_, String>("id")?);
+    let namespace = Namespace::new(row.get::<_, String>("namespace")?)?;
+    let name = row.get::<_, String>("name")?;
+    let description = row.get::<_, String>("description")?;
+    let audit_fields = AuditFields::new(
+        row.get("created_at")?,
+        row.get("updated_at")?,
+        row.get::<_, i64>("is_deleted")? != 0,
+    );
+    let source_kind = row.get::<_, Option<String>>("source_kind")?;
+    match source_kind.as_deref() {
+        Some("plugin") => Skill::new_plugin(
+            id,
+            namespace.clone(),
+            name,
+            description,
+            PluginId::parse(namespace.as_ref())?,
+            PathBuf::from(row.get::<_, String>("source_package_root")?),
+            audit_fields,
+        )
+        .map_err(Into::into),
+        Some(other) => Err(crate::DatabaseError::CorruptEffectState(format!(
+            "unexpected Skill source kind `{other}`"
+        ))),
+        None => Skill::new(id, namespace, name, description, audit_fields).map_err(Into::into),
+    }
 }
 
 /// Converts database failures into application-port errors.

--- a/crates/db/src/repository_tests.rs
+++ b/crates/db/src/repository_tests.rs
@@ -1,20 +1,22 @@
 use ora_application::{
-    ProjectRepository, SessionRepository, WorkflowRepository, WorkflowRunCreateOutcome,
-    WorkflowRunRepository,
+    ProjectRepository, SessionRepository, SkillRepository, WorkflowRepository,
+    WorkflowRunCreateOutcome, WorkflowRunRepository,
 };
 use ora_domain::{
-    AgentRef, AuditFields, Namespace, Project, ProjectId, Session, SessionId, SessionStatus,
-    Workflow, WorkflowId, WorkflowRun, WorkflowRunId, WorkflowRunStatus, WorkflowSnapshot,
-    WorkflowSnapshotId, Workspace, WorkspaceKind, WorkspaceLifecycle, WorkspaceLocation,
+    AgentRef, AuditFields, Namespace, PluginId, Project, ProjectId, Session, SessionId,
+    SessionStatus, SkillOrigin, Workflow, WorkflowId, WorkflowRun, WorkflowRunId,
+    WorkflowRunStatus, WorkflowSnapshot, WorkflowSnapshotId, Workspace, WorkspaceKind,
+    WorkspaceLifecycle, WorkspaceLocation,
 };
 use ora_logging::with_trace_logging;
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
 use crate::{
-    DatabaseBootstrapper, DatabaseLocation, RepositoryPool, SqliteProjectRepository,
-    SqliteSessionRepository, SqliteWorkflowRepository, SqliteWorkflowRunRepository,
-    SqliteWorkspaceRepository, TimestampSource, default_migration_catalog,
+    DatabaseBootstrapper, DatabaseLocation, PluginSkillProjection, RepositoryPool,
+    SqliteProjectRepository, SqliteSessionRepository, SqliteSkillRepository,
+    SqliteWorkflowRepository, SqliteWorkflowRunRepository, SqliteWorkspaceRepository,
+    TimestampSource, default_migration_catalog,
 };
 
 /// Supplies deterministic timestamps for repository integration fixtures.
@@ -28,6 +30,42 @@ impl TimestampSource for FixedTimestampSource {
     }
 }
 
+/// Verifies plugin Skills use the existing Effect source table as their origin and package locator.
+#[test]
+fn plugin_skill_projection_round_trips_and_is_removed_with_its_plugin() {
+    let (temp_dir, pool) = bootstrapped_pool();
+    let repository = SqliteSkillRepository::new(pool);
+    let plugin_id = PluginId::new("official", "review-pack").unwrap();
+    let package_root = temp_dir.path().join("plugins/review-pack/review");
+    repository
+        .replace_plugin_skills(
+            &plugin_id,
+            "1.2.3",
+            &[PluginSkillProjection {
+                name: "review".to_string(),
+                description: "Reviews changes".to_string(),
+                package_root: package_root.clone(),
+                skill_md_digest: format!("sha256:{}", "a".repeat(64)),
+            }],
+            10,
+        )
+        .unwrap();
+
+    let skills = repository.list_skills().unwrap();
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].namespace.as_ref(), "official/review-pack");
+    assert_eq!(skills[0].name, "review");
+    assert_eq!(
+        skills[0].origin,
+        SkillOrigin::Plugin {
+            plugin_id: plugin_id.clone(),
+            package_root,
+        }
+    );
+
+    repository.remove_plugin_skills(&plugin_id, 20).unwrap();
+    assert!(repository.list_skills().unwrap().is_empty());
+}
 /// Verifies project creation materializes the shared main workspace used by ordinary sessions.
 #[test]
 fn project_creation_creates_main_workspace() {

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -42,7 +42,7 @@ pub use session::{HistoryState, Session, SessionStatus};
 pub use session_title::{MAX_SESSION_TITLE_CHARS, SessionTitle, SessionTitleError};
 pub use skill::{
     BACKUP_DIR_NAME, JOURNAL_DIR_NAME, STAGING_DIR_NAME, Skill, SkillDescriptionError,
-    SkillNameError, validate_skill_description, validate_skill_name,
+    SkillNameError, SkillOrigin, validate_skill_description, validate_skill_name,
 };
 pub use task::Task;
 pub use workflow::{

--- a/crates/domain/src/skill.rs
+++ b/crates/domain/src/skill.rs
@@ -1,5 +1,17 @@
-use crate::{AuditFields, DomainModelError, Namespace, SkillId};
+use crate::{AuditFields, DomainModelError, Namespace, PluginId, SkillId};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Identifies who owns a Skill package and whether users may mutate it directly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SkillOrigin {
+    Local,
+    Plugin {
+        plugin_id: PluginId,
+        package_root: PathBuf,
+    },
+}
 
 /// Represents one reusable skill definition available to configurable agents.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -8,6 +20,7 @@ pub struct Skill {
     pub namespace: Namespace,
     pub name: String,
     pub description: String,
+    pub origin: SkillOrigin,
     pub audit_fields: AuditFields,
 }
 
@@ -38,8 +51,32 @@ impl Skill {
             namespace,
             name,
             description,
+            origin: SkillOrigin::Local,
             audit_fields,
         })
+    }
+
+    /// Creates an immutable Skill projected from an installed plugin package.
+    pub fn new_plugin(
+        id: SkillId,
+        namespace: Namespace,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        plugin_id: PluginId,
+        package_root: PathBuf,
+        audit_fields: AuditFields,
+    ) -> Result<Self, DomainModelError> {
+        let mut skill = Self::new(id, namespace, name, description, audit_fields)?;
+        skill.origin = SkillOrigin::Plugin {
+            plugin_id,
+            package_root,
+        };
+        Ok(skill)
+    }
+
+    /// Returns whether this Skill is owned by an installed plugin and therefore immutable.
+    pub fn is_read_only(&self) -> bool {
+        matches!(self.origin, SkillOrigin::Plugin { .. })
     }
 }
 

--- a/crates/domain/src/tests.rs
+++ b/crates/domain/src/tests.rs
@@ -102,6 +102,7 @@ fn constructs_schema_backed_entities() {
             namespace: Namespace::local(),
             name: "review".to_string(),
             description: "Reviews implementation changes".to_string(),
+            origin: crate::SkillOrigin::Local,
             audit_fields: audit_fields.clone(),
         }
     );

--- a/crates/plugin-lifecycle/README.md
+++ b/crates/plugin-lifecycle/README.md
@@ -12,8 +12,9 @@ which is what keeps the runtime state reported to the settings surface identical
 that actually exist. When a process starts depends on the contribution kind: enabling an agent
 plugin also launches it, because its agent supervisor attaches to a running process rather than
 starting one, so durable intent and reported runtime never disagree beyond the transition itself;
-enabling a ui plugin only records eligibility, because its process is started on demand by the
-first surface that needs it and stopped again when it has been idle.
+enabling a workbench plugin only records eligibility, because its process is started on demand by
+the first surface that needs it and stopped again when it has been idle. Webview and skill plugins
+have no process; enabling them records eligibility and reports an `enabled` + `stopped` state.
 
 Consumers that need to speak a protocol over a plugin connect to it instead of launching it
 (`ensure_running` / `connection`, see the data plane below). This is how the agent runtime reaches
@@ -48,9 +49,10 @@ uninstall removes that package directory and the plugin's data directory.
 
 Before launching, the lifecycle creates `<data-dir>/plugins/data/<namespace>/<name>/` (with
 `downloads/`) through `PluginDataDirectories`, derives Deno permissions from the plugin kind
-(`permissions_for`: ui plugins get no `--allow-*` flag at all; agent plugins keep the broad
-historical set, also exported as `agent_permissions` for the backend's agent supervisor, and
-narrowing it is out of scope here), and passes the package root as working directory. No
+(`permissions_for`: workbench plugins get no `--allow-*` flag at all; webview and skill plugins
+are never launched; agent plugins keep the broad historical set, also exported as
+`agent_permissions` for the backend's agent supervisor, and narrowing it is out of scope here),
+and passes the package root as working directory. No
 environment variable is injected: a plugin learns nothing about host paths. A permission path
 containing a comma refuses to launch, because Deno reads commas as list separators.
 
@@ -59,11 +61,9 @@ the runtime as the `HostRequestHandler` for that process, so plugin identity is 
 launch, never by request params.
 
 After a successful handshake the registration is validated against the manifest kind
-(`validate_registration`): a ui plugin with any remote-site surface must serve
-`ora/ui/download_completed`; one with any panel surface must serve `ora/ui/request` and declare
-`ora/ui/push` in `emits`; otherwise the runtime is stopped and the plugin enters `Failed`. Agent
-contracts are verified by the backend's agent runtime, not here. The `ora/ui/*` method names are
-defined once in `registration` and exported (`UI_*_METHOD`) for the desktop surface host.
+(`validate_registration`). Workbench registrations may expose well-formed methods but cannot
+declare emitted notifications. Webview and skill plugins cannot register because they have no
+process. Agent contracts are verified by the backend's agent runtime, not here.
 
 ## Storage host methods
 

--- a/crates/plugin-lifecycle/src/lib.rs
+++ b/crates/plugin-lifecycle/src/lib.rs
@@ -260,7 +260,12 @@ where
                     );
                     Some(attempt)
                 }
-                (PluginContribution::Workbench(_) | PluginContribution::Webview(_), true) => {
+                (
+                    PluginContribution::Workbench(_)
+                    | PluginContribution::Webview(_)
+                    | PluginContribution::Skill(_),
+                    true,
+                ) => {
                     state.set_managed(
                         &plugin_id,
                         ManagedPluginState::Enabled(EnabledRuntime::Stopped),
@@ -270,7 +275,8 @@ where
                 (
                     PluginContribution::Agent(_)
                     | PluginContribution::Workbench(_)
-                    | PluginContribution::Webview(_),
+                    | PluginContribution::Webview(_)
+                    | PluginContribution::Skill(_),
                     false,
                 ) => None,
             };

--- a/crates/plugin-lifecycle/src/permissions.rs
+++ b/crates/plugin-lifecycle/src/permissions.rs
@@ -84,11 +84,14 @@ fn scoped_flag(flag: &str, path: &Path) -> Result<OsString, PermissionFlagError>
 /// environment access is a hard `PermissionDenied`, and everything it legitimately needs (its
 /// data directory) is served by the host over `ora/storage/*`. An agent plugin keeps the broad
 /// grants it has always had (see `agent_permissions`); narrowing them is deliberately out of
-/// scope here. A webview plugin is never launched, so its (empty) set is only exhaustiveness.
+/// scope here. Webview and skill plugins are never launched, so their empty sets only make the
+/// match exhaustive.
 pub fn permissions_for(contribution: &PluginContribution) -> Vec<DenoPermission> {
     match contribution {
         PluginContribution::Agent(_) => agent_permissions(),
-        PluginContribution::Workbench(_) | PluginContribution::Webview(_) => Vec::new(),
+        PluginContribution::Workbench(_)
+        | PluginContribution::Webview(_)
+        | PluginContribution::Skill(_) => Vec::new(),
     }
 }
 
@@ -164,6 +167,15 @@ mod tests {
     #[test]
     fn workbench_plugins_get_no_permissions() {
         assert_eq!(permissions_for(&workbench_contribution()), Vec::new());
+    }
+
+    /// Skill plugins are static packages and never receive runtime permissions.
+    #[test]
+    fn skill_plugins_get_no_permissions() {
+        assert_eq!(
+            permissions_for(&PluginContribution::Skill(Default::default())),
+            Vec::new()
+        );
     }
 
     /// Scoped grants render the canonical path so Deno's own canonical comparison matches.

--- a/crates/plugin-lifecycle/src/registration.rs
+++ b/crates/plugin-lifecycle/src/registration.rs
@@ -43,6 +43,9 @@ pub fn validate_registration(
         PluginContribution::Webview(_) => Err(PluginRuntimeFailure::new(
             "webview plugins have no process and cannot register",
         )),
+        PluginContribution::Skill(_) => Err(PluginRuntimeFailure::new(
+            "skill plugins have no process and cannot register",
+        )),
     }
 }
 
@@ -117,6 +120,20 @@ mod tests {
         assert_eq!(
             validate_registration(&contribution, &PluginRegistration::default()),
             Ok(()),
+        );
+    }
+
+    /// Static skill plugins have no runtime handshake.
+    #[test]
+    fn skill_plugins_cannot_register() {
+        assert_eq!(
+            validate_registration(
+                &PluginContribution::Skill(Default::default()),
+                &PluginRegistration::default(),
+            ),
+            Err(PluginRuntimeFailure::new(
+                "skill plugins have no process and cannot register",
+            )),
         );
     }
 }

--- a/crates/plugin-lifecycle/src/state.rs
+++ b/crates/plugin-lifecycle/src/state.rs
@@ -202,6 +202,7 @@ pub(super) fn discovered_plugin_contract<Runtime>(
             title: plugin.display_name.clone(),
             start_url: webview.start_url.to_string(),
         },
+        PluginContribution::Skill(_) => InstalledPluginContribution::Skill,
     };
 
     InstalledPlugin {

--- a/crates/plugin-lifecycle/src/tests.rs
+++ b/crates/plugin-lifecycle/src/tests.rs
@@ -140,6 +140,80 @@ fn opens_with_discovered_plugins_disabled_and_stopped() {
     });
 }
 
+/// Verifies a static Skill plugin can be listed and managed but never activated.
+#[tokio::test]
+async fn manages_static_skill_plugin_without_a_runtime() {
+    let _logging = trace_logging_guard();
+    let temp_dir = TempDir::new().expect("create plugin lifecycle directory");
+    write_skill_plugin_package(temp_dir.path(), "ora.skill-pack");
+    let pool = DatabaseBootstrapper::system()
+        .bootstrap_repository_pool(
+            &DatabaseLocation::path(temp_dir.path().join("ora.sqlite3")),
+            &default_migration_catalog().expect("build migration catalog"),
+        )
+        .expect("bootstrap plugin lifecycle database");
+    let lifecycle = open_without_runtime(temp_dir.path(), SqlitePluginStateRepository::new(pool));
+    let plugin_id = "official/ora.skill-pack".to_string();
+
+    assert_eq!(
+        lifecycle.list_installed_plugins(),
+        ListInstalledPluginsResponse {
+            plugins: vec![expected_skill_plugin(false)],
+        }
+    );
+    assert_eq!(
+        lifecycle
+            .enable_plugin(EnablePluginRequest {
+                plugin_id: plugin_id.clone(),
+            })
+            .await
+            .expect("enable Skill plugin"),
+        EnablePluginResponse {
+            plugin: expected_skill_plugin(true),
+        }
+    );
+    assert!(matches!(
+        lifecycle
+            .activate_plugin(ActivatePluginRequest {
+                plugin_id: plugin_id.clone(),
+            })
+            .await,
+        Err(PluginLifecycleError::NoProcess { plugin_id: found }) if found == plugin_id
+    ));
+    assert_eq!(
+        lifecycle
+            .disable_plugin(DisablePluginRequest {
+                plugin_id: plugin_id.clone(),
+            })
+            .await
+            .expect("disable Skill plugin"),
+        DisablePluginResponse {
+            plugin: expected_skill_plugin(false),
+        }
+    );
+    lifecycle
+        .enable_plugin(EnablePluginRequest {
+            plugin_id: plugin_id.clone(),
+        })
+        .await
+        .expect("re-enable Skill plugin");
+    assert_eq!(
+        lifecycle
+            .uninstall_plugin(UninstallPluginRequest {
+                plugin_id: plugin_id.clone(),
+            })
+            .await
+            .expect("uninstall Skill plugin"),
+        UninstallPluginResponse { plugin_id }
+    );
+    assert_eq!(
+        lifecycle.list_installed_plugins(),
+        ListInstalledPluginsResponse {
+            plugins: Vec::new(),
+        }
+    );
+    assert!(!package_version_root(temp_dir.path(), "ora.skill-pack").exists());
+}
 /// Verifies startup joins a discovered package with the user's durable enabled intent.
 #[test]
 fn opens_with_persisted_plugin_eligibility() {
@@ -1238,6 +1312,23 @@ fn expected_plugin(enabled: bool) -> InstalledPlugin {
     )
 }
 
+/// Builds the expected wire contract for the static Skill package fixture.
+fn expected_skill_plugin(enabled: bool) -> InstalledPlugin {
+    InstalledPlugin {
+        id: "official/ora.skill-pack".to_string(),
+        namespace: "official".to_string(),
+        name: "ora.skill-pack".to_string(),
+        display_name: "ora.skill-pack".to_string(),
+        version: "1.0.0".to_string(),
+        description: "Example Skill plugin".to_string(),
+        homepage: None,
+        license: None,
+        contribution: InstalledPluginContribution::Skill,
+        enabled,
+        logo: Some(PACKAGE_LOGO.to_string()),
+        runtime: PluginRuntimeStatus::Stopped,
+    }
+}
 /// Builds the expected package contract with an explicit lifecycle state.
 fn expected_plugin_with_runtime(
     enabled: PluginEnabledState,
@@ -1586,6 +1677,30 @@ pub(super) fn package_version_root(data_dir: &std::path::Path, name: &str) -> st
         .join("1.0.0")
 }
 
+/// Writes one static Skill package without a process entrypoint.
+fn write_skill_plugin_package(data_dir: &std::path::Path, name: &str) {
+    let package_root = package_version_root(data_dir, name);
+    fs::create_dir_all(package_root.join("assets/skills/review"))
+        .expect("create Skill plugin assets");
+    fs::write(
+        package_root.join("assets/skills/review/SKILL.md"),
+        "---\nname: review\ndescription: Reviews code\n---\n",
+    )
+    .expect("write bundled Skill manifest");
+    fs::write(package_root.join("logo.svg"), PACKAGE_LOGO).expect("write plugin logo");
+    fs::write(
+        package_root.join("orax.toml"),
+        format!(
+            r#"name = "{name}"
+namespace = "official"
+kind = "skill"
+version = "1.0.0"
+description = "Example Skill plugin"
+"#
+        ),
+    )
+    .expect("write Skill plugin manifest");
+}
 /// Writes one complete agent package into the versioned installed layout.
 pub(super) fn write_plugin_package(data_dir: &std::path::Path, name: &str) {
     let package_root = package_version_root(data_dir, name);

--- a/crates/plugin-manager/Cargo.toml
+++ b/crates/plugin-manager/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 ora-domain = { workspace = true }
 ora-plugin-manifest = { workspace = true }
+ora-skill-package = { workspace = true }
 ora-utils = { workspace = true, features = ["archive", "http", "validation"] }
 semver = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/plugin-manager/README.md
+++ b/crates/plugin-manager/README.md
@@ -10,10 +10,14 @@ orchestrates checksum-verified installs of new plugin releases.
   when that selected package is invalid.
 - Read the selected package's `orax.toml` through `ora-plugin-manifest`, which owns the manifest
   schema, and require the manifest version to match the version directory.
-- Resolve the fixed `main.js` entrypoint at the package root as an existing regular file whose
-  canonical target remains inside its package, then retain its normalized portable relative path.
-- Keep `kind` and its contribution in one value (`PluginContribution::Agent` or `::Ui`), so a
-  validated plugin always carries exactly what its kind promises.
+- Resolve the fixed `main.js` entrypoint for agent and workbench packages as an existing regular
+  file whose canonical target remains inside its package, then retain its portable relative path.
+  Webview and skill packages have no process entrypoint.
+- Keep `kind` and its contribution in one value (`PluginContribution::Agent`, `::Workbench`,
+  `::Webview`, or `::Skill`), so a validated plugin always carries exactly what its kind promises.
+  Skill contributions carry no additional contract fields, but the package must contain one or
+  more `assets/skills/<name>/SKILL.md` trees. Each Skill manifest is parsed and its declared name
+  must match the package directory before it can be cataloged.
 - Apply the host's surface policy to `[[ui.surfaces]]`: entry URL scheme and host allow lists
   for remote sites, the on-disk asset directory and entry document for panels, surface count and
   title limits, and id uniqueness, producing typed values (`SurfaceId`, `HostName`, `Url`,
@@ -56,8 +60,10 @@ grammar, enum spellings, that `[ui]` is present exactly for `kind = "ui"`, that 
 a slug `id` and a non-empty `title`, and that each `source.kind` carries its own fields. This
 crate adds what depends on the host or on the package on disk:
 
-- `kind = "workbench"` is rejected; only `agent` and `ui` run here.
-- `main.js` must exist at the package root; the manifest has no entrypoint field.
+- Agent and workbench packages must contain `main.js`; webview and skill packages do not.
+- A skill package must contain `assets/skills/` with at least one immediate Skill directory, and
+  every such directory must contain a regular root `SKILL.md`. Optional `scripts/`, `references/`,
+  and nested `assets/` contents are preserved but not interpreted in this release.
 - `display_name` is the plugin `name` for every kind; a ui plugin's user-visible entries are its
   surface titles. One agent-kind package contributes exactly one agent with no identifier of its
   own: the package's plugin id is that agent's identity everywhere in the host.

--- a/crates/plugin-manager/src/install.rs
+++ b/crates/plugin-manager/src/install.rs
@@ -35,6 +35,9 @@ pub enum InstallError {
     /// The in-archive `orax.toml` could not be parsed or validated.
     #[error("imported plugin manifest is invalid: {0}")]
     InvalidManifest(#[from] ora_plugin_manifest::ManifestError),
+    /// The extracted package does not satisfy the host-side requirements for its kind.
+    #[error("plugin package is invalid at `{field_path}`: {message}")]
+    InvalidPackage { field_path: String, message: String },
     /// The imported archive digest does not match the digest the in-archive manifest declares.
     #[error("imported archive digest {actual} does not match the declared sha256 {expected}")]
     ChecksumMismatch { expected: String, actual: String },
@@ -60,6 +63,15 @@ pub enum InstallError {
 impl From<ora_utils::http::DownloadError> for InstallError {
     fn from(source: ora_utils::http::DownloadError) -> Self {
         Self::Download(Box::new(source))
+    }
+}
+
+impl InstallError {
+    fn invalid_package(source: crate::validation::ManifestValidationError) -> Self {
+        Self::InvalidPackage {
+            field_path: source.field_path().to_owned(),
+            message: source.to_string(),
+        }
     }
 }
 
@@ -104,17 +116,42 @@ where
         data_dir: &Path,
     ) -> Result<PathBuf, InstallError> {
         let archive_path = self.download_package(manifest, source, data_dir).await?;
-        let package_dir = installed_root(data_dir)
-            .join(manifest.namespace().as_str())
-            .join(manifest.name().as_str())
-            .join(manifest.version().to_string());
+        let namespace = manifest.namespace();
+        let name = manifest.name();
+        let version = manifest.version().to_string();
+        let package_parent = installed_root(data_dir)
+            .join(namespace.as_str())
+            .join(name.as_str());
+        let package_dir = package_parent.join(&version);
+        if package_dir.exists() {
+            return Err(InstallError::AlreadyInstalled {
+                path: package_dir,
+                namespace: namespace.as_str().to_owned(),
+                name: name.as_str().to_owned(),
+                version,
+            });
+        }
+        std::fs::create_dir_all(&package_parent).map_err(|source| InstallError::Io {
+            path: package_parent.clone(),
+            source,
+        })?;
+        let staging = tempfile::tempdir_in(&package_parent).map_err(|source| InstallError::Io {
+            path: package_parent,
+            source,
+        })?;
         extract_archive(
             ArchiveFormat::Zip,
             &archive_path,
-            &package_dir,
+            staging.path(),
             &ExtractLimits::default(),
         )
         .map_err(|source| InstallError::Extract {
+            path: staging.path().to_path_buf(),
+            source,
+        })?;
+        crate::validation::validate(staging.path(), manifest, None)
+            .map_err(InstallError::invalid_package)?;
+        std::fs::rename(staging.path(), &package_dir).map_err(|source| InstallError::Io {
             path: package_dir.clone(),
             source,
         })?;
@@ -196,6 +233,8 @@ where
                 version,
             });
         }
+        crate::validation::validate(staging.path(), &manifest, None)
+            .map_err(InstallError::invalid_package)?;
         if let Some(parent) = destination.parent() {
             std::fs::create_dir_all(parent).map_err(|source| InstallError::Io {
                 path: parent.to_path_buf(),
@@ -291,10 +330,20 @@ mod tests {
         writer.finish().unwrap();
     }
 
-    /// Builds an orax manifest whose sha256 matches `digest`.
+    /// Builds an agent orax manifest whose sha256 matches `digest`.
     fn manifest_with_digest(name: &str, version: &str, digest: [u8; 32]) -> String {
+        manifest_with_kind_digest(name, version, "agent", digest)
+    }
+
+    /// Builds a marketplace manifest for `kind` whose sha256 matches `digest`.
+    fn manifest_with_kind_digest(
+        name: &str,
+        version: &str,
+        kind: &str,
+        digest: [u8; 32],
+    ) -> String {
         format!(
-            "resolver = 1\nname = \"{name}\"\nnamespace = \"official\"\nkind = \"workbench\"\nversion = \"{version}\"\ndescription = \"A test plugin\"\nurl = \"https://example.com/{name}.orax\"\nsha256 = \"{}\"\n",
+            "resolver = 1\nname = \"{name}\"\nnamespace = \"official\"\nkind = \"{kind}\"\nversion = \"{version}\"\ndescription = \"A test plugin\"\nurl = \"https://example.com/{name}.orax\"\nsha256 = \"{}\"\n",
             hex(digest)
         )
     }
@@ -351,6 +400,43 @@ mod tests {
         );
     }
 
+    /// A marketplace Skill release is validated and committed with its complete static tree.
+    #[test]
+    fn installs_marketplace_skill_release_with_required_assets() {
+        let temp_dir = TempDir::new().unwrap();
+        let release_path = temp_dir.path().join("skill-pack.orax");
+        write_orax_zip(
+            &release_path,
+            &[
+                (
+                    "orax.toml",
+                    b"name = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.0.0\"\ndescription = \"Skill plugin test\"\n".as_slice(),
+                ),
+                (
+                    "assets/skills/review/SKILL.md",
+                    b"---\nname: review\ndescription: Reviews code\n---\n".as_slice(),
+                ),
+            ],
+        );
+        let manifest = PluginManifest::parse(&manifest_with_kind_digest(
+            "ora.skill-pack",
+            "1.0.0",
+            "skill",
+            sha256_file(&release_path),
+        ))
+        .unwrap();
+
+        let package_dir = block_on(Installer::new(LocalFileDownloader).install(
+            &manifest,
+            DownloadSource::Local(release_path),
+            temp_dir.path(),
+        ))
+        .expect("install marketplace Skill release");
+
+        assert!(package_dir.join("assets/skills/review/SKILL.md").is_file());
+        assert!(!package_dir.join("main.js").exists());
+    }
+
     /// A mismatched digest aborts before any package lands in the installed tree.
     #[test]
     fn rejects_checksum_mismatch_and_installs_nothing() {
@@ -383,6 +469,93 @@ mod tests {
                 .join("official")
                 .join("weather")
                 .join("1.0.0")
+                .exists()
+        );
+    }
+    /// Imports a Skill archive that contains one or more required static Skill packages.
+    #[test]
+    fn imports_local_skill_archive_with_required_skill_assets() {
+        let temp_dir = TempDir::new().unwrap();
+        let release_path = temp_dir.path().join("skill-pack.orax");
+        write_orax_zip(
+            &release_path,
+            &[
+                (
+                    "orax.toml",
+                    &b"name = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"0.1.1\"\ndescription = \"Skill plugin test\"\n"[..],
+                ),
+                (
+                    "assets/skills/review/SKILL.md",
+                    b"---\nname: review\ndescription: Reviews code\n---\n".as_slice(),
+                ),
+                (
+                    "assets/skills/testing/SKILL.md",
+                    b"---\nname: testing\ndescription: Tests code\n---\n".as_slice(),
+                ),
+                (
+                    "assets/skills/review/scripts/check.js",
+                    b"export {};\n".as_slice(),
+                ),
+            ],
+        );
+
+        let installer = Installer::new(LocalFileDownloader);
+        let package = installer
+            .install_local(&release_path, temp_dir.path())
+            .expect("import static Skill archive");
+
+        assert_eq!(package.id, "official/ora.skill-pack");
+        assert_eq!(
+            package.package_dir,
+            temp_dir
+                .path()
+                .join("plugins")
+                .join("installed")
+                .join("official")
+                .join("ora.skill-pack")
+                .join("0.1.1")
+        );
+        assert!(package.package_dir.join("orax.toml").is_file());
+        assert!(
+            package
+                .package_dir
+                .join("assets/skills/review/SKILL.md")
+                .is_file()
+        );
+        assert!(
+            package
+                .package_dir
+                .join("assets/skills/testing/SKILL.md")
+                .is_file()
+        );
+        assert!(!package.package_dir.join("main.js").exists());
+    }
+
+    /// A Skill archive without `assets/skills/<name>/SKILL.md` is never committed.
+    #[test]
+    fn rejects_local_skill_archive_without_skill_assets() {
+        let temp_dir = TempDir::new().unwrap();
+        let release_path = temp_dir.path().join("incomplete-skill.orax");
+        write_orax_zip(
+            &release_path,
+            &[(
+                "orax.toml",
+                &b"name = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"0.1.1\"\ndescription = \"Skill plugin test\"\n"[..],
+            )],
+        );
+
+        let error = Installer::new(LocalFileDownloader)
+            .install_local(&release_path, temp_dir.path())
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            InstallError::InvalidPackage { ref field_path, .. } if field_path == "skill"
+        ));
+        assert!(
+            !temp_dir
+                .path()
+                .join("plugins/installed/official/ora.skill-pack/0.1.1")
                 .exists()
         );
     }

--- a/crates/plugin-manager/src/kind_tests.rs
+++ b/crates/plugin-manager/src/kind_tests.rs
@@ -79,7 +79,9 @@ fn discovers_workbench_package_with_and_without_methods() {
                 descriptor.asset_root.clone(),
                 descriptor.declared_methods.clone(),
             ),
-            PluginContribution::Agent(_) | PluginContribution::Webview(_) => {
+            PluginContribution::Agent(_)
+            | PluginContribution::Webview(_)
+            | PluginContribution::Skill(_) => {
                 panic!("expected workbench contributions")
             }
         })
@@ -145,7 +147,9 @@ allowed_origins = ["https://www.example.com", "https://example.com"]
             .iter()
             .map(|origin| origin.as_str().to_string())
             .collect::<Vec<_>>(),
-        PluginContribution::Agent(_) | PluginContribution::Workbench(_) => {
+        PluginContribution::Agent(_)
+        | PluginContribution::Workbench(_)
+        | PluginContribution::Skill(_) => {
             panic!("expected a webview contribution")
         }
     };

--- a/crates/plugin-manager/src/lib.rs
+++ b/crates/plugin-manager/src/lib.rs
@@ -5,6 +5,7 @@ mod discovery;
 mod install;
 mod issue;
 mod logo;
+mod skill;
 mod validation;
 mod webview;
 mod workbench;
@@ -17,6 +18,9 @@ mod tests;
 pub use discovery::{MANIFEST_FILE_NAME, installed_root};
 pub use install::{InstallError, InstalledPackage, Installer};
 pub use issue::{PluginDiscoveryIssue, PluginDiscoveryIssueKind};
+pub use skill::{
+    InstalledSkill, InstalledSkillDescriptor, SKILL_ASSET_DIRECTORY, SKILL_MANIFEST_FILE_NAME,
+};
 pub use validation::{
     INSTALLED_ENTRYPOINT, InstalledPlugin, InstalledPluginAgent, PluginContribution,
 };

--- a/crates/plugin-manager/src/skill.rs
+++ b/crates/plugin-manager/src/skill.rs
@@ -1,0 +1,207 @@
+use crate::validation::{ManifestValidationError, invalid};
+use ora_skill_package::Limits;
+use ora_skill_package::manifest::parse_manifest;
+use ora_utils::path::{CanonicalPathRoot, PortableRelativePath};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Package-relative directory containing every Skill contributed by a Skill plugin.
+pub const SKILL_ASSET_DIRECTORY: &str = "assets/skills";
+/// Fixed manifest filename required at the root of each contributed Skill.
+pub const SKILL_MANIFEST_FILE_NAME: &str = "SKILL.md";
+
+/// Holds every validated Skill contributed by one installed plugin.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InstalledSkillDescriptor {
+    pub skills: Vec<InstalledSkill>,
+}
+
+/// Holds the catalog metadata and immutable package root of one contributed Skill.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledSkill {
+    pub name: String,
+    pub description: String,
+    pub package_root: PathBuf,
+}
+
+/// Validates and parses every Skill shipped by an installed Skill plugin.
+pub(crate) fn validate_skill(
+    package_root: &Path,
+) -> Result<InstalledSkillDescriptor, ManifestValidationError> {
+    let skills_relative = PortableRelativePath::parse(SKILL_ASSET_DIRECTORY).map_err(|error| {
+        invalid(
+            "skill",
+            format!("Skill asset directory name is invalid: {error}"),
+        )
+    })?;
+    let package = CanonicalPathRoot::new(package_root).map_err(|error| {
+        invalid(
+            "skill",
+            format!("plugin package root is unavailable: {error}"),
+        )
+    })?;
+    let skills_root = package.resolve_existing(&skills_relative).map_err(|error| {
+        invalid(
+            "skill",
+            format!(
+                "Skill package must ship an `{SKILL_ASSET_DIRECTORY}/` directory inside the package: {error}"
+            ),
+        )
+    })?;
+    if !skills_root.is_dir() {
+        return Err(invalid(
+            "skill",
+            format!("`{SKILL_ASSET_DIRECTORY}` must be a directory"),
+        ));
+    }
+
+    let mut skill_roots = fs::read_dir(&skills_root)
+        .map_err(|error| {
+            invalid(
+                "skill",
+                format!("failed to read `{SKILL_ASSET_DIRECTORY}/`: {error}"),
+            )
+        })?
+        .filter_map(|entry| match entry {
+            Ok(entry) => match entry.file_type() {
+                Ok(file_type) if file_type.is_dir() => Some(Ok(entry.path())),
+                Ok(_) => None,
+                Err(error) => Some(Err(invalid(
+                    "skill",
+                    format!(
+                        "failed to inspect `{SKILL_ASSET_DIRECTORY}/{}/`: {error}",
+                        entry.file_name().to_string_lossy()
+                    ),
+                ))),
+            },
+            Err(error) => Some(Err(invalid(
+                "skill",
+                format!("failed to enumerate `{SKILL_ASSET_DIRECTORY}/`: {error}"),
+            ))),
+        })
+        .collect::<Result<Vec<PathBuf>, ManifestValidationError>>()?;
+    skill_roots.sort();
+
+    if skill_roots.is_empty() {
+        return Err(invalid(
+            "skill",
+            format!("`{SKILL_ASSET_DIRECTORY}/` must contain at least one Skill directory"),
+        ));
+    }
+
+    let manifest_relative =
+        PortableRelativePath::parse(SKILL_MANIFEST_FILE_NAME).map_err(|error| {
+            invalid(
+                "skill",
+                format!("Skill manifest filename is invalid: {error}"),
+            )
+        })?;
+    let mut installed = Vec::with_capacity(skill_roots.len());
+    let mut names = BTreeSet::new();
+    for skill_root in skill_roots {
+        let skill_name = skill_root
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "<unknown>".to_owned());
+        let skill = CanonicalPathRoot::new(&skill_root).map_err(|error| {
+            invalid(
+                "skill",
+                format!(
+                    "Skill directory `{SKILL_ASSET_DIRECTORY}/{skill_name}/` is unavailable: {error}"
+                ),
+            )
+        })?;
+        let manifest = skill.resolve_existing(&manifest_relative).map_err(|error| {
+            invalid(
+                "skill",
+                format!(
+                    "Skill directory `{SKILL_ASSET_DIRECTORY}/{skill_name}/` must ship `{SKILL_MANIFEST_FILE_NAME}`: {error}"
+                ),
+            )
+        })?;
+        if !manifest.is_file() {
+            return Err(invalid(
+                "skill",
+                format!(
+                    "`{SKILL_ASSET_DIRECTORY}/{skill_name}/{SKILL_MANIFEST_FILE_NAME}` must be a regular file"
+                ),
+            ));
+        }
+        let bytes = fs::read(&manifest).map_err(|error| {
+            invalid(
+                "skill",
+                format!(
+                    "failed to read `{SKILL_ASSET_DIRECTORY}/{skill_name}/{SKILL_MANIFEST_FILE_NAME}`: {error}"
+                ),
+            )
+        })?;
+        let parsed = parse_manifest(&bytes, Limits::default().max_manifest_bytes).map_err(|error| {
+            invalid(
+                "skill",
+                format!(
+                    "`{SKILL_ASSET_DIRECTORY}/{skill_name}/{SKILL_MANIFEST_FILE_NAME}` is invalid: {error}"
+                ),
+            )
+        })?;
+        if !parsed.name.eq_ignore_ascii_case(&skill_name) {
+            return Err(invalid(
+                "skill",
+                format!(
+                    "Skill directory `{skill_name}` must match the SKILL.md name `{}`",
+                    parsed.name
+                ),
+            ));
+        }
+        if !names.insert(parsed.name.to_ascii_lowercase()) {
+            return Err(invalid(
+                "skill",
+                format!("duplicate Skill name `{}`", parsed.name),
+            ));
+        }
+        installed.push(InstalledSkill {
+            name: parsed.name,
+            description: parsed.description,
+            package_root: skill_root,
+        });
+    }
+
+    Ok(InstalledSkillDescriptor { skills: installed })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SKILL_ASSET_DIRECTORY, SKILL_MANIFEST_FILE_NAME, validate_skill};
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn accepts_one_or_more_skill_directories() {
+        let package = TempDir::new().unwrap();
+        for name in ["review", "testing"] {
+            let root = package.path().join(SKILL_ASSET_DIRECTORY).join(name);
+            fs::create_dir_all(root.join("scripts")).unwrap();
+            fs::write(
+                root.join(SKILL_MANIFEST_FILE_NAME),
+                format!("---\nname: {name}\ndescription: Test skill\n---\n"),
+            )
+            .unwrap();
+        }
+
+        assert!(validate_skill(package.path()).is_ok());
+    }
+
+    #[test]
+    fn rejects_missing_empty_and_incomplete_skill_trees() {
+        let missing = TempDir::new().unwrap();
+        let empty = TempDir::new().unwrap();
+        fs::create_dir_all(empty.path().join(SKILL_ASSET_DIRECTORY)).unwrap();
+        let incomplete = TempDir::new().unwrap();
+        fs::create_dir_all(incomplete.path().join(SKILL_ASSET_DIRECTORY).join("review")).unwrap();
+
+        for package in [&missing, &empty, &incomplete] {
+            let error = validate_skill(package.path()).unwrap_err();
+            assert_eq!(error.field_path(), "skill");
+        }
+    }
+}

--- a/crates/plugin-manager/src/tests.rs
+++ b/crates/plugin-manager/src/tests.rs
@@ -43,6 +43,69 @@ fn discovers_complete_manifest() {
     );
 }
 
+/// Verifies a Skill plugin is static but must contain at least one complete Skill package.
+#[test]
+fn discovers_skill_plugin_with_required_skill_assets() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut manifest = agent_manifest();
+    manifest["name"] = Value::from("ora.skill-pack");
+    manifest["kind"] = Value::from("skill");
+    let package_root = write_manifest(temp_dir.path(), "ora.skill-pack", manifest);
+    fs::remove_file(package_root.join("main.js")).unwrap();
+    for name in ["review", "testing"] {
+        let skill_root = package_root.join("assets/skills").join(name);
+        fs::create_dir_all(&skill_root).unwrap();
+        fs::write(
+            skill_root.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: Example\n---\n"),
+        )
+        .unwrap();
+    }
+
+    let manager = PluginManager::discover(temp_dir.path());
+
+    assert_eq!(manager.discovery_issues(), &[]);
+    assert_eq!(manager.installed_plugins().len(), 1);
+    let PluginContribution::Skill(descriptor) = &manager.installed_plugins()[0].contributes else {
+        panic!("expected Skill contribution");
+    };
+    assert_eq!(
+        descriptor
+            .skills
+            .iter()
+            .map(|skill| skill.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["review", "testing"]
+    );
+}
+
+/// Verifies missing, empty, or incomplete `assets/skills` trees are not discovered.
+#[test]
+fn rejects_skill_plugins_without_complete_skill_assets() {
+    let mut managers = Vec::new();
+    for case in ["missing", "empty", "incomplete"] {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manifest = agent_manifest();
+        manifest["name"] = Value::from(format!("ora.skill-{case}"));
+        manifest["kind"] = Value::from("skill");
+        let package_root = write_manifest(temp_dir.path(), case, manifest);
+        fs::remove_file(package_root.join("main.js")).unwrap();
+        if case != "missing" {
+            fs::create_dir_all(package_root.join("assets/skills")).unwrap();
+        }
+        if case == "incomplete" {
+            fs::create_dir_all(package_root.join("assets/skills/review")).unwrap();
+        }
+
+        let manager = PluginManager::discover(temp_dir.path());
+        managers.push((temp_dir, manager));
+    }
+
+    for (_, manager) in managers {
+        assert_eq!(manager.installed_plugins(), &[]);
+        assert_eq!(manager.discovery_issues()[0].field_path(), Some("skill"));
+    }
+}
 /// Verifies a missing installed root represents an empty installation.
 #[test]
 fn missing_installed_root_is_empty() {

--- a/crates/plugin-manager/src/validation.rs
+++ b/crates/plugin-manager/src/validation.rs
@@ -1,3 +1,4 @@
+use crate::skill::{InstalledSkillDescriptor, validate_skill};
 use crate::webview::{InstalledWebviewDescriptor, validate_webview};
 use crate::workbench::{InstalledWorkbenchDescriptor, validate_workbench};
 use ora_domain::PluginId;
@@ -21,6 +22,7 @@ pub enum PluginContribution {
     Agent(InstalledPluginAgent),
     Workbench(InstalledWorkbenchDescriptor),
     Webview(InstalledWebviewDescriptor),
+    Skill(InstalledSkillDescriptor),
 }
 
 impl PluginContribution {
@@ -30,6 +32,7 @@ impl PluginContribution {
             Self::Agent(_) => "agent",
             Self::Workbench(_) => "workbench",
             Self::Webview(_) => "webview",
+            Self::Skill(_) => "skill",
         }
     }
 
@@ -38,7 +41,7 @@ impl PluginContribution {
         match self {
             Self::Agent(agent) => Some(&agent.entrypoint),
             Self::Workbench(workbench) => Some(&workbench.entrypoint),
-            Self::Webview(_) => None,
+            Self::Webview(_) | Self::Skill(_) => None,
         }
     }
 }
@@ -127,6 +130,7 @@ pub(crate) fn validate(
             })?;
             PluginContribution::Webview(validate_webview(package_root, webview)?)
         }
+        PluginKind::Skill => PluginContribution::Skill(validate_skill(package_root)?),
     };
 
     Ok(InstalledPlugin {

--- a/crates/plugin-manifest/README.md
+++ b/crates/plugin-manifest/README.md
@@ -9,7 +9,7 @@ immutable domain object whose public types preserve the schema's semantic invari
 
 - Reject malformed TOML, missing or unknown fields, unsupported resolver versions, and invalid
   field values with structured errors.
-- Model plugin names, source categories, plugin kinds (`workbench`, `agent`, `ui`), HTTPS URLs,
+- Model plugin names, source categories, plugin kinds (`workbench`, `agent`, `webview`, `skill`), HTTPS URLs,
   SHA-256 digests, optional source repository metadata, and optional Ora host version
   requirements as validated values.
 - Parse the `[ui]` section of a ui-kind plugin: every `[[ui.surfaces]]` entry has a slug `id`, a

--- a/crates/plugin-manifest/src/enums.rs
+++ b/crates/plugin-manifest/src/enums.rs
@@ -50,6 +50,7 @@ pub enum PluginKind {
     Workbench,
     Agent,
     Webview,
+    Skill,
 }
 
 impl PluginKind {
@@ -59,6 +60,7 @@ impl PluginKind {
             Self::Workbench => "workbench",
             Self::Agent => "agent",
             Self::Webview => "webview",
+            Self::Skill => "skill",
         }
     }
 }
@@ -79,6 +81,7 @@ impl FromStr for PluginKind {
             "workbench" => Ok(Self::Workbench),
             "agent" => Ok(Self::Agent),
             "webview" => Ok(Self::Webview),
+            "skill" => Ok(Self::Skill),
             found => Err(PluginKindError::Unsupported {
                 found: found.to_owned(),
             }),

--- a/crates/plugin-manifest/src/manifest.rs
+++ b/crates/plugin-manifest/src/manifest.rs
@@ -254,13 +254,13 @@ fn validate_kind_sections(
     let workbench = match (kind, workbench) {
         (PluginKind::Workbench, Some(workbench)) => Some(PluginWorkbench::try_from(workbench)?),
         (PluginKind::Workbench, None) => None,
-        (PluginKind::Agent | PluginKind::Webview, Some(_)) => {
+        (PluginKind::Agent | PluginKind::Webview | PluginKind::Skill, Some(_)) => {
             return Err(invalid_field(
                 ManifestField::Workbench,
                 InvalidFieldReason::NotAllowedForKind { kind },
             ));
         }
-        (PluginKind::Agent | PluginKind::Webview, None) => None,
+        (PluginKind::Agent | PluginKind::Webview | PluginKind::Skill, None) => None,
     };
     let webview = match (kind, webview) {
         (PluginKind::Webview, Some(webview)) => Some(PluginWebview::try_from(webview)?),
@@ -270,13 +270,13 @@ fn validate_kind_sections(
                 InvalidFieldReason::MissingForKind { kind },
             ));
         }
-        (PluginKind::Agent | PluginKind::Workbench, Some(_)) => {
+        (PluginKind::Agent | PluginKind::Workbench | PluginKind::Skill, Some(_)) => {
             return Err(invalid_field(
                 ManifestField::Webview,
                 InvalidFieldReason::NotAllowedForKind { kind },
             ));
         }
-        (PluginKind::Agent | PluginKind::Workbench, None) => None,
+        (PluginKind::Agent | PluginKind::Workbench | PluginKind::Skill, None) => None,
     };
 
     Ok((workbench, webview))

--- a/crates/plugin-manifest/src/tests.rs
+++ b/crates/plugin-manifest/src/tests.rs
@@ -128,6 +128,57 @@ fn parses_agent_kind_manifest() {
     assert_eq!(manifest.kind().as_str(), "agent");
 }
 
+/// Verifies the Skill kind is accepted by the marketplace manifest schema.
+#[test]
+fn parses_skill_kind_marketplace_manifest() {
+    let manifest = success(
+        PluginManifest::parse(&MINIMAL_MANIFEST.replacen("workbench", "skill", 1)),
+        "skill-kind marketplace manifest",
+    );
+
+    assert_eq!(manifest.kind(), PluginKind::Skill);
+    assert_eq!(manifest.kind().as_str(), "skill");
+}
+
+/// Verifies a local Skill plugin needs only the installed-manifest core fields.
+#[test]
+fn parses_installed_skill_manifest_without_resolver_or_download_fields() {
+    let installed = "name = \"user.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.2.0\"\ndescription = \"A Skill package\"\n";
+    let manifest = success(
+        PluginManifest::parse_installed(installed),
+        "installed Skill manifest",
+    );
+
+    assert_eq!(manifest.resolver(), 1);
+    assert_eq!(manifest.kind(), PluginKind::Skill);
+    assert_eq!(manifest.release(), None);
+}
+
+/// Verifies Skill plugins cannot smuggle either existing kind-specific section.
+#[test]
+fn skill_kind_rejects_workbench_and_webview_sections() {
+    let workbench = WORKBENCH_MANIFEST.replacen("kind = \"workbench\"", "kind = \"skill\"", 1);
+    let webview = WEBVIEW_MANIFEST.replacen("kind = \"webview\"", "kind = \"skill\"", 1);
+
+    assert!(matches!(
+        PluginManifest::parse_installed(&workbench),
+        Err(ManifestError::InvalidField {
+            field: ManifestField::Workbench,
+            reason: InvalidFieldReason::NotAllowedForKind {
+                kind: PluginKind::Skill
+            },
+        })
+    ));
+    assert!(matches!(
+        PluginManifest::parse_installed(&webview),
+        Err(ManifestError::InvalidField {
+            field: ManifestField::Webview,
+            reason: InvalidFieldReason::NotAllowedForKind {
+                kind: PluginKind::Skill
+            },
+        })
+    ));
+}
 /// Verifies an installed package manifest omits download-only fields and still parses.
 #[test]
 fn parses_installed_manifest_without_download_fields() {

--- a/crates/surface/src/definition.rs
+++ b/crates/surface/src/definition.rs
@@ -82,7 +82,7 @@ impl SurfaceDefinition {
     /// truth and this is a pure type transfer.
     pub fn from_installed(plugin: &InstalledPlugin) -> Option<Self> {
         let source = match &plugin.contributes {
-            PluginContribution::Agent(_) => return None,
+            PluginContribution::Agent(_) | PluginContribution::Skill(_) => return None,
             PluginContribution::Workbench(descriptor) => {
                 SurfaceSource::Workbench(WorkbenchDefinition {
                     asset_root: descriptor.asset_root.clone(),
@@ -157,7 +157,7 @@ mod tests {
     }
 
     /// A webview plugin becomes a singleton remote-site definition, a workbench plugin a
-    /// multi-instance page definition, and an agent none at all.
+    /// multi-instance page definition, and agents and skills none at all.
     #[test]
     fn maps_installed_contributions_to_definitions() {
         let webview = installed(
@@ -184,6 +184,7 @@ mod tests {
                 entrypoint: PortableRelativePath::parse("main.js").expect("entrypoint"),
             }),
         );
+        let skill = installed("acme.skill", PluginContribution::Skill(Default::default()));
 
         let webview_definition = SurfaceDefinition::from_installed(&webview);
         let workbench_definition = SurfaceDefinition::from_installed(&workbench);
@@ -199,6 +200,7 @@ mod tests {
                     .as_ref()
                     .map(SurfaceDefinition::instance_policy),
                 SurfaceDefinition::from_installed(&agent),
+                SurfaceDefinition::from_installed(&skill),
             ),
             (
                 Some(SurfaceDefinition {
@@ -216,6 +218,7 @@ mod tests {
                 Some(InstancePolicy::Singleton),
                 Some(SurfaceKind::Workbench),
                 Some(InstancePolicy::Multiple),
+                None,
                 None,
             )
         );

--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -412,6 +412,7 @@ describe("Composer", () => {
             namespace: "local",
             name: "code-review",
             description: "Review the current diff",
+            source: { kind: "local" } as const,
             availability: "available",
           },
         ]}
@@ -441,6 +442,7 @@ describe("Composer", () => {
             namespace: "local",
             name: "code-review",
             description: "Review the current diff",
+            source: { kind: "local" } as const,
             availability: "available",
           },
           {
@@ -448,6 +450,7 @@ describe("Composer", () => {
             namespace: "local",
             name: "missing-skill",
             description: "Lost package",
+            source: { kind: "local" } as const,
             availability: "unavailable",
           },
         ]}
@@ -1003,6 +1006,7 @@ describe("Composer", () => {
             namespace: "local",
             name: "code-review",
             description: "Review",
+            source: { kind: "local" } as const,
             availability: "available",
           },
         ]}

--- a/packages/app-shell/src/features/settings/atoms-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/atoms-settings.test.tsx
@@ -44,6 +44,7 @@ function renderSettings(
         namespace: "local",
         name: "review-skill",
         description: "Reviews changes",
+        source: { kind: "local" } as const,
         availability: "available",
       },
     ];
@@ -115,6 +116,85 @@ describe("atom settings content", () => {
     );
   });
 
+  it("labels disabled plugin Skills with their source and status and hides mutation actions", async () => {
+    renderSettings("skill", (client) => {
+      client.skill.list = async () => ({
+        skills: [
+          {
+            id: "plugin:official/review-pack:review",
+            namespace: "official/review-pack",
+            name: "review",
+            description: "Reviews changes",
+            source: { kind: "plugin", pluginId: "official/review-pack" },
+            availability: "available",
+          },
+        ],
+      });
+      client.plugin.listInstalled = async () => ({
+        plugins: [
+          {
+            id: "official/review-pack",
+            namespace: "official",
+            name: "review-pack",
+            description: "Review skills",
+            homepage: null,
+            license: null,
+            displayName: "Review pack",
+            version: "1.0.0",
+            kind: "skill",
+            enabled: false,
+            logo: null,
+            runtime: "stopped",
+          },
+        ],
+      });
+    });
+
+    const item = await screen.findByRole("listitem");
+    const source = within(item).getByText("official/review-pack");
+    expect(source).toBeVisible();
+    expect(
+      source.closest('[data-slot="badge"]')?.querySelector("svg"),
+    ).not.toBeNull();
+    expect(await within(item).findByText("已禁用")).toBeVisible();
+    expect(within(item).queryByText(/来自/)).toBeNull();
+    expect(within(item).queryByRole("button", { name: "编辑" })).toBeNull();
+    expect(within(item).queryByRole("button", { name: "删除" })).toBeNull();
+  });
+  it("collapses long plugin sources to an icon and reveals the full id on hover", async () => {
+    const user = userEvent.setup();
+    const pluginId = "official/review-pack-with-a-name-that-does-not-fit";
+    renderSettings("skill", (client) => {
+      client.skill.list = async () => ({
+        skills: [
+          {
+            id: "plugin:" + pluginId + ":review",
+            namespace: pluginId,
+            name: "review",
+            description: "Reviews changes",
+            source: { kind: "plugin", pluginId },
+            availability: "available",
+          },
+        ],
+      });
+      client.plugin.listInstalled = async () => ({ plugins: [] });
+    });
+
+    const item = await screen.findByRole("listitem");
+    const sourceIcon = within(item).getByRole("button", { name: pluginId });
+    expect(within(item).queryByText(pluginId)).toBeNull();
+
+    await user.hover(sourceIcon);
+    const tooltip = await screen.findByText(pluginId);
+    expect(tooltip).toBeVisible();
+    expect(tooltip).toHaveClass(
+      "max-w-64",
+      "whitespace-normal",
+      "break-all",
+      "text-left",
+    );
+  });
+
   it("loads and clears editable Skill content", async () => {
     const user = userEvent.setup();
     const update = vi.fn(async () => ({
@@ -123,6 +203,7 @@ describe("atom settings content", () => {
         namespace: "local",
         name: "review-skill",
         description: "Reviews changes",
+        source: { kind: "local" } as const,
         availability: "available" as const,
       },
     }));
@@ -202,6 +283,7 @@ describe("atom settings content", () => {
             namespace: "local",
             name: request.name,
             description: request.description,
+            source: { kind: "local" } as const,
             availability: "available" as const,
           },
         }),
@@ -277,6 +359,7 @@ describe("atom settings content", () => {
         name: "review-skill",
         namespace: "local",
         description: "Reviews changes",
+        source: { kind: "local" } as const,
         availability: "unavailable",
       },
     ];

--- a/packages/app-shell/src/features/settings/atoms-settings.tsx
+++ b/packages/app-shell/src/features/settings/atoms-settings.tsx
@@ -33,12 +33,16 @@ import {
   Input,
   Label,
   Textarea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   cn,
 } from "@ora/ui";
 import {
   IconAlertTriangle,
   IconPencil,
   IconPlus,
+  IconPuzzle,
   IconRobot,
   IconSearch,
   IconSparkles,
@@ -53,6 +57,7 @@ import {
   localizeSkillImportStatus,
 } from "../../i18n/skill-import-reason";
 import { useAgents } from "../../state/hooks/use-agents";
+import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
 import { useSkills } from "../../state/hooks/use-skills";
 import {
   useCreateAgent,
@@ -96,6 +101,11 @@ interface AtomManagerConfig {
   notice?: ReactNode;
   /** Marks rows that cannot be edited and should open recovery instead. */
   isItemUnavailable?: (item: AtomRecord) => boolean;
+  /** Marks rows supplied by immutable sources such as installed plugins. */
+  isItemReadOnly?: (item: AtomRecord) => boolean;
+
+  /** Renders source ownership in the row's top-right action area. */
+  getItemBadge?: (item: AtomRecord) => ReactNode;
   /** Opens pane-owned recovery when an unavailable row is activated. */
   onActivateUnavailable?: (item: AtomRecord) => void;
   /** Chooses between compact rows and the wider card grid used by Skills. */
@@ -163,10 +173,39 @@ export function RolesSettings() {
 
 /** The Skills pane manages the reusable skills surfaced to Ora sessions. */
 const EMPTY_SKILLS: Skill[] = [];
+const MAX_INLINE_PLUGIN_ID_LENGTH = 24;
+
+function PluginSourceBadge({ pluginId }: { pluginId: string }) {
+  if (pluginId.length <= MAX_INLINE_PLUGIN_ID_LENGTH) {
+    return (
+      <Badge variant="secondary" className="max-w-52 normal-case">
+        <IconPuzzle aria-hidden="true" />
+        {pluginId}
+      </Badge>
+    );
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        aria-label={pluginId}
+        className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground"
+      >
+        <IconPuzzle className="size-3" aria-hidden="true" />
+      </TooltipTrigger>
+      <TooltipContent
+        align="end"
+        className="max-w-64 whitespace-normal break-all text-left"
+      >
+        {pluginId}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 export function SkillsSettings() {
   const { t } = useTranslation();
   const skillsQuery = useSkills();
+  const installedPluginsQuery = useInstalledPlugins();
   const createSkill = useCreateSkill();
   const updateSkill = useUpdateSkill();
   const deleteSkill = useDeleteSkill();
@@ -177,6 +216,15 @@ export function SkillsSettings() {
   const [recoverTarget, setRecoverTarget] = useState<Skill | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Skill | null>(null);
   const skills = skillsQuery.data ?? EMPTY_SKILLS;
+  const disabledPluginIds = useMemo(
+    () =>
+      new Set(
+        (installedPluginsQuery.data ?? [])
+          .filter((plugin) => !plugin.enabled)
+          .map((plugin) => plugin.id),
+      ),
+    [installedPluginsQuery.data],
+  );
   const unavailableCount = skills.filter(
     (skill) => skill.availability === "unavailable",
   ).length;
@@ -236,8 +284,30 @@ export function SkillsSettings() {
           ) : undefined
         }
         isItemUnavailable={(item) =>
-          "availability" in item && item.availability === "unavailable"
+          "availability" in item &&
+          item.availability === "unavailable" &&
+          item.source.kind === "local"
         }
+        isItemReadOnly={(item) =>
+          "source" in item && item.source.kind === "plugin"
+        }
+
+        getItemBadge={(item) => {
+          if (!("source" in item) || item.source.kind !== "plugin") {
+            return undefined;
+          }
+          const disabled = disabledPluginIds.has(item.source.pluginId);
+          return (
+            <div className="flex max-w-full flex-wrap items-center justify-end gap-1.5">
+              <PluginSourceBadge pluginId={item.source.pluginId} />
+              {disabled && (
+                <Badge variant="outline" className="text-muted-foreground">
+                  {t("settings.skills.pluginDisabled")}
+                </Badge>
+              )}
+            </div>
+          );
+        }}
         onActivateUnavailable={(item) => {
           if ("availability" in item) setRecoverTarget(item);
         }}
@@ -309,6 +379,9 @@ function AtomManager({
   extraAction,
   notice,
   isItemUnavailable,
+  isItemReadOnly,
+
+  getItemBadge,
   onActivateUnavailable,
   presentation = "list",
 }: AtomManagerConfig) {
@@ -452,6 +525,9 @@ function AtomManager({
             visibleItems.map((item) => {
               const Icon = icon;
               const unavailable = isItemUnavailable?.(item) === true;
+              const readOnly = isItemReadOnly?.(item) === true;
+
+              const itemBadge = getItemBadge?.(item);
               return (
                 <div
                   key={item.id}
@@ -497,36 +573,41 @@ function AtomManager({
                       </p>
                     </div>
                   </div>
-                  <div className="flex justify-end gap-1">
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      className="text-muted-foreground"
-                      aria-label={
-                        unavailable
-                          ? t(`${tPrefix}.unavailableAction`)
-                          : t("common.edit")
-                      }
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        if (unavailable) onActivateUnavailable?.(item);
-                        else setEditing({ item });
-                      }}
-                    >
-                      {unavailable ? <IconAlertTriangle /> : <IconPencil />}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                      aria-label={t("common.delete")}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        setDeleteTarget(item);
-                      }}
-                    >
-                      <IconTrash />
-                    </Button>
+                  <div className="flex items-start justify-end gap-1">
+                    {itemBadge}
+                    {!readOnly && (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="text-muted-foreground"
+                          aria-label={
+                            unavailable
+                              ? t(`${tPrefix}.unavailableAction`)
+                              : t("common.edit")
+                          }
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            if (unavailable) onActivateUnavailable?.(item);
+                            else setEditing({ item });
+                          }}
+                        >
+                          {unavailable ? <IconAlertTriangle /> : <IconPencil />}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                          aria-label={t("common.delete")}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setDeleteTarget(item);
+                          }}
+                        >
+                          <IconTrash />
+                        </Button>
+                      </>
+                    )}
                   </div>
                 </div>
               );

--- a/packages/app-shell/src/features/settings/filter-discovered-plugins.ts
+++ b/packages/app-shell/src/features/settings/filter-discovered-plugins.ts
@@ -12,7 +12,11 @@ export function filterDiscoveredPlugins(
       plugin.displayName,
       plugin.id,
       plugin.description,
-      ...(plugin.kind === "agent" ? [plugin.agentDisplayName] : [plugin.title]),
+      ...(plugin.kind === "agent"
+        ? [plugin.agentDisplayName]
+        : plugin.kind === "skill"
+          ? []
+          : [plugin.title]),
     ].some((value) => value.toLowerCase().includes(needle)),
   );
 }

--- a/packages/app-shell/src/features/settings/plugin-manager.test.ts
+++ b/packages/app-shell/src/features/settings/plugin-manager.test.ts
@@ -33,6 +33,20 @@ const plugins: InstalledPlugin[] = [
     logo: null,
     runtime: "stopped",
   },
+  {
+    id: "official/skill-test",
+    namespace: "official",
+    name: "skill-test",
+    description: "Static skill package",
+    homepage: null,
+    license: null,
+    displayName: "skill-test",
+    version: "0.1.0",
+    kind: "skill",
+    enabled: true,
+    logo: null,
+    runtime: "stopped",
+  },
 ];
 
 describe("filterDiscoveredPlugins", () => {
@@ -45,6 +59,7 @@ describe("filterDiscoveredPlugins", () => {
     ["description", "ora.planner plugin", "official/ora.planner"],
     ["canonical id", "official/ora.reviewer", "official/ora.reviewer"],
     ["agent display name", "plan agent", "official/ora.planner"],
+    ["skill description", "static skill", "official/skill-test"],
   ])("searches by %s", (_field, query, expectedId) => {
     expect(
       filterDiscoveredPlugins(plugins, query).map((plugin) => plugin.id),

--- a/packages/app-shell/src/features/settings/workflow-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/workflow-settings.test.tsx
@@ -170,6 +170,7 @@ function renderSettings(
       namespace: "local",
       name: "openspec-verify-change",
       description: "skill",
+      source: { kind: "local" } as const,
       availability: "available",
     },
     {
@@ -177,6 +178,7 @@ function renderSettings(
       namespace: "local",
       name: "openspec-archive-change",
       description: "skill",
+      source: { kind: "local" } as const,
       availability: "available",
     },
     {
@@ -184,6 +186,7 @@ function renderSettings(
       namespace: "local",
       name: "openspec-explore",
       description: "skill",
+      source: { kind: "local" } as const,
       availability: "available",
     },
     {
@@ -191,6 +194,7 @@ function renderSettings(
       namespace: "local",
       name: "cdase:sfmea_review",
       description: "skill",
+      source: { kind: "local" } as const,
       availability: "available",
     },
     {
@@ -198,6 +202,7 @@ function renderSettings(
       namespace: "local",
       name: "missing-skill",
       description: "skill",
+      source: { kind: "local" } as const,
       availability: "unavailable",
     },
   ];
@@ -922,6 +927,7 @@ describe("WorkflowSettings", () => {
         namespace: "local",
         name: "openspec-verify-change",
         description: "skill",
+        source: { kind: "local" } as const,
         availability: "available",
       },
     ];

--- a/packages/app-shell/src/features/workflow-run/run-act-inspector.test.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-act-inspector.test.tsx
@@ -51,6 +51,7 @@ function renderInspector() {
       namespace: "local",
       name: "openspec-explore",
       description: "探索仓库结构与约束",
+      source: { kind: "local" } as const,
       availability: "available",
     },
     {
@@ -58,6 +59,7 @@ function renderInspector() {
       namespace: "local",
       name: "hidden-skill",
       description: "Should not appear",
+      source: { kind: "local" } as const,
       availability: "available",
     },
   ];

--- a/packages/app-shell/src/i18n/i18n-instance.ts
+++ b/packages/app-shell/src/i18n/i18n-instance.ts
@@ -688,6 +688,7 @@ export const translationResources = {
     "settings.skills.deleteDescription":
       "该技能将从可用命令中移除，此操作无法撤销。",
     "settings.skills.unavailable": "不可用",
+    "settings.skills.pluginDisabled": "已禁用",
     "settings.skills.unavailableTitle": "“{{name}}”的技能包已丢失",
     "settings.skills.unavailableDescription":
       "这个技能还在列表里，但本地文件找不到了。请删除，或重新上传同名技能包。",
@@ -2158,6 +2159,7 @@ export const translationResources = {
     "settings.skills.deleteDescription":
       "This skill will be removed from available commands. This cannot be undone.",
     "settings.skills.unavailable": "Unavailable",
+    "settings.skills.pluginDisabled": "Disabled",
     "settings.skills.unavailableTitle":
       "The “{{name}}” skill package is missing",
     "settings.skills.unavailableDescription":

--- a/packages/app-shell/src/state/hooks/use-app-events.ts
+++ b/packages/app-shell/src/state/hooks/use-app-events.ts
@@ -35,6 +35,7 @@ export function useAppEvents(client: ContractsClient) {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.agentRuntimeStatus,
       });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.skills });
     };
     const scheduleReconnect = () => {
       if (disposed) return;

--- a/packages/app-shell/src/state/hooks/use-atom-mutations.test.ts
+++ b/packages/app-shell/src/state/hooks/use-atom-mutations.test.ts
@@ -29,6 +29,7 @@ const SKILL_X: Skill = {
   namespace: "local",
   name: "Refactor",
   description: "Refactoring skill",
+  source: { kind: "local" } as const,
   availability: "available",
 };
 
@@ -186,6 +187,7 @@ describe("useUpdateSkill", () => {
       namespace: "local",
       name: "Renamed",
       description: "new desc",
+      source: { kind: "local" } as const,
       availability: "available",
     });
   });

--- a/packages/app-shell/src/test/mock-client.ts
+++ b/packages/app-shell/src/test/mock-client.ts
@@ -558,6 +558,7 @@ export function createMockClient(state: MockClientState): ContractsClient {
           namespace: "local",
           name: req.name,
           description: req.description,
+          source: { kind: "local" } as const,
           availability: "available",
         };
         state.skills.push(skill);
@@ -572,6 +573,7 @@ export function createMockClient(state: MockClientState): ContractsClient {
           namespace: existing.namespace,
           name: req.name,
           description: req.description,
+          source: { kind: "local" } as const,
           availability: existing.availability,
         };
         state.skills[idx] = updated;

--- a/packages/contracts/src/plugin.ts
+++ b/packages/contracts/src/plugin.ts
@@ -96,10 +96,12 @@ export type InstalledPlugin =
      */
     logo: string | null;
   }
-  & ({ "kind": "agent"; agentDisplayName: string } | {
-    "kind": "workbench";
-    title: string;
-  } | { "kind": "webview"; title: string; startUrl: string })
+  & (
+    | { "kind": "agent"; agentDisplayName: string }
+    | { "kind": "workbench"; title: string }
+    | { "kind": "webview"; title: string; startUrl: string }
+    | { "kind": "skill" }
+  )
   & ({ "runtime": "stopped" } | { "runtime": "starting" } | {
     "runtime": "running";
   } | { "runtime": "failed"; failureReason: string });
@@ -116,7 +118,8 @@ export type InstalledPlugin =
 export type InstalledPluginContribution =
   | { "kind": "agent"; agentDisplayName: string }
   | { "kind": "workbench"; title: string }
-  | { "kind": "webview"; title: string; startUrl: string };
+  | { "kind": "webview"; title: string; startUrl: string }
+  | { "kind": "skill" };
 
 /**
  * Requests the cached marketplace registry index used to populate the plugin catalog.

--- a/packages/contracts/src/skill.ts
+++ b/packages/contracts/src/skill.ts
@@ -52,6 +52,7 @@ export type Skill = {
   namespace: string;
   name: string;
   description: string;
+  source: SkillSource;
   availability: SkillAvailability;
 };
 
@@ -69,7 +70,16 @@ export type SkillDetails = {
   name: string;
   description: string;
   content: string;
+  source: SkillSource;
   availability: SkillAvailability;
+};
+
+/**
+ * Identifies whether a Skill is user-owned or supplied by an immutable plugin package.
+ */
+export type SkillSource = { "kind": "local" } | {
+  "kind": "plugin";
+  pluginId: string;
 };
 
 /**


### PR DESCRIPTION
- parse and validate skill plugin packages
- persist plugin skills in the existing catalog tables
- keep plugin-provided skills read-only
- sync plugin enablement state in skill settings
- display plugin source, status, and overflow-safe tooltips