### PR TITLE
feat(effect): drive Skill materialization with a durable reconcile worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,6 +3004,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -41,6 +41,7 @@ chrono-tz = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "rt", "sync", "time"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/backend/src/agent_runtime/mod.rs
+++ b/crates/backend/src/agent_runtime/mod.rs
@@ -4,7 +4,7 @@ mod connection;
 mod events;
 mod handoff;
 mod history;
-mod plugin_agent;
+pub(crate) mod plugin_agent;
 mod replay;
 mod restart_circuit;
 mod routing;

--- a/crates/backend/src/agent_runtime/plugin_agent/README.md
+++ b/crates/backend/src/agent_runtime/plugin_agent/README.md
@@ -99,10 +99,11 @@ has also blocked new turns that could read the surface. The barrier remains held
 reinitialize every affected Agent instance before releasing the barrier. Ora can retry either call
 after a process or database failure, so both methods must be idempotent.
 
-The IPC seam has a fake runtime test because no production Agent plugin implements this contract
-yet. Surface declarations already persist durable reconcile requests; the worker-side invocation
-is intentionally isolated behind the same seam so introducing the first real plugin does not
-change locator or coordination semantics.
+`ora_backend::effect_worker` drives both calls. It claims a durable reconcile request and holds
+that claim's lease while coordination waits on a consumer, so a plugin that never answers costs one
+lease interval rather than the surface. A consumer whose plugin is not currently running is skipped
+rather than started: it holds no turn a mutation could corrupt, and it reads the surface fresh when
+it next starts.
 
 ## Sandboxing
 

--- a/crates/backend/src/agent_runtime/plugin_agent/effect.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/effect.rs
@@ -89,10 +89,6 @@ pub(crate) fn registered_skill_surfaces(
 }
 
 /// Asks the plugin to wait for all affected Agent instances to become idle and hold a barrier.
-#[allow(
-    dead_code,
-    reason = "the Effect worker will call this IPC seam once Agent plugins ship"
-)]
 pub(crate) async fn wait_for_idle(
     runtime: &PluginRuntime,
     surface_key: &SurfaceKey,
@@ -103,10 +99,6 @@ pub(crate) async fn wait_for_idle(
 }
 
 /// Restarts every affected Agent instance and releases the barrier for the applied generation.
-#[allow(
-    dead_code,
-    reason = "the Effect worker will call this IPC seam once Agent plugins ship"
-)]
 pub(crate) async fn restart(
     runtime: &PluginRuntime,
     surface_key: &SurfaceKey,

--- a/crates/backend/src/agent_runtime/plugin_agent/mod.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mod.rs
@@ -7,6 +7,7 @@ mod transport;
 mod tests;
 
 pub(crate) use control::{PluginAgentError, PluginAgentModel, list_models, stop_agent};
+pub(crate) use effect::{WaitForIdleOutcome, restart, wait_for_idle};
 pub(crate) use transport::{AgentTransport, PluginAcpTransport};
 
 use std::path::Path;

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -194,6 +194,13 @@ impl Backend {
         let repository_gates = git_cleanup_worker.repository_gates();
         let git_cleanup = git_cleanup_worker.spawn();
 
+        // Durable Effect reconciliation: the first pass replays every surface a previous process
+        // left short of its Desired generation, including the retirement cleanup an uninstall
+        // started but could not finish.
+        let effect_worker = crate::effect_worker::EffectWorker::new(pool.clone(), plugin.clone());
+        effect_worker.recover();
+        plugin.set_effect_reconcile(effect_worker.spawn());
+
         Ok(Self {
             project: Arc::new(ProjectApi::new(pool.clone(), sessions_root.clone(), clock)),
             task: Arc::new(TaskApi::new(

--- a/crates/backend/src/effect_worker.rs
+++ b/crates/backend/src/effect_worker.rs
@@ -1,0 +1,1100 @@
+//! Drives durable Effect reconcile requests until each declared surface matches Desired State.
+//!
+//! The worker owns no state of its own. Every pass re-reads what the database currently says is
+//! owed, which is what makes a lost in-process wakeup harmless: the periodic scan finds the same
+//! request again, and a request that was merged with a later edit is served once at the newer
+//! generation rather than replayed per edit.
+
+use crate::agent_runtime::plugin_agent;
+use crate::clock::SystemClock;
+use crate::plugin::PluginApi;
+use ora_application::Clock;
+use ora_db::{
+    ClaimedReconcile, DueSurfaceReconcile, ReconcileClaim, RepositoryPool, SqliteEffectRepository,
+};
+use ora_domain::PluginId;
+use ora_effect::{
+    Condition, ConsumerCoordinator, ConsumerId, CoordinationError, CoordinationOutcome,
+    FilesystemSurfaceAdapter, Generation, Reconciler, RetryPolicy, SurfaceKey, SurfaceLifecycle,
+    SurfacePath, UuidManagedIdentityGenerator,
+};
+use ora_logging::{ora_info, ora_warn};
+use std::path::Path;
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::time::Duration;
+use tokio::runtime::Handle;
+use uuid::Uuid;
+
+/// Idle interval between scans when nothing wakes the worker.
+const SCAN_INTERVAL: Duration = Duration::from_secs(30);
+/// Upper bound on how many surfaces one pass reconciles, for fairness across Workspaces.
+const SURFACE_BATCH_SIZE: usize = 16;
+/// How long a claim stays valid without renewal.
+///
+/// Long enough that an ordinary reconcile never has to renew, short enough that a crashed worker's
+/// surfaces become claimable again well inside a user's patience.
+const LEASE_DURATION: Duration = Duration::from_secs(60);
+/// How often a claim is renewed while one reconcile is still running.
+const LEASE_RENEWAL_INTERVAL: Duration = Duration::from_secs(20);
+/// How often blocked requests are re-armed, covering runtime events lost to a crash.
+const SAFETY_SCAN_INTERVAL: Duration = Duration::from_secs(300);
+/// Backoff before the next attempt, indexed by the attempt that just failed.
+const RETRY_BACKOFF_MS: [i64; 5] = [5_000, 30_000, 120_000, 600_000, 1_800_000];
+
+/// Coalesced wake-up signal shared between Desired writers and the worker thread.
+///
+/// The signal only reduces latency. SQLite holds the durable request, so a lost notification costs
+/// at most one scan interval and never a reconcile.
+#[derive(Debug, Default)]
+struct WakeSignal {
+    pending: Mutex<bool>,
+    changed: Condvar,
+}
+
+impl WakeSignal {
+    /// Requests one worker pass; concurrent requests coalesce into the same pass.
+    fn notify(&self) {
+        *self.pending.lock().unwrap_or_else(PoisonError::into_inner) = true;
+        self.changed.notify_one();
+    }
+
+    /// Waits until notified or until the scan interval elapses.
+    fn wait(&self, timeout: Duration) {
+        let mut pending = self.pending.lock().unwrap_or_else(PoisonError::into_inner);
+        if !*pending {
+            let (guard, _timed_out) = self
+                .changed
+                .wait_timeout(pending, timeout)
+                .unwrap_or_else(PoisonError::into_inner);
+            pending = guard;
+        }
+        *pending = false;
+    }
+}
+
+/// Wakes the Effect worker after a Desired or declaration change is already committed.
+#[derive(Clone, Debug)]
+pub(crate) struct EffectWorkerHandle {
+    wake: Arc<WakeSignal>,
+}
+
+impl EffectWorkerHandle {
+    /// Asks for one pass without naming a Workspace, generation, or payload.
+    ///
+    /// Carrying no arguments is deliberate: the worker must re-read current state anyway, so a
+    /// caller cannot accidentally pin it to a snapshot that a later commit has already replaced.
+    pub(crate) fn notify(&self) {
+        self.wake.notify();
+    }
+}
+
+/// Reconciles every surface owing work, coordinating live Agent plugins around each mutation.
+pub(crate) struct EffectWorker {
+    repository: SqliteEffectRepository,
+    plugin_host: Arc<PluginApi>,
+    clock: SystemClock,
+    wake: Arc<WakeSignal>,
+    /// Identifies this worker's claims; a fresh value per process so a crashed one is never
+    /// mistaken for the live one when its rows are still marked claimed.
+    worker_id: String,
+    /// When the low-frequency safety scan may run again.
+    next_safety_scan: Mutex<i64>,
+}
+
+impl EffectWorker {
+    pub(crate) fn new(pool: RepositoryPool, plugin_host: Arc<PluginApi>) -> Self {
+        Self {
+            repository: SqliteEffectRepository::new(pool),
+            plugin_host,
+            clock: SystemClock,
+            wake: Arc::new(WakeSignal::default()),
+            worker_id: Uuid::new_v4().to_string(),
+            next_safety_scan: Mutex::new(0),
+        }
+    }
+
+    /// Hands out the wake handle before the worker takes ownership of itself in `spawn`.
+    pub(crate) fn handle(&self) -> EffectWorkerHandle {
+        EffectWorkerHandle {
+            wake: self.wake.clone(),
+        }
+    }
+
+    /// Runs passes on a dedicated thread until the process ends.
+    ///
+    /// A plain OS thread rather than a Tokio task, because reconciliation is synchronous
+    /// filesystem work that would otherwise occupy an async worker for the whole copy. The thread
+    /// owns the small runtime its plugin IPC needs instead of borrowing the caller's, so the
+    /// worker does not require `Backend::open` to itself run inside a runtime.
+    pub(crate) fn spawn(self) -> EffectWorkerHandle {
+        let handle = self.handle();
+        let spawned = std::thread::Builder::new()
+            .name("effect-worker".to_string())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        ora_warn!(
+                            operation = "effect_reconcile",
+                            error = %error,
+                            "failed to build the Effect worker runtime; reconciliation deferred to next start",
+                        );
+                        return;
+                    }
+                };
+                loop {
+                    self.run_pass(runtime.handle());
+                    self.wake.wait(SCAN_INTERVAL);
+                }
+            });
+        if let Err(error) = spawned {
+            // Without the worker nothing materializes this process lifetime, but every request
+            // stays in SQLite; the next start picks them all up.
+            ora_warn!(
+                operation = "effect_reconcile",
+                error = %error,
+                "failed to spawn Effect worker thread; reconciliation deferred to next start",
+            );
+        }
+        handle
+    }
+
+    /// Rebuilds work a previous process left unscheduled, before serving ordinary wakeups.
+    ///
+    /// Running this first is what makes a crash recoverable rather than silently lossy: a surface
+    /// left short of its generation, an operation left unfinished, or a lease left held by a dead
+    /// process all become claimable again here.
+    pub(crate) fn recover(&self) {
+        match self
+            .repository
+            .recover_reconcile_requests(self.clock.now_timestamp_millis())
+        {
+            Ok(0) => {}
+            Ok(recovered) => ora_info!(
+                operation = "effect_reconcile",
+                recovered = recovered,
+                "rescheduled Effect work left behind by a previous process",
+            ),
+            Err(error) => ora_warn!(
+                operation = "effect_reconcile",
+                error = %error,
+                "Effect startup recovery failed; the next safety scan retries it",
+            ),
+        }
+    }
+
+    /// Reconciles one batch of claimed surfaces, isolating each so one cannot stall the rest.
+    pub(crate) fn run_pass(&self, runtime: &Handle) {
+        let now = self.clock.now_timestamp_millis();
+        self.run_safety_scan(now);
+        let claimed = match self.repository.claim_due_reconcile_requests(
+            &self.worker_id,
+            now,
+            now + LEASE_DURATION.as_millis() as i64,
+            SURFACE_BATCH_SIZE,
+        ) {
+            Ok(claimed) => claimed,
+            Err(error) => {
+                ora_warn!(
+                    operation = "effect_reconcile",
+                    error = %error,
+                    "failed to claim due Effect reconcile requests",
+                );
+                return;
+            }
+        };
+        for request in claimed {
+            self.reconcile_claimed(runtime, request);
+        }
+    }
+
+    /// Re-arms blocked requests occasionally, covering a runtime event lost to a crash.
+    fn run_safety_scan(&self, now: i64) {
+        {
+            let mut next = self
+                .next_safety_scan
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            if now < *next {
+                return;
+            }
+            *next = now + SAFETY_SCAN_INTERVAL.as_millis() as i64;
+        }
+        match self.repository.rearm_blocked_reconcile_requests(now) {
+            Ok(0) => {}
+            Ok(rearmed) => ora_info!(
+                operation = "effect_reconcile",
+                rearmed = rearmed,
+                "safety scan re-armed blocked Effect surfaces",
+            ),
+            Err(error) => ora_warn!(
+                operation = "effect_reconcile",
+                error = %error,
+                "Effect safety scan failed",
+            ),
+        }
+    }
+
+    /// Runs one claimed surface against the live Agent plugins declared as its consumers.
+    fn reconcile_claimed(&self, runtime: &Handle, request: ClaimedReconcile) {
+        let ClaimedReconcile { claim, due } = request;
+        let workspace_root = due.workspace_root.clone();
+        let relative_path = due.descriptor.path.clone();
+        // Coordination can wait on a consumer for as long as a turn runs, so the lease is renewed
+        // underneath the reconcile rather than being sized for the slowest possible one.
+        let renewal = LeaseRenewal::start(self, &claim);
+        let coordinator = PluginSurfaceCoordinator {
+            plugin_host: self.plugin_host.as_ref(),
+            runtime,
+            workspace_root: &workspace_root,
+            relative_path: &relative_path,
+        };
+        let outcome = reconcile_one(
+            &self.repository,
+            &coordinator,
+            due,
+            self.clock.now_timestamp_millis(),
+        );
+        renewal.stop();
+        self.settle(&claim, outcome);
+    }
+
+    /// Records what the reconcile decided, choosing the schedule its outcome earns.
+    fn settle(&self, claim: &ReconcileClaim, outcome: SurfaceOutcome) {
+        let now = self.clock.now_timestamp_millis();
+        let result = match outcome {
+            SurfaceOutcome::Converged { generation } => self
+                .repository
+                .complete_reconcile_request(claim, generation, now)
+                .map(|_| ()),
+            // Nothing this worker can do sooner helps, so the surface is parked until an external
+            // fact changes rather than burning attempts against an unmet precondition.
+            SurfaceOutcome::Blocked { reason } => self
+                .repository
+                .block_reconcile_request(claim, reason, now)
+                .map(|_| ()),
+            SurfaceOutcome::Retry { reason } => {
+                let delay = backoff_delay(claim.attempt);
+                self.repository
+                    .retry_reconcile_request(claim, reason, now + delay, now)
+                    .map(|_| ())
+            }
+        };
+        if let Err(error) = result {
+            // The claim's lease still expires on its own, so a failure to record the decision
+            // costs one lease interval rather than the surface.
+            ora_warn!(
+                operation = "effect_reconcile",
+                surface = claim.surface_key.as_str(),
+                error = %error,
+                "failed to record an Effect reconcile outcome; the lease will expire and retry",
+            );
+        }
+    }
+}
+
+/// What one reconcile earned, in the terms the request store schedules on.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SurfaceOutcome {
+    Converged { generation: Generation },
+    Blocked { reason: &'static str },
+    Retry { reason: &'static str },
+}
+
+/// Spreads retries of a shared failure apart instead of stacking every surface on one instant.
+///
+/// The jitter is derived from a fresh UUID rather than a seeded generator: it only has to break
+/// synchronization between surfaces, and nothing depends on the sequence being reproducible.
+fn backoff_delay(attempt: i64) -> i64 {
+    let index = (attempt.max(1) - 1).clamp(0, RETRY_BACKOFF_MS.len() as i64 - 1) as usize;
+    let base = RETRY_BACKOFF_MS[index];
+    let spread = base / 4;
+    let jitter = i64::from(Uuid::new_v4().as_bytes()[0]) * spread / i64::from(u8::MAX);
+    base - spread / 2 + jitter
+}
+
+/// Keeps one claim alive on a background thread for as long as its reconcile runs.
+struct LeaseRenewal {
+    stop: Arc<(Mutex<bool>, Condvar)>,
+    joiner: Option<std::thread::JoinHandle<()>>,
+}
+
+impl LeaseRenewal {
+    /// Starts renewing until `stop`, leaving the claim untouched if the thread cannot start.
+    fn start(worker: &EffectWorker, claim: &ReconcileClaim) -> Self {
+        let stop = Arc::new((Mutex::new(false), Condvar::new()));
+        let repository = worker.repository.clone();
+        let worker_id = worker.worker_id.clone();
+        let claim = claim.clone();
+        let clock = worker.clock;
+        let signal = stop.clone();
+        let joiner = std::thread::Builder::new()
+            .name("effect-lease".to_string())
+            .spawn(move || {
+                let (lock, changed) = &*signal;
+                loop {
+                    let mut stopped = lock.lock().unwrap_or_else(PoisonError::into_inner);
+                    if !*stopped {
+                        let (guard, _timed_out) = changed
+                            .wait_timeout(stopped, LEASE_RENEWAL_INTERVAL)
+                            .unwrap_or_else(PoisonError::into_inner);
+                        stopped = guard;
+                    }
+                    if *stopped {
+                        return;
+                    }
+                    drop(stopped);
+                    let now = clock.now_timestamp_millis();
+                    match repository.renew_reconcile_claim(
+                        &claim,
+                        &worker_id,
+                        now + LEASE_DURATION.as_millis() as i64,
+                        now,
+                    ) {
+                        // Losing the lease means another worker already owns this surface. There is
+                        // nothing safe left to renew, so renewal simply stops; the in-flight
+                        // reconcile's own writes are fenced by the token it no longer holds.
+                        Ok(false) => return,
+                        Ok(true) => {}
+                        Err(error) => ora_warn!(
+                            operation = "effect_reconcile",
+                            surface = claim.surface_key.as_str(),
+                            error = %error,
+                            "failed to renew an Effect reconcile lease",
+                        ),
+                    }
+                }
+            })
+            .ok();
+        Self { stop, joiner }
+    }
+
+    /// Ends renewal and waits for the thread, so no renewal outlives the work it protected.
+    fn stop(mut self) {
+        let (lock, changed) = &*self.stop;
+        *lock.lock().unwrap_or_else(PoisonError::into_inner) = true;
+        changed.notify_all();
+        if let Some(joiner) = self.joiner.take() {
+            let _ = joiner.join();
+        }
+    }
+}
+
+/// Runs one surface through scan, plan, coordinated mutation, and durable status.
+///
+/// Returns what the surface earned rather than scheduling it, so the request-store transitions stay
+/// with the claim that authorizes them, and so the whole decision can be exercised against a
+/// substituted coordinator.
+fn reconcile_one<Coordinator: ConsumerCoordinator>(
+    repository: &SqliteEffectRepository,
+    coordinator: &Coordinator,
+    due: DueSurfaceReconcile,
+    occurred_at: i64,
+) -> SurfaceOutcome {
+    let adapter = FilesystemSurfaceAdapter::new(
+        due.workspace_id.clone(),
+        due.workspace_root.clone(),
+        due.descriptor.surface_key.clone(),
+        due.descriptor.path.clone(),
+    );
+    let identity_generator = UuidManagedIdentityGenerator;
+    let reconciler = Reconciler::new(repository, repository, coordinator, &identity_generator);
+
+    let outcome = match reconciler.reconcile_surface(
+        &adapter,
+        &due.descriptor,
+        &due.workspace_id,
+        occurred_at,
+    ) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            // A scan or filesystem failure is exactly what a timed retry is for: nothing about the
+            // declaration is wrong, the target was momentarily unreadable.
+            ora_warn!(
+                operation = "effect_reconcile",
+                surface = due.descriptor.surface_key.as_str(),
+                error = %error,
+                "Effect surface reconcile failed; scheduling a backoff retry",
+            );
+            return SurfaceOutcome::Retry {
+                reason: "reconcile_failed",
+            };
+        }
+    };
+
+    ora_info!(
+        operation = "effect_reconcile",
+        surface = due.descriptor.surface_key.as_str(),
+        phase = ?outcome.status.phase,
+        applied_generation = outcome.status.applied_generation.value(),
+        desired_generation = outcome.status.desired_generation.value(),
+        "reconciled one Effect surface",
+    );
+
+    // A condition is the reconciler's own account of why it could not finish, and its reason
+    // already carries the retry policy that reason deserves; deriving the schedule from the policy
+    // keeps that judgement in the domain instead of re-deciding it per call site here.
+    if let Some(condition) = strictest_condition(&outcome.status.conditions) {
+        return match condition.retry_policy {
+            RetryPolicy::Manual => SurfaceOutcome::Blocked {
+                reason: "recovery_required",
+            },
+            RetryPolicy::Backoff => SurfaceOutcome::Retry {
+                reason: "transient_failure",
+            },
+            RetryPolicy::OnChange => SurfaceOutcome::Blocked {
+                reason: "awaiting_external_change",
+            },
+        };
+    }
+
+    // Only a surface whose files were confirmed to match may clear its request; anything short of
+    // that stays owed so a later pass re-reads it rather than treating partial work as done.
+    if outcome.status.applied_generation < outcome.status.desired_generation {
+        return SurfaceOutcome::Retry {
+            reason: "generation_not_applied",
+        };
+    }
+    let generation = outcome.status.applied_generation;
+    finish_retirement(repository, &due, generation);
+    SurfaceOutcome::Converged { generation }
+}
+
+/// Picks the condition whose policy decides the schedule, strictest first.
+///
+/// Manual outranks everything because an unproven target must never be retried automatically, and a
+/// timed backoff outranks waiting on an external change so a transient failure still makes progress
+/// when both are present.
+fn strictest_condition(conditions: &[Condition]) -> Option<&Condition> {
+    let rank = |condition: &Condition| match condition.retry_policy {
+        RetryPolicy::Manual => 0,
+        RetryPolicy::Backoff => 1,
+        RetryPolicy::OnChange => 2,
+    };
+    conditions.iter().min_by_key(|condition| rank(condition))
+}
+
+/// Deletes a retired surface once its ledger is empty, ending the lifecycle Ora started.
+fn finish_retirement(
+    repository: &SqliteEffectRepository,
+    due: &DueSurfaceReconcile,
+    completed: Generation,
+) {
+    if due.descriptor.lifecycle != SurfaceLifecycle::Retiring {
+        return;
+    }
+    match repository.delete_retired_surface(&due.descriptor.surface_key) {
+        Ok(true) => ora_info!(
+            operation = "effect_reconcile",
+            surface = due.descriptor.surface_key.as_str(),
+            generation = completed.value(),
+            "retired Effect surface removed after its ledger was emptied",
+        ),
+        // Still-owned targets keep the surface alive on purpose; the ledger outlives the
+        // declaration until cleanup can prove every managed target is gone.
+        Ok(false) => {}
+        Err(error) => ora_warn!(
+            operation = "effect_reconcile",
+            surface = due.descriptor.surface_key.as_str(),
+            error = %error,
+            "failed to delete a retired Effect surface",
+        ),
+    }
+}
+
+/// Bridges the synchronous reconciler onto one surface's live Agent plugin consumers.
+///
+/// The coordination contract is per-surface while the port is per-consumer, so the locator travels
+/// on the struct rather than through the trait: Ora resolves and validates the absolute Workspace
+/// root, and a plugin only ever receives the path it already declared.
+struct PluginSurfaceCoordinator<'a> {
+    plugin_host: &'a PluginApi,
+    runtime: &'a Handle,
+    workspace_root: &'a Path,
+    relative_path: &'a SurfacePath,
+}
+
+impl PluginSurfaceCoordinator<'_> {
+    /// Resolves one consumer onto the running plugin generation that must be coordinated.
+    ///
+    /// A consumer whose plugin is not currently running needs no coordination at all: it holds no
+    /// turn that a mutation could corrupt, and it re-reads the surface when it next starts. Only a
+    /// live generation can be asked to quiesce, so absence resolves to `None` rather than an error
+    /// that would block materialization whenever the agent happens to be disconnected.
+    fn running_runtime(
+        &self,
+        consumer: &ConsumerId,
+    ) -> Result<Option<ora_plugin_runtime::PluginRuntime>, CoordinationError> {
+        let plugin_id = PluginId::parse(consumer.as_str()).map_err(CoordinationError::new)?;
+        Ok(self
+            .plugin_host
+            .lifecycle
+            .connection(&plugin_id)
+            .ok()
+            .map(|connection| connection.runtime().process().clone()))
+    }
+}
+
+impl ConsumerCoordinator for PluginSurfaceCoordinator<'_> {
+    /// Asks every live consumer to reach an idle boundary, stopping at the first one still busy.
+    ///
+    /// Reporting `WaitingForIdle` as soon as one consumer is busy is what keeps the barrier
+    /// idempotent: consumers already holding theirs keep holding it, and the next pass re-asks
+    /// everyone rather than tracking who answered on a previous attempt.
+    fn quiesce(
+        &self,
+        surface_key: &SurfaceKey,
+        consumers: &[ConsumerId],
+    ) -> Result<CoordinationOutcome, CoordinationError> {
+        for consumer in consumers {
+            let Some(runtime) = self.running_runtime(consumer)? else {
+                continue;
+            };
+            let outcome = self
+                .runtime
+                .block_on(plugin_agent::wait_for_idle(
+                    &runtime,
+                    surface_key,
+                    self.workspace_root,
+                    self.relative_path,
+                ))
+                .map_err(CoordinationError::new)?;
+            if outcome == plugin_agent::WaitForIdleOutcome::WaitingForIdle {
+                return Ok(CoordinationOutcome::WaitingForIdle);
+            }
+        }
+        Ok(CoordinationOutcome::Ready)
+    }
+
+    /// Restarts one consumer so it observes the generation just written, releasing its barrier.
+    fn resume(
+        &self,
+        surface_key: &SurfaceKey,
+        consumer: &ConsumerId,
+        generation: Generation,
+    ) -> Result<(), CoordinationError> {
+        let Some(runtime) = self.running_runtime(consumer)? else {
+            return Ok(());
+        };
+        self.runtime
+            .block_on(plugin_agent::restart(
+                &runtime,
+                surface_key,
+                self.workspace_root,
+                self.relative_path,
+                generation,
+            ))
+            .map_err(CoordinationError::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SurfaceOutcome, reconcile_one};
+    use crate::project::ProjectApi;
+    use ora_contracts::CreateProjectRequest;
+    use ora_db::{
+        ClaimedReconcile, DatabaseBootstrapper, DatabaseLocation, RepositoryPool,
+        SourcePublication, SqliteEffectRepository, SqliteWorkspaceRepository,
+        default_migration_catalog,
+    };
+    use ora_domain::{Namespace, WorkspaceId};
+    use ora_effect::{
+        ConsumerCoordination, ConsumerCoordinator, ConsumerId, CoordinationError,
+        CoordinationOutcome, DesiredSkillState, Digest, EffectRepository, FilesystemSkillSurface,
+        Generation, MARKER_FILE_NAME, MaterializationFormat, SkillName, SkillSelectionKey,
+        SkillSource, SkillState, SourceKind, SourceVersion, SurfaceDescriptorSet, SurfaceKey,
+        SurfacePath, WorkspaceEffectSpec,
+    };
+    use pretty_assertions::assert_eq;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::{Mutex, PoisonError};
+    use tempfile::TempDir;
+
+    /// Later than any row the real clock writes during `ProjectApi::create`, whose Workspace
+    /// trigger seeds `workspace_effects` and whose CHECK forbids a write dated before it.
+    const PUBLISHED_AT: i64 = 4_000_000_000_000;
+    const WORKER: &str = "worker-1";
+
+    const MANIFEST: &str = "---\nname: grilling\ndescription: Grill a plan relentlessly.\n---\n\nAsk hard questions.\n";
+
+    /// Records coordination calls and answers with a scripted quiesce outcome.
+    #[derive(Debug, Default)]
+    struct RecordingCoordinator {
+        busy: bool,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl ConsumerCoordinator for RecordingCoordinator {
+        fn quiesce(
+            &self,
+            _surface_key: &SurfaceKey,
+            consumers: &[ConsumerId],
+        ) -> Result<CoordinationOutcome, CoordinationError> {
+            for consumer in consumers {
+                self.calls
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .push(format!("quiesce:{}", consumer.as_str()));
+            }
+            Ok(if self.busy {
+                CoordinationOutcome::WaitingForIdle
+            } else {
+                CoordinationOutcome::Ready
+            })
+        }
+
+        fn resume(
+            &self,
+            _surface_key: &SurfaceKey,
+            consumer: &ConsumerId,
+            generation: Generation,
+        ) -> Result<(), CoordinationError> {
+            self.calls
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(format!(
+                    "resume:{}@{}",
+                    consumer.as_str(),
+                    generation.value()
+                ));
+            Ok(())
+        }
+    }
+
+    /// Builds a pool whose single Workspace is the given directory, via the real create path.
+    ///
+    /// Going through `ProjectApi` instead of inserting rows keeps the fixture honest about what a
+    /// Workspace is, including the location row the Effect surface locator is resolved against.
+    fn fixture(data_root: &Path, workspace_root: &Path) -> (RepositoryPool, WorkspaceId) {
+        let pool = DatabaseBootstrapper::system()
+            .bootstrap_repository_pool(
+                &DatabaseLocation::path(data_root.join("ora.sqlite3")),
+                &default_migration_catalog().unwrap(),
+            )
+            .unwrap();
+        ProjectApi::new(
+            pool.clone(),
+            data_root.join("sessions"),
+            crate::clock::SystemClock,
+        )
+        .create(CreateProjectRequest {
+            name: "Demo".to_string(),
+            main_workspace_path: workspace_root.to_string_lossy().into_owned(),
+        })
+        .unwrap();
+        let workspace_id = SqliteWorkspaceRepository::new(pool.clone())
+            .list_all_workspaces()
+            .unwrap()
+            .remove(0)
+            .id;
+        (pool, workspace_id)
+    }
+
+    /// Publishes one Local Skill source, which also selects it into every Workspace's Desired set.
+    fn select_grilling(
+        repository: &SqliteEffectRepository,
+        workspace_id: &WorkspaceId,
+        catalog: &Path,
+    ) {
+        fs::create_dir_all(catalog).unwrap();
+        fs::write(catalog.join("SKILL.md"), MANIFEST).unwrap();
+        let name = SkillName::parse("grilling").unwrap();
+        let key = SkillSelectionKey::new(SourceKind::Local, Namespace::local(), name.clone());
+        let state = DesiredSkillState::try_new(SkillState {
+            name,
+            skill_md_digest: Digest::sha256(MANIFEST.as_bytes()),
+            source: SkillSource::Local {
+                namespace: Namespace::local(),
+                version: SourceVersion::parse("1").unwrap(),
+            },
+        })
+        .unwrap();
+        repository
+            .publish_source(&state, catalog, SourcePublication::Create, PUBLISHED_AT)
+            .unwrap();
+        // Asserting the coupling rather than replacing the spec: an install that stopped reaching
+        // Desired would otherwise be masked by the test writing it by hand.
+        assert_eq!(
+            repository.load_workspace_effect(workspace_id).unwrap().spec,
+            WorkspaceEffectSpec {
+                skills: BTreeMap::from([(key, state)]),
+            }
+        );
+    }
+
+    /// Declares one Agent-consumed surface rooted at the given Workspace directory.
+    fn declare_surface(
+        repository: &SqliteEffectRepository,
+        workspace_id: &WorkspaceId,
+        workspace_root: &Path,
+    ) {
+        let descriptors = SurfaceDescriptorSet::merge(
+            workspace_id,
+            [FilesystemSkillSurface {
+                workspace_relative_path: SurfacePath::parse(".opencode/skills").unwrap(),
+                materialization_format: MaterializationFormat::skill_directory_v1(),
+                consumer: ConsumerId::new("official/ora-space.opencode"),
+                coordination: ConsumerCoordination::WaitForIdleAndRestart,
+            }],
+        )
+        .unwrap();
+        repository
+            .replace_surfaces(
+                workspace_id,
+                workspace_root,
+                &descriptors,
+                PUBLISHED_AT + 10,
+            )
+            .unwrap();
+    }
+
+    /// Claims the single request under test with a lease long enough to outlive the assertions.
+    fn claim(repository: &SqliteEffectRepository, now: i64) -> ClaimedReconcile {
+        repository
+            .claim_due_reconcile_requests(WORKER, now, now + 60_000, 8)
+            .unwrap()
+            .remove(0)
+    }
+
+    /// Counts what is currently claimable, which is what a later pass would actually pick up.
+    fn claimable(repository: &SqliteEffectRepository, now: i64) -> usize {
+        let claimed = repository
+            .claim_due_reconcile_requests("probe", now, now + 60_000, 8)
+            .unwrap();
+        for entry in &claimed {
+            // Release the probe's claim so the assertion does not change what it measured.
+            repository
+                .retry_reconcile_request(&entry.claim, "probe", now, now)
+                .unwrap();
+        }
+        claimed.len()
+    }
+
+    /// The whole chain: a selected Skill reaches the declared surface and is marked Ora-owned.
+    #[test]
+    fn a_selected_skill_is_materialized_into_the_declared_surface() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspace");
+        fs::create_dir_all(&workspace_root).unwrap();
+        let (pool, workspace_id) = fixture(temp.path(), &workspace_root);
+        let repository = SqliteEffectRepository::new(pool);
+        select_grilling(&repository, &workspace_id, &temp.path().join("catalog"));
+        declare_surface(&repository, &workspace_id, &workspace_root);
+        let coordinator = RecordingCoordinator::default();
+        let request = claim(&repository, PUBLISHED_AT + 20);
+        let surface_key = request.due.descriptor.surface_key.clone();
+
+        let outcome = reconcile_one(&repository, &coordinator, request.due, PUBLISHED_AT + 20);
+        assert_eq!(
+            outcome,
+            SurfaceOutcome::Converged {
+                generation: Generation::new(1),
+            }
+        );
+        assert!(
+            repository
+                .complete_reconcile_request(&request.claim, Generation::new(1), PUBLISHED_AT + 20)
+                .unwrap(),
+        );
+
+        let materialized = workspace_root
+            .join(".opencode")
+            .join("skills")
+            .join("grilling");
+        assert_eq!(
+            fs::read_to_string(materialized.join("SKILL.md")).unwrap(),
+            MANIFEST
+        );
+        // The ownership marker separates an Ora-managed target from Preserved State; without it a
+        // materialized directory is indistinguishable from a Skill the user wrote themselves.
+        assert!(materialized.join(MARKER_FILE_NAME).exists());
+        assert_eq!(
+            repository
+                .load_managed_skills(&workspace_id, &surface_key)
+                .unwrap()
+                .len(),
+            1,
+            "materializing a target must record the ownership it just took",
+        );
+        assert_eq!(
+            claimable(&repository, PUBLISHED_AT + 30),
+            0,
+            "a surface that reached its Desired generation owes no further reconcile",
+        );
+        assert_eq!(
+            coordinator
+                .calls
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone(),
+            vec![
+                "quiesce:official/ora-space.opencode".to_string(),
+                "resume:official/ora-space.opencode@1".to_string(),
+            ],
+            "the consumer is paused before the write and restarted onto the applied generation",
+        );
+    }
+
+    /// A busy consumer defers the mutation instead of writing underneath a running turn.
+    #[test]
+    fn a_busy_consumer_defers_materialization_and_keeps_the_request() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspace");
+        fs::create_dir_all(&workspace_root).unwrap();
+        let (pool, workspace_id) = fixture(temp.path(), &workspace_root);
+        let repository = SqliteEffectRepository::new(pool);
+        select_grilling(&repository, &workspace_id, &temp.path().join("catalog"));
+        declare_surface(&repository, &workspace_id, &workspace_root);
+        let coordinator = RecordingCoordinator {
+            busy: true,
+            calls: Mutex::default(),
+        };
+
+        let request = claim(&repository, PUBLISHED_AT + 20);
+        let outcome = reconcile_one(&repository, &coordinator, request.due, PUBLISHED_AT + 20);
+
+        // Waiting on a turn is an unmet precondition, not a failure: retrying sooner cannot help,
+        // so the surface parks until the runtime or the safety scan says something changed.
+        assert_eq!(
+            outcome,
+            SurfaceOutcome::Blocked {
+                reason: "awaiting_external_change",
+            }
+        );
+        // Scanning creates the surface root itself, so absence of the Skill — not of the
+        // directory — is what proves the deferral held.
+        assert!(
+            !workspace_root
+                .join(".opencode")
+                .join("skills")
+                .join("grilling")
+                .exists()
+        );
+        assert!(
+            repository
+                .block_reconcile_request(
+                    &request.claim,
+                    "awaiting_external_change",
+                    PUBLISHED_AT + 20
+                )
+                .unwrap(),
+        );
+        assert_eq!(
+            claimable(&repository, PUBLISHED_AT + 30),
+            0,
+            "a blocked surface is not retried on a timer",
+        );
+        assert_eq!(
+            repository
+                .rearm_blocked_reconcile_requests(PUBLISHED_AT + 40)
+                .unwrap(),
+            1,
+            "the safety scan is what recovers a runtime event lost before it arrived",
+        );
+        assert_eq!(
+            claimable(&repository, PUBLISHED_AT + 50),
+            1,
+            "a re-armed surface becomes claimable again",
+        );
+        assert_eq!(
+            coordinator
+                .calls
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone(),
+            vec!["quiesce:official/ora-space.opencode".to_string()],
+            "a consumer that never paused must never be resumed",
+        );
+    }
+
+    /// Two workers must never hold the same surface, or two plans would hit the same targets.
+    #[test]
+    fn a_claimed_surface_is_invisible_to_a_second_worker_until_its_lease_expires() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspace");
+        fs::create_dir_all(&workspace_root).unwrap();
+        let (pool, workspace_id) = fixture(temp.path(), &workspace_root);
+        let repository = SqliteEffectRepository::new(pool);
+        select_grilling(&repository, &workspace_id, &temp.path().join("catalog"));
+        declare_surface(&repository, &workspace_id, &workspace_root);
+
+        let first = repository
+            .claim_due_reconcile_requests(WORKER, PUBLISHED_AT + 20, PUBLISHED_AT + 80, 8)
+            .unwrap();
+        assert_eq!(first.len(), 1);
+        assert!(
+            repository
+                .claim_due_reconcile_requests("worker-2", PUBLISHED_AT + 30, PUBLISHED_AT + 90, 8)
+                .unwrap()
+                .is_empty(),
+            "a live lease keeps a sibling worker off the surface",
+        );
+
+        // Past the lease, the surface must become claimable again: a worker that crashed mid-run
+        // leaves its row claimed forever otherwise.
+        let stolen = repository
+            .claim_due_reconcile_requests("worker-2", PUBLISHED_AT + 100, PUBLISHED_AT + 160, 8)
+            .unwrap();
+        assert_eq!(stolen.len(), 1);
+        assert_ne!(
+            stolen[0].claim.token, first[0].claim.token,
+            "taking over a surface must invalidate the previous owner's fence",
+        );
+    }
+
+    /// A worker that lost its lease must not be able to write the outcome of stale work.
+    #[test]
+    fn a_stale_claim_can_no_longer_complete_block_or_reschedule() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspace");
+        fs::create_dir_all(&workspace_root).unwrap();
+        let (pool, workspace_id) = fixture(temp.path(), &workspace_root);
+        let repository = SqliteEffectRepository::new(pool);
+        select_grilling(&repository, &workspace_id, &temp.path().join("catalog"));
+        declare_surface(&repository, &workspace_id, &workspace_root);
+        let stale = claim(&repository, PUBLISHED_AT + 20).claim;
+        // A second worker takes over once the first lease has expired.
+        let live = repository
+            .claim_due_reconcile_requests(
+                "worker-2",
+                PUBLISHED_AT + 100_000,
+                PUBLISHED_AT + 160_000,
+                8,
+            )
+            .unwrap()
+            .remove(0)
+            .claim;
+
+        assert!(
+            !repository
+                .renew_reconcile_claim(
+                    &stale,
+                    WORKER,
+                    PUBLISHED_AT + 300_000,
+                    PUBLISHED_AT + 100_010
+                )
+                .unwrap(),
+            "renewal is the signal that tells a superseded worker to stop",
+        );
+        assert!(
+            !repository
+                .complete_reconcile_request(&stale, Generation::new(1), PUBLISHED_AT + 100_010)
+                .unwrap(),
+        );
+        assert!(
+            !repository
+                .block_reconcile_request(&stale, "stale", PUBLISHED_AT + 100_010)
+                .unwrap(),
+        );
+        assert!(
+            !repository
+                .retry_reconcile_request(
+                    &stale,
+                    "stale",
+                    PUBLISHED_AT + 400_000,
+                    PUBLISHED_AT + 100_010
+                )
+                .unwrap(),
+        );
+        assert!(
+            repository
+                .renew_reconcile_claim(
+                    &live,
+                    "worker-2",
+                    PUBLISHED_AT + 400_000,
+                    PUBLISHED_AT + 100_010
+                )
+                .unwrap(),
+            "the current owner keeps its lease across the same window",
+        );
+    }
+
+    /// A transient failure must wait out its persisted delay instead of spinning.
+    #[test]
+    fn a_scheduled_retry_is_not_claimable_before_its_delay_elapses() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspace");
+        fs::create_dir_all(&workspace_root).unwrap();
+        let (pool, workspace_id) = fixture(temp.path(), &workspace_root);
+        let repository = SqliteEffectRepository::new(pool);
+        select_grilling(&repository, &workspace_id, &temp.path().join("catalog"));
+        declare_surface(&repository, &workspace_id, &workspace_root);
+        let request = claim(&repository, PUBLISHED_AT + 20);
+
+        repository
+            .retry_reconcile_request(
+                &request.claim,
+                "transient_failure",
+                PUBLISHED_AT + 5_000,
+                PUBLISHED_AT + 20,
+            )
+            .unwrap();
+
+        assert_eq!(claimable(&repository, PUBLISHED_AT + 1_000), 0);
+        assert_eq!(claimable(&repository, PUBLISHED_AT + 6_000), 1);
+    }
+
+    /// A newer Desired must clear an old backoff, because it may be exactly what fixes the failure.
+    #[test]
+    fn a_new_generation_re_arms_a_surface_that_was_waiting_out_a_backoff() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspace");
+        fs::create_dir_all(&workspace_root).unwrap();
+        let (pool, workspace_id) = fixture(temp.path(), &workspace_root);
+        let repository = SqliteEffectRepository::new(pool);
+        select_grilling(&repository, &workspace_id, &temp.path().join("catalog"));
+        declare_surface(&repository, &workspace_id, &workspace_root);
+        let request = claim(&repository, PUBLISHED_AT + 20);
+        repository
+            .retry_reconcile_request(
+                &request.claim,
+                "transient_failure",
+                PUBLISHED_AT + 1_000_000,
+                PUBLISHED_AT + 20,
+            )
+            .unwrap();
+        assert_eq!(claimable(&repository, PUBLISHED_AT + 30), 0);
+
+        // Re-declaring the surface stands in for any committed change that raises the generation.
+        declare_surface(&repository, &workspace_id, &workspace_root);
+
+        assert_eq!(
+            claimable(&repository, PUBLISHED_AT + 40),
+            1,
+            "a committed change must not have to wait out the previous failure's delay",
+        );
+    }
+
+    /// Startup must rebuild work whose only remaining evidence is unconverged durable state.
+    #[test]
+    fn recovery_rebuilds_a_request_for_a_surface_left_short_of_its_generation() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspace");
+        fs::create_dir_all(&workspace_root).unwrap();
+        let (pool, workspace_id) = fixture(temp.path(), &workspace_root);
+        let repository = SqliteEffectRepository::new(pool);
+        select_grilling(&repository, &workspace_id, &temp.path().join("catalog"));
+        declare_surface(&repository, &workspace_id, &workspace_root);
+        // Losing the request is what a crash between commit and scheduling looks like.
+        let request = claim(&repository, PUBLISHED_AT + 20);
+        repository
+            .complete_reconcile_request(&request.claim, Generation::new(1), PUBLISHED_AT + 20)
+            .unwrap();
+        assert_eq!(claimable(&repository, PUBLISHED_AT + 30), 0);
+
+        assert_eq!(
+            repository
+                .recover_reconcile_requests(PUBLISHED_AT + 40)
+                .unwrap(),
+            1,
+            "status still proves the surface never applied its generation",
+        );
+        assert_eq!(claimable(&repository, PUBLISHED_AT + 50), 1);
+    }
+}

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -3,6 +3,7 @@ mod agent_runtime;
 mod app_event;
 mod bootstrap;
 mod clock;
+mod effect_worker;
 mod error;
 mod git_cleanup;
 mod identity;

--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -1,5 +1,6 @@
 use crate::app_event::AppEventPublisher;
 use crate::clock::SystemClock;
+use crate::effect_worker::EffectWorkerHandle;
 use crate::error::{BackendError, ErrorClassification};
 use gitlancer::{BranchName, CliGitRunner, Git};
 use ora_application::Clock;
@@ -32,7 +33,7 @@ use ora_plugin_registry::{
 use ora_utils::http::{DownloadSource, ProxyConfig, ReqwestDownloader};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 
@@ -173,6 +174,11 @@ pub(crate) struct PluginApi {
     effect_repository: SqliteEffectRepository,
     workspace_repository: SqliteWorkspaceRepository,
     agent_effect_surfaces: Mutex<BTreeMap<PluginId, Vec<FilesystemSkillSurface>>>,
+    /// Set once the Effect worker exists, which is after this API the worker itself borrows.
+    ///
+    /// Its absence only costs latency: a declaration change is already durable before the wake
+    /// would fire, so the worker's periodic scan still converges the surface.
+    effect_reconcile: OnceLock<EffectWorkerHandle>,
     clock: SystemClock,
 }
 
@@ -221,8 +227,17 @@ impl PluginApi {
             effect_repository: SqliteEffectRepository::new(pool.clone()),
             workspace_repository: SqliteWorkspaceRepository::new(pool),
             agent_effect_surfaces: Mutex::new(BTreeMap::new()),
+            effect_reconcile: OnceLock::new(),
             clock,
         })
+    }
+
+    /// Connects the Effect worker's wake handle once it exists.
+    ///
+    /// The worker borrows this API, so it cannot be built before it; wiring the wake afterwards
+    /// keeps that one-way dependency instead of making the two constructors mutually recursive.
+    pub(crate) fn set_effect_reconcile(&self, handle: EffectWorkerHandle) {
+        let _ = self.effect_reconcile.set(handle);
     }
 
     /// Rebuilds catalog projections for every Skill plugin already installed on disk.
@@ -400,6 +415,11 @@ impl PluginApi {
                 .map_err(|error| {
                     BackendError::internal("failed to persist Agent Effect surfaces", error)
                 })?;
+        }
+        // Waking after the commit, never before it: the request the worker will read is already
+        // durable, so a wake lost to a crash costs a scan interval rather than a reconcile.
+        if let Some(reconcile) = self.effect_reconcile.get() {
+            reconcile.notify();
         }
         Ok(())
     }

--- a/crates/db/src/effect_repository_tests.rs
+++ b/crates/db/src/effect_repository_tests.rs
@@ -7,7 +7,7 @@ use ora_effect::{
     ConsumerCoordination, ConsumerId, DesiredSkillState, Digest, EffectRepository,
     FilesystemSkillSurface, Generation, MaterializationFormat, ReplaceEffectOutcome, SkillName,
     SkillSelectionKey, SkillSource, SkillState, SourceKind, SourceVersion, SurfaceDescriptorSet,
-    SurfacePath, WorkspaceEffectSpec,
+    SurfaceLifecycle, SurfacePath, WorkspaceEffectSpec,
 };
 use ora_logging::with_trace_logging;
 use pretty_assertions::assert_eq;
@@ -274,5 +274,157 @@ fn unavailable_source_cannot_enter_desired_state() {
         ReplaceEffectOutcome::SourceUnavailable {
             selection_key: source.0,
         }
+    );
+}
+
+/// The worker reads a self-contained descriptor, so it never rebuilds one from a live declaration.
+///
+/// A request outlives the process that created it, and the plugin that declared the surface may be
+/// gone by the time it is served, so everything the reconciler needs has to come back out of the
+/// database rather than out of whatever happens to be running.
+#[test]
+fn due_requests_carry_the_locator_and_consumers_the_reconciler_needs() {
+    let (_directory, pool, workspace_id) = fixture();
+    let repository = SqliteEffectRepository::new(pool);
+    register_surface(&repository, &workspace_id, 10);
+
+    let due = repository
+        .claim_due_reconcile_requests("worker-1", 10, 10_000, 8)
+        .unwrap_or_else(|error| panic!("claim due requests: {error}"));
+
+    assert_eq!(due.len(), 1);
+    let entry = &due[0].due;
+    assert_eq!(entry.workspace_id, workspace_id);
+    assert_eq!(entry.workspace_root, std::path::Path::new("/workspace"));
+    assert_eq!(entry.descriptor.path.as_str(), ".agents/skills");
+    assert_eq!(
+        entry.descriptor.format,
+        MaterializationFormat::skill_directory_v1()
+    );
+    assert_eq!(entry.descriptor.lifecycle, SurfaceLifecycle::Active);
+    assert_eq!(
+        entry.descriptor.consumers,
+        BTreeMap::from([(
+            ConsumerId::new("codex"),
+            ConsumerCoordination::WaitForIdleAndRestart
+        )])
+    );
+}
+
+/// Completing at a stale generation must not discard the wakeup a later edit already merged in.
+///
+/// Desired can advance while a reconcile is mid-flight. Nothing re-creates a deleted request, so
+/// clearing one the reconcile never caught up with would strand that surface until the next
+/// unrelated edit.
+#[test]
+fn completing_a_request_respects_a_generation_that_advanced_mid_reconcile() {
+    let (_directory, pool, workspace_id) = fixture();
+    let repository = SqliteEffectRepository::new(pool);
+    register_surface(&repository, &workspace_id, 10);
+    let claim = repository
+        .claim_due_reconcile_requests("worker-1", 10, 10_000, 8)
+        .unwrap_or_else(|error| panic!("claim due requests: {error}"))
+        .remove(0)
+        .claim;
+
+    let source = local_source("1", b"manifest-v1");
+    repository
+        .publish_source(
+            &source.1,
+            std::path::Path::new("/catalog/review"),
+            SourcePublication::Create,
+            20,
+        )
+        .unwrap_or_else(|error| panic!("publish source: {error}"));
+
+    // Publishing installed the source into every Workspace, so the request now asks for
+    // generation 1 while the in-flight reconcile only ever observed the empty generation 0.
+    assert!(
+        !repository
+            .complete_reconcile_request(&claim, Generation::default(), 30)
+            .unwrap_or_else(|error| panic!("complete stale: {error}")),
+    );
+    // Falling back to pending rather than deleting is what keeps the newer generation scheduled.
+    let reclaimed = repository
+        .claim_due_reconcile_requests("worker-1", 30, 10_000, 8)
+        .unwrap_or_else(|error| panic!("reclaim after stale: {error}"));
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(
+        reclaimed[0].due.requested_generation,
+        Generation::new(1),
+        "the request must carry the generation that landed mid-reconcile",
+    );
+
+    assert!(
+        repository
+            .complete_reconcile_request(&reclaimed[0].claim, Generation::new(1), 40)
+            .unwrap_or_else(|error| panic!("complete current: {error}")),
+    );
+    assert!(
+        repository
+            .claim_due_reconcile_requests("worker-1", 40, 10_000, 8)
+            .unwrap_or_else(|error| panic!("claim after current: {error}"))
+            .is_empty(),
+    );
+}
+
+/// A retired surface may only be forgotten once nothing on disk is still owned through it.
+#[test]
+fn retired_surface_deletion_waits_for_an_empty_ownership_ledger() {
+    let (_directory, pool, workspace_id) = fixture();
+    let repository = SqliteEffectRepository::new(pool.clone());
+    register_surface(&repository, &workspace_id, 10);
+    let surface_key = repository
+        .claim_due_reconcile_requests("worker-1", 10, 10_000, 8)
+        .unwrap_or_else(|error| panic!("claim due requests: {error}"))
+        .remove(0)
+        .due
+        .descriptor
+        .surface_key;
+    // Withdrawing every declaration retires the surface without deleting it.
+    repository
+        .replace_surfaces(&workspace_id, std::path::Path::new("/workspace"), &[], 20)
+        .unwrap_or_else(|error| panic!("retire surface: {error}"));
+
+    let source = local_source("1", b"manifest-v1");
+    repository
+        .publish_source(
+            &source.1,
+            std::path::Path::new("/catalog/review"),
+            SourcePublication::Create,
+            30,
+        )
+        .unwrap_or_else(|error| panic!("publish source: {error}"));
+    pool.with_connection(|connection| {
+        connection.execute(
+            "INSERT INTO effect_managed_items (
+                 id, surface_id, source_id, applied_revision_id, target_key, target_json,
+                 applied_fingerprint, applied_generation, created_at, updated_at
+             )
+             SELECT 'managed-1', ?1, heads.source_id, heads.revision_id, 'review', '{}',
+                    'sha256:0', 0, 40, 40
+             FROM effect_source_heads heads",
+            params![surface_key.as_str()],
+        )?;
+        Ok(())
+    })
+    .unwrap_or_else(|error| panic!("insert managed item: {error}"));
+
+    assert!(
+        !repository
+            .delete_retired_surface(&surface_key)
+            .unwrap_or_else(|error| panic!("delete owned surface: {error}")),
+    );
+
+    pool.with_connection(|connection| {
+        connection.execute("DELETE FROM effect_managed_items", [])?;
+        Ok(())
+    })
+    .unwrap_or_else(|error| panic!("clear ledger: {error}"));
+
+    assert!(
+        repository
+            .delete_retired_surface(&surface_key)
+            .unwrap_or_else(|error| panic!("delete cleaned surface: {error}")),
     );
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -21,10 +21,11 @@ pub use error::{DatabaseError, MigrationDirection};
 pub use location::DatabaseLocation;
 pub use migration::{AppliedMigration, Migration, MigrationCatalog, default_migration_catalog};
 pub use repository::{
-    CascadeDeleteOutcome, PluginSkillProjection, RepositoryPool, SourceMutationOutcome,
-    SourcePublication, SqliteAgentDefinitionRepository, SqliteCascadeRepository,
-    SqliteEffectRepository, SqliteGitCleanupJobRepository, SqlitePluginStateRepository,
-    SqliteProjectRepository, SqliteSessionRepository, SqliteSkillRepository, SqliteTaskRepository,
+    CascadeDeleteOutcome, ClaimedReconcile, DueSurfaceReconcile, PluginSkillProjection,
+    ReconcileClaim, RepositoryPool, SourceMutationOutcome, SourcePublication,
+    SqliteAgentDefinitionRepository, SqliteCascadeRepository, SqliteEffectRepository,
+    SqliteGitCleanupJobRepository, SqlitePluginStateRepository, SqliteProjectRepository,
+    SqliteSessionRepository, SqliteSkillRepository, SqliteTaskRepository,
     SqliteTaskWorkspaceRepository, SqliteUserConfigRepository, SqliteWorkflowRepository,
     SqliteWorkflowRunEngineRepository, SqliteWorkflowRunRepository, SqliteWorkspaceRepository,
     SqliteWorktreeProvisioningLeaseRepository, SqliteWorktreeRepository,

--- a/crates/db/src/migration/README.md
+++ b/crates/db/src/migration/README.md
@@ -16,6 +16,11 @@ This module owns Ora's linear, reversible SQLite schema history and reconciles a
   normalized Workspace Desired items; Surface and Consumer declarations/status; Managed ownership;
   current Conditions; durable reconcile/propagation requests; mutation Operations and recovery
   Artifacts; and append-only Audit events.
+- A reconcile request carries its own scheduling state: `pending`, `claimed`, `blocked`, or
+  `retry_scheduled`, plus the lease that proves who currently owns the surface and the
+  `request_token` that fences that owner's writes. Only one worker can hold a surface, an expired
+  lease makes it claimable again so a crashed worker cannot strand it, and the retry delay lives in
+  the row so a restart cannot turn a backing-off surface back into an immediate retry.
 - Every Workspace has exactly one Effect aggregate. The first release installs every active Skill
   Source by default: publishing a new local or plugin Skill adds it to all existing Workspaces, and
   the Workspace insert trigger selects all active Skill Heads for a newly created Workspace.

--- a/crates/db/src/migration/schema_v0006.rs
+++ b/crates/db/src/migration/schema_v0006.rs
@@ -88,13 +88,21 @@ CREATE UNIQUE INDEX effect_conditions_consumer_unique
 CREATE TABLE effect_reconcile_requests (
     surface_id TEXT PRIMARY KEY REFERENCES effect_surfaces(id) ON DELETE CASCADE,
     requested_generation INTEGER NOT NULL, request_token TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending', wake_reason TEXT NOT NULL DEFAULT 'desired_changed',
+    blocked_reason TEXT, lease_owner TEXT, lease_expires_at INTEGER,
     attempt_count INTEGER NOT NULL DEFAULT 0, requested_at INTEGER NOT NULL,
     not_before_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
     CHECK (requested_generation >= 0), CHECK (attempt_count >= 0),
-    CHECK (not_before_at >= requested_at), CHECK (updated_at >= requested_at)
+    CHECK (not_before_at >= requested_at), CHECK (updated_at >= requested_at),
+    CHECK (state IN ('pending', 'claimed', 'blocked', 'retry_scheduled')),
+    CHECK ((state = 'claimed') = (lease_owner IS NOT NULL)),
+    CHECK ((state = 'claimed') = (lease_expires_at IS NOT NULL)),
+    CHECK ((state = 'blocked') = (blocked_reason IS NOT NULL))
 );
 CREATE INDEX effect_reconcile_requests_due
-    ON effect_reconcile_requests(not_before_at, requested_at, surface_id);
+    ON effect_reconcile_requests(state, not_before_at, requested_at, surface_id);
+CREATE INDEX effect_reconcile_requests_leases
+    ON effect_reconcile_requests(lease_expires_at) WHERE state = 'claimed';
 CREATE TABLE effect_propagation_requests (
     source_id TEXT PRIMARY KEY REFERENCES effect_sources(id) ON DELETE CASCADE,
     head_revision_id TEXT NOT NULL, request_token TEXT NOT NULL, attempt_count INTEGER NOT NULL DEFAULT 0,

--- a/crates/db/src/repository/effect/mapping.rs
+++ b/crates/db/src/repository/effect/mapping.rs
@@ -191,7 +191,14 @@ pub(super) fn enqueue_workspace_surfaces(
              WHERE surface_id = ?1",
             params![&key, generation_to_sql(generation)?, requested_at],
         )?;
-        upsert_reconcile_request(transaction, workspace_id, &key, generation, requested_at)?;
+        upsert_reconcile_request(
+            transaction,
+            workspace_id,
+            &key,
+            generation,
+            requested_at,
+            "desired_changed",
+        )?;
     }
     Ok(())
 }
@@ -313,22 +320,32 @@ pub(super) fn upsert_reconcile_request(
     surface_key: &str,
     generation: Generation,
     requested_at: i64,
+    wake_reason: &str,
 ) -> Result<(), DatabaseError> {
     transaction.execute(
+        // A wakeup re-arms whatever the last attempt decided: a newer Desired may be exactly what
+        // clears a transient failure or an unmet precondition, so backoff and blocked reasons are
+        // dropped rather than carried forward. A claim in flight is deliberately left alone — its
+        // worker still owns the surface, and raising the generation is enough to stop it from
+        // completing away work it never observed.
         "INSERT INTO effect_reconcile_requests (
-             surface_id, requested_generation, request_token, attempt_count,
-             requested_at, not_before_at, updated_at
-         ) VALUES (?1, ?2, ?3, 0, ?4, ?4, ?4)
+             surface_id, requested_generation, request_token, state, wake_reason,
+             blocked_reason, attempt_count, requested_at, not_before_at, updated_at
+         ) VALUES (?1, ?2, ?3, 'pending', ?5, NULL, 0, ?4, ?4, ?4)
          ON CONFLICT(surface_id) DO UPDATE SET
              requested_generation = MAX(requested_generation, excluded.requested_generation),
-             request_token = excluded.request_token, attempt_count = 0,
-             requested_at = excluded.requested_at, not_before_at = excluded.not_before_at,
+             request_token = CASE WHEN state = 'claimed'
+                 THEN request_token ELSE excluded.request_token END,
+             state = CASE WHEN state = 'claimed' THEN 'claimed' ELSE 'pending' END,
+             wake_reason = excluded.wake_reason, blocked_reason = NULL, attempt_count = 0,
+             not_before_at = MAX(requested_at, excluded.not_before_at),
              updated_at = excluded.updated_at",
         params![
             surface_key,
             generation_to_sql(generation)?,
             Uuid::new_v4().to_string(),
             requested_at,
+            wake_reason,
         ],
     )?;
     Ok(())

--- a/crates/db/src/repository/effect/mod.rs
+++ b/crates/db/src/repository/effect/mod.rs
@@ -4,14 +4,16 @@ use crate::{DatabaseError, RepositoryPool};
 use mapping::*;
 use ora_domain::WorkspaceId;
 use ora_effect::{
-    ConsumerStatus, DesiredSkillState, Digest, EffectOperation, EffectRepository, Generation,
-    LedgerTransition, ManagedIdentity, ManagedSkill, ReplaceEffectOutcome, RepositoryError,
-    SkillSelectionKey, SourceError, SourceProvider, SourceSnapshot, SourceVersion,
-    SurfaceDescriptorSet, SurfaceStatus, WorkspaceEffect, WorkspaceEffectSpec,
+    ConsumerCoordination, ConsumerId, ConsumerStatus, DesiredSkillState, Digest, EffectOperation,
+    EffectRepository, Generation, LedgerTransition, ManagedIdentity, ManagedSkill,
+    MaterializationFormat, ReplaceEffectOutcome, RepositoryError, SkillSelectionKey, SourceError,
+    SourceProvider, SourceSnapshot, SourceVersion, SurfaceDescriptorSet, SurfaceKey,
+    SurfaceLifecycle, SurfacePath, SurfaceStatus, WorkspaceEffect, WorkspaceEffectSpec,
 };
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 /// Selects whether publishing a source revision should wake existing Desired references.
@@ -291,6 +293,7 @@ impl SqliteEffectRepository {
                         &surface_key,
                         generation,
                         updated_at,
+                        "surface_retiring",
                     )?;
                 }
             }
@@ -388,6 +391,7 @@ impl SqliteEffectRepository {
                     surface.surface_key.as_str(),
                     generation,
                     updated_at,
+                    "surface_declared",
                 )?;
             }
             transaction.commit()?;
@@ -508,6 +512,386 @@ impl SqliteEffectRepository {
             }
             Ok(requests)
         })
+    }
+
+    /// Atomically takes ownership of the surfaces currently owed a reconcile.
+    ///
+    /// The rows are durable level-triggered state, not an event log: a worker reads what is owed
+    /// now rather than replaying how it came to be owed, which is what lets repeated wakeups merge
+    /// into one request. Claiming inside a single immediate transaction is what makes two workers
+    /// unable to hold the same surface, and a claim whose lease has expired is reclaimable so a
+    /// crashed worker cannot strand a surface forever.
+    ///
+    /// The returned token fences every later transition: a worker that lost its lease while it was
+    /// stalled finds its token replaced and can no longer write the outcome of stale work.
+    pub fn claim_due_reconcile_requests(
+        &self,
+        worker_id: &str,
+        now: i64,
+        lease_expires_at: i64,
+        limit: usize,
+    ) -> Result<Vec<ClaimedReconcile>, DatabaseError> {
+        self.pool.with_connection_mut(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let claimable = {
+                let mut statement = transaction.prepare(
+                    "SELECT surface_id FROM effect_reconcile_requests
+                     WHERE (state IN ('pending', 'retry_scheduled') AND not_before_at <= ?1)
+                        OR (state = 'claimed' AND lease_expires_at <= ?1)
+                     ORDER BY not_before_at, requested_at, surface_id
+                     LIMIT ?2",
+                )?;
+                let mut rows = statement.query(params![now, limit as i64])?;
+                let mut keys = Vec::new();
+                while let Some(row) = rows.next()? {
+                    keys.push(row.get::<_, String>(0)?);
+                }
+                keys
+            };
+
+            let mut claimed = Vec::new();
+            for surface_key in claimable {
+                let token = Uuid::new_v4().to_string();
+                let taken = transaction.execute(
+                    "UPDATE effect_reconcile_requests
+                     SET state = 'claimed', lease_owner = ?2, lease_expires_at = ?3,
+                         request_token = ?4, blocked_reason = NULL,
+                         attempt_count = attempt_count + 1, updated_at = ?5
+                     WHERE surface_id = ?1
+                       AND ((state IN ('pending', 'retry_scheduled') AND not_before_at <= ?5)
+                            OR (state = 'claimed' AND lease_expires_at <= ?5))",
+                    params![&surface_key, worker_id, lease_expires_at, &token, now],
+                )?;
+                if taken == 0 {
+                    continue;
+                }
+                let (mapped, attempt) = transaction.query_row(
+                    "SELECT surfaces.id, surfaces.workspace_id, surfaces.locator_key,
+                            surfaces.locator_json, surfaces.format_kind, surfaces.lifecycle,
+                            requests.requested_generation, requests.attempt_count
+                     FROM effect_reconcile_requests requests
+                     JOIN effect_surfaces surfaces ON surfaces.id = requests.surface_id
+                     WHERE requests.surface_id = ?1",
+                    params![&surface_key],
+                    |row| Ok((map_due_reconcile(row), row.get::<_, i64>(7)?)),
+                )?;
+                let mut due = mapped?;
+                {
+                    let mut statement = transaction.prepare(
+                        "SELECT consumer_id, coordination_kind FROM effect_surface_consumers
+                         WHERE surface_id = ?1 ORDER BY consumer_id",
+                    )?;
+                    let mut rows = statement.query(params![&surface_key])?;
+                    while let Some(row) = rows.next()? {
+                        let consumer = ConsumerId::new(row.get::<_, String>(0)?);
+                        let coordination = parse_coordination(&row.get::<_, String>(1)?)?;
+                        due.descriptor.consumers.insert(consumer, coordination);
+                    }
+                }
+                claimed.push(ClaimedReconcile {
+                    claim: ReconcileClaim {
+                        surface_key: due.descriptor.surface_key.clone(),
+                        token,
+                        attempt,
+                    },
+                    due,
+                });
+            }
+            transaction.commit()?;
+            Ok(claimed)
+        })
+    }
+
+    /// Extends a claim that is still genuinely held, reporting whether it survived.
+    ///
+    /// A `false` answer means the lease was taken over while this worker was busy. That is the one
+    /// moment a worker must stop touching the surface: another worker is already reconciling it,
+    /// and continuing would apply two plans to the same targets.
+    pub fn renew_reconcile_claim(
+        &self,
+        claim: &ReconcileClaim,
+        worker_id: &str,
+        lease_expires_at: i64,
+        now: i64,
+    ) -> Result<bool, DatabaseError> {
+        self.pool.with_connection_mut(|connection| {
+            let renewed = connection.execute(
+                "UPDATE effect_reconcile_requests
+                 SET lease_expires_at = ?3, updated_at = ?4
+                 WHERE surface_id = ?1 AND request_token = ?2 AND state = 'claimed'
+                   AND lease_owner = ?5",
+                params![
+                    claim.surface_key.as_str(),
+                    &claim.token,
+                    lease_expires_at,
+                    now,
+                    worker_id,
+                ],
+            )?;
+            Ok(renewed > 0)
+        })
+    }
+
+    /// Clears the request when the reconcile reached the generation it was asked for.
+    ///
+    /// A Desired edit landing mid-reconcile raises `requested_generation`, so an unconditional
+    /// delete would drop a wakeup nothing would re-create. Falling back to `pending` instead of
+    /// deleting is what lets the worker loop straight onto the newer generation.
+    pub fn complete_reconcile_request(
+        &self,
+        claim: &ReconcileClaim,
+        completed_generation: Generation,
+        now: i64,
+    ) -> Result<bool, DatabaseError> {
+        self.pool.with_connection_mut(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let removed = transaction.execute(
+                "DELETE FROM effect_reconcile_requests
+                 WHERE surface_id = ?1 AND request_token = ?2
+                   AND requested_generation <= ?3",
+                params![
+                    claim.surface_key.as_str(),
+                    &claim.token,
+                    generation_to_sql(completed_generation)?,
+                ],
+            )?;
+            if removed == 0 {
+                transaction.execute(
+                    "UPDATE effect_reconcile_requests
+                     SET state = 'pending', lease_owner = NULL, lease_expires_at = NULL,
+                         blocked_reason = NULL, attempt_count = 0,
+                         not_before_at = MAX(requested_at, ?3), updated_at = ?3
+                     WHERE surface_id = ?1 AND request_token = ?2 AND state = 'claimed'",
+                    params![claim.surface_key.as_str(), &claim.token, now],
+                )?;
+            }
+            transaction.commit()?;
+            Ok(removed > 0)
+        })
+    }
+
+    /// Parks a request until an external fact changes, without scheduling a timed retry.
+    ///
+    /// A surface waiting on an idle Session, a missing consumer, or an unresolved conflict cannot
+    /// be helped by trying again sooner, so it is left owed but not runnable. The safety scan and
+    /// the next Desired or declaration change are what re-arm it.
+    pub fn block_reconcile_request(
+        &self,
+        claim: &ReconcileClaim,
+        reason: &str,
+        now: i64,
+    ) -> Result<bool, DatabaseError> {
+        self.pool.with_connection_mut(|connection| {
+            let blocked = connection.execute(
+                "UPDATE effect_reconcile_requests
+                 SET state = 'blocked', blocked_reason = ?3, lease_owner = NULL,
+                     lease_expires_at = NULL, updated_at = ?4
+                 WHERE surface_id = ?1 AND request_token = ?2 AND state = 'claimed'",
+                params![claim.surface_key.as_str(), &claim.token, reason, now],
+            )?;
+            Ok(blocked > 0)
+        })
+    }
+
+    /// Schedules the next attempt after a transient failure, persisting the backoff itself.
+    ///
+    /// The delay lives in the row rather than in the worker, so a restart cannot turn a backing-off
+    /// surface back into an immediate retry and spin on the same failure.
+    pub fn retry_reconcile_request(
+        &self,
+        claim: &ReconcileClaim,
+        reason: &str,
+        not_before_at: i64,
+        now: i64,
+    ) -> Result<bool, DatabaseError> {
+        self.pool.with_connection_mut(|connection| {
+            let scheduled = connection.execute(
+                "UPDATE effect_reconcile_requests
+                 SET state = 'retry_scheduled', blocked_reason = NULL, wake_reason = ?3,
+                     lease_owner = NULL, lease_expires_at = NULL,
+                     not_before_at = MAX(requested_at, ?4), updated_at = ?5
+                 WHERE surface_id = ?1 AND request_token = ?2 AND state = 'claimed'",
+                params![
+                    claim.surface_key.as_str(),
+                    &claim.token,
+                    reason,
+                    not_before_at,
+                    now,
+                ],
+            )?;
+            Ok(scheduled > 0)
+        })
+    }
+
+    /// Rebuilds durable work that a crash, a lost notification, or drift left unscheduled.
+    ///
+    /// Correctness cannot rest on a process staying alive, so this recreates a request for every
+    /// surface whose durable state still proves work is owed: a generation short of applied, an
+    /// operation left unfinished, or a retirement that never completed. Requests already claimed by
+    /// a live lease are left alone.
+    pub fn recover_reconcile_requests(&self, now: i64) -> Result<usize, DatabaseError> {
+        self.pool.with_connection_mut(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            // A lease that outlived its worker is released rather than reclaimed here, so the
+            // ordinary claim path decides who picks it up next.
+            let released = transaction.execute(
+                "UPDATE effect_reconcile_requests
+                 SET state = 'pending', lease_owner = NULL, lease_expires_at = NULL,
+                     not_before_at = MAX(requested_at, ?1), updated_at = ?1
+                 WHERE state = 'claimed' AND lease_expires_at <= ?1",
+                params![now],
+            )?;
+            let unconverged = transaction.execute(
+                "INSERT INTO effect_reconcile_requests (
+                     surface_id, requested_generation, request_token, state, wake_reason,
+                     blocked_reason, attempt_count, requested_at, not_before_at, updated_at
+                 )
+                 SELECT status.surface_id, status.desired_generation, ?2, 'pending',
+                        'startup_recovery', NULL, 0, ?1, ?1, ?1
+                 FROM effect_surface_status status
+                 JOIN effect_surfaces surfaces ON surfaces.id = status.surface_id
+                 WHERE (status.applied_generation < status.desired_generation
+                        OR surfaces.lifecycle = 'retiring'
+                        OR EXISTS (
+                            SELECT 1 FROM effect_operations operations
+                            WHERE operations.surface_id = status.surface_id
+                              AND operations.phase != 'finalized'
+                        ))
+                   AND NOT EXISTS (
+                       SELECT 1 FROM effect_reconcile_requests existing
+                       WHERE existing.surface_id = status.surface_id
+                   )",
+                params![now, Uuid::new_v4().to_string()],
+            )?;
+            transaction.commit()?;
+            Ok(released + unconverged)
+        })
+    }
+
+    /// Re-arms blocked requests so a lost runtime event cannot park a surface permanently.
+    ///
+    /// Blocking is correct — nothing is gained by retrying a surface waiting on a busy Session —
+    /// but the event that should unblock it travels in process and can be lost to a crash. This is
+    /// the low-frequency safety net for that, not the primary schedule.
+    pub fn rearm_blocked_reconcile_requests(&self, now: i64) -> Result<usize, DatabaseError> {
+        self.pool.with_connection_mut(|connection| {
+            let rearmed = connection.execute(
+                "UPDATE effect_reconcile_requests
+                 SET state = 'pending', blocked_reason = NULL, wake_reason = 'safety_scan',
+                     not_before_at = MAX(requested_at, ?1), updated_at = ?1
+                 WHERE state = 'blocked'",
+                params![now],
+            )?;
+            Ok(rearmed)
+        })
+    }
+
+    /// Ends a retired surface's lifecycle once its ownership ledger is provably empty.
+    ///
+    /// Deletion is refused while any Managed item still names the surface: that ledger is the only
+    /// proof of what Ora may still touch on disk, so it has to outlive the declaration that created
+    /// it instead of disappearing through a cascade.
+    pub fn delete_retired_surface(&self, surface_key: &SurfaceKey) -> Result<bool, DatabaseError> {
+        self.pool.with_connection_mut(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let managed: i64 = transaction.query_row(
+                "SELECT count(*) FROM effect_managed_items WHERE surface_id = ?1",
+                params![surface_key.as_str()],
+                |row| row.get(0),
+            )?;
+            if managed > 0 {
+                transaction.commit()?;
+                return Ok(false);
+            }
+            let deleted = transaction.execute(
+                "DELETE FROM effect_surfaces WHERE id = ?1 AND lifecycle = 'retiring'",
+                params![surface_key.as_str()],
+            )?;
+            transaction.commit()?;
+            Ok(deleted > 0)
+        })
+    }
+}
+
+/// One surface owing a reconcile, with the Workspace root its adapter must be rooted at.
+#[derive(Clone, Debug)]
+pub struct DueSurfaceReconcile {
+    pub workspace_id: WorkspaceId,
+    pub workspace_root: PathBuf,
+    pub descriptor: SurfaceDescriptorSet,
+    pub requested_generation: Generation,
+}
+
+/// Proof that one worker currently owns a surface, and the fence its writes are checked against.
+///
+/// The token is regenerated on every claim, so a worker whose lease expired and was taken over
+/// cannot commit the outcome of work the new owner has already redone.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReconcileClaim {
+    pub surface_key: SurfaceKey,
+    pub token: String,
+    /// How many attempts this request has cost, including the one just claimed; drives backoff.
+    pub attempt: i64,
+}
+
+/// A claimed request together with everything the reconciler needs to serve it.
+#[derive(Clone, Debug)]
+pub struct ClaimedReconcile {
+    pub claim: ReconcileClaim,
+    pub due: DueSurfaceReconcile,
+}
+
+/// Rebuilds one descriptor from its persisted locator, leaving consumers for the caller to attach.
+fn map_due_reconcile(row: &rusqlite::Row<'_>) -> Result<DueSurfaceReconcile, DatabaseError> {
+    let locator: serde_json::Value =
+        serde_json::from_str(&row.get::<_, String>(3)?).map_err(effect_json_error)?;
+    let workspace_root = locator
+        .get("workspace_root")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            DatabaseError::CorruptEffectState(
+                "Effect surface locator is missing workspace_root".to_string(),
+            )
+        })?;
+    let lifecycle = match row.get::<_, String>(5)?.as_str() {
+        "active" => SurfaceLifecycle::Active,
+        "retiring" => SurfaceLifecycle::Retiring,
+        other => {
+            return Err(DatabaseError::CorruptEffectState(format!(
+                "unknown Effect surface lifecycle {other}"
+            )));
+        }
+    };
+    Ok(DueSurfaceReconcile {
+        workspace_id: WorkspaceId::new(row.get::<_, String>(1)?),
+        workspace_root: PathBuf::from(workspace_root),
+        descriptor: SurfaceDescriptorSet {
+            surface_key: SurfaceKey::new(row.get::<_, String>(0)?),
+            path: SurfacePath::parse(&row.get::<_, String>(2)?).map_err(|error| {
+                DatabaseError::CorruptEffectState(format!("invalid Effect surface path: {error}"))
+            })?,
+            format: MaterializationFormat::named(row.get::<_, String>(4)?).map_err(|error| {
+                DatabaseError::CorruptEffectState(format!("invalid Effect surface format: {error}"))
+            })?,
+            consumers: BTreeMap::new(),
+            lifecycle,
+        },
+        requested_generation: generation_from_sql(row.get::<_, i64>(6)?)?,
+    })
+}
+
+/// Maps the persisted coordination policy back onto its domain value.
+fn parse_coordination(value: &str) -> Result<ConsumerCoordination, DatabaseError> {
+    match value {
+        "uninterrupted" => Ok(ConsumerCoordination::Uninterrupted),
+        "wait_for_idle_and_restart" => Ok(ConsumerCoordination::WaitForIdleAndRestart),
+        other => Err(DatabaseError::CorruptEffectState(format!(
+            "unknown Effect consumer coordination {other}"
+        ))),
     }
 }
 
@@ -875,6 +1259,7 @@ impl EffectRepository for SqliteEffectRepository {
                         surface_key.as_str(),
                         current_generation(&transaction, workspace_id)?,
                         requested_at,
+                        "user_retry",
                     )?;
                 }
                 transaction.commit()?;

--- a/crates/db/src/repository/mod.rs
+++ b/crates/db/src/repository/mod.rs
@@ -20,7 +20,10 @@ mod worktree_provisioning_lease;
 pub use agent_definition::SqliteAgentDefinitionRepository;
 pub use cascade::{CascadeDeleteOutcome, SqliteCascadeRepository};
 pub use connection::RepositoryPool;
-pub use effect::{SourceMutationOutcome, SourcePublication, SqliteEffectRepository};
+pub use effect::{
+    ClaimedReconcile, DueSurfaceReconcile, ReconcileClaim, SourceMutationOutcome,
+    SourcePublication, SqliteEffectRepository,
+};
 pub use git_cleanup_job::SqliteGitCleanupJobRepository;
 pub use plugin::SqlitePluginStateRepository;
 pub use project::SqliteProjectRepository;


### PR DESCRIPTION
## Why

Effect v2 landed the schema, the repository, declaration persistence, and the agent IPC seam — but nothing drove them. `effect_reconcile_requests` rows were only ever inserted and never claimed, `Reconciler` and `FilesystemSurfaceAdapter` were referenced nowhere outside their own crate, and `effect/waitForIdle` / `effect/restart` were still marked `dead_code`.

The visible consequence: selecting a Skill persisted Desired state and a reconcile request, and an Agent plugin declaring `.opencode/skills` persisted its surface and consumer — and then nothing ever wrote a file. On a live database the request sat at `attempt_count = 0` with `applied_generation` stuck at 0 forever.

This adds the worker that closes the loop, along with the durable scheduling the watcher spec requires of it.

## Request store

The store gains the transitions a crash-safe schedule needs:

| Method | Guarantee |
| --- | --- |
| `claim_due_reconcile_requests` | Takes ownership inside one immediate transaction, so two workers can never hold the same surface. Regenerates `request_token` as a fence against a superseded owner's writes. An expired lease is reclaimable, so a crashed worker cannot strand a surface. |
| `renew_reconcile_claim` | Extends a live claim. A `false` answer is exactly what tells a worker its lease was taken over and it must stop touching the surface. |
| `complete_reconcile_request` | Clears a request only when the reconcile reached the generation it was asked for; otherwise releases it back to `pending`, so a Desired edit landing mid-reconcile is never discarded. |
| `block_reconcile_request` / `retry_reconcile_request` | Separate "wait for an external fact" from "try again later". The delay is persisted, so a restart cannot turn backoff into a hot loop. |
| `recover_reconcile_requests` | Rebuilds work whose only remaining evidence is durable state: an unapplied generation, an unfinished operation, a retirement left mid-flight, or a lease still held by a dead process. |
| `rearm_blocked_reconcile_requests` | Low-frequency safety net for an in-process runtime event lost to a crash. Not the primary schedule. |

## Worker

`ora_backend::effect_worker` claims a request, reconciles, and records the outcome under the claim that authorizes it.

- **Schedule comes from the domain.** Outcomes map through `ConditionReason::retry_policy()` rather than being re-decided per call site: `Manual` blocks, `Backoff` retries on a persisted delay with jitter, `OnChange` parks until something external moves.
- **The lease is held across coordination.** Waiting on a consumer can take as long as a turn runs, so a background thread renews rather than sizing one lease for the slowest possible reconcile. A plugin that never answers costs one lease interval, not the surface.
- **A consumer whose plugin is not running is skipped, not started.** It holds no turn a mutation could corrupt, and it re-reads the surface when it next starts. Starting a plugin only to ask it to restart would be wasted work, and refusing to proceed would mean nothing ever materializes while an agent happens to be disconnected.
- **It owns its own thread and runtime.** `Backend::open` is not itself inside a Tokio runtime (three existing tests prove it — an earlier draft using `Handle::current()` panicked on them), and reconciliation is synchronous filesystem work that would otherwise occupy an async worker for a whole copy.

`effect/waitForIdle` and `effect/restart` are now genuinely called, so their `dead_code` markers are gone.

## Migration

`0006` is edited rather than superseded, following this catalog's stated model of describing only the current schema. `effect_reconcile_requests` gains `state`, `wake_reason`, `blocked_reason`, `lease_owner`, and `lease_expires_at`, with CHECK constraints tying `claimed` to its lease fields and `blocked` to its reason.

Existing development databases roll `0006` back and rebuild it, which clears Effect state only. That state self-heals on the next start: `reconcile_skill_storage` re-publishes local Skill sources and reinstalls them into every Workspace, agent plugins re-declare their surfaces on attach, and the worker's recovery pass plus first scan materialize the result.

## Verification

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, and `cargo test --workspace` all pass — 60 test binaries, zero failures.

The end-to-end proof is `a_selected_skill_is_materialized_into_the_declared_surface`, which asserts a selected Skill actually reaches `<workspace>/.opencode/skills/grilling/SKILL.md` with an ownership marker and a ledger entry, and that the consumer is quiesced before the write and restarted onto the applied generation.

Seven worker tests cover: materialization; a busy consumer deferring and the safety scan re-arming it; two workers never sharing a surface; takeover after lease expiry; a stale claim being unable to complete, block, or reschedule; a scheduled retry not being claimable before its delay elapses; a new generation clearing an old backoff; and recovery rebuilding a request from status alone.

Three existing `ora-backend` tests that called `Backend::open` outside a runtime are fixed by the worker owning its runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
