### PR TITLE
feat(plugin): adjust the plugin management ui and add an update feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ packages/contracts/.test-dist/
 
 /specs
 /memories
+# Local scratch / agent working files
+.pnpm-store/
+.tmp_patch.txt
+HANDOFF*.md
+plugin-doc/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,6 +2991,7 @@ dependencies = [
  "ora-plugin-config",
  "ora-plugin-lifecycle",
  "ora-plugin-manager",
+ "ora-plugin-manifest",
  "ora-plugin-registry",
  "ora-plugin-runtime",
  "ora-process",

--- a/apps/desktop/src-tauri/permissions/main-commands.toml
+++ b/apps/desktop/src-tauri/permissions/main-commands.toml
@@ -69,6 +69,7 @@ commands.allow = [
     "stop_plugin",
     "uninstall_plugin",
     "install_plugin",
+    "update_plugin",
     "import_plugin",
     "update_agent",
     "delete_agent",

--- a/apps/desktop/src-tauri/src/app_commands.rs
+++ b/apps/desktop/src-tauri/src/app_commands.rs
@@ -67,6 +67,7 @@ desktop_command_registry! {
     commands::stop_plugin,
     commands::uninstall_plugin,
     commands::install_plugin,
+    commands::update_plugin,
     commands::import_plugin,
     commands::update_agent,
     commands::delete_agent,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1125,6 +1125,13 @@ async_backend_command!(
     "Installs one marketplace plugin by downloading, verifying, and extracting it."
 );
 async_backend_command!(
+    update_plugin,
+    UpdatePluginRequest,
+    UpdatePluginResponse,
+    update_plugin,
+    "Updates one installed plugin to the version its marketplace source publishes."
+);
+async_backend_command!(
     import_plugin,
     ImportPluginRequest,
     ImportPluginResponse,

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,10 +1,29 @@
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
+import { readFileSync } from "node:fs";
 import * as path from "node:path";
+
+/** Reads the workspace version that Cargo.toml owns for the whole Rust workspace. */
+function readWorkspaceVersion(): string {
+  const cargoToml = readFileSync(
+    path.resolve(__dirname, "../../Cargo.toml"),
+    "utf8",
+  );
+  const match = cargoToml.match(
+    /^\[workspace\.package\][\s\S]*?^version\s*=\s*"([^"]+)"/m,
+  );
+  if (match === null) {
+    throw new Error("workspace.package version missing in Cargo.toml");
+  }
+  return match[1];
+}
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __ORA_APP_VERSION__: JSON.stringify(readWorkspaceVersion()),
+  },
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: [

--- a/apps/desktop/web/tauri-transport.test.ts
+++ b/apps/desktop/web/tauri-transport.test.ts
@@ -122,6 +122,21 @@ describe("createTauriTransport", () => {
       request: { pluginId: "official/weather" },
     });
   });
+  it("maps marketplace plugin updates to the Desktop plugin command", async () => {
+    const response = { pluginId: "official/weather" };
+    const invoke = vi.fn().mockResolvedValue(response);
+    const transport = createTauriTransport(invoke);
+
+    await expect(
+      transport.send({
+        operationName: "updatePlugin",
+        request: { pluginId: "official/weather" },
+      }),
+    ).resolves.toEqual(response);
+    expect(invoke).toHaveBeenCalledWith("update_plugin", {
+      request: { pluginId: "official/weather" },
+    });
+  });
   it("maps local archive import to the Desktop plugin command", async () => {
     const response = { pluginId: "official/weather" };
     const invoke = vi.fn().mockResolvedValue(response);

--- a/apps/desktop/web/tauri-transport.ts
+++ b/apps/desktop/web/tauri-transport.ts
@@ -135,6 +135,7 @@ const tauriCommands = {
   stopPlugin: "stop_plugin",
   uninstallPlugin: "uninstall_plugin",
   installPlugin: "install_plugin",
+  updatePlugin: "update_plugin",
   importPlugin: "import_plugin",
 
   // =============================================================================

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -23,6 +23,7 @@ ora-fs = { workspace = true }
 ora-history = { workspace = true }
 ora-logging = { workspace = true }
 ora-plugin-config = { workspace = true }
+ora-plugin-manifest = { workspace = true }
 ora-plugin-lifecycle = { workspace = true }
 ora-plugin-manager = { workspace = true }
 ora-plugin-runtime = { workspace = true }

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -424,6 +424,20 @@ impl Backend {
         Ok(response)
     }
 
+    /// Updates one installed marketplace plugin to the version its source publishes and
+    /// reconciles the agent set afterwards.
+    ///
+    /// The agent set is reconciled so a replaced agent package supplies a reachable agent in this
+    /// process rather than only after the next restart.
+    pub async fn update_plugin(
+        &self,
+        request: UpdatePluginRequest,
+    ) -> Result<UpdatePluginResponse, BackendError> {
+        let response = self.plugin.update(request).await?;
+        self.agent_runtime.sync_plugin_agents();
+        Ok(response)
+    }
+
     /// Imports one local release archive and reconciles the agent set afterwards.
     ///
     /// The agent set is reconciled so the imported package supplies a reachable agent in this

--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -16,7 +16,8 @@ use ora_contracts::{
     ListMarketplaceSourcesResponse, PublicError, ScanPluginsRequest, ScanPluginsResponse,
     StopPluginRequest, StopPluginResponse, SyncAvailablePluginsRequest,
     SyncAvailablePluginsResponse, UninstallPluginRequest, UninstallPluginResponse,
-    UpdateMarketplaceSourceRequest, UpdateMarketplaceSourceResponse,
+    UpdateMarketplaceSourceRequest, UpdateMarketplaceSourceResponse, UpdatePluginRequest,
+    UpdatePluginResponse,
 };
 use ora_db::{
     PluginSkillProjection, RepositoryPool, SqliteEffectRepository,
@@ -32,6 +33,7 @@ use ora_plugin_lifecycle::{
     PluginLifecycleError, PluginNotificationSink, PluginRuntimeTimeouts,
 };
 use ora_plugin_manager::{Installer, PluginContribution, PluginManager};
+use ora_plugin_manifest::PluginManifest;
 use ora_plugin_registry::{RegistryEntry, RegistryError, RegistryIndex, RegistrySync};
 use ora_utils::http::{DownloadSource, ProxyConfig, ReqwestDownloader};
 use std::collections::BTreeMap;
@@ -552,35 +554,7 @@ impl PluginApi {
         &self,
         request: InstallPluginRequest,
     ) -> Result<InstallPluginResponse, BackendError> {
-        let registry_sources = self.prepared_registry_sources()?;
-        // A malformed identifier can never name a registry entry, so it is reported the same way
-        // as an unknown one instead of leaking the id grammar as a separate error class.
-        let plugin_id = PluginId::parse(&request.plugin_id).map_err(|_| {
-            BackendError::new(
-                ErrorClassification::NotFound,
-                PublicError::PluginNotFound(EmptyErrorParams {}),
-                "marketplace plugin id is not a valid `<namespace>/<name>`",
-            )
-        })?;
-        let mut resolved = None;
-        for (source, use_proxy) in &registry_sources {
-            let registry_dir = source.checkout_dir().join("registry");
-            if let Some(manifest) = RegistryIndex::resolve_manifest(&registry_dir, &plugin_id)
-                .map_err(|error| {
-                    BackendError::internal("failed to resolve plugin release manifest", error)
-                })?
-            {
-                resolved = Some((manifest, *use_proxy));
-                break;
-            }
-        }
-        let (manifest, use_proxy) = resolved.ok_or_else(|| {
-            BackendError::new(
-                ErrorClassification::NotFound,
-                PublicError::PluginNotFound(EmptyErrorParams {}),
-                "marketplace plugin was not found in the registry",
-            )
-        })?;
+        let (manifest, use_proxy) = self.resolve_marketplace_release(&request.plugin_id)?;
         let release_url = manifest
             .url()
             .ok_or_else(|| {
@@ -591,16 +565,7 @@ impl PluginApi {
             })?
             .as_url();
         ora_info!(plugin_id = %request.plugin_id, url = %release_url, "installing marketplace plugin");
-        let proxy_settings = self.user_config.network_proxy_settings()?;
-        let download_proxy = if use_proxy {
-            proxy::download_proxy(proxy_settings.as_ref())?.ok_or_else(|| {
-                BackendError::invalid_proxy_settings(
-                    "a marketplace source uses the proxy but no proxy is configured",
-                )
-            })?
-        } else {
-            ProxyConfig::default()
-        };
+        let download_proxy = self.download_proxy_for(use_proxy)?;
         Installer::new(ReqwestDownloader::new(download_proxy))
             .install(
                 &manifest,
@@ -613,6 +578,99 @@ impl PluginApi {
         ora_info!(plugin_id = %request.plugin_id, "installed marketplace plugin");
         Ok(InstallPluginResponse {
             plugin_id: request.plugin_id,
+        })
+    }
+
+    /// Updates one installed marketplace plugin to the version its source publishes.
+    ///
+    /// The source resolution and proxy policy are identical to an install: the winning
+    /// marketplace source decides whether the download goes through the configured proxy. The
+    /// running process is stopped before its package is replaced, and the installed snapshot is
+    /// rescanned afterwards so the new version becomes effective without a restart.
+    pub(crate) async fn update(
+        &self,
+        request: UpdatePluginRequest,
+    ) -> Result<UpdatePluginResponse, BackendError> {
+        let (manifest, use_proxy) = self.resolve_marketplace_release(&request.plugin_id)?;
+        let release_url = manifest
+            .url()
+            .ok_or_else(|| {
+                BackendError::internal(
+                    "marketplace plugin manifest is missing its release url",
+                    std::io::Error::new(std::io::ErrorKind::InvalidData, "missing release url"),
+                )
+            })?
+            .as_url();
+        ora_info!(plugin_id = %request.plugin_id, url = %release_url, "updating marketplace plugin");
+        // The package directory is replaced while the plugin may be running, so the process is
+        // stopped first; stopping a webview/skill/MCP package is a no-op.
+        self.lifecycle
+            .stop_plugin(StopPluginRequest {
+                plugin_id: request.plugin_id.clone(),
+            })
+            .await
+            .map_err(BackendError::from)?;
+        let download_proxy = self.download_proxy_for(use_proxy)?;
+        Installer::new(ReqwestDownloader::new(download_proxy))
+            .update(
+                &manifest,
+                DownloadSource::Url(release_url.clone()),
+                &self.data_directory,
+            )
+            .await
+            .map_err(|error| BackendError::internal("failed to update plugin", error))?;
+        self.finalize_new_install(&request.plugin_id).await?;
+        ora_info!(plugin_id = %request.plugin_id, "updated marketplace plugin");
+        Ok(UpdatePluginResponse {
+            plugin_id: request.plugin_id,
+        })
+    }
+
+    /// Resolves the release manifest for one marketplace identifier across the configured sources.
+    ///
+    /// Sources are consulted in precedence order, and the returned flag is the winning source's
+    /// proxy policy so installs and updates honor the same per-source setting as the git sync.
+    fn resolve_marketplace_release(
+        &self,
+        plugin_id: &str,
+    ) -> Result<(PluginManifest, bool), BackendError> {
+        let registry_sources = self.prepared_registry_sources()?;
+        // A malformed identifier can never name a registry entry, so it is reported the same way
+        // as an unknown one instead of leaking the id grammar as a separate error class.
+        let plugin_id = PluginId::parse(plugin_id).map_err(|_| {
+            BackendError::new(
+                ErrorClassification::NotFound,
+                PublicError::PluginNotFound(EmptyErrorParams {}),
+                "marketplace plugin id is not a valid `<namespace>/<name>`",
+            )
+        })?;
+        for (source, use_proxy) in &registry_sources {
+            let registry_dir = source.checkout_dir().join("registry");
+            if let Some(manifest) = RegistryIndex::resolve_manifest(&registry_dir, &plugin_id)
+                .map_err(|error| {
+                    BackendError::internal("failed to resolve plugin release manifest", error)
+                })?
+            {
+                return Ok((manifest, *use_proxy));
+            }
+        }
+        Err(BackendError::new(
+            ErrorClassification::NotFound,
+            PublicError::PluginNotFound(EmptyErrorParams {}),
+            "marketplace plugin was not found in the registry",
+        ))
+    }
+
+    /// Returns the downloader proxy configuration for one marketplace source's proxy policy.
+    fn download_proxy_for(&self, use_proxy: bool) -> Result<ProxyConfig, BackendError> {
+        if !use_proxy {
+            return Ok(ProxyConfig::default());
+        }
+        let proxy_settings = self.user_config.network_proxy_settings()?;
+        proxy::download_proxy(proxy_settings.as_ref())?.ok_or_else(|| {
+            BackendError::invalid_proxy_settings(
+                "a marketplace source uses the proxy but no proxy is configured",
+            )
         })
     }
 

--- a/crates/contracts/src/plugin.rs
+++ b/crates/contracts/src/plugin.rs
@@ -422,6 +422,22 @@ pub struct InstallPluginResponse {
     pub plugin_id: String,
 }
 
+/// Requests updating one installed marketplace plugin to the version its source publishes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "plugin.ts")]
+pub struct UpdatePluginRequest {
+    pub plugin_id: String,
+}
+
+/// Confirms the identifier updated after the new release is verified and stale versions removed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "plugin.ts")]
+pub struct UpdatePluginResponse {
+    pub plugin_id: String,
+}
+
 /// Requests importing one local `.orax` release archive into the installed plugins tree.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -548,6 +564,8 @@ pub(crate) fn export(config: &ts_rs::Config) -> Result<(), ts_rs::ExportError> {
     UninstallPluginResponse::export(config)?;
     InstallPluginRequest::export(config)?;
     InstallPluginResponse::export(config)?;
+    UpdatePluginRequest::export(config)?;
+    UpdatePluginResponse::export(config)?;
     ImportPluginRequest::export(config)?;
     ImportPluginResponse::export(config)?;
     GetPluginConfigurationRequest::export(config)?;
@@ -571,7 +589,7 @@ mod tests {
         ListMarketplaceSourcesResponse, MarketplaceSource, PluginConfigurationSummary,
         PluginInstallationValidity, PluginRuntimeStatus, SyncAvailablePluginsRequest,
         SyncAvailablePluginsResponse, UpdateMarketplaceSourceRequest,
-        UpdateMarketplaceSourceResponse,
+        UpdateMarketplaceSourceResponse, UpdatePluginRequest, UpdatePluginResponse,
     };
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -915,6 +933,25 @@ mod tests {
         );
         assert_eq!(
             serde_json::to_value(InstallPluginResponse {
+                plugin_id: "official/weather".to_string(),
+            })
+            .unwrap(),
+            json!({ "pluginId": "official/weather" })
+        );
+    }
+
+    /// Verifies the update request/response wire shape for an installed marketplace plugin.
+    #[test]
+    fn serializes_update_plugin_contract() {
+        assert_eq!(
+            serde_json::to_value(UpdatePluginRequest {
+                plugin_id: "official/weather".to_string(),
+            })
+            .unwrap(),
+            json!({ "pluginId": "official/weather" })
+        );
+        assert_eq!(
+            serde_json::to_value(UpdatePluginResponse {
                 plugin_id: "official/weather".to_string(),
             })
             .unwrap(),

--- a/crates/plugin-manager/README.md
+++ b/crates/plugin-manager/README.md
@@ -37,6 +37,10 @@ orchestrates checksum-verified installs of new plugin releases.
 - Install a plugin release: download the `.orax` package (through an injected `ora-utils::http`
   `HttpDownload`), verify its SHA-256 while downloading, and safely extract it into
   `<data-dir>/plugins/installed/<namespace>/<name>/<version>` with `ora-utils::archive`.
+- Update an installed plugin release by refusing no-op and downgrade attempts (the marketplace
+  manifest must declare a higher version than the highest installed SemVer directory), then
+  downloading, verifying, and extracting the new release into its version directory and retiring
+  every other version directory underneath `<data-dir>/plugins/installed/<namespace>/<name>`.
 - Import one local `.orax` release archive by extracting into a disposable staging directory,
   parsing its in-archive `orax.toml`, verifying a declared `sha256`, and then moving only the
   validated tree into `<data-dir>/plugins/installed/<namespace>/<name>/<version>`.
@@ -57,7 +61,8 @@ resulting snapshot through `installed_plugins()` and report any non-fatal proble
 archive is imported with `Installer::install_local(archive_path, data_dir)`, which returns an
 `InstalledPackage` carrying the materialized `package_dir` and the `namespace/name` plugin id
 derived from the in-archive manifest. `Installer::new` accepts any `HttpDownload`; `install`
-returns the package directory it extracted into.
+returns the package directory it extracted into, and `update` returns the committed
+`InstalledPackage` after stale versions are retired.
 
 ## Validation split
 

--- a/crates/plugin-manager/src/install.rs
+++ b/crates/plugin-manager/src/install.rs
@@ -1,10 +1,11 @@
-//! Installs a plugin release by downloading its package and safely extracting it.
+//! Installs and updates plugin releases by downloading and safely extracting their package.
 
 use crate::discovery::installed_root;
 use ora_plugin_manifest::PluginManifest;
 use ora_utils::archive::{ArchiveFormat, ExtractLimits, extract_archive};
 use ora_utils::hash;
 use ora_utils::http::{Checksum, DownloadOptions, DownloadRequest, DownloadSource, HttpDownload};
+use semver::Version;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -73,6 +74,37 @@ impl InstallError {
             message: source.to_string(),
         }
     }
+}
+
+/// Reports why one plugin release could not be updated.
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    /// The new release could not be downloaded, verified, or materialized.
+    #[error("failed to install the updated release: {0}")]
+    Install(#[from] InstallError),
+    /// No installed package exists for the plugin, so there is nothing to update.
+    #[error("plugin `{id}` is not installed")]
+    NotFound { id: String },
+    /// The marketplace still publishes the version that is already installed.
+    #[error("plugin `{id}` version `{version}` is already up to date")]
+    AlreadyUpToDate { id: String, version: String },
+    /// The marketplace publishes a version older than the installed one.
+    #[error(
+        "marketplace version `{available}` is older than installed version `{installed}` for plugin `{id}`"
+    )]
+    Downgrade {
+        id: String,
+        installed: String,
+        available: String,
+    },
+    /// A stale version directory could not be removed after the new version landed.
+    #[error("failed to remove stale plugin version {path} for `{id}`: {source}")]
+    Retire {
+        id: String,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 /// Describes one package materialized from a local release archive.
@@ -156,6 +188,60 @@ where
             source,
         })?;
         Ok(package_dir)
+    }
+
+    /// Updates one installed plugin to `manifest`'s version by downloading, verifying, and
+    /// extracting the new release, then retiring every older version directory.
+    ///
+    /// The currently installed version is derived from the highest valid SemVer directory below
+    /// `<data-dir>/plugins/installed/<namespace>/<name>`, so the marketplace cannot silently
+    /// downgrade a package or re-materialize an identical release. Only a verified package is
+    /// ever committed, and stale versions are removed after the new one is on disk so a failed
+    /// download leaves the previous installation untouched.
+    pub async fn update(
+        &self,
+        manifest: &PluginManifest,
+        source: DownloadSource,
+        data_dir: &Path,
+    ) -> Result<InstalledPackage, UpdateError> {
+        let namespace = manifest.namespace();
+        let name = manifest.name();
+        let id = format!("{}/{}", namespace.as_str(), name.as_str());
+        let plugin_root = installed_root(data_dir)
+            .join(namespace.as_str())
+            .join(name.as_str());
+        let latest_installed = match latest_installed_version(&plugin_root) {
+            Ok(latest) => latest,
+            // A missing name root means the plugin was never installed, which is a distinct
+            // outcome from a stale-version removal failure.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(source) => {
+                return Err(UpdateError::Retire {
+                    id: id.clone(),
+                    path: plugin_root.clone(),
+                    source,
+                });
+            }
+        };
+        let Some(latest_installed) = latest_installed else {
+            return Err(UpdateError::NotFound { id });
+        };
+        if manifest.version() == &latest_installed {
+            return Err(UpdateError::AlreadyUpToDate {
+                id,
+                version: latest_installed.to_string(),
+            });
+        }
+        if manifest.version() < &latest_installed {
+            return Err(UpdateError::Downgrade {
+                id,
+                installed: latest_installed.to_string(),
+                available: manifest.version().to_string(),
+            });
+        }
+        let package_dir = self.install(manifest, source, data_dir).await?;
+        retire_stale_versions(&id, &plugin_root, &package_dir)?;
+        Ok(InstalledPackage { package_dir, id })
     }
 
     /// Imports an already-downloaded release archive from `archive_path` into the installed tree.
@@ -286,9 +372,59 @@ where
         Ok(archive_path)
     }
 }
+
+/// Returns the highest valid SemVer version directory below `plugin_root`, if any.
+///
+/// Directory names that are not valid SemVer are ignored here exactly as discovery treats them:
+/// they cannot decide whether an update is a no-op or a downgrade, and they are retired along
+/// with every other stale version once a new release lands.
+fn latest_installed_version(plugin_root: &Path) -> std::io::Result<Option<Version>> {
+    let mut latest = None;
+    for entry in std::fs::read_dir(plugin_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        if let Ok(version) = Version::parse(&entry.file_name().to_string_lossy())
+            && (latest.as_ref().is_none_or(|installed| version > *installed))
+        {
+            latest = Some(version);
+        }
+    }
+    Ok(latest)
+}
+
+/// Removes every version directory below `plugin_root` except the one that was just installed.
+///
+/// The plugin name root is derived from manifest-validated segments and the retained directory is
+/// the exact path the installer just committed, so only sibling version directories can be
+/// touched. A removal failure is reported after the new version is already committed; the caller
+/// keeps the installed plugin usable and can retry cleanup independently.
+fn retire_stale_versions(id: &str, plugin_root: &Path, retain: &Path) -> Result<(), UpdateError> {
+    for entry in std::fs::read_dir(plugin_root).map_err(|source| UpdateError::Retire {
+        id: id.to_owned(),
+        path: plugin_root.to_path_buf(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| UpdateError::Retire {
+            id: id.to_owned(),
+            path: plugin_root.to_path_buf(),
+            source,
+        })?;
+        if entry.path() == retain {
+            continue;
+        }
+        std::fs::remove_dir_all(entry.path()).map_err(|source| UpdateError::Retire {
+            id: id.to_owned(),
+            path: entry.path(),
+            source,
+        })?;
+    }
+    Ok(())
+}
 #[cfg(test)]
 mod tests {
-    use super::{InstallError, InstalledPackage, Installer};
+    use super::{InstallError, InstalledPackage, Installer, UpdateError};
     use futures::executor::block_on;
     use ora_plugin_manifest::PluginManifest;
     use ora_utils::http::{DownloadSource, LocalFileDownloader};
@@ -592,5 +728,201 @@ mod tests {
         );
         assert!(package.package_dir.join("main.js").exists());
         assert!(package.package_dir.join("logo.svg").exists());
+    }
+
+    /// Stages one installed package version below `<data>/plugins/installed/official/weather`.
+    fn stage_installed_weather_version(data_dir: &Path, version: &str) {
+        let package_root = data_dir
+            .join("plugins")
+            .join("installed")
+            .join("official")
+            .join("weather")
+            .join(version);
+        std::fs::create_dir_all(&package_root).unwrap();
+        std::fs::write(
+            package_root.join("orax.toml"),
+            format!(
+                "resolver = 1\nidentifier = \"weather\"\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"{version}\"\ndescription = \"A test plugin\"\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(package_root.join("main.js"), "export {};\n").unwrap();
+    }
+
+    /// Updates an installed plugin to the marketplace release and retires the older package.
+    #[test]
+    fn updates_installed_plugin_and_retires_old_versions() {
+        let temp_dir = TempDir::new().unwrap();
+        stage_installed_weather_version(temp_dir.path(), "0.9.0");
+        let release_path = temp_dir.path().join("weather-1.0.0.orax");
+        write_orax_zip(
+            &release_path,
+            &[
+                (
+                    "orax.toml",
+                    &b"resolver = 1\nidentifier = \"weather\"\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"1.0.0\"\ndescription = \"A test plugin\"\n"[..],
+                ),
+                ("main.js", b"export {};\n".as_slice()),
+                ("logo.svg", b"<svg/>".as_slice()),
+            ],
+        );
+        let manifest = PluginManifest::parse(&manifest_with_digest(
+            "weather",
+            "1.0.0",
+            sha256_file(&release_path),
+        ))
+        .unwrap();
+
+        let package = block_on(Installer::new(LocalFileDownloader).update(
+            &manifest,
+            DownloadSource::Local(release_path),
+            temp_dir.path(),
+        ))
+        .unwrap();
+
+        let new_package = temp_dir
+            .path()
+            .join("plugins")
+            .join("installed")
+            .join("official")
+            .join("weather")
+            .join("1.0.0");
+        assert_eq!(
+            package,
+            InstalledPackage {
+                package_dir: new_package.clone(),
+                id: "official/weather".to_owned(),
+            }
+        );
+        assert!(new_package.join("main.js").is_file());
+        assert!(
+            !temp_dir
+                .path()
+                .join("plugins")
+                .join("installed")
+                .join("official")
+                .join("weather")
+                .join("0.9.0")
+                .exists()
+        );
+    }
+
+    /// An update is refused when the marketplace still publishes the installed version.
+    #[test]
+    fn rejects_updating_a_plugin_already_at_the_latest_version() {
+        let temp_dir = TempDir::new().unwrap();
+        stage_installed_weather_version(temp_dir.path(), "1.0.0");
+        let release_path = temp_dir.path().join("weather-1.0.0.orax");
+        write_orax_zip(
+            &release_path,
+            &[(
+                "orax.toml",
+                &b"resolver = 1\nidentifier = \"weather\"\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"1.0.0\"\ndescription = \"A test plugin\"\n"[..],
+            )],
+        );
+        let manifest = PluginManifest::parse(&manifest_with_digest(
+            "weather",
+            "1.0.0",
+            sha256_file(&release_path),
+        ))
+        .unwrap();
+
+        let error = block_on(Installer::new(LocalFileDownloader).update(
+            &manifest,
+            DownloadSource::Local(release_path),
+            temp_dir.path(),
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateError::AlreadyUpToDate { ref id, .. } if id == "official/weather"
+        ));
+        assert!(
+            temp_dir
+                .path()
+                .join("plugins")
+                .join("installed")
+                .join("official")
+                .join("weather")
+                .join("1.0.0")
+                .join("main.js")
+                .is_file()
+        );
+    }
+
+    /// The marketplace is never allowed to downgrade an installed plugin.
+    #[test]
+    fn rejects_downgrading_an_installed_plugin() {
+        let temp_dir = TempDir::new().unwrap();
+        stage_installed_weather_version(temp_dir.path(), "2.0.0");
+        let release_path = temp_dir.path().join("weather-1.0.0.orax");
+        write_orax_zip(
+            &release_path,
+            &[(
+                "orax.toml",
+                &b"resolver = 1\nidentifier = \"weather\"\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"1.0.0\"\ndescription = \"A test plugin\"\n"[..],
+            )],
+        );
+        let manifest = PluginManifest::parse(&manifest_with_digest(
+            "weather",
+            "1.0.0",
+            sha256_file(&release_path),
+        ))
+        .unwrap();
+
+        let error = block_on(Installer::new(LocalFileDownloader).update(
+            &manifest,
+            DownloadSource::Local(release_path),
+            temp_dir.path(),
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateError::Downgrade { ref id, .. } if id == "official/weather"
+        ));
+        assert!(
+            !temp_dir
+                .path()
+                .join("plugins")
+                .join("installed")
+                .join("official")
+                .join("weather")
+                .join("1.0.0")
+                .exists()
+        );
+    }
+
+    /// Updating a plugin that has no installed package reports NotFound.
+    #[test]
+    fn rejects_updating_a_plugin_that_is_not_installed() {
+        let temp_dir = TempDir::new().unwrap();
+        let release_path = temp_dir.path().join("weather-1.0.0.orax");
+        write_orax_zip(
+            &release_path,
+            &[(
+                "orax.toml",
+                &b"resolver = 1\nidentifier = \"weather\"\nnamespace = \"official\"\nkind = \"agent\"\nversion = \"1.0.0\"\ndescription = \"A test plugin\"\n"[..],
+            )],
+        );
+        let manifest = PluginManifest::parse(&manifest_with_digest(
+            "weather",
+            "1.0.0",
+            sha256_file(&release_path),
+        ))
+        .unwrap();
+
+        let error = block_on(Installer::new(LocalFileDownloader).update(
+            &manifest,
+            DownloadSource::Local(release_path),
+            temp_dir.path(),
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateError::NotFound { ref id } if id == "official/weather"
+        ));
     }
 }

--- a/crates/plugin-manager/src/lib.rs
+++ b/crates/plugin-manager/src/lib.rs
@@ -17,7 +17,7 @@ mod kind_tests;
 mod tests;
 
 pub use discovery::{MANIFEST_FILE_NAME, installed_root};
-pub use install::{InstallError, InstalledPackage, Installer};
+pub use install::{InstallError, InstalledPackage, Installer, UpdateError};
 pub use issue::{PluginDiscoveryIssue, PluginDiscoveryIssueKind};
 pub use mcp::{InstalledMcpDescriptor, MCP_CONFIGURATION_FILE};
 pub use skill::{

--- a/packages/app-shell/src/features/settings/plugin-manager.tsx
+++ b/packages/app-shell/src/features/settings/plugin-manager.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { InstalledPlugin } from "@ora/contracts";
+import type { AvailablePlugin, InstalledPlugin } from "@ora/contracts";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -25,10 +25,13 @@ import {
   toast,
 } from "@ora/ui";
 import {
+  IconArrowBigUpLines,
   IconDots,
   IconLoader2,
+  IconProgressDown,
   IconRefresh,
   IconSearch,
+  IconSettingsBolt,
   IconTrash,
 } from "@tabler/icons-react";
 import { filterDiscoveredPlugins } from "./filter-discovered-plugins";
@@ -36,16 +39,19 @@ import { localizeContractError } from "../../i18n/contract-error";
 import { PluginLogo } from "./plugin-logo";
 import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
 import { usePluginScan } from "../../state/hooks/use-plugin-scan";
+import { useUpdatePlugin } from "../../state/hooks/use-update-plugin";
 
 /** The installed-plugin manager exposes runtime and package lifecycle commands. */
 export function PluginManager({
   plugins,
   onBack,
   onConfigure,
+  availableById,
 }: {
   plugins: InstalledPlugin[];
   onBack: () => void;
   onConfigure: (plugin: Pick<InstalledPlugin, "id" | "displayName">) => void;
+  availableById?: ReadonlyMap<string, AvailablePlugin>;
 }) {
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
@@ -130,6 +136,7 @@ export function PluginManager({
               key={plugin.id}
               plugin={plugin}
               onConfigure={onConfigure}
+              available={availableById?.get(plugin.id)}
             />
           ))}
         </div>
@@ -141,19 +148,29 @@ export function PluginManager({
 function InstalledPluginRow({
   plugin,
   onConfigure,
+  available,
 }: {
   plugin: InstalledPlugin;
   onConfigure: (plugin: Pick<InstalledPlugin, "id" | "displayName">) => void;
+  available: AvailablePlugin | undefined;
 }) {
   const { t } = useTranslation();
+  const update = useUpdatePlugin(plugin.id);
   const mutations = usePluginMutations(
     plugin.id,
     plugin.kind === "agent" ? plugin.name : undefined,
   );
   const uninstalling = mutations.uninstall.isPending;
-  const busy = uninstalling;
+  const busy = uninstalling || update.isPending;
+  const hasUpdate =
+    available !== undefined && available.version !== plugin.version;
   const [uninstallOpen, setUninstallOpen] = useState(false);
   const [deleteData, setDeleteData] = useState(true);
+  const failUpdate = (cause: unknown) => {
+    toast.error(t("settings.plugins.updateFailed"), {
+      description: localizeContractError(cause, t),
+    });
+  };
   const failUninstall = (cause: unknown) => {
     toast.error(t("settings.plugins.uninstallFailed"), {
       description: localizeContractError(cause, t),
@@ -195,6 +212,18 @@ function InstalledPluginRow({
           )}
         </span>
 
+        {hasUpdate && (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => update.mutate({}, { onError: failUpdate })}
+          >
+            {update.isPending ? <IconProgressDown /> : <IconArrowBigUpLines />}
+            {t("settings.plugins.update")}
+          </Button>
+        )}
+
         {plugin.installationValidity.validity === "valid" &&
           plugin.configuration.state !== "not_declared" && (
             <Button
@@ -203,6 +232,7 @@ function InstalledPluginRow({
               disabled={busy}
               onClick={() => onConfigure(plugin)}
             >
+              <IconSettingsBolt />
               {t("settings.plugins.configuration.configure")}
             </Button>
           )}

--- a/packages/app-shell/src/features/settings/plugin-sources-manager.tsx
+++ b/packages/app-shell/src/features/settings/plugin-sources-manager.tsx
@@ -1,6 +1,17 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Input, Switch, toast } from "@ora/ui";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Button,
+  Input,
+  Switch,
+  toast,
+} from "@ora/ui";
 import { IconLoader2, IconPlus, IconTrash } from "@tabler/icons-react";
 import { localizeContractError } from "../../i18n/contract-error";
 import {
@@ -26,7 +37,6 @@ export function PluginSourcesManager({ onBack }: { onBack: () => void }) {
   const updateSource = useUpdateMarketplaceSource();
   const [url, setUrl] = useState("");
   const [branch, setBranch] = useState("main");
-  const [useProxy, setUseProxy] = useState(false);
 
   const sources = sourcesQuery.data?.sources ?? [];
 
@@ -35,7 +45,7 @@ export function PluginSourcesManager({ onBack }: { onBack: () => void }) {
     const nextBranch = branch.trim();
     if (nextUrl === "" || nextBranch === "") return;
     addSource.mutate(
-      { url: nextUrl, branch: nextBranch, useProxy },
+      { url: nextUrl, branch: nextBranch, useProxy: false },
       {
         onSuccess: () => {
           setUrl("");
@@ -52,18 +62,29 @@ export function PluginSourcesManager({ onBack }: { onBack: () => void }) {
 
   return (
     <div className="space-y-5">
-      <header className="flex flex-wrap items-center gap-3">
-        <Button variant="ghost" size="sm" className="shrink-0" onClick={onBack}>
-          {t("settings.plugins.back")}
-        </Button>
-        <div className="min-w-0 flex-1">
-          <h2 className="text-lg font-semibold">
-            {t("settings.plugins.manageSources")}
-          </h2>
-          <p className="mt-1 text-sm leading-6 text-muted-foreground">
-            {t("settings.plugins.manageSourcesDescription")}
-          </p>
-        </div>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink render={<button type="button" onClick={onBack} />}>
+              {t("settings.plugins.title")}
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>
+              {t("settings.plugins.manageSources")}
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <header>
+        <h2 className="text-lg font-semibold">
+          {t("settings.plugins.manageSources")}
+        </h2>
+        <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
+          {t("settings.plugins.manageSourcesDescription")}
+        </p>
       </header>
 
       <form
@@ -87,16 +108,6 @@ export function PluginSourcesManager({ onBack }: { onBack: () => void }) {
           aria-label={t("settings.plugins.sourceBranch")}
           className="bg-background sm:w-40"
         />
-        <div className="flex items-center gap-2 sm:pl-2">
-          <Switch
-            checked={useProxy}
-            onCheckedChange={setUseProxy}
-            aria-label={t("settings.plugins.sourceUseProxy")}
-          />
-          <span className="text-xs text-muted-foreground">
-            {t("settings.plugins.sourceUseProxy")}
-          </span>
-        </div>
         <Button
           type="submit"
           variant="outline"
@@ -133,25 +144,31 @@ export function PluginSourcesManager({ onBack }: { onBack: () => void }) {
                   <span className="font-mono">{source.branch}</span>
                 </span>
               </span>
-              <Switch
-                checked={source.useProxy}
-                disabled={updateSource.isPending}
-                onCheckedChange={(checked) =>
-                  updateSource.mutate(
-                    { url: source.url, useProxy: checked },
-                    {
-                      onError: (cause) =>
-                        toast.error(
-                          t("settings.plugins.sourceProxyUpdateFailed"),
-                          {
-                            description: localizeContractError(cause, t),
-                          },
-                        ),
-                    },
-                  )
-                }
-                aria-label={`${t("settings.plugins.sourceUseProxy")}: ${source.url}`}
-              />
+              <label className="flex items-center gap-2">
+                <Switch
+                  checked={source.useProxy}
+                  title={t("settings.plugins.sourceUseProxy")}
+                  disabled={updateSource.isPending}
+                  onCheckedChange={(checked) =>
+                    updateSource.mutate(
+                      { url: source.url, useProxy: checked },
+                      {
+                        onError: (cause) =>
+                          toast.error(
+                            t("settings.plugins.sourceProxyUpdateFailed"),
+                            {
+                              description: localizeContractError(cause, t),
+                            },
+                          ),
+                      },
+                    )
+                  }
+                  aria-label={`${t("settings.plugins.sourceUseProxy")}: ${source.url}`}
+                />
+                <span className="text-xs text-muted-foreground">
+                  {t("settings.plugins.sourceUseProxy")}
+                </span>
+              </label>
               <Button
                 variant="ghost"
                 size="icon-sm"

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -125,9 +125,6 @@ it("renders marketplace plugins from the registry index", async () => {
   renderSettings(client);
 
   expect(await screen.findByText("Weather")).toBeInTheDocument();
-  expect(
-    screen.getByText(/weather · official · agent · 1.2.0/),
-  ).toBeInTheDocument();
   expect(screen.getByText("Weather plugin")).toBeInTheDocument();
 });
 
@@ -148,7 +145,7 @@ it("installs a marketplace plugin through the backend", async () => {
     version: "1.2.0",
   });
   expect(
-    await screen.findByRole("button", { name: /卸载|Uninstall/ }),
+    await screen.findByRole("button", { name: /已安装|Installed/ }),
   ).toBeInTheDocument();
 });
 

--- a/packages/app-shell/src/features/settings/plugins-settings.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.tsx
@@ -1,37 +1,49 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AvailablePlugin, InstalledPlugin } from "@ora/contracts";
+import { Button, Input, toast } from "@ora/ui";
 import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  Button,
-  Input,
-  toast,
-} from "@ora/ui";
-import {
+  IconArrowBigUpLines,
+  IconCircleCheck,
   IconLoader2,
+  IconPlus,
+  IconProgressDown,
   IconRefresh,
   IconSearch,
+  IconSettings,
   IconUpload,
 } from "@tabler/icons-react";
 import { localizeContractError } from "../../i18n/contract-error";
 import { usePlatform } from "../../platform";
 import { useAvailablePlugins } from "../../state/hooks/use-available-plugins";
 import { useInstallPlugin } from "../../state/hooks/use-install-plugin";
+import { useUpdatePlugin } from "../../state/hooks/use-update-plugin";
 import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
 import { usePluginImport } from "../../state/hooks/use-plugin-import";
-import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
 import { usePluginRegistrySync } from "../../state/hooks/use-plugin-registry-sync";
 import { PluginLogo } from "./plugin-logo";
 import { PluginSourcesManager } from "./plugin-sources-manager";
 import { PluginManager } from "./plugin-manager";
 import { PluginConfigurationEditor } from "./plugin-configuration-editor";
 import type { PluginConfigurationNavigationGuard } from "./plugin-configuration-editor";
+
+/** The registry kind order shown in the marketplace, mirroring the contracts docs. */
+const MARKETPLACE_KIND_ORDER = [
+  "agent",
+  "workbench",
+  "webview",
+  "skill",
+  "mcp",
+];
+
+/** Readable marketplace section labels for the known plugin kinds. */
+const MARKETPLACE_KIND_LABELS: Record<string, string> = {
+  agent: "Agent",
+  workbench: "Workbench",
+  webview: "Webview",
+  skill: "Skill",
+  mcp: "MCP",
+};
 
 /**
  * The plugin marketplace pane backed by the registry contract: the browse grid reads the
@@ -67,6 +79,13 @@ export function PluginsSettings({
     return byId;
   }, [installed.data]);
 
+  const availableById = useMemo(() => {
+    const byId = new Map<string, AvailablePlugin>();
+    for (const plugin of available.data?.plugins ?? [])
+      byId.set(plugin.id, plugin);
+    return byId;
+  }, [available.data]);
+
   const needle = query.trim().toLowerCase();
   const visiblePlugins = useMemo(
     () =>
@@ -84,6 +103,24 @@ export function PluginsSettings({
       ),
     [available.data, needle],
   );
+
+  const groupedPlugins = useMemo(() => {
+    const byKind = new Map<string, AvailablePlugin[]>();
+    for (const plugin of visiblePlugins) {
+      const group = byKind.get(plugin.kind) ?? [];
+      group.push(plugin);
+      byKind.set(plugin.kind, group);
+    }
+    return [...byKind.entries()].sort(([left], [right]) => {
+      const leftRank = MARKETPLACE_KIND_ORDER.indexOf(left);
+      const rightRank = MARKETPLACE_KIND_ORDER.indexOf(right);
+      const leftIndex =
+        leftRank === -1 ? MARKETPLACE_KIND_ORDER.length : leftRank;
+      const rightIndex =
+        rightRank === -1 ? MARKETPLACE_KIND_ORDER.length : rightRank;
+      return leftIndex - rightIndex || left.localeCompare(right);
+    });
+  }, [visiblePlugins]);
 
   const updatedAt = available.data?.updatedAt;
   const lastSynced =
@@ -138,6 +175,7 @@ export function PluginsSettings({
       <PluginManager
         plugins={installed.data ?? []}
         onBack={() => setManaging(false)}
+        availableById={availableById}
         onConfigure={(plugin) =>
           setConfigurationPlugin({
             id: plugin.id,
@@ -204,6 +242,7 @@ export function PluginsSettings({
               size="sm"
               onClick={() => setManaging(true)}
             >
+              <IconSettings />
               {t("settings.plugins.manageInstalled")}
             </Button>
             <Button
@@ -211,6 +250,7 @@ export function PluginsSettings({
               size="sm"
               onClick={() => setManagingSources(true)}
             >
+              <IconSettings />
               {t("settings.plugins.manageSources")}
             </Button>
             <Button
@@ -238,13 +278,22 @@ export function PluginsSettings({
           {t("settings.plugins.empty")}
         </p>
       ) : (
-        <div className="divide-y divide-border border-y border-border">
-          {visiblePlugins.map((plugin) => (
-            <AvailablePluginRow
-              key={plugin.id}
-              plugin={plugin}
-              installed={installedById.get(plugin.id)}
-            />
+        <div className="space-y-6">
+          {groupedPlugins.map(([kind, plugins]) => (
+            <section key={kind}>
+              <h3 className="mb-2 text-sm font-semibold">
+                {MARKETPLACE_KIND_LABELS[kind] ?? kind}
+              </h3>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {plugins.map((plugin) => (
+                  <AvailablePluginCard
+                    key={plugin.id}
+                    plugin={plugin}
+                    installed={installedById.get(plugin.id)}
+                  />
+                ))}
+              </div>
+            </section>
           ))}
         </div>
       )}
@@ -252,8 +301,8 @@ export function PluginsSettings({
   );
 }
 
-/** One registry entry with backend-driven install and uninstall actions. */
-function AvailablePluginRow({
+/** One marketplace entry presented as a compact card with its brand, title, and summary. */
+function AvailablePluginCard({
   plugin,
   installed,
 }: {
@@ -262,116 +311,81 @@ function AvailablePluginRow({
 }) {
   const { t } = useTranslation();
   const install = useInstallPlugin(plugin.id);
-  const mutations = usePluginMutations(
-    plugin.id,
-    installed?.kind === "agent" ? installed.name : undefined,
-  );
-  const busy = install.isPending || mutations.uninstall.isPending;
-  const [uninstallOpen, setUninstallOpen] = useState(false);
-  const [deleteData, setDeleteData] = useState(true);
+  const update = useUpdatePlugin(plugin.id);
+  const busy = install.isPending || update.isPending;
+  const hasUpdate = plugin.version !== installed?.version;
 
   const failInstall = (cause: unknown) => {
     toast.error(t("settings.plugins.installFailed"), {
       description: localizeContractError(cause, t),
     });
   };
-  const failUninstall = (cause: unknown) => {
-    toast.error(t("settings.plugins.uninstallFailed"), {
+  const failUpdate = (cause: unknown) => {
+    toast.error(t("settings.plugins.updateFailed"), {
       description: localizeContractError(cause, t),
     });
   };
 
   return (
-    <>
-      <div className="flex items-center gap-3 py-3">
-        <PluginLogo logo={plugin.logo} />
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-sm font-medium">
-            {plugin.title || plugin.name}
-          </span>
-          <span className="block truncate text-xs text-muted-foreground">
-            {[plugin.name, plugin.namespace, plugin.kind, plugin.version]
-              .filter(Boolean)
-              .join(" · ")}
-          </span>
-          {plugin.description !== "" && (
-            <span className="mt-0.5 block truncate text-[11px] text-muted-foreground/80">
-              {plugin.description}
-            </span>
-          )}
+    <div className="flex items-start gap-3 rounded-lg border border-border p-3">
+      <PluginLogo logo={plugin.logo} />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium">
+          {plugin.title || plugin.name}
         </span>
+        {plugin.description !== "" && (
+          <span className="mt-0.5 block line-clamp-2 text-xs leading-5 text-muted-foreground">
+            {plugin.description}
+          </span>
+        )}
+      </span>
+      <span className="flex shrink-0 items-center">
         {busy ? (
-          <Button variant="outline" size="sm" disabled className="shrink-0">
-            <IconLoader2 className="animate-spin" />
-            {t(
-              installed === undefined
-                ? "settings.plugins.installing"
-                : "settings.plugins.uninstalling",
+          <Button
+            variant="outline"
+            size="icon-sm"
+            disabled
+            className="shrink-0"
+            aria-label={t(
+              update.isPending
+                ? "settings.plugins.updating"
+                : "settings.plugins.installing",
             )}
+          >
+            <IconProgressDown />
           </Button>
         ) : installed === undefined ? (
           <Button
             variant="outline"
-            size="sm"
+            size="icon-sm"
             className="shrink-0"
             onClick={() => install.mutate({}, { onError: failInstall })}
+            aria-label={t("settings.plugins.install")}
           >
-            {t("settings.plugins.install")}
+            <IconPlus />
+          </Button>
+        ) : hasUpdate ? (
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className="shrink-0"
+            aria-label={t("settings.plugins.update")}
+            onClick={() => update.mutate({}, { onError: failUpdate })}
+          >
+            <IconArrowBigUpLines />
           </Button>
         ) : (
           <Button
             variant="outline"
-            size="sm"
+            size="icon-sm"
+            disabled
             className="shrink-0"
-            onClick={() => setUninstallOpen(true)}
+            aria-label={t("settings.plugins.installed")}
           >
-            {t("settings.plugins.uninstall")}
+            <IconCircleCheck />
           </Button>
         )}
-      </div>
-      <AlertDialog
-        open={uninstallOpen}
-        onOpenChange={(open) => {
-          setUninstallOpen(open);
-          if (open) setDeleteData(true);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("settings.plugins.uninstallTitle", { name: plugin.name })}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("settings.plugins.uninstallDescription")}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={deleteData}
-              onChange={(event) => setDeleteData(event.target.checked)}
-            />
-            {t("settings.plugins.deleteConfigurationData")}
-          </label>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={mutations.uninstall.isPending}>
-              {t("common.cancel")}
-            </AlertDialogCancel>
-            <Button
-              variant="destructive"
-              disabled={mutations.uninstall.isPending}
-              onClick={() =>
-                mutations.uninstall.mutate(deleteData ? "delete" : "retain", {
-                  onError: failUninstall,
-                  onSuccess: () => setUninstallOpen(false),
-                })
-              }
-            >
-              {t("settings.plugins.uninstall")}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+      </span>
+    </div>
   );
 }

--- a/packages/app-shell/src/features/settings/settings-dialog.tsx
+++ b/packages/app-shell/src/features/settings/settings-dialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { localizeContractError } from "../../i18n/contract-error";
+import { appVersion } from "../../lib/app-version";
 import { usePlatform } from "../../platform";
 import {
   AlertDialog,
@@ -36,9 +37,9 @@ import {
   IconLanguage,
   IconLock,
   IconMoon,
+  IconProng,
   IconPuzzle,
   IconRobot,
-  IconRoute,
   IconShieldCheck,
   IconSparkles,
   IconSun,
@@ -133,7 +134,7 @@ export function SettingsDialog() {
     { id: "roles", icon: IconRobot, label: t("settings.nav.roles") },
     { id: "skills", icon: IconSparkles, label: t("settings.nav.skills") },
     { id: "plugins", icon: IconPuzzle, label: t("settings.nav.plugins") },
-    { id: "proxy", icon: IconRoute, label: t("settings.nav.proxy") },
+    { id: "proxy", icon: IconProng, label: t("settings.nav.proxy") },
     {
       id: "permissions",
       icon: IconShieldCheck,
@@ -204,10 +205,8 @@ export function SettingsDialog() {
                   );
                 })}
               </nav>
-              <p className="mt-auto hidden px-2 pb-1 pt-6 text-[10px] leading-4 text-muted-foreground sm:block">
-                {t("settings.productName")}
-                <br />
-                {t("settings.prototypeLabel")}
+              <p className="mt-auto hidden px-2 pb-1 pt-6 text-xs leading-5 text-muted-foreground sm:block">
+                v{appVersion}
               </p>
             </aside>
 

--- a/packages/app-shell/src/i18n/i18n-instance.ts
+++ b/packages/app-shell/src/i18n/i18n-instance.ts
@@ -347,8 +347,6 @@ export const translationResources = {
     "account.language": "语言",
     "account.switchEnglish": "English",
     "account.switchChinese": "简体中文",
-    "settings.productName": "Ora Agent IDE",
-    "settings.prototypeLabel": "原型设置",
     "settings.description":
       "配置 Ora 的界面、角色、技能、模型和 Agent 执行策略。",
     "settings.nav.appearance": "外观",
@@ -775,7 +773,7 @@ export const translationResources = {
     "settings.plugins.syncMarketplace": "同步插件市场",
     "settings.plugins.syncFailed": "同步插件市场失败。",
     "settings.plugins.back": "返回",
-    "settings.plugins.manageSources": "管理市场源",
+    "settings.plugins.manageSources": "管理市场",
     "settings.plugins.manageSourcesDescription":
       "添加或删除用于同步插件市场的 Git 源。列表顺序决定同名插件的优先级。",
     "settings.plugins.sourceUrl": "Git URL",
@@ -820,6 +818,9 @@ export const translationResources = {
     "settings.plugins.showLess": "收起",
     "settings.plugins.empty": "没有匹配的插件。",
     "settings.plugins.install": "安装",
+    "settings.plugins.update": "更新",
+    "settings.plugins.updating": "更新中",
+    "settings.plugins.updateFailed": "更新失败",
     "settings.plugins.uninstall": "卸载",
     "settings.plugins.uninstallTitle": "卸载“{{name}}”？",
     "settings.plugins.uninstallDescription":
@@ -1825,8 +1826,6 @@ export const translationResources = {
     "account.language": "Language",
     "account.switchEnglish": "English",
     "account.switchChinese": "简体中文",
-    "settings.productName": "Ora Agent IDE",
-    "settings.prototypeLabel": "Prototype settings",
     "settings.description":
       "Configure Ora appearance, roles, skills, models, and agent execution policies.",
     "settings.nav.appearance": "Appearance",
@@ -2299,7 +2298,7 @@ export const translationResources = {
     "settings.proxy.loadError": "Could not read proxy settings.",
     "settings.proxy.updateError": "Could not save proxy settings.",
     "settings.plugins.back": "Back",
-    "settings.plugins.manageSources": "Manage marketplace sources",
+    "settings.plugins.manageSources": "Manage marketplace",
     "settings.plugins.manageSourcesDescription":
       "Add or remove the Git sources used to sync the plugin marketplace. List order determines precedence for duplicate plugin ids.",
     "settings.plugins.sourceUrl": "Git URL",
@@ -2331,6 +2330,9 @@ export const translationResources = {
     "settings.plugins.showLess": "Show less",
     "settings.plugins.empty": "No matching plugins.",
     "settings.plugins.install": "Install",
+    "settings.plugins.update": "Update",
+    "settings.plugins.updating": "Updating",
+    "settings.plugins.updateFailed": "Update failed",
     "settings.plugins.uninstall": "Uninstall",
     "settings.plugins.uninstallTitle": "Uninstall {{name}}?",
     "settings.plugins.uninstallDescription":

--- a/packages/app-shell/src/lib/README.md
+++ b/packages/app-shell/src/lib/README.md
@@ -11,6 +11,7 @@ not grow into a feature module: chat, diff, and files keep their own folders.
 - Review-panel motion helpers (`panel-motion.ts`)
 - Workspace path matching shared by Changes and chat inline links (`workspace-path.ts`)
 - Host path directory derivation for "open folder" actions (`path.ts`)
+- Workspace version for the settings stamp, injected by the desktop build (`app-version.ts`)
 
 ## Path matching
 

--- a/packages/app-shell/src/lib/app-version.ts
+++ b/packages/app-shell/src/lib/app-version.ts
@@ -1,0 +1,11 @@
+/**
+ * The desktop build injects the workspace version it reads from Cargo.toml at compile time.
+ * Other hosts and the app-shell test suite do not set the global, so they fall back to the
+ * workspace default and the settings stamp still renders a value.
+ */
+declare const __ORA_APP_VERSION__: string | undefined;
+
+export const appVersion =
+  typeof __ORA_APP_VERSION__ === "string" && __ORA_APP_VERSION__ !== ""
+    ? __ORA_APP_VERSION__
+    : "0.0.0";

--- a/packages/app-shell/src/state/hooks/use-update-plugin.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-update-plugin.test.tsx
@@ -1,0 +1,55 @@
+import { act, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  createMockClient,
+  createMockClientState,
+} from "../../test/mock-client";
+import { renderHookWithClient } from "../../test/hook-harness";
+import { useUpdatePlugin } from "./use-update-plugin";
+
+describe("useUpdatePlugin", () => {
+  it("updates an installed plugin and refreshes the installed surface", async () => {
+    const state = createMockClientState();
+    state.availablePlugins.push({
+      id: "official/weather",
+      name: "weather",
+      title: "Weather",
+      kind: "agent",
+      namespace: "official",
+      version: "1.1.0",
+      description: "Weather",
+      logo: null,
+    });
+    state.installedPlugins.push({
+      id: "official/weather",
+      namespace: "official",
+      name: "weather",
+      displayName: "weather",
+      version: "1.0.0",
+      description: "Weather",
+      homepage: null,
+      license: null,
+      kind: "agent",
+      agentDisplayName: "weather",
+      logo: null,
+      installationValidity: { validity: "valid" },
+      configuration: { state: "not_declared" },
+      runtime: "stopped",
+    });
+    const client = createMockClient(state);
+    const { result } = renderHookWithClient(
+      () => useUpdatePlugin("official/weather"),
+      client,
+    );
+
+    act(() => result.current.mutate({}));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(
+      state.installedPlugins.find((item) => item.id === "official/weather"),
+    ).toMatchObject({
+      id: "official/weather",
+      version: "1.1.0",
+    });
+  });
+});

--- a/packages/app-shell/src/state/hooks/use-update-plugin.ts
+++ b/packages/app-shell/src/state/hooks/use-update-plugin.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useContractsClient } from "../../contracts-client-context";
+import { queryKeys } from "./query-keys";
+
+/**
+ * Updates one installed marketplace plugin to the version its source publishes and refreshes
+ * the installed and available surfaces once the backend settles. The optional `signal` lets the
+ * caller cancel the pending request; the installed lookup is refreshed either way.
+ */
+export function useUpdatePlugin(pluginId: string) {
+  const client = useContractsClient();
+  const queryClient = useQueryClient();
+  const invalidate = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.installedPlugins }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.availablePlugins }),
+    ]);
+
+  return useMutation({
+    mutationFn: ({ signal }: { signal?: AbortSignal } = {}) =>
+      client.plugin.update({ pluginId }, { signal }),
+    onSettled: invalidate,
+  });
+}

--- a/packages/app-shell/src/test/mock-client.ts
+++ b/packages/app-shell/src/test/mock-client.ts
@@ -563,6 +563,22 @@ export function createMockClient(state: MockClientState): ContractsClient {
         });
         return { pluginId: req.pluginId };
       },
+      update: async (req) => {
+        const available = state.availablePlugins.find(
+          (p) => p.id === req.pluginId,
+        );
+        if (!available)
+          throw new Error(`available plugin ${req.pluginId} not found`);
+        const installed = state.installedPlugins.find(
+          (p) => p.id === req.pluginId,
+        );
+        if (!installed)
+          throw new Error(`installed plugin ${req.pluginId} not found`);
+        installed.version = available.version;
+        installed.description = available.description;
+        installed.logo = available.logo;
+        return { pluginId: req.pluginId };
+      },
     },
     agent: {
       list: async () => ({ agents: [...state.agents] }),

--- a/packages/contracts/src/client.ts
+++ b/packages/contracts/src/client.ts
@@ -217,6 +217,8 @@ export function createContractsClient(
         executeOperation("uninstallPlugin", request, transport, options),
       install: (request, options) =>
         executeOperation("installPlugin", request, transport, options),
+      update: (request, options) =>
+        executeOperation("updatePlugin", request, transport, options),
       import: (request, options) =>
         executeOperation("importPlugin", request, transport, options),
     },

--- a/packages/contracts/src/endpoints.ts
+++ b/packages/contracts/src/endpoints.ts
@@ -5,7 +5,7 @@ import type { AppEvent, WatchAppEventsRequest } from "./app_event.js";
 import type { DeveloperModeResponse, GetDeveloperModeRequest, SetDeveloperModeRequest } from "./developerMode.js";
 import type { ListProjectDirectoryRequest, ListWorkspaceDirectoryRequest, ListWorkspaceDirectoryResponse, ReadProjectFileRequest, ReadWorkspaceFileRequest, ReadWorkspaceFileResponse, SearchProjectRequest, SearchWorkspaceRequest, SearchWorkspaceResponse, WatchProjectRequest, WatchWorkspaceRequest, WorkspaceFileEventBatch } from "./file-system.js";
 import type { GetGitIdentityRequest, GitIdentityResponse } from "./git.js";
-import type { ActivatePluginRequest, ActivatePluginResponse, AddMarketplaceSourceRequest, AddMarketplaceSourceResponse, DeleteMarketplaceSourceRequest, DeleteMarketplaceSourceResponse, GetPluginConfigurationRequest, GetPluginConfigurationResponse, ImportPluginRequest, ImportPluginResponse, InstallPluginRequest, InstallPluginResponse, ListAvailablePluginsRequest, ListAvailablePluginsResponse, ListInstalledPluginsRequest, ListInstalledPluginsResponse, ListMarketplaceSourcesRequest, ListMarketplaceSourcesResponse, ResetPluginConfigurationRequest, ResetPluginConfigurationResponse, SavePluginConfigurationRequest, SavePluginConfigurationResponse, ScanPluginsRequest, ScanPluginsResponse, StopPluginRequest, StopPluginResponse, SyncAvailablePluginsRequest, SyncAvailablePluginsResponse, UninstallPluginRequest, UninstallPluginResponse, UpdateMarketplaceSourceRequest, UpdateMarketplaceSourceResponse } from "./plugin.js";
+import type { ActivatePluginRequest, ActivatePluginResponse, AddMarketplaceSourceRequest, AddMarketplaceSourceResponse, DeleteMarketplaceSourceRequest, DeleteMarketplaceSourceResponse, GetPluginConfigurationRequest, GetPluginConfigurationResponse, ImportPluginRequest, ImportPluginResponse, InstallPluginRequest, InstallPluginResponse, ListAvailablePluginsRequest, ListAvailablePluginsResponse, ListInstalledPluginsRequest, ListInstalledPluginsResponse, ListMarketplaceSourcesRequest, ListMarketplaceSourcesResponse, ResetPluginConfigurationRequest, ResetPluginConfigurationResponse, SavePluginConfigurationRequest, SavePluginConfigurationResponse, ScanPluginsRequest, ScanPluginsResponse, StopPluginRequest, StopPluginResponse, SyncAvailablePluginsRequest, SyncAvailablePluginsResponse, UninstallPluginRequest, UninstallPluginResponse, UpdateMarketplaceSourceRequest, UpdateMarketplaceSourceResponse, UpdatePluginRequest, UpdatePluginResponse } from "./plugin.js";
 import type { CreateProjectRequest, CreateProjectResponse, DeleteProjectRequest, DeleteProjectResponse, GetProjectRequest, GetProjectResponse, ListProjectBranchesRequest, ListProjectBranchesResponse, ListProjectsRequest, ListProjectsResponse, UpdateProjectRequest, UpdateProjectResponse } from "./project.js";
 import type { GetProxySettingsRequest, GetProxySettingsResponse, SetProxySettingsRequest, SetProxySettingsResponse } from "./proxy.js";
 import type { GetRuntimeLogLevelRequest, RuntimeLogLevelStateResponse, SetRuntimeLogLevelRequest } from "./runtimeLogLevel.js";
@@ -91,6 +91,7 @@ export type RequestByOperation = {
   stopPlugin: StopPluginRequest;
   uninstallPlugin: UninstallPluginRequest;
   installPlugin: InstallPluginRequest;
+  updatePlugin: UpdatePluginRequest;
   importPlugin: ImportPluginRequest;
   getProxySettings: GetProxySettingsRequest;
   setProxySettings: SetProxySettingsRequest;
@@ -202,6 +203,7 @@ export type ResponseByOperation = {
   stopPlugin: StopPluginResponse;
   uninstallPlugin: UninstallPluginResponse;
   installPlugin: InstallPluginResponse;
+  updatePlugin: UpdatePluginResponse;
   importPlugin: ImportPluginResponse;
   getProxySettings: GetProxySettingsResponse;
   setProxySettings: SetProxySettingsResponse;
@@ -754,6 +756,14 @@ export const endpoints = {
     memberName: "install",
     requestType: "InstallPluginRequest",
     responseType: "InstallPluginResponse",
+    responseMode: "unary",
+  },
+  updatePlugin: {
+    operationName: "updatePlugin",
+    namespace: "plugin",
+    memberName: "update",
+    requestType: "UpdatePluginRequest",
+    responseType: "UpdatePluginResponse",
     responseMode: "unary",
   },
   importPlugin: {

--- a/packages/contracts/src/plugin.ts
+++ b/packages/contracts/src/plugin.ts
@@ -390,3 +390,13 @@ export type UpdateMarketplaceSourceRequest = { url: string; useProxy: boolean };
 export type UpdateMarketplaceSourceResponse = {
   sources: Array<MarketplaceSource>;
 };
+
+/**
+ * Requests updating one installed marketplace plugin to the version its source publishes.
+ */
+export type UpdatePluginRequest = { pluginId: string };
+
+/**
+ * Confirms the identifier updated after the new release is verified and stale versions removed.
+ */
+export type UpdatePluginResponse = { pluginId: string };

--- a/xtask/src/export_contracts.rs
+++ b/xtask/src/export_contracts.rs
@@ -374,6 +374,8 @@ fn contract_module_for_type(type_name: &str) -> &'static str {
         | "UninstallPluginResponse"
         | "InstallPluginRequest"
         | "InstallPluginResponse"
+        | "UpdatePluginRequest"
+        | "UpdatePluginResponse"
         | "ImportPluginRequest"
         | "ImportPluginResponse"
         | "AddMarketplaceSourceRequest"

--- a/xtask/src/frontend/namespaces/plugin.rs
+++ b/xtask/src/frontend/namespaces/plugin.rs
@@ -111,6 +111,13 @@ pub(super) const ENDPOINTS: &[FrontendEndpoint] = &[
         response_type: "InstallPluginResponse",
     },
     FrontendEndpoint {
+        operation_name: "updatePlugin",
+        namespace: NAMESPACE,
+        member_name: "update",
+        request_type: "UpdatePluginRequest",
+        response_type: "UpdatePluginResponse",
+    },
+    FrontendEndpoint {
         operation_name: "importPlugin",
         namespace: NAMESPACE,
         member_name: "import",


### PR DESCRIPTION
修改内容
- crates/plugin-manager/src/install.rs：新增 Installer::update + UpdateError（NotFound/AlreadyUpToDate/Downgrade/Install/Retire）。复用 Install 的下载、SHA-256 校验与安全解压；以 <data>/plugins/installed/<ns>/<name> 下最高 SemVer 目录为准，拒绝“未安装/已是最新/降级”，成功后删除其余旧版本目录。
- crates/plugin-manager/src/lib.rs、README.md：导出 UpdateError 并补充 update 职责说明。
- crates/backend/src/plugin.rs：把原 install 里的“按市场源优先级解析 release manifest + 命中源代理策略”抽取为 resolve_marketplace_release；“是否走代理”抽取为 download_proxy_for，install 与 update 共用。新增 PluginApi::update（解析 → lifecycle.stop_plugin 停老进程 → 按命中源代理下载更新 → finalize_new_install 重扫）。
- crates/backend/src/bootstrap.rs、Cargo.toml：update_plugin 透传 + sync_plugin_agents()；补 ora-plugin-manifest 直接依赖（用于命名返回类型）。
- crates/contracts/src/plugin.rs：新增 UpdatePluginRequest/Response、导出与序列化测试。
- Tauri/xtask/transport：commands.rs、app_commands.rs、permissions/main-commands.toml 注册 update_plugin；xtask/src/frontend/namespaces/plugin.rs 与 xtask/src/export_contracts.rs 注册 updatePlugin；tauri-transport.ts 增加映射。
- 前端：cargo xtask export-contracts 重新生成 plugin.ts/endpoints.ts；手写 client.ts 增加 plugin.update；新增 use-update-plugin.ts hook；plugins-settings.tsx 市场行与 plugin-manager.tsx 已安装页均显示“更新”按钮；mock-client.ts 增加 update mock；i18n 中英文 key。
- packages/app-shell/src/features/settings/plugins-settings.tsx：按 kind 分组（Agent/Workbench/Webview/Skill/MCP）展示，两列网格；卡片只展示 logo、title、description（去掉 name · namespace · kind · version 元信息行）。
- 卡片右侧按钮改为纯图标：
  - 未安装 → IconPlus（点击安装）
  - 安装中/更新中 → IconProgressDown
  - 已安装且最新 → IconCircleCheck
  - 已安装有更新 → IconArrowBigUpLines（点击更新）
- 市集卡片不再有卸载入口（卸载只在“管理插件”界面），移除对应 AlertDialog 与 usePluginMutations 调用。
- plugin-manager.tsx：更新按钮 → IconArrowBigUpLines，更新中 → IconProgressDown；“配置”按钮左侧新增 IconSettingsBolt。

- plugin-sources-manager.tsx：页面顶部改为与管理插件一致的面包屑导航（点击插件名返回）；移除添加表单里的“使用代理”开关（新增源默认 useProxy: false）；市场源卡片开关保留 title="使用代理" 并补上“使用代理”文字说明。
- settings-dialog.tsx：代理导航图标换成 IconProng；左下角“Ora Agent IDE 原型设置”替换为 v0.0.0（字号从 text-[10px] 调大到 text-xs）。
- apps/desktop/vite.config.ts：构建时读取 Cargo.toml 的 [workspace.package] version 注入 __ORA_APP_VERSION__。
- 新增 packages/app-shell/src/lib/app-version.ts（注入值 + 测试/其他宿主回退 0.0.0）。
- i18n-instance.ts：移除不再使用的 settings.productName / settings.prototypeLabel。

新增能力
- 市场行与“管理插件”页均可对已安装插件一键更新：市场源按配置优先级解析，命中源的 use_proxy 决定是否走代理；更新前自动停止运行中的旧进程；新版本校验通过后仅保留新版本目录；更新后自动重扫快照并同步 Agent 集合。
- 版本号由 Cargo.toml 单一来源驱动，之后 bump 版本无需改前端。
- 市集卡片状态与 GPT 插件市场风格一致：四种状态纯图标、无汉字。

测试结果
- Rust：ora-plugin-manager 45 通过（含 4 个新 update 用例）、ora-contracts 40 通过、ora-backend lib 197 通过；cargo clippy（4 个改动 crate，-D warnings）与 cargo fmt --all --check 全绿。
- Tauri：cargo check -p ora-desktop 通过（build.rs 命令注册校验满足）。
- 前端：tauri-transport 27 通过（含新 updatePlugin 映射用例）；app-shell use-update-plugin/use-install-plugin 2 通过、plugins-settings.test.tsx 14 通过；app-shell 与 desktop tsc、改动文件 eslint、prettier 均通过。