### PR TITLE
fix(ci): 修复 desktop-build 工作流过时路径导致的三平台构建失败

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -63,13 +63,13 @@ jobs:
       # Installs the toolchain pinned by rust-toolchain.toml.
       - name: Install Rust toolchain
         run: rustup show active-toolchain || rustup toolchain install
-      # Two independent cargo workspaces: the root workspace (compiled by
-      # `cargo xtask export-contracts`) and the standalone src-tauri workspace.
+      # The Tauri crate is a member of the single root cargo workspace, so
+      # `tauri build` compiles the binary and writes every bundle into the
+      # root `target/` directory (there is no separate src-tauri workspace).
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             . -> target
-            apps/desktop/src-tauri -> target
       # System libraries required to compile and bundle Tauri 2 on Ubuntu 22.04.
       # Keep in sync with https://v2.tauri.app/start/prerequisites/#linux when
       # upgrading Tauri.
@@ -104,15 +104,20 @@ jobs:
         env:
           DENO_VERSION: v2.9.5
           RG_VERSION: 15.2.0
+      # Each platform produces only the bundle types valid for its OS
+      # (macOS=dmg, Windows=nsis, Linux=appimage+deb). Listing all four
+      # globs is safe: upload-artifact combines them into one search and
+      # only fails when the combined result is empty, so a per-platform
+      # miss on the other types never trips `if-no-files-found: error`.
       - uses: actions/upload-artifact@v6
         with:
           name: ora-desktop-${{ matrix.os }}
           if-no-files-found: error
           path: |
-            apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
-            apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
-            apps/desktop/src-tauri/target/release/bundle/appimage/*.AppImage
-            apps/desktop/src-tauri/target/release/bundle/deb/*.deb
+            target/release/bundle/dmg/*.dmg
+            target/release/bundle/nsis/*.exe
+            target/release/bundle/appimage/*.AppImage
+            target/release/bundle/deb/*.deb
 
   release:
     needs: bundle


### PR DESCRIPTION
## 修复了什么

修复 `desktop-build.yml`（Ora 桌面端三平台打包工作流）中两处过时配置，解决 v0.0.1 标签构建在 Ubuntu / macOS / Windows 三平台全部失败的问题。

## 解决了什么问题

[失败 run](https://github.com/ora-space/desktop/actions/runs/32943288645) 在三平台都报同一个错：

> No files were found with the provided path: apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg

但日志显示 `task build:desktop` 这一步**本身成功了**——Tauri 确实编译并打包出了安装包，只是最后 `upload-artifact`（上传构建产物步骤）找不到文件。也就是说：构建没坏，是“去哪里找产物”这件事错了。

## 根因

提交 `d710f0b8`（refactor(workspace): consolidate Rust and desktop runtime boundaries）做了两件和本 PR 直接相关的事：

1. **删除了 `apps/web/server/`**——Ora 早期的一个 Rust HTTP 服务 crate（即“删除了 ora 中的 server”）。
2. **把 Tauri crate 合并进根 Cargo 工作区**，删除了 `apps/desktop/src-tauri/Cargo.lock`（原 6932 行的独立工作区锁文件）。

这次合并同时更新了 `pr-tests.yml`，但**漏掉了 `desktop-build.yml`**。于是工作流的路径配置还停留在合并前的状态。

### 为什么 bundle 路径会变

- **Cargo 工作区（Cargo workspace）**：Rust 的一个机制，让多个 crate 共享同一套依赖版本和一个公共的编译输出目录。
- 合并前，`apps/desktop/src-tauri` 是一个独立工作区，它的编译产物（含 Tauri 打包出的安装包）落在 `apps/desktop/src-tauri/target/`。
- 合并后，它只是根工作区的一个成员 crate，编译产物落在仓库根目录的 `target/`。Tauri 打包出的安装包也就跟着落到了 `target/release/bundle/` 下。

所以 workflow 里 `apps/desktop/src-tauri/target/release/bundle/...` 这套路径，合并后永远匹配不到任何文件。

### 为什么三平台都失败、而且报错文案里带 dmg

`upload-artifact` 在 `if-no-files-found: error`（“一个文件都没找到就报错”）模式下，会把所有 path 行**合并成一次搜索**——只有当**所有行加起来一个文件都没命中**时才报错。它把全部 4 行路径一起列在报错里，所以即便 Ubuntu 根本不产出 dmg，报错文案也带 dmg。这并不意味着单独某一行没命中就报错，关键是总数为 0。我读了 `actions/upload-artifact@v6` 源码（`src/shared/search.ts` + `src/upload/upload-artifact.ts`）确认了这一点。

## 改动详情

**1. `upload-artifact` 的 path 前缀**（直接修复构建失败）

```diff
- apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
- apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
- apps/desktop/src-tauri/target/release/bundle/appimage/*.AppImage
- apps/desktop/src-tauri/target/release/bundle/deb/*.deb
+ target/release/bundle/dmg/*.dmg
+ target/release/bundle/nsis/*.exe
+ target/release/bundle/appimage/*.AppImage
+ target/release/bundle/deb/*.deb
```

日志佐证三平台实际产物路径与新 glob 完全吻合：

- macOS: `target/release/bundle/dmg/ora_0.1.0_aarch64.dmg`
- Ubuntu: `target/release/bundle/{appimage,deb}/ora_0.1.0_amd64.*`
- Windows: `target/release/bundle/nsis/ora_0.1.0_x64-setup.exe`

**2. `Swatinem/rust-cache` 的工作区声明**

```diff
  workspaces: |
-   . -> target
-   apps/desktop/src-tauri -> target
+   . -> target
```

`apps/desktop/src-tauri -> target` 这条是合并前的残留——src-tauri 已不再是独立工作区，这条声明指向一个不再被使用的目录。去掉它，与 `pr-tests.yml` 的单工作区声明对齐。同时更新了原来“两个独立 cargo 工作区”那段已失实的注释。

## 权衡与考虑的点

- **为什么一次性列 4 种安装包类型、不按平台拆分 path**：靠 `upload-artifact`“合并搜索、总数为 0 才报错”的语义，每平台只要命中自己产出的那一类（≥1）就不会误报，反而能在“本该产出却没产出”时可靠报错。按平台拆分要么写 `if` 分支、要么为每平台单独命名 artifact，徒增复杂度而无收益。新增的注释把这个非显而易见的安全边界写明了。
- **为什么保留 `if-no-files-found: error`**：打包是发布流程的关键产物，“没产出安装包”必须挡下来，不能静默放过。
- **为什么 `rust-cache` 只去掉多余条目、不改缓存策略**：根工作区那条 `. -> target` 一直是对的（合并前后都覆盖根 target），多出的第二条只是死重量。没引入 `save-if` 之类，避免改变缓存写入行为、与历史缓存键冲突。
- **为什么保留 `ubuntu-22.04` 而非跟随 `pr-tests.yml` 的 `ubuntu-latest`**：注释里写明是为了压低 glibc 版本底线，保证打出来的 AppImage/deb 能在更老的 Linux 发行版上跑。这是打包流程的有意取舍，跟 pr-tests（只编译不打包）用途不同。
- **为什么不动 Ubuntu 的 apt 依赖列表**：打包比单纯编译多需要 `patchelf`（AppImage 打包用）、`pkg-config`、`libdbus-1-dev` 等，这些是打包流程必需的；`pr-tests.yml` 那份更精简是因为它只编译不打包。两者差异是有意为之，不是过时。
- **关于 Rust 工具链步骤**：`desktop-build.yml` 用 `rustup show active-toolchain`、`pr-tests.yml` 用 `dtolnay/rust-toolchain@stable`，两者最终都由仓库根的 `rust-toolchain.toml`（锁定 1.95.0）决定实际编译器版本，功能等价，未改。

## 验证

- **YAML 语法**：用 PyYAML 解析通过；脚本断言无 `apps/desktop/src-tauri/target` 残留、rust-cache 为单工作区、4 个 glob 前缀正确。
- **产物路径对齐**：从失败 run 的日志逐行确认三平台 bundle 实际路径与新 glob 匹配。
- **行为依据**：读 `upload-artifact@v6` 源码确认“合并搜索、总数为 0 才报错”，保证改完后不会因为“某平台缺某类安装包”而误报。

## 术语小词典

- **Cargo workspace / member crate**：Rust 的多 crate 组织机制；member crate 共享依赖版本和公共编译输出目录。
- **target 目录**：Cargo 默认的编译产物输出目录，位于工作区根。
- **bundle / installer**：Tauri 把编译出的二进制打包成各平台安装包（macOS 的 `.dmg`、Windows 的 `.exe`(NSIS)、Linux 的 `.AppImage`/`.deb`）。
- **glob**：通配符路径模式，如 `*.dmg`。
- **upload-artifact**：GitHub Actions 把构建产物上传为可下载 artifact 的官方 action。
- **rust-cache**：`Swatinem/rust-cache`，缓存 Cargo 编译产物以加速 CI。
- **glibc**：Linux 的 C 标准库实现；版本越低，能跑的二进制兼容的发行版越老。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
