### PR TITLE
feat(plugin): adopt new orax manifest schema and multi-source registry

### DIFF
--- a/crates/backend/src/agent_runtime/connection.rs
+++ b/crates/backend/src/agent_runtime/connection.rs
@@ -1180,7 +1180,7 @@ mod tests {
         fs::write(
             package_root.join("orax.toml"),
             format!(
-                "resolver = 1\nname = {package_name:?}\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"1.0.0\"\ndescription = \"Example\"\n"
+                "resolver = 1\nidentifier = {package_name:?}\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"1.0.0\"\ndescription = \"Example\"\n"
             ),
         )
         .expect("write plugin manifest");

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -1686,7 +1686,7 @@ mod tests {
         fs::create_dir_all(&skill_root).expect("create installed Skill tree");
         fs::write(
             package_root.join("orax.toml"),
-            "name = \"review-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.0.0\"\ndescription = \"Review skills\"\n",
+            "identifier = \"review-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.0.0\"\ndescription = \"Review skills\"\n",
         )
         .expect("write plugin manifest");
         fs::write(

--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -28,15 +28,17 @@ use ora_plugin_registry::{
     RegistryEntry, RegistryError, RegistryIndex, RegistrySource, RegistrySync,
 };
 use ora_utils::http::{DownloadSource, ProxyConfig, ReqwestDownloader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 
-/// The marketplace repository mirrored into the local registry source checkout.
-const MARKETPLACE_REPOSITORY_URL: &str = "https://github.com/ora-space/marketplace";
-/// The branch tracked by the marketplace registry source.
-const MARKETPLACE_REPOSITORY_BRANCH: &str = "main";
+/// The default marketplace sources this backend syncs, each tracked on its own branch.
+///
+/// Order matters only for overlapping plugin ids: when two sources publish the same plugin, the
+/// earlier source wins both the merged listing and the install-time lookup.
+const MARKETPLACE_SOURCES: &[(&str, &str)] =
+    &[("https://github.com/ora-space/marketplace", "main")];
 
 /// The concrete lifecycle composition the backend runs.
 pub(crate) type BackendPluginLifecycle = PluginLifecycle<
@@ -158,7 +160,7 @@ pub(crate) struct AgentPluginAttachment {
 /// Groups plugin discovery and lifecycle operations behind the backend's plugin interface.
 pub(crate) struct PluginApi {
     lifecycle: BackendPluginLifecycle,
-    registry_source: RegistrySource,
+    registry_sources: Vec<RegistrySource>,
     registry_index_path: PathBuf,
     data_directory: PathBuf,
     installer: Installer<ReqwestDownloader>,
@@ -177,15 +179,13 @@ impl PluginApi {
         publisher: AppEventPublisher,
     ) -> Result<Self, PluginLifecycleError> {
         let plugins_directory = data_directory.join("plugins");
-        let registry_source = RegistrySource::new(
-            MARKETPLACE_REPOSITORY_URL,
-            BranchName::new(MARKETPLACE_REPOSITORY_BRANCH),
-            plugins_directory
-                .join("sources")
-                .join("github.com")
-                .join("ora-space")
-                .join("marketplace"),
-        );
+        let sources_root = plugins_directory.join("sources");
+        let registry_sources = MARKETPLACE_SOURCES
+            .iter()
+            .map(|(url, branch)| {
+                RegistrySource::from_git(*url, BranchName::new(*branch), &sources_root)
+            })
+            .collect();
         let registry_index_path = plugins_directory.join("cache").join("registry_index.json");
         let installer = Installer::new(ReqwestDownloader::new(ProxyConfig::default()));
         let notifications = BroadcastNotificationSink::new();
@@ -203,7 +203,7 @@ impl PluginApi {
 
         Ok(Self {
             lifecycle,
-            registry_source,
+            registry_sources,
             registry_index_path,
             data_directory,
             installer,
@@ -243,15 +243,21 @@ impl PluginApi {
         }
     }
 
-    /// Pulls the marketplace source, rebuilds its registry index, and atomically replaces the cache.
+    /// Pulls every marketplace source, merges their registry indexes, and atomically replaces the
+    /// cache.
     pub(crate) fn sync_available_plugins(
         &self,
         _request: SyncAvailablePluginsRequest,
     ) -> Result<SyncAvailablePluginsResponse, RegistryError> {
-        let checkout_directory =
-            RegistrySync::sync(&Git::new(CliGitRunner), &self.registry_source)?;
-        let build = RegistryIndex::build(
-            &checkout_directory.join("registry"),
+        let git = Git::new(CliGitRunner);
+        let mut registry_dirs: Vec<PathBuf> = Vec::with_capacity(self.registry_sources.len());
+        for source in &self.registry_sources {
+            let checkout_directory = RegistrySync::sync(&git, source)?;
+            registry_dirs.push(checkout_directory.join("registry"));
+        }
+        let registry_dir_refs: Vec<&Path> = registry_dirs.iter().map(PathBuf::as_path).collect();
+        let build = RegistryIndex::build_all(
+            &registry_dir_refs,
             ora_logging::clock::now_local().unix_timestamp(),
         );
         if let Some(cache_directory) = self.registry_index_path.parent() {
@@ -364,16 +370,22 @@ impl PluginApi {
             .map_err(|error| BackendError::internal("failed to remove plugin Skills", error))?;
         Ok(response)
     }
-    /// Installs a marketplace plugin by resolving its release manifest from the synced source and
+    /// Installs a marketplace plugin by resolving its release manifest from the synced sources and
     /// downloading, verifying, and extracting its package through the network-backed installer.
     ///
-    /// The source registry is read only for the release `url`/`sha256` (the cached index carries
-    /// display fields only), so this returns NotFound when the identifier is not in the checkout.
+    /// The source registries are read only for the release `url`/`sha256` (the cached index
+    /// carries display fields only), so this returns NotFound when the identifier is not in any
+    /// checkout.
     pub(crate) async fn install(
         &self,
         request: InstallPluginRequest,
     ) -> Result<InstallPluginResponse, BackendError> {
-        let registry_directory = self.registry_source.checkout_dir().join("registry");
+        let registry_dirs: Vec<PathBuf> = self
+            .registry_sources
+            .iter()
+            .map(|source| source.checkout_dir().join("registry"))
+            .collect();
+        let registry_dir_refs: Vec<&Path> = registry_dirs.iter().map(PathBuf::as_path).collect();
         // A malformed identifier can never name a registry entry, so it is reported the same way
         // as an unknown one instead of leaking the id grammar as a separate error class.
         let plugin_id = PluginId::parse(&request.plugin_id).map_err(|_| {
@@ -383,7 +395,7 @@ impl PluginApi {
                 "marketplace plugin id is not a valid `<namespace>/<name>`",
             )
         })?;
-        let manifest = RegistryIndex::resolve_manifest(&registry_directory, &plugin_id)
+        let manifest = RegistryIndex::resolve_manifest_all(&registry_dir_refs, &plugin_id)
             .map_err(|error| {
                 BackendError::internal("failed to resolve plugin release manifest", error)
             })?
@@ -533,6 +545,8 @@ fn available_plugin(entry: &RegistryEntry) -> ora_contracts::AvailablePlugin {
     ora_contracts::AvailablePlugin {
         id: entry.id().canonical(),
         name: entry.name().to_owned(),
+        title: entry.title().to_owned(),
+        kind: entry.kind().to_owned(),
         namespace: entry.namespace().to_owned(),
         version: entry.version().to_string(),
         description: entry.description().to_owned(),

--- a/crates/contracts/src/plugin.rs
+++ b/crates/contracts/src/plugin.rs
@@ -85,6 +85,11 @@ pub struct InstalledPlugin {
 pub struct AvailablePlugin {
     pub id: String,
     pub name: String,
+    /// Human-readable display title declared by the manifest; falls back to `name` when a cached
+    /// index or older manifest omits it.
+    pub title: String,
+    /// The plugin kind (`agent`, `workbench`, or `webview`).
+    pub kind: String,
     pub namespace: String,
     pub version: String,
     pub description: String,
@@ -469,6 +474,8 @@ mod tests {
                 plugins: vec![AvailablePlugin {
                     id: "official/weather".to_string(),
                     name: "weather".to_string(),
+                    title: "Weather".to_string(),
+                    kind: "agent".to_string(),
                     namespace: "official".to_string(),
                     version: "1.2.0".to_string(),
                     description: "Weather plugin".to_string(),
@@ -481,6 +488,8 @@ mod tests {
                 "plugins": [{
                     "id": "official/weather",
                     "name": "weather",
+                    "title": "Weather",
+                    "kind": "agent",
                     "namespace": "official",
                     "version": "1.2.0",
                     "description": "Weather plugin",

--- a/crates/plugin-lifecycle/src/data_plane_tests.rs
+++ b/crates/plugin-lifecycle/src/data_plane_tests.rs
@@ -259,7 +259,7 @@ fn write_workbench_plugin_package(data_dir: &Path, name: &str) {
         package_root.join("orax.toml"),
         format!(
             r#"resolver = 1
-name = "{name}"
+identifier = "{name}"
 namespace = "official"
 kind = "workbench"
 version = "1.0.0"

--- a/crates/plugin-lifecycle/src/tests.rs
+++ b/crates/plugin-lifecycle/src/tests.rs
@@ -1691,7 +1691,7 @@ fn write_skill_plugin_package(data_dir: &std::path::Path, name: &str) {
     fs::write(
         package_root.join("orax.toml"),
         format!(
-            r#"name = "{name}"
+            r#"identifier = "{name}"
 namespace = "official"
 kind = "skill"
 version = "1.0.0"
@@ -1711,7 +1711,7 @@ pub(super) fn write_plugin_package(data_dir: &std::path::Path, name: &str) {
         package_root.join("orax.toml"),
         format!(
             r#"resolver = 1
-name = "{name}"
+identifier = "{name}"
 namespace = "official"
 kind = "agent"
 version = "1.0.0"

--- a/crates/plugin-manager/src/discovery.rs
+++ b/crates/plugin-manager/src/discovery.rs
@@ -63,7 +63,7 @@ pub(crate) fn discover(data_dir: &Path) -> PluginDiscovery {
                     issues.push(PluginDiscoveryIssue::new(
                         manifest_path,
                         PluginDiscoveryIssueKind::DuplicatePluginId,
-                        Some("name".to_string()),
+                        Some("identifier".to_string()),
                         format!(
                             "plugin `{}` was already discovered at {}",
                             plugin.id,

--- a/crates/plugin-manager/src/install.rs
+++ b/crates/plugin-manager/src/install.rs
@@ -343,7 +343,7 @@ mod tests {
         digest: [u8; 32],
     ) -> String {
         format!(
-            "resolver = 1\nname = \"{name}\"\nnamespace = \"official\"\nkind = \"{kind}\"\nversion = \"{version}\"\ndescription = \"A test plugin\"\nurl = \"https://example.com/{name}.orax\"\nsha256 = \"{}\"\n",
+            "resolver = 1\nidentifier = \"{name}\"\nnamespace = \"official\"\nkind = \"{kind}\"\nversion = \"{version}\"\ndescription = \"A test plugin\"\nurl = \"https://example.com/{name}.orax\"\nsha256 = \"{}\"\n",
             hex(digest)
         )
     }
@@ -358,7 +358,7 @@ mod tests {
             &[
                 (
                     "orax.toml",
-                    b"resolver = 1\nname = \"weather\"\n".as_slice(),
+                    b"resolver = 1\nidentifier = \"weather\"\n".as_slice(),
                 ),
                 ("main.js", b"export {};\n".as_slice()),
                 ("logo.svg", b"<svg/>".as_slice()),
@@ -410,7 +410,7 @@ mod tests {
             &[
                 (
                     "orax.toml",
-                    b"name = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.0.0\"\ndescription = \"Skill plugin test\"\n".as_slice(),
+                    b"identifier = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.0.0\"\ndescription = \"Skill plugin test\"\n".as_slice(),
                 ),
                 (
                     "assets/skills/review/SKILL.md",
@@ -482,7 +482,7 @@ mod tests {
             &[
                 (
                     "orax.toml",
-                    &b"name = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"0.1.1\"\ndescription = \"Skill plugin test\"\n"[..],
+                    &b"identifier = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"0.1.1\"\ndescription = \"Skill plugin test\"\n"[..],
                 ),
                 (
                     "assets/skills/review/SKILL.md",
@@ -540,7 +540,7 @@ mod tests {
             &release_path,
             &[(
                 "orax.toml",
-                &b"name = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"0.1.1\"\ndescription = \"Skill plugin test\"\n"[..],
+                &b"identifier = \"ora.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"0.1.1\"\ndescription = \"Skill plugin test\"\n"[..],
             )],
         );
 
@@ -570,7 +570,7 @@ mod tests {
             &[
                 (
                     "orax.toml",
-                    &b"resolver = 1\nname = \"ora-space.opencode\"\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"0.1.2\"\ndescription = \"Ora Space OpenCode Agent\"\n"[..],
+                    &b"resolver = 1\nidentifier = \"ora-space.opencode\"\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"0.1.2\"\ndescription = \"Ora Space OpenCode Agent\"\n"[..],
                 ),
                 ("main.js", b"export {};\n".as_slice()),
                 ("logo.svg", b"<svg/>".as_slice()),

--- a/crates/plugin-manager/src/kind_tests.rs
+++ b/crates/plugin-manager/src/kind_tests.rs
@@ -63,7 +63,7 @@ fn discovers_workbench_package_with_and_without_methods() {
     write_page(&package_root);
     let static_root = write_manifest(temp_dir.path(), "ora.static", {
         let mut manifest = workbench_manifest(None);
-        manifest["name"] = Value::from("ora.static");
+        manifest["identifier"] = Value::from("ora.static");
         manifest
     });
     write_page(&static_root);

--- a/crates/plugin-manager/src/tests.rs
+++ b/crates/plugin-manager/src/tests.rs
@@ -48,7 +48,7 @@ fn discovers_complete_manifest() {
 fn discovers_skill_plugin_with_required_skill_assets() {
     let temp_dir = TempDir::new().unwrap();
     let mut manifest = agent_manifest();
-    manifest["name"] = Value::from("ora.skill-pack");
+    manifest["identifier"] = Value::from("ora.skill-pack");
     manifest["kind"] = Value::from("skill");
     let package_root = write_manifest(temp_dir.path(), "ora.skill-pack", manifest);
     fs::remove_file(package_root.join("main.js")).unwrap();
@@ -86,7 +86,7 @@ fn rejects_skill_plugins_without_complete_skill_assets() {
     for case in ["missing", "empty", "incomplete"] {
         let temp_dir = TempDir::new().unwrap();
         let mut manifest = agent_manifest();
-        manifest["name"] = Value::from(format!("ora.skill-{case}"));
+        manifest["identifier"] = Value::from(format!("ora.skill-{case}"));
         manifest["kind"] = Value::from("skill");
         let package_root = write_manifest(temp_dir.path(), case, manifest);
         fs::remove_file(package_root.join("main.js")).unwrap();
@@ -123,7 +123,7 @@ fn missing_installed_root_is_empty() {
 fn sorts_plugins_by_identifier_and_accepts_minimal_metadata() {
     let temp_dir = TempDir::new().unwrap();
     let mut zeta = agent_manifest();
-    zeta["name"] = Value::from("ora.zeta");
+    zeta["identifier"] = Value::from("ora.zeta");
     zeta["version"] = Value::from("1.2.3-alpha.1+build.7");
     zeta.as_table_mut().unwrap().remove("homepage");
     zeta.as_table_mut().unwrap().remove("license");
@@ -131,7 +131,7 @@ fn sorts_plugins_by_identifier_and_accepts_minimal_metadata() {
     // The directory is deliberately named against sort order: identity comes from the manifest.
     write_manifest(temp_dir.path(), "a-directory", zeta);
     let mut alpha = agent_manifest();
-    alpha["name"] = Value::from("ora.alpha");
+    alpha["identifier"] = Value::from("ora.alpha");
     alpha["version"] = Value::from("2.0.0");
     write_manifest(temp_dir.path(), "z-directory", alpha);
 
@@ -192,7 +192,10 @@ fn reports_duplicate_plugin_ids() {
             .iter()
             .map(|issue| (issue.kind(), issue.field_path()))
             .collect::<Vec<_>>(),
-        vec![(PluginDiscoveryIssueKind::DuplicatePluginId, Some("name"))]
+        vec![(
+            PluginDiscoveryIssueKind::DuplicatePluginId,
+            Some("identifier")
+        )]
     );
 }
 
@@ -201,7 +204,7 @@ fn reports_duplicate_plugin_ids() {
 fn isolates_malformed_and_unsupported_packages() {
     let temp_dir = TempDir::new().unwrap();
     write_manifest(temp_dir.path(), "ora.valid", named("ora.valid"));
-    write_raw_manifest(temp_dir.path(), "ora.broken", b"name = [");
+    write_raw_manifest(temp_dir.path(), "ora.broken", b"identifier = [");
     let mut unsupported = named("ora.future");
     unsupported["resolver"] = Value::from(2);
     write_manifest(temp_dir.path(), "ora.future", unsupported);
@@ -366,15 +369,15 @@ fn rejects_invalid_names_and_namespaces() {
     let long_segment = "a".repeat(70);
     let long_name = format!("{long_segment}.{long_segment}");
     let cases = [
-        ("name", ""),
-        ("name", "   "),
-        ("name", "Ora.example"),
-        ("name", "ora.skill_hub"),
-        ("name", "ora.space.example"),
-        ("name", "ora."),
-        ("name", ".example"),
-        ("name", "ora..example"),
-        ("name", long_name.as_str()),
+        ("identifier", ""),
+        ("identifier", "   "),
+        ("identifier", "Ora.example"),
+        ("identifier", "ora.skill_hub"),
+        ("identifier", "ora.space.example"),
+        ("identifier", "ora."),
+        ("identifier", ".example"),
+        ("identifier", "ora..example"),
+        ("identifier", long_name.as_str()),
         ("namespace", ""),
         ("namespace", "Official"),
         ("namespace", "community"),
@@ -668,7 +671,7 @@ pub(crate) fn agent_manifest() -> Value {
     toml::from_str(
         r#"
 resolver = 1
-name = "ora.claude-code"
+identifier = "ora.claude-code"
 namespace = "official"
 kind = "agent"
 version = "0.1.0"
@@ -686,7 +689,7 @@ ora = ">=0.1.0, <0.2.0"
 /// Creates the agent manifest under another plugin name.
 fn named(name: &str) -> Value {
     let mut manifest = agent_manifest();
-    manifest["name"] = Value::from(name);
+    manifest["identifier"] = Value::from(name);
     manifest
 }
 

--- a/crates/plugin-manager/src/validation.rs
+++ b/crates/plugin-manager/src/validation.rs
@@ -108,8 +108,12 @@ pub(crate) fn validate(
     let name = manifest.name().as_str();
     // Both segments passed the manifest grammar, which is a strict subset of what the domain
     // id accepts, so this conversion cannot fail for a reason the user could act on.
-    let id = PluginId::new(manifest.namespace().as_str(), name)
-        .map_err(|error| invalid("name", format!("plugin id is not representable: {error}")))?;
+    let id = PluginId::new(manifest.namespace().as_str(), name).map_err(|error| {
+        invalid(
+            "identifier",
+            format!("plugin id is not representable: {error}"),
+        )
+    })?;
     let contributes = match manifest.kind() {
         PluginKind::Agent => PluginContribution::Agent(InstalledPluginAgent {
             display_name: name.to_owned(),

--- a/crates/plugin-manifest/README.md
+++ b/crates/plugin-manifest/README.md
@@ -3,7 +3,8 @@
 `ora-plugin-manifest` parses and validates the `orax.toml` manifest of one Ora plugin, in its
 marketplace release form (`PluginManifest::parse`) and in the form shipped inside an installed
 package (`PluginManifest::parse_installed`). It accepts caller-provided text and returns an
-immutable domain object whose public types preserve the schema's semantic invariants.
+immutable domain object whose public types preserve the schema's semantic invariants. Both
+forms accept an optional human-readable `title` that falls back to the identifier when omitted.
 
 ## Responsibilities and boundaries
 

--- a/crates/plugin-manifest/src/error.rs
+++ b/crates/plugin-manifest/src/error.rs
@@ -32,7 +32,11 @@ pub enum ManifestError {
 /// Identifies one semantic manifest field without requiring callers to parse dotted strings.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ManifestField {
-    Name,
+    /// The human-readable display title, distinct from the identifier it falls back to.
+    Title,
+    /// The installed package's name segment, spelled `identifier` in the `orax.toml` shipped
+    /// inside a package (distinct from the marketplace release form's `name` field).
+    Identifier,
     Namespace,
     Kind,
     Version,
@@ -73,7 +77,8 @@ impl fmt::Display for ManifestField {
     /// Writes the stable dotted manifest path, with array indices in brackets.
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Name => formatter.write_str("name"),
+            Self::Title => formatter.write_str("title"),
+            Self::Identifier => formatter.write_str("identifier"),
             Self::Namespace => formatter.write_str("namespace"),
             Self::Kind => formatter.write_str("kind"),
             Self::Version => formatter.write_str("version"),

--- a/crates/plugin-manifest/src/manifest.rs
+++ b/crates/plugin-manifest/src/manifest.rs
@@ -16,6 +16,7 @@ const SUPPORTED_RESOLVER: u64 = 1;
 pub struct PluginManifest {
     pub(crate) resolver: u64,
     pub(crate) name: PluginName,
+    pub(crate) title: String,
     pub(crate) namespace: PluginNamespace,
     pub(crate) kind: PluginKind,
     pub(crate) version: Version,
@@ -33,12 +34,12 @@ pub struct PluginManifest {
 impl PluginManifest {
     /// Parses and validates one plugin release manifest from TOML text.
     ///
-    /// A release manifest is the marketplace form and must declare the download metadata
-    /// (`resolver`, `url`, `sha256`) needed to fetch and verify the package.
+    /// A release manifest is the marketplace form. It spells the name segment `identifier` like
+    /// an installed package and may carry the optional `url`/`sha256` download metadata.
     pub fn parse(source: &str) -> Result<Self, ManifestError> {
         let raw: RawPluginManifest = deserialize(source)?;
         let (metadata, resolver, url, sha256) = raw.into_parts();
-        Self::from_raw_parts(metadata, resolver, Some(url), Some(sha256))
+        Self::from_raw_parts(metadata, resolver, url, sha256)
     }
 
     /// Parses and validates an installed plugin's manifest (the `orax.toml` shipped inside a
@@ -53,6 +54,9 @@ impl PluginManifest {
 
     /// Applies every semantic validation rule to the values shared by both manifest forms,
     /// keeping the release and installed schemas on one validated domain model.
+    ///
+    /// Both forms spell the name segment `identifier`, so a rejected name always reports that
+    /// field.
     fn from_raw_parts(
         metadata: RawMetadata,
         resolver: u64,
@@ -65,7 +69,17 @@ impl PluginManifest {
 
         // Keep semantic conversion explicit so the first error follows schema declaration order.
         let name = PluginName::parse(&metadata.name)
-            .map_err(|reason| invalid_field(ManifestField::Name, reason.into()))?;
+            .map_err(|reason| invalid_field(ManifestField::Identifier, reason.into()))?;
+        // The display title is descriptive metadata; a manifest that omits it falls back to the
+        // identifier so a plugin never lacks a name to show.
+        let title = match metadata.title.as_deref() {
+            Some(value) => {
+                validate_text(value, TextPolicy::Title)
+                    .map_err(|reason| invalid_field(ManifestField::Title, reason))?;
+                value.to_owned()
+            }
+            None => name.as_str().to_owned(),
+        };
         let namespace = PluginNamespace::from_str(&metadata.namespace)
             .map_err(|reason| invalid_field(ManifestField::Namespace, reason.into()))?;
         let kind = PluginKind::from_str(&metadata.kind)
@@ -118,6 +132,7 @@ impl PluginManifest {
         Ok(Self {
             resolver,
             name,
+            title,
             namespace,
             kind,
             version,
@@ -141,6 +156,11 @@ impl PluginManifest {
     /// Returns the complete plugin identifier.
     pub fn name(&self) -> &PluginName {
         &self.name
+    }
+
+    /// Returns the human-readable display title, falling back to the identifier when unset.
+    pub fn title(&self) -> &str {
+        &self.title
     }
 
     /// Returns the plugin source namespace.
@@ -332,15 +352,16 @@ impl PluginDependencies {
 #[serde(deny_unknown_fields)]
 struct RawPluginManifest {
     resolver: u64,
-    name: String,
+    identifier: String,
+    title: Option<String>,
     namespace: String,
     kind: String,
     version: String,
     description: String,
     homepage: Option<String>,
     license: Option<String>,
-    url: String,
-    sha256: String,
+    url: Option<String>,
+    sha256: Option<String>,
     head: Option<RawHead>,
     dependencies: Option<RawDependencies>,
     workbench: Option<RawWorkbench>,
@@ -351,7 +372,11 @@ struct RawPluginManifest {
 #[serde(deny_unknown_fields)]
 struct RawInstalledManifest {
     resolver: Option<u64>,
-    name: String,
+    /// Identifier segment of the installed package, spelled `identifier` (not `name`) because an
+    /// installed manifest is only ever addressed by the full id the host resolves from its name
+    /// and namespace.
+    identifier: String,
+    title: Option<String>,
     namespace: String,
     kind: String,
     version: String,
@@ -385,6 +410,7 @@ struct RawDependencies {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RawMetadata {
     name: String,
+    title: Option<String>,
     namespace: String,
     kind: String,
     version: String,
@@ -398,10 +424,14 @@ struct RawMetadata {
 }
 
 impl RawPluginManifest {
-    /// Splits the release form into shared metadata and required download fields.
-    fn into_parts(self) -> (RawMetadata, u64, String, String) {
+    /// Splits the release form into shared metadata and optional download fields.
+    fn into_parts(self) -> (RawMetadata, u64, Option<String>, Option<String>) {
         let metadata = RawMetadata {
-            name: self.name,
+            // The marketplace release form spells the name segment `identifier` like the
+            // installed form, and the download fields are optional now that the marketplace no
+            // longer publishes `.orax` release URLs.
+            name: self.identifier,
+            title: self.title,
             namespace: self.namespace,
             kind: self.kind,
             version: self.version,
@@ -421,7 +451,10 @@ impl RawInstalledManifest {
     /// Splits the installed form into shared metadata and optional download fields.
     fn into_parts(self) -> (RawMetadata, Option<u64>, Option<String>, Option<String>) {
         let metadata = RawMetadata {
-            name: self.name,
+            // The installed manifest spells the name segment `identifier`, mapping it onto the
+            // shared metadata name so both forms converge on one validated domain model.
+            name: self.identifier,
+            title: self.title,
             namespace: self.namespace,
             kind: self.kind,
             version: self.version,
@@ -439,6 +472,7 @@ impl RawInstalledManifest {
 
 #[derive(Clone, Copy)]
 enum TextPolicy {
+    Title,
     Description,
     License,
 }
@@ -447,6 +481,7 @@ impl TextPolicy {
     /// Returns the maximum byte length for this field category.
     fn max_bytes(self) -> usize {
         match self {
+            Self::Title => 128,
             Self::Description => 1000,
             Self::License => 256,
         }

--- a/crates/plugin-manifest/src/tests.rs
+++ b/crates/plugin-manifest/src/tests.rs
@@ -12,7 +12,7 @@ use semver::{Version, VersionReq};
 const DIGEST: &str = "feab001d7e9ff4ce66011ebd70791de93eb1554d34d3ea44c33d102a25c1be0a";
 
 const MINIMAL_MANIFEST: &str = r#"resolver = 1
-name = "user.ora-weather"
+identifier = "user.ora-weather"
 namespace = "official"
 kind = "workbench"
 version = "1.2.0"
@@ -21,8 +21,19 @@ url = "https://example.com/ora-weather.orax"
 sha256 = "feab001d7e9ff4ce66011ebd70791de93eb1554d34d3ea44c33d102a25c1be0a"
 "#;
 
+/// The installed-package spelling of the minimal manifest: it drops the download fields and
+/// spells the name segment `identifier`, matching what a shipped `orax.toml` contains.
+const INSTALLED_MINIMAL_MANIFEST: &str = r#"resolver = 1
+identifier = "user.ora-weather"
+namespace = "official"
+kind = "workbench"
+version = "1.2.0"
+description = "????????? Ora ??"
+"#;
+
 const FULL_MANIFEST: &str = r#"resolver = 1
-name = "user.ora-weather"
+identifier = "user.ora-weather"
+title = "Ora Weather"
 namespace = "official"
 kind = "workbench"
 version = "1.2.0"
@@ -55,6 +66,7 @@ fn parses_complete_manifest_into_full_domain_object() {
     let expected = PluginManifest {
         resolver: 1,
         name: success(PluginName::parse("user.ora-weather"), "plugin name"),
+        title: "Ora Weather".to_owned(),
         namespace: PluginNamespace::Official,
         kind: PluginKind::Workbench,
         version: success(Version::parse("1.2.0"), "version"),
@@ -95,6 +107,7 @@ fn parses_manifest_without_optional_fields() {
 
     assert_eq!(manifest.resolver(), 1);
     assert_eq!(manifest.name().as_str(), "user.ora-weather");
+    assert_eq!(manifest.title(), "user.ora-weather");
     assert_eq!(manifest.namespace(), PluginNamespace::Official);
     assert_eq!(manifest.kind(), PluginKind::Workbench);
     assert_eq!(
@@ -143,7 +156,7 @@ fn parses_skill_kind_marketplace_manifest() {
 /// Verifies a local Skill plugin needs only the installed-manifest core fields.
 #[test]
 fn parses_installed_skill_manifest_without_resolver_or_download_fields() {
-    let installed = "name = \"user.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.2.0\"\ndescription = \"A Skill package\"\n";
+    let installed = "identifier = \"user.skill-pack\"\nnamespace = \"official\"\nkind = \"skill\"\nversion = \"1.2.0\"\ndescription = \"A Skill package\"\n";
     let manifest = success(
         PluginManifest::parse_installed(installed),
         "installed Skill manifest",
@@ -182,7 +195,7 @@ fn skill_kind_rejects_workbench_and_webview_sections() {
 /// Verifies an installed package manifest omits download-only fields and still parses.
 #[test]
 fn parses_installed_manifest_without_download_fields() {
-    let installed = "name = \"user.ora-weather\"\nnamespace = \"official\"\nkind = \"workbench\"\nversion = \"1.2.0\"\ndescription = \"A test plugin\"\n";
+    let installed = "identifier = \"user.ora-weather\"\nnamespace = \"official\"\nkind = \"workbench\"\nversion = \"1.2.0\"\ndescription = \"A test plugin\"\n";
     let manifest = success(
         PluginManifest::parse_installed(installed),
         "installed manifest",
@@ -190,10 +203,106 @@ fn parses_installed_manifest_without_download_fields() {
 
     assert_eq!(manifest.resolver(), 1);
     assert_eq!(manifest.name().as_str(), "user.ora-weather");
+    assert_eq!(manifest.title(), "user.ora-weather");
     assert_eq!(manifest.kind(), PluginKind::Workbench);
     assert_eq!(manifest.url(), None);
     assert_eq!(manifest.sha256(), None);
     assert_eq!(manifest.release(), None);
+}
+
+/// Verifies the current installed-package schema, which spells the name segment `identifier` and
+/// adds a human-readable `title`, parses into a manifest that exposes both.
+#[test]
+fn parses_new_installed_schema_with_title() {
+    let source = r#"resolver = 1
+title = "OpenCode"
+identifier = "ora-space.opencode"
+namespace = "official"
+kind = "agent"
+version = "0.1.2"
+description = "Ora Space OpenCode Agent"
+homepage = "https://github.com/ora-space/opencode-agent"
+license = "Apache-2.0"
+"#;
+    let manifest = success(
+        PluginManifest::parse_installed(source),
+        "new installed schema",
+    );
+    assert_eq!(manifest.title(), "OpenCode");
+    assert_eq!(manifest.name().as_str(), "ora-space.opencode");
+    assert_eq!(manifest.namespace(), PluginNamespace::Official);
+    assert_eq!(manifest.kind(), PluginKind::Agent);
+    assert_eq!(
+        manifest.homepage().map(HomepageUrl::as_str),
+        Some("https://github.com/ora-space/opencode-agent")
+    );
+    assert_eq!(manifest.license(), Some("Apache-2.0"));
+    assert_eq!(manifest.url(), None);
+    assert_eq!(manifest.sha256(), None);
+}
+
+/// Verifies the marketplace release form accepts the same new schema: `identifier`/`title` with
+/// no `.orax` download fields, so a synced registry entry is no longer skipped for display.
+#[test]
+fn parses_new_marketplace_schema_without_download_fields() {
+    let source = r#"resolver = 1
+title = "OpenCode"
+identifier = "ora-space.opencode"
+namespace = "official"
+kind = "agent"
+version = "0.1.2"
+description = "Ora Space OpenCode Agent"
+"#;
+    let manifest = success(PluginManifest::parse(source), "new marketplace schema");
+    assert_eq!(manifest.title(), "OpenCode");
+    assert_eq!(manifest.name().as_str(), "ora-space.opencode");
+    assert_eq!(manifest.namespace(), PluginNamespace::Official);
+    assert_eq!(manifest.kind(), PluginKind::Agent);
+    assert_eq!(manifest.url(), None);
+    assert_eq!(manifest.sha256(), None);
+    assert_eq!(manifest.release(), None);
+}
+
+/// Verifies the full marketplace release schema, including Markdown-linked `homepage`/`url`, parses
+/// and exposes the download metadata the installer needs.
+#[test]
+fn parses_full_new_marketplace_manifest_with_markdown_urls() {
+    let source = r#"resolver = 1
+title = "OpenCode"
+identifier = "ora-space.opencode"
+namespace = "official"
+kind = "agent"
+version = "0.1.2"
+description = "Ora Space OpenCode Agent"
+homepage = "[https://github.com/ora-space/opencode-agent](https://github.com/ora-space/opencode-agent)"
+license = "Apache-2.0"
+url = "[https://github.com/ora-space/opencode-agent/releases/download/v0.1.2/ora-space.opencode-v0.1.2.orax](https://github.com/ora-space/opencode-agent/releases/download/v0.1.2/ora-space.opencode-v0.1.2.orax)"
+sha256 = "18263de8e26fab1ea64d6c24913f0815d2151e0ae49cea9ef8aa46f453798558"
+"#;
+    let manifest = success(
+        PluginManifest::parse(source),
+        "full new marketplace manifest",
+    );
+
+    assert_eq!(manifest.title(), "OpenCode");
+    assert_eq!(manifest.name().as_str(), "ora-space.opencode");
+    assert_eq!(manifest.namespace(), PluginNamespace::Official);
+    assert_eq!(manifest.kind(), PluginKind::Agent);
+    assert_eq!(
+        manifest.homepage().map(HomepageUrl::as_str),
+        Some("https://github.com/ora-space/opencode-agent")
+    );
+    assert_eq!(
+        manifest.url().map(ReleaseUrl::as_str),
+        Some(
+            "https://github.com/ora-space/opencode-agent/releases/download/v0.1.2/ora-space.opencode-v0.1.2.orax"
+        )
+    );
+    assert_eq!(
+        manifest.sha256().map(ToString::to_string),
+        Some("18263de8e26fab1ea64d6c24913f0815d2151e0ae49cea9ef8aa46f453798558".to_owned())
+    );
+    assert!(manifest.release().is_some());
 }
 
 /// Verifies unsupported resolver versions take priority over semantic field validation.
@@ -201,7 +310,11 @@ fn parses_installed_manifest_without_download_fields() {
 fn rejects_unsupported_resolver_before_fields() {
     let source = MINIMAL_MANIFEST
         .replacen("resolver = 1", "resolver = 2", 1)
-        .replacen("name = \"user.ora-weather\"", "name = \"INVALID\"", 1);
+        .replacen(
+            "identifier = \"user.ora-weather\"",
+            "identifier = \"INVALID\"",
+            1,
+        );
 
     assert!(matches!(
         PluginManifest::parse(&source),
@@ -231,21 +344,13 @@ fn reports_structural_toml_errors_with_spans() {
 fn rejects_missing_and_mistyped_required_fields() {
     let fields = [
         ("resolver = 1\n", "resolver = \"one\"\n"),
-        ("name = \"user.ora-weather\"\n", "name = true\n"),
+        ("identifier = \"user.ora-weather\"\n", "identifier = true\n"),
         ("namespace = \"official\"\n", "namespace = true\n"),
         ("kind = \"workbench\"\n", "kind = true\n"),
         ("version = \"1.2.0\"\n", "version = true\n"),
         (
             "description = \"获取实时天气信息的 Ora 插件\"\n",
             "description = true\n",
-        ),
-        (
-            "url = \"https://example.com/ora-weather.orax\"\n",
-            "url = true\n",
-        ),
-        (
-            "sha256 = \"feab001d7e9ff4ce66011ebd70791de93eb1554d34d3ea44c33d102a25c1be0a\"\n",
-            "sha256 = true\n",
         ),
     ];
 
@@ -266,9 +371,9 @@ fn rejects_missing_and_mistyped_required_fields() {
 fn rejects_empty_required_strings() {
     let fields = [
         (
-            "name = \"user.ora-weather\"",
-            "name = \"\"",
-            ManifestField::Name,
+            "identifier = \"user.ora-weather\"",
+            "identifier = \"\"",
+            ManifestField::Identifier,
         ),
         (
             "namespace = \"official\"",
@@ -311,13 +416,17 @@ fn rejects_empty_required_strings() {
 #[test]
 fn returns_first_root_field_error_deterministically() {
     let source = MINIMAL_MANIFEST
-        .replacen("name = \"user.ora-weather\"", "name = \"INVALID\"", 1)
+        .replacen(
+            "identifier = \"user.ora-weather\"",
+            "identifier = \"INVALID\"",
+            1,
+        )
         .replacen("namespace = \"official\"", "namespace = \"community\"", 1);
 
     assert!(matches!(
         PluginManifest::parse(&source),
         Err(ManifestError::InvalidField {
-            field: ManifestField::Name,
+            field: ManifestField::Identifier,
             reason: InvalidFieldReason::InvalidPluginName(_),
         })
     ));
@@ -519,7 +628,7 @@ fn formats_structured_manifest_fields() {
 }
 
 const WORKBENCH_MANIFEST: &str = r#"resolver = 1
-name = "user.ora-weather"
+identifier = "user.ora-weather"
 namespace = "official"
 kind = "workbench"
 version = "1.2.0"
@@ -530,7 +639,7 @@ methods = ["weather/get_current", "weather/search_city"]
 "#;
 
 const WEBVIEW_MANIFEST: &str = r#"resolver = 1
-name = "acme.hub"
+identifier = "acme.hub"
 namespace = "official"
 kind = "webview"
 version = "1.0.0"
@@ -580,7 +689,7 @@ fn parses_workbench_section_into_method_list() {
 #[test]
 fn workbench_section_is_optional_and_kind_exclusive() {
     let static_page = success(
-        PluginManifest::parse_installed(MINIMAL_MANIFEST),
+        PluginManifest::parse_installed(INSTALLED_MINIMAL_MANIFEST),
         "static workbench",
     );
     assert_eq!(static_page.workbench(), None);

--- a/crates/plugin-manifest/src/urls.rs
+++ b/crates/plugin-manifest/src/urls.rs
@@ -141,8 +141,27 @@ pub enum UrlError {
     QueryNotAllowed,
 }
 
+/// Unwraps a Markdown `[label](target)` value into its embedded `target`, leaving strings that
+/// do not use that wrapper unchanged.
+///
+/// Marketplace authors write link-valued fields as Markdown links, so the validators strip the
+/// wrapper before applying HTTPS invariants to the embedded URL.
+fn strip_markdown_link(value: &str) -> &str {
+    let Some(rest) = value.strip_prefix('[') else {
+        return value;
+    };
+    let Some(close_bracket) = rest.find("](") else {
+        return value;
+    };
+    let Some(target) = rest[close_bracket + 2..].strip_suffix(')') else {
+        return value;
+    };
+    target
+}
+
 /// Applies common HTTPS URL invariants plus one field-specific query policy.
 fn parse_https_url(value: &str, query_policy: QueryPolicy) -> Result<Url, UrlError> {
+    let value = strip_markdown_link(value);
     if value.len() > MAX_URL_BYTES {
         return Err(UrlError::TooLong {
             max_bytes: MAX_URL_BYTES,
@@ -202,6 +221,25 @@ mod tests {
             ReleaseUrl::parse("https://example.com/plugin.orax#digest"),
             Err(UrlError::FragmentNotAllowed)
         ));
+    }
+
+    /// Verifies Markdown-wrapped URLs (as marketplace authors write them) unwrap before validation.
+    #[test]
+    fn unwraps_markdown_linked_urls() {
+        let homepage = "[https://example.com/ora-weather](https://example.com/ora-weather)";
+        assert_eq!(
+            HomepageUrl::parse(homepage).expect("homepage").as_str(),
+            "https://example.com/ora-weather"
+        );
+
+        let release = "[https://example.com/plugin.orax](https://example.com/plugin.orax)";
+        assert_eq!(
+            ReleaseUrl::parse(release).expect("release").as_str(),
+            "https://example.com/plugin.orax"
+        );
+
+        // Plain URLs pass through unchanged.
+        assert!(ReleaseUrl::parse("https://example.com/plugin.orax").is_ok());
     }
 
     /// Verifies the shared URL byte limit accepts its boundary and rejects one byte above it.

--- a/crates/plugin-registry/README.md
+++ b/crates/plugin-registry/README.md
@@ -7,11 +7,19 @@
 
 - `RegistrySync::sync` clones a marketplace source when absent, otherwise fetches, checks out the
   tracked branch, and fast-forwards it against its remote through an injected `gitlancer::Git`.
+- `RegistrySource::from_git` derives a source's checkout directory from its git URL beneath the
+  sources root, so several marketplace sources can be synced side by side without a manual
+  URL-to-directory mapping.
 - `RegistryIndex::build` recursively scans a directory for `orax.toml` files, parses each valid
   manifest into a `RegistryEntry`, and returns a deterministically ordered index built at an
   injected Unix timestamp.
+- `RegistryIndex::build_all` scans several registry directories and merges their entries into one
+  index: a shared `namespace/name` id is listed once and the first source in source order wins.
 - `RegistryIndex::load` reads a previously written index file; `RegistryIndex::write` replaces the
   target file atomically through `ora-utils` so readers never observe a partial index.
+- Each entry carries the manifest's display `title` (falling back to the identifier when the
+  manifest or an older cached index omits it), so consumers render a human name without
+  re-reading `orax.toml`.
 - Each entry's optional `logo.svg`, read from the directory holding its `orax.toml` and accepted by
   `ora-utils::svg`, is inlined into the index so consumers can render the listing from the cached
   index alone. A missing, unreadable, or unsafe icon leaves the entry listed without one.
@@ -27,6 +35,8 @@
 ## Public interface
 
 `RegistryIndex::build(dir, updated_at)` returns a `RegistryBuild` carrying the ordered index and any
-skipped manifests. `RegistryIndex::load(path)` / `RegistryIndex::write(path)` read and atomically
-persist an index. `RegistrySync::sync(&git, &source)` returns the checkout directory so callers can
-then build an index from it.
+skipped manifests; `RegistryIndex::build_all(dirs, updated_at)` does the same across several
+source directories. `RegistryIndex::load(path)` / `RegistryIndex::write(path)` read and atomically
+persist an index, and `RegistryIndex::resolve_manifest_all(dirs, id)` finds a release manifest
+across sources in source order. `RegistrySync::sync(&git, &source)` returns the checkout directory
+so callers can then build an index from it.

--- a/crates/plugin-registry/src/entry.rs
+++ b/crates/plugin-registry/src/entry.rs
@@ -11,6 +11,13 @@ use serde::{Deserialize, Serialize};
 pub struct RegistryEntry {
     id: PluginId,
     name: String,
+    /// Human-readable display title from the manifest. Old cached indexes predate this field, so
+    /// it defaults to empty and consumers fall back to `name` until the next resync.
+    #[serde(default)]
+    title: String,
+    /// The plugin kind (`agent`, `workbench`, or `webview`) surfaced for the marketplace card.
+    #[serde(default)]
+    kind: String,
     namespace: String,
     version: Version,
     description: String,
@@ -29,6 +36,8 @@ impl RegistryEntry {
         Self {
             id: entry_id(manifest),
             name: manifest.name().as_str().to_owned(),
+            title: manifest.title().to_owned(),
+            kind: manifest.kind().as_str().to_owned(),
             namespace: manifest.namespace().as_str().to_owned(),
             version: manifest.version().clone(),
             description: manifest.description().to_owned(),
@@ -41,9 +50,19 @@ impl RegistryEntry {
         &self.id
     }
 
-    /// Returns the plugin name.
+    /// Returns the plugin name (the identifier segment).
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Returns the human-readable display title, empty when an older cache indexed it without one.
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns the plugin kind, empty when an older cache indexed it without one.
+    pub fn kind(&self) -> &str {
+        &self.kind
     }
 
     /// Returns the plugin source namespace.

--- a/crates/plugin-registry/src/index.rs
+++ b/crates/plugin-registry/src/index.rs
@@ -31,24 +31,37 @@ impl RegistryIndex {
     /// Malformed or unreadable manifests are skipped, logged as warnings, and reported through
     /// the returned [`RegistryBuild`] so a single bad file never blocks the whole build.
     pub fn build(dir: &Path, updated_at: i64) -> RegistryBuild {
+        Self::build_all(&[dir], updated_at)
+    }
+
+    /// Scans every injected registry directory for `orax.toml`, parses each valid manifest, and
+    /// merges the results into one deterministically ordered index built at `updated_at`.
+    ///
+    /// Sources covering the same `namespace/name` id are merged: the id is listed once, and the
+    /// first occurrence in source-then-scan order wins, so the combined listing has no duplicate
+    /// ids regardless of how heavily the sources overlap.
+    pub fn build_all(registry_dirs: &[&Path], updated_at: i64) -> RegistryBuild {
         let mut entries = Vec::new();
         let mut skipped = Vec::new();
-        for path in orax_manifest_paths(dir) {
-            match parse_manifest(&path) {
-                Ok(manifest) => {
-                    let logo = logo::read_beside_manifest(&path);
-                    entries.push(RegistryEntry::from_manifest(&manifest, logo));
-                }
-                Err(error) => {
-                    ora_warn!(path = %path.display(), %error, "skipping invalid registry plugin manifest");
-                    skipped.push(SkippedManifest {
-                        path,
-                        reason: error.to_string(),
-                    });
+        for dir in registry_dirs {
+            for path in orax_manifest_paths(dir) {
+                match parse_manifest(&path) {
+                    Ok(manifest) => {
+                        let logo = logo::read_beside_manifest(&path);
+                        entries.push(RegistryEntry::from_manifest(&manifest, logo));
+                    }
+                    Err(error) => {
+                        ora_warn!(path = %path.display(), %error, "skipping invalid registry plugin manifest");
+                        skipped.push(SkippedManifest {
+                            path,
+                            reason: error.to_string(),
+                        });
+                    }
                 }
             }
         }
         entries.sort_by(|left, right| left.id().cmp(right.id()));
+        entries.dedup_by(|left, right| left.id() == right.id());
 
         let index = Self {
             updated_at,
@@ -83,6 +96,24 @@ impl RegistryIndex {
         }
         Ok(None)
     }
+
+    /// Resolves the full release manifest for a marketplace identifier across every source
+    /// `registry` directory, returning the first source that declares it.
+    ///
+    /// This is the install-time companion of [`Self::build_all`] for multiple sources: search
+    /// follows source order so duplicate ids resolve to the same entry the merged index lists.
+    pub fn resolve_manifest_all(
+        registry_dirs: &[&Path],
+        id: &PluginId,
+    ) -> Result<Option<PluginManifest>, RegistryError> {
+        for dir in registry_dirs {
+            if let Some(manifest) = Self::resolve_manifest(dir, id)? {
+                return Ok(Some(manifest));
+            }
+        }
+        Ok(None)
+    }
+
     /// Loads an index from a previously written JSON file so consumers can read it without rescanning.
     pub fn load(path: &Path) -> Result<Self, RegistryError> {
         let bytes = fs::read(path)?;
@@ -196,7 +227,7 @@ mod tests {
     fn valid_manifest(name: &str, description: &str) -> String {
         format!(
             "resolver = 1\n\
-             name = \"{name}\"\n\
+             identifier = \"{name}\"\n\
              namespace = \"official\"\n\
              kind = \"workbench\"\n\
              version = \"1.2.0\"\n\
@@ -404,6 +435,86 @@ mod tests {
         let root = TempDir::new()?;
 
         assert!(RegistryIndex::load(&root.path().join("missing.json")).is_err());
+        Ok(())
+    }
+
+    /// Verifies multiple sources merge into one index and a shared id is listed exactly once,
+    /// keeping the first source's entry.
+    #[test]
+    fn merges_multiple_sources_and_dedups_by_id() -> Result<(), Box<dyn std::error::Error>> {
+        let first = TempDir::new()?;
+        let second = TempDir::new()?;
+        write_manifest(first.path(), "a", &valid_manifest("a", "A from first"))?;
+        write_manifest(
+            first.path(),
+            "shared",
+            &valid_manifest("shared", "Shared from first"),
+        )?;
+        write_manifest(
+            second.path(),
+            "shared",
+            &valid_manifest("shared", "Shared from second"),
+        )?;
+        write_manifest(second.path(), "b", &valid_manifest("b", "B from second"))?;
+
+        let dirs = vec![
+            first.path().join("registry"),
+            second.path().join("registry"),
+        ];
+        let dir_refs: Vec<&Path> = dirs.iter().map(PathBuf::as_path).collect();
+        let build = RegistryIndex::build_all(&dir_refs, UPDATED_AT);
+
+        let ids = build
+            .index()
+            .plugins()
+            .iter()
+            .map(|entry| entry.id().canonical())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["official/a", "official/b", "official/shared"]);
+        let shared = build
+            .index()
+            .plugins()
+            .iter()
+            .find(|entry| entry.id().canonical() == "official/shared")
+            .ok_or_else(|| std::io::Error::other("expected the shared plugin"))?;
+        assert_eq!(shared.description(), "Shared from first");
+        assert_eq!(build.skipped().len(), 0);
+        Ok(())
+    }
+
+    /// Verifies install-time resolution searches sources in order and honors the first match.
+    #[test]
+    fn resolves_manifest_across_sources_in_source_order() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let first = TempDir::new()?;
+        let second = TempDir::new()?;
+        write_manifest(
+            first.path(),
+            "weather",
+            &valid_manifest("weather", "Weather first"),
+        )?;
+        write_manifest(
+            second.path(),
+            "weather",
+            &valid_manifest("weather", "Weather second"),
+        )?;
+
+        let dirs = vec![
+            first.path().join("registry"),
+            second.path().join("registry"),
+        ];
+        let dir_refs: Vec<&Path> = dirs.iter().map(PathBuf::as_path).collect();
+        let weather = PluginId::new("official", "weather").expect("plugin id");
+
+        let found = RegistryIndex::resolve_manifest_all(&dir_refs, &weather)?
+            .ok_or_else(|| std::io::Error::other("expected a resolved manifest"))?;
+        assert_eq!(found.description(), "Weather first");
+
+        let missing = RegistryIndex::resolve_manifest_all(
+            &dir_refs,
+            &PluginId::new("official", "absent").expect("plugin id"),
+        )?;
+        assert!(missing.is_none());
         Ok(())
     }
 }

--- a/crates/plugin-registry/src/source.rs
+++ b/crates/plugin-registry/src/source.rs
@@ -27,6 +27,37 @@ impl RegistrySource {
         }
     }
 
+    /// Creates a source from a git URL and tracked branch, deriving its local checkout directory
+    /// from the URL beneath `sources_root`.
+    ///
+    /// Deriving the directory from the URL keeps additional marketplace sources distinct without
+    /// a manual URL-to-directory mapping, and reproduces the layout that predates multiple
+    /// sources: the scheme is stripped and the remainder is joined as path segments, so
+    /// `https://github.com/ora-space/marketplace` checks out at
+    /// `<sources_root>/github.com/ora-space/marketplace`.
+    pub fn from_git(
+        url: impl Into<String>,
+        branch: BranchName,
+        sources_root: impl AsRef<Path>,
+    ) -> Self {
+        let url = url.into();
+        // Strip the scheme so the checkout mirrors the remote repository path; each remainder
+        // segment is appended on its own so two sources never share a directory.
+        let rest = url
+            .strip_prefix("https://")
+            .or_else(|| url.strip_prefix("http://"))
+            .unwrap_or(&url);
+        let mut checkout_dir = sources_root.as_ref().to_path_buf();
+        for segment in rest.split('/').filter(|segment| !segment.is_empty()) {
+            checkout_dir = checkout_dir.join(segment);
+        }
+        Self {
+            url,
+            branch,
+            checkout_dir,
+        }
+    }
+
     /// Returns the git URL that hosts this registry source.
     pub fn url(&self) -> &str {
         &self.url
@@ -179,6 +210,29 @@ mod tests {
             vec!["pull", "--ff-only", "origin", "main"]
         );
         assert_eq!(commands[2].intent, GitIntent::Network);
+        Ok(())
+    }
+
+    /// Verifies `from_git` derives a stable checkout directory from the URL beneath sources root.
+    #[test]
+    fn derives_checkout_dir_from_git_url() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = TempDir::new()?;
+        let sources_root = temp.path().join("sources");
+        let source = RegistrySource::from_git(
+            "https://github.com/ora-space/marketplace",
+            BranchName::new("main"),
+            &sources_root,
+        );
+
+        assert_eq!(
+            source.checkout_dir(),
+            sources_root
+                .join("github.com")
+                .join("ora-space")
+                .join("marketplace")
+        );
+        assert_eq!(source.url(), "https://github.com/ora-space/marketplace");
+        assert_eq!(source.branch().as_str(), "main");
         Ok(())
     }
 }

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -44,6 +44,8 @@ function clientWithWeather(logo: string | null = null) {
   state.availablePlugins.push({
     id: "official/weather",
     name: "weather",
+    title: "Weather",
+    kind: "agent",
     namespace: "official",
     version: "1.2.0",
     description: "Weather plugin",
@@ -76,8 +78,10 @@ it("renders marketplace plugins from the registry index", async () => {
   const { client } = clientWithWeather();
   renderSettings(client);
 
-  expect(await screen.findByText("weather")).toBeInTheDocument();
-  expect(screen.getByText(/official · 1.2.0/)).toBeInTheDocument();
+  expect(await screen.findByText("Weather")).toBeInTheDocument();
+  expect(
+    screen.getByText(/weather · official · agent · 1.2.0/),
+  ).toBeInTheDocument();
   expect(screen.getByText("Weather plugin")).toBeInTheDocument();
 });
 
@@ -205,7 +209,7 @@ it("renders the brand mark shipped with a marketplace plugin", async () => {
   const { client } = clientWithWeather(WEATHER_LOGO);
   const { container } = renderSettings(client);
 
-  await screen.findByText("weather");
+  await screen.findByText("Weather");
   const logo = container.querySelector("img");
   expect(logo).toHaveAttribute(
     "src",
@@ -218,7 +222,7 @@ it("falls back to the generic mark when a plugin ships no logo", async () => {
   const { client } = clientWithWeather();
   const { container } = renderSettings(client);
 
-  await screen.findByText("weather");
+  await screen.findByText("Weather");
   expect(container.querySelector("img")).toBeNull();
 });
 

--- a/packages/app-shell/src/features/settings/plugins-settings.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.tsx
@@ -48,9 +48,14 @@ export function PluginsSettings() {
       (available.data?.plugins ?? []).filter(
         (plugin) =>
           !needle ||
-          [plugin.name, plugin.namespace, plugin.description, plugin.id].some(
-            (value) => value.toLowerCase().includes(needle),
-          ),
+          [
+            plugin.title,
+            plugin.name,
+            plugin.kind,
+            plugin.namespace,
+            plugin.description,
+            plugin.id,
+          ].some((value) => value.toLowerCase().includes(needle)),
       ),
     [available.data, needle],
   );
@@ -210,10 +215,12 @@ function AvailablePluginRow({
       <PluginLogo logo={plugin.logo} />
       <span className="min-w-0 flex-1">
         <span className="block truncate text-sm font-medium">
-          {plugin.name}
+          {plugin.title || plugin.name}
         </span>
         <span className="block truncate text-xs text-muted-foreground">
-          {plugin.namespace} · {plugin.version}
+          {[plugin.name, plugin.namespace, plugin.kind, plugin.version]
+            .filter(Boolean)
+            .join(" · ")}
         </span>
         {plugin.description !== "" && (
           <span className="mt-0.5 block truncate text-[11px] text-muted-foreground/80">

--- a/packages/app-shell/src/state/hooks/use-available-plugins.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-available-plugins.test.tsx
@@ -14,6 +14,8 @@ describe("useAvailablePlugins", () => {
     state.availablePlugins.push({
       id: "official/weather",
       name: "weather",
+      title: "Weather",
+      kind: "workbench",
       namespace: "official",
       version: "1.2.0",
       description: "Weather plugin",

--- a/packages/app-shell/src/state/hooks/use-install-plugin.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-install-plugin.test.tsx
@@ -13,6 +13,8 @@ describe("useInstallPlugin", () => {
     state.availablePlugins.push({
       id: "official/weather",
       name: "weather",
+      title: "Weather",
+      kind: "agent",
       namespace: "official",
       version: "1.2.0",
       description: "Weather",

--- a/packages/contracts/src/plugin.ts
+++ b/packages/contracts/src/plugin.ts
@@ -16,6 +16,15 @@ export type ActivatePluginResponse = { plugin: InstalledPlugin };
 export type AvailablePlugin = {
   id: string;
   name: string;
+  /**
+   * Human-readable display title declared by the manifest; falls back to `name` when a cached
+   * index or older manifest omits it.
+   */
+  title: string;
+  /**
+   * The plugin kind (`agent`, `workbench`, or `webview`).
+   */
+  kind: string;
   namespace: string;
   version: string;
   description: string;


### PR DESCRIPTION
## Summary
Updates the plugin manager to match the new marketplace `orax.toml` schema and
to support multiple marketplace sources. The marketplace now lists `title`,
`identifier`, `namespace`, `kind`, `version`, and `description` on the card, and
the registry can merge several sources into a single view.

## What changed

**Manifest schema (`orax.toml`)**
- Name segment is unified to `identifier` for both the marketplace release form
  and the installed-package form (`name` is no longer accepted).
- Added optional `title` (display title), falling back to the `identifier` when
  omitted.
- Release-form `url`/`sha256` are now optional, so plugins published from source
  (`--head`) without a `.orax` release are supported.
- `homepage`/`url` accept Markdown-linked `[<url>](<url>)` values; the wrapper is
  stripped before HTTPS validation.

**Multiple marketplace sources**
- `RegistrySource::from_git` derives each source's checkout directory from its
  git URL beneath the sources root.
- `RegistryIndex::build_all` / `resolve_manifest_all` merge several sources and
  resolve install manifests across them; on duplicate ids the earlier source
  wins, keeping listing and install lookup consistent.

**Registry, contracts & frontend**
- `RegistryEntry` and the `AvailablePlugin` contract gain `title` and `kind`;
  TypeScript contracts regenerated.
- Marketplace card renders `title`/`identifier · namespace · kind · version`
  plus `description`, and search now covers `title` and `kind`.

**Docs**
- Updated `crates/plugin-manifest/README.md`, `crates/plugin-registry/README.md`,
  and `plugin-doc/plugin-manager.md`.

## Migration note
Installed manifests now require `identifier` (no backward-compat, per repo
policy). Marketplace packages that still ship an internal `orax.toml` with the
old `name` field will not be discovered, so login/auto-enable after install can
report “installed plugin … not found”. Such packages must be re-published with
the new schema.

## Testing
- `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings` clean.
- Rust unit tests green across `ora-plugin-manifest`, `ora-plugin-registry`,
  `ora-plugin-manager`, `ora-plugin-lifecycle`, `ora-contracts`, `ora-backend`.
- Frontend `tsc`, `eslint`, `prettier`, and Vitest green for app-shell plugin
  settings/hook tests.