### PR TITLE
fix(http): 公司内网 MITM 代理下插件安装失败——信任系统证书库并保留 reqwest 错误链

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,6 +1897,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2914,6 +2915,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -3993,6 +4000,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4141,6 +4149,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,6 +4200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4266,6 +4295,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ portable-pty = "0.9"
 pretty_assertions = "1"
 r2d2 = "0.8"
 regex = "1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "stream"] }
 semver = "1"
 quick-xml = "0.41"
 sha2 = "0.10"

--- a/crates/utils/README.md
+++ b/crates/utils/README.md
@@ -25,6 +25,9 @@ that any other crate can consume without introducing dependency cycles.
 - `http-reqwest` (Cargo feature `http-reqwest`, implies `http`): the `reqwest`-backed
   `ReqwestDownloader` that streams remote HTTP(S) responses with timeouts, retries, progress,
   cancellation, and proxy resolution driven by explicit config and `*_PROXY`/`NO_PROXY` variables.
+  It trusts the operating system native certificate store (alongside the bundled webpki roots) so
+  downloads succeed behind corporate MITM proxies whose root CA is installed in the OS trust
+  store, and it preserves the full reqwest cause chain in network errors for diagnosability.
 - `html` (Cargo feature `validation`): conservative validation rejecting README text that embeds
   scriptable HTML (forbidden tags, `on*` event handlers, `javascript:`/`data:` URIs).
 - `svg` (Cargo feature `validation`): security validation for SVG icons — accepts well-formed

--- a/crates/utils/src/http/README.md
+++ b/crates/utils/src/http/README.md
@@ -23,7 +23,7 @@ Generic, domain-free download capability used by crates that fetch release artif
 ## Non-responsibilities
 
 - Choosing a concrete transport: only `http` is shipped by default; the network backend is opt-in.
-- TLS handling, redirect-target validation, resume, and digital-signature verification.
+- TLS handling, redirect-target validation, resume, and digital-signature verification. The reqwest backend does, however, trust the operating system native certificate store (in addition to the bundled webpki roots) so it works behind corporate MITM proxies whose root CA is installed in the OS trust store, matching the behavior of a browser or `git` on the same machine.
 - Concurrency budgeting across parallel installs; that is the orchestrator`s job.
 
 ## Key invariants

--- a/crates/utils/src/http/reqwest.rs
+++ b/crates/utils/src/http/reqwest.rs
@@ -6,6 +6,7 @@
 //! variables, so it needs an async runtime provided by the caller.
 
 use sha2::{Digest, Sha256};
+use std::error::Error as StdError;
 use std::fs::File;
 use std::future::Future;
 use std::io::Write;
@@ -242,12 +243,30 @@ fn proxy_reqwest(proxy: Proxy) -> Result<reqwest::Proxy, DownloadError> {
 /// Wraps a reqwest transport error as a structured error, carrying a URL for context.
 ///
 /// The shared error model exposes `io::Error` as the transport source, so the richer `reqwest::Error`
-/// is flattened into a displayable error string.
+/// is flattened into a displayable error string that preserves the full cause chain, so the real
+/// failure reason (for example a TLS certificate verification error) is not hidden behind the
+/// outermost "error sending request" message.
 fn network_error(url: &Url, error: reqwest::Error) -> DownloadError {
     DownloadError::Network {
         url: url.clone(),
-        source: std::io::Error::other(error.to_string()),
+        source: std::io::Error::other(flatten_reqwest_error(&error)),
     }
+}
+
+/// Flattens a reqwest error and its whole cause chain into a single displayable string.
+///
+/// reqwest's `Display` only surfaces the outermost error (for example "error sending request for
+/// url ..."), hiding the underlying cause (such as "invalid peer certificate: UnknownIssuer") in
+/// its `source()` chain. Joining every link with " <- " keeps that context without pulling in a
+/// logging dependency.
+fn flatten_reqwest_error(error: &reqwest::Error) -> String {
+    let mut links: Vec<String> = vec![error.to_string()];
+    let mut current: Option<&(dyn StdError + 'static)> = error.source();
+    while let Some(cause) = current {
+        links.push(cause.to_string());
+        current = cause.source();
+    }
+    links.join(" <- ")
 }
 
 /// Returns true for failures that are worth retrying (transient or rate-limited).

--- a/crates/utils/src/http/tests.rs
+++ b/crates/utils/src/http/tests.rs
@@ -374,4 +374,41 @@ mod reqwest_integration {
         }
         assert!(!destination.exists());
     }
+
+    /// A failed connection surfaces the full reqwest cause chain instead of only the outermost
+    /// message, so the real TLS/connect reason stays visible.
+    ///
+    /// We point at a loopback port that refuses connections (`127.0.0.1:1`), which forces a
+    /// connect-time failure whose error carries an inner cause (the underlying connect error).
+    #[tokio::test]
+    async fn network_error_preserves_cause_chain() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let destination = temp_dir.path().join("pkg.orax");
+        let downloader = ReqwestDownloader::new(Default::default());
+        // Port 1 is reserved and refuses TCP connections, guaranteeing a connect-time failure.
+        let url = Url::parse("http://127.0.0.1:1/pkg.orax").unwrap();
+
+        let error = downloader
+            .download(DownloadRequest {
+                source: DownloadSource::Url(url),
+                destination: destination.clone(),
+                checksum: None,
+                options: DownloadOptions::default(),
+                progress: None,
+                cancel: None,
+            })
+            .await
+            .unwrap_err();
+
+        let message = match error {
+            DownloadError::Network { source, .. } => source.to_string(),
+            other => panic!("expected network error, got {other:?}"),
+        };
+        // The flattened chain must keep the outermost message plus at least one inner cause,
+        // proving the " <- " joining happened instead of only `error.to_string()`.
+        assert!(
+            message.contains(" <- "),
+            "expected a cause chain joined by ' <- ', got: {message}"
+        );
+    }
 }


### PR DESCRIPTION
## 关联 Issue

Closes #472

> PR 合并后将自动关闭该 Issue。

---

## 一、背景：解决了什么问题

在公司内网环境下，插件安装会失败。

### 现象

公司内网里 `github.com` 等外网站点只能通过公司代理（例如 `proxysg.huawei.com:8080`）访问，直连会超时。代理本身配置没问题（`user_config` 里的 proxy 配置、use proxy 开关都已生效、能正常走代理），但插件 `.orax` 包下载这一步会挂掉，日志里只有一句笼统的：

```
error sending request for url (https://github.com/...)
```

### 根因

公司代理是一台 **MITM（中间人，Man-In-The-Middle）代理**：它不是简单地转发流量，而是在代理侧"终止"原来的 TLS（Transport Layer Security，传输层安全协议，即 HTTPS 用的加密层）连接，再用**公司内部 CA（Certificate Authority，证书颁发机构）**为 `github.com` 重新签发一张证书。这是企业内网管控外网 HTTPS 流量的常见做法。

后果是：任何 HTTPS 客户端要访问 `github.com`，都必须信任这台"公司内部 CA"，否则 TLS 握手时的证书校验会直接拒绝。

而下载 `.orax` 用的是 `reqwest` 客户端，`Cargo.toml` 里只开了 `rustls-tls` feature。在 `reqwest 0.12` 里，这个 feature 是 `rustls-tls-webpki-roots` 的别名——**它只信任捆绑在二进制里的 Mozilla 根证书集合**（webpki roots，一组随程序发布的、被广泛认可的根证书）。公司内部 CA 当然不在 Mozilla 根里，于是 rustls（一个纯 Rust 的 TLS 实现）报：

```
invalid peer certificate: UnknownIssuer
```

**关键验证**（在出问题机器上实测，坐实了根因）：
- 直连 `github.com` → 超时（防火墙拦截）
- `curl`（用**操作系统证书库**）→ HTTP 200 ✅
- Python + `certifi`（自带根证书，和 rustls 类似不读系统库）→ `SSLCertVerificationError` ❌

结论很明确：**只要客户端能信任操作系统证书库，就能装成功**。curl 能成功，正是因为它读系统证书库；rustls 失败，正是因为它只认自己捆绑的 Mozilla 根。

### 排查被拖慢的次要原因

真正的 `UnknownIssuer` 错误信息被 `network_error()` 函数用 `error.to_string()` **抹掉**了。`reqwest::Error` 把底层真实原因放在 `source()`（错误原因链，即"错误 A 是由错误 B 引起，B 又由 C 引起"的链式结构）里，而 `to_string()` 只输出最外层那一句话 `error sending request for url (...)`，把链里的 `UnknownIssuer` 丢掉了。这就是为什么日志看起来像"代理没生效"，而真正坏在 TLS 证书校验上——排查方向被误导。

---

## 二、本次提交做了什么

### 1. `Cargo.toml` —— 开启系统证书库

```diff
- reqwest = { ..., features = ["rustls-tls", "stream"] }
+ reqwest = { ..., features = ["rustls-tls", "rustls-tls-native-roots", "stream"] }
```

新增 `rustls-tls-native-roots`：它通过 `rustls-native-certs` 在**运行时**读取操作系统的证书库——Windows 上是"证书存储（证书管理控制台里的受信任根）"，macOS 上是 Keychain，Linux 上是 `/etc/ssl/certs`（ca-certificates 包），把里面所有受信任根证书加载进 rustls 的信任列表。

在 `reqwest 0.12` 源码里，`webpki roots` 和 `native roots` 是两个**独立的配置块**：两个 feature 同时开时，rustls 同时信任"Mozillla 捆绑根 + 系统证书库根"。而公司内部 CA 早已被 IT 部门部署到这台机器的系统证书库里，于是握手通过。

### 2. `crates/utils/src/http/reqwest.rs` —— 保留完整错误链

新增 `flatten_reqwest_error()`：把 `reqwest::Error` 整条 `source()` 链用 ` <- ` 串成一句话，替换原来只取最外层的 `to_string()`。失败时日志会变成：

```
error sending request for url (...) <- client error (Connect) <- tcp connect error: ... <- invalid peer certificate: UnknownIssuer
```

以后再出问题，一眼就能看到真实的 TLS / 连接原因，不用再猜。

### 3. 测试 + 文档

- `tests.rs` 新增 `network_error_preserves_cause_chain`：断言网络错误保留了 ` <- ` 完整链路。做法是 loopback（本机回环地址 `127.0.0.1`）连一个拒绝连接的端口 `127.0.0.1:1`，制造一次确定性的连接失败，再校验错误消息里含 ` <- `。
- `crates/utils/README.md` 与 `crates/utils/src/http/README.md` 补充了"信任操作系统证书库"的职责说明，并把它和浏览器、`git` 行为对齐。
- `Cargo.lock` 自动加入 `rustls-native-certs` 依赖树。

### 4. 验证

- `cargo build -p ora-utils --features http-reqwest`：编译通过；
- `cargo test -p ora-utils --features http-reqwest`：82 个测试全部通过（含新增的 cause chain 测试）；
- `cargo clippy -p ora-utils --features http-reqwest -- -D warnings`（即项目 `task lint:crates` 对库代码执行的检查级别）：通过；
- `cargo fmt --all -p ora-utils -- --check`：通过。

---

## 三、为什么这么改：考虑点与权衡

### 1. 不内置任何公司特定 CA

这个下载器是 `ora-utils`——workspace（工作区，即一个 Cargo 仓库下多个 crate 共享依赖管理的结构）里**最低层、最通用的 crate**，按项目约定不能耦合任何 Ora 领域概念，更不能硬编码某个公司的内部 CA。否则换一台机器、换一家公司就废了。信任"**操作系统证书库**"是标准做法——浏览器、`git`、`curl` 在同一台机器上的行为和它完全一致，公司内部 CA 早已由 IT 部署到系统库，托管机器上即开即用。

### 2. 保留 webpki roots 做兜底，不"二选一"

两个 feature 同时开，而不是用 `rustls-tls-native-roots` 替换 `rustls-tls`：
- **公司 / 托管机器**：系统库里有内部 CA，靠 native roots 走通；
- **家庭 / 非托管机器**：系统库里不一定有所有公共 CA，仍能靠 Mozilla 捆绑根访问公共站点。

这样两套环境都不挂，鲁棒性更好。代价是多引入 `rustls-native-certs` 一个依赖，但它轻量、纯读证书、无副作用，值得。

### 3. 错误链保真是"诊断可及性"，不是功能修复

下载这种跨网络功能一定会再出问题（代理变、证书续期、DNS 抖动……）。把 cause chain 保留下来，下一次排查时日志直接给出真实原因，而不是一句空泛的 "error sending request"。这是把"隐性故障"变"显性故障"的工程治理，和本次修复同等重要。

### 4. 不引入新的日志依赖

`flatten_reqwest_error()` 只是把 `reqwest::Error` 自带的 `source()` 链拼成字符串塞进既有的 `io::Error` 里，复用现有 `DownloadError::Network` 的展示通道，没有为此拉一个日志/tracing 依赖进来，符合 `ora-utils` "保持轻量、可选依赖才引入"的定位。

### 5. 取舍：测试用 `127.0.0.1:1` 而非真实 MITM 代理

真实场景需要一台公司代理 + 内部 CA 才能复现 `UnknownIssuer`，CI 环境无法稳定提供。因此测试改用"被拒绝的 loopback 连接"制造一次确定性的、带 inner cause 的网络错误，只断言"` <- `链路被保留"这一**不变量**，而不绑定某个具体的底层报错文案——后者跨平台、跨版本不稳定。这是用"测结构而非测文案"换取测试的稳定与可移植。
