### PR TITLE
让 Agent 插件通过 Host 托管子进程

### DIFF
--- a/crates/plugin-lifecycle/Cargo.toml
+++ b/crates/plugin-lifecycle/Cargo.toml
@@ -23,7 +23,7 @@ ora-process = { workspace = true }
 ora-utils = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+tokio = { workspace = true, features = ["io-util", "macros", "rt", "sync", "time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/plugin-lifecycle/README.md
+++ b/crates/plugin-lifecycle/README.md
@@ -105,7 +105,12 @@ unknown `ora/storage/*` methods get `-32601`. Filesystem work runs on the blocki
 `PluginProcessHost` lets a plugin ask the host to own a subprocess on its behalf instead of
 spawning one itself inside its own sandboxed runtime — the process is created and torn down
 through `ora-process`'s tree-wide termination (a Windows Job Object or a Unix process group), the
-same guarantee every other Ora-managed child process already gets.
+same guarantee every other Ora-managed child process already gets. Only agent plugins can reach
+it: `DenoPluginRuntimeLauncher` mounts `PluginProcessHost` per launch based on
+`PluginLaunchRequest::allow_childprocess`, which is set only for the agent contribution kind. A
+workbench, webview, skill, or MCP plugin runs with zero Deno permissions specifically so it cannot
+start a process (see `permissions::permissions_for`); every `ora/childprocess/*` call from one of
+those kinds gets the same `-32601` a genuinely unknown method would.
 
 | Method                        | Params                           | Result                                   |
 | ----------------------------- | -------------------------------- | ---------------------------------------- |
@@ -121,7 +126,14 @@ The host pushes back three notifications the plugin never declares receiving (mi
 `processId` is scoped to one plugin generation, not globally unique. Failures carry `data.kind`
 `invalid_params` / `invalid_command` (`-32602`), `not_found` (`-32004`), `program_not_found` or
 `io` (`-32000`) — `program_not_found` means the OS could not resolve the executable, distinct from
-any other spawn or I/O failure.
+any other spawn or I/O failure. `write` rejects a `bytesBase64` payload that would decode to more
+than `MAX_WRITE_BYTES` (8 MiB, mirroring `MAX_STORAGE_FILE_BYTES`) as `invalid_params` before
+decoding it, so a plugin cannot force unbounded host memory growth through one oversized write.
+
+The exit notification for one process is never sent ahead of its last `stdout`/`stderr` chunk: the
+exit watcher joins that process's output-pumping tasks before pushing `ora/childprocess/exit`,
+even though the process's `wait()` and its pipes are read by independent tasks that would otherwise
+race.
 
 Every process a plugin generation spawned this way is killed, best effort, the moment that
 generation's `PluginRuntime` reports exit for any reason — intentional stop, uninstall, restart,

--- a/crates/plugin-lifecycle/README.md
+++ b/crates/plugin-lifecycle/README.md
@@ -72,7 +72,14 @@ After a successful handshake the registration is validated against the manifest 
 declare emitted notifications. Webview, skill, MCP, and Hook plugins cannot register because they
 have no process. Agent contracts are verified by the backend's agent runtime, not here.
 
-## Storage host methods
+## Host request methods
+
+Every plugin process launches with exactly one `HostRequestHandler` (`ora-plugin-runtime`'s
+`launch` is monomorphic over it), so `DenoPluginRuntimeLauncher::launch` composes the two request
+namespaces below into one small dispatcher (`PluginHostRequests` in `runtime.rs`) that routes by
+method prefix.
+
+### Storage
 
 `PluginStorage` serves `ora/storage/list`, `read`, `write`, and `remove`, all taking a logical
 `path` relative to the plugin's data directory (`""` is the directory itself for `list`):
@@ -92,6 +99,35 @@ capped at `MAX_STORAGE_FILE_BYTES` (8 MiB) in both directions because base64 mus
 frame. Failures are JSON-RPC errors whose `data.kind` is one of `invalid_params` (`-32602`),
 `invalid_path` (`-32602`), `not_found` (`-32004`), `too_large` (`-32005`), or `io` (`-32000`);
 unknown `ora/storage/*` methods get `-32601`. Filesystem work runs on the blocking pool.
+
+### Child processes
+
+`PluginProcessHost` lets a plugin ask the host to own a subprocess on its behalf instead of
+spawning one itself inside its own sandboxed runtime — the process is created and torn down
+through `ora-process`'s tree-wide termination (a Windows Job Object or a Unix process group), the
+same guarantee every other Ora-managed child process already gets.
+
+| Method                        | Params                           | Result                                   |
+| ----------------------------- | -------------------------------- | ---------------------------------------- |
+| `ora/childprocess/spawn`      | `{ command, args?, cwd?, env? }` | `{ processId, pid }`                     |
+| `ora/childprocess/write`      | `{ processId, bytesBase64 }`     | `{}`                                     |
+| `ora/childprocess/closeStdin` | `{ processId }`                  | `{}` (signals EOF, does not kill)        |
+| `ora/childprocess/kill`       | `{ processId }`                  | `{}` (idempotent, best-effort tree-kill) |
+
+The host pushes back three notifications the plugin never declares receiving (mirroring how
+`agent/acp` already flows host→plugin): `ora/childprocess/stdout` and `ora/childprocess/stderr`
+(`{ processId, bytesBase64 }`, raw chunks — the plugin owns any line framing) and
+`ora/childprocess/exit` (`{ processId, code, signal }`, `signal` only ever set on Unix).
+`processId` is scoped to one plugin generation, not globally unique. Failures carry `data.kind`
+`invalid_params` / `invalid_command` (`-32602`), `not_found` (`-32004`), `program_not_found` or
+`io` (`-32000`) — `program_not_found` means the OS could not resolve the executable, distinct from
+any other spawn or I/O failure.
+
+Every process a plugin generation spawned this way is killed, best effort, the moment that
+generation's `PluginRuntime` reports exit for any reason — intentional stop, uninstall, restart,
+or failure (`PluginProcessHost::kill_all`, awaited off `wait_for_exit` in
+`DenoPluginRuntimeLauncher::launch`) — so a host-spawned process never outlives the plugin that
+asked for it.
 
 ## Data plane
 

--- a/crates/plugin-lifecycle/src/childprocess.rs
+++ b/crates/plugin-lifecycle/src/childprocess.rs
@@ -26,6 +26,7 @@ use ora_process::{ManagedProcess, ProcessSpawner, ProcessSpec, ProcessStdio};
 use serde_json::{Value, json};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
 
 /// Spawns one child process; returns `{ processId, pid }`.
 pub const CHILDPROCESS_SPAWN_METHOD: &str = "ora/childprocess/spawn";
@@ -49,6 +50,15 @@ const IO_CODE: i64 = -32000;
 
 /// Chunk size used when pumping a spawned process's stdout or stderr into notifications.
 const READ_CHUNK_BYTES: usize = 32 * 1024;
+
+/// Upper bound on one `write` request's decoded payload, mirroring
+/// [`crate::storage::MAX_STORAGE_FILE_BYTES`] so a plugin cannot force unbounded host memory
+/// growth by streaming an oversized chunk to a spawned process's stdin.
+pub(crate) const MAX_WRITE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Longest base64 string that can decode to `MAX_WRITE_BYTES`, checked before `BASE64.decode`
+/// allocates so an oversized payload is rejected without ever being decoded.
+const MAX_WRITE_BASE64_LEN: usize = MAX_WRITE_BYTES.div_ceil(3) * 4;
 
 /// Stable classification of a child-process failure, serialized as `data.kind`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,6 +137,11 @@ enum StdinCommand {
 struct Tracked<P> {
     process: Arc<P>,
     stdin_tx: mpsc::Sender<StdinCommand>,
+    /// Joined by `watch_exit` before it pushes the exit notification: `wait()` and these pump
+    /// tasks race independently against the same pipes, so without joining them first the exit
+    /// notification could reach the plugin before the last stdout/stderr chunk does.
+    stdout_done: JoinHandle<()>,
+    stderr_done: JoinHandle<()>,
 }
 
 struct Inner<S: ProcessSpawner> {
@@ -263,6 +278,18 @@ where
         tokio::spawn(run_stdin_writer(stdin, stdin_rx));
 
         let process = Arc::new(process);
+        let stdout_done = tokio::spawn(pump_output(
+            self.clone(),
+            process_id.clone(),
+            stdout,
+            CHILDPROCESS_STDOUT_METHOD,
+        ));
+        let stderr_done = tokio::spawn(pump_output(
+            self.clone(),
+            process_id.clone(),
+            stderr,
+            CHILDPROCESS_STDERR_METHOD,
+        ));
         self.0
             .tracked
             .lock()
@@ -272,21 +299,11 @@ where
                 Tracked {
                     process: Arc::clone(&process),
                     stdin_tx,
+                    stdout_done,
+                    stderr_done,
                 },
             );
 
-        tokio::spawn(pump_output(
-            self.clone(),
-            process_id.clone(),
-            stdout,
-            CHILDPROCESS_STDOUT_METHOD,
-        ));
-        tokio::spawn(pump_output(
-            self.clone(),
-            process_id.clone(),
-            stderr,
-            CHILDPROCESS_STDERR_METHOD,
-        ));
         tokio::spawn(watch_exit(self.clone(), process_id.clone(), process));
 
         Ok(json!({ "processId": process_id, "pid": pid }))
@@ -303,6 +320,13 @@ where
                     "missing string bytesBase64",
                 )
             })?;
+        if bytes_base64.len() > MAX_WRITE_BASE64_LEN {
+            return Err(ChildProcessError::new(
+                ChildProcessErrorKind::InvalidParams,
+                format!("bytesBase64 decodes to more than {MAX_WRITE_BYTES} bytes"),
+            )
+            .into());
+        }
         let bytes = BASE64.decode(bytes_base64).map_err(|error| {
             ChildProcessError::new(
                 ChildProcessErrorKind::InvalidParams,
@@ -432,11 +456,17 @@ where
     S::Process: Send + Sync + 'static,
 {
     let status = process.wait().await;
-    host.0
+    let tracked = host
+        .0
         .tracked
         .lock()
         .unwrap_or_else(PoisonError::into_inner)
         .remove(&process_id);
+    // Drain whatever stdout/stderr the pumps already read before announcing exit, so the plugin
+    // never sees the exit notification arrive ahead of the process's last output.
+    if let Some(tracked) = tracked {
+        let _ = tokio::join!(tracked.stdout_done, tracked.stderr_done);
+    }
     if let Err(error) = &status {
         ora_warn!(
             plugin_id = %host.0.plugin_id,

--- a/crates/plugin-lifecycle/src/childprocess.rs
+++ b/crates/plugin-lifecycle/src/childprocess.rs
@@ -1,0 +1,576 @@
+//! Serves `ora/childprocess/*`: lets a plugin ask the host to spawn, write to, and kill a
+//! subprocess, with its stdout, stderr, and exit pushed back as host-originated notifications.
+//!
+//! The host owns the OS process instead of the plugin's own sandboxed runtime spawning it
+//! directly. It is created and torn down through `ora-process`'s tree-wide termination (a Windows
+//! Job Object or a Unix process group), which is the same guarantee every other Ora-managed child
+//! process already relies on. Every process tracked for one plugin generation is killed, best
+//! effort, the moment that generation's [`PluginRuntime`](ora_plugin_runtime::PluginRuntime) stops
+//! for any reason; see [`PluginProcessHost::kill_all`] and its wiring in
+//! `runtime::DenoPluginRuntimeLauncher::launch`.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::PathBuf;
+use std::process::ExitStatus;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, PoisonError};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use ora_logging::ora_warn;
+use ora_plugin_runtime::{
+    HostRequestError, HostRequestHandler, PluginRuntime as ProcessPluginRuntime,
+};
+use ora_process::{ManagedProcess, ProcessSpawner, ProcessSpec, ProcessStdio};
+use serde_json::{Value, json};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{mpsc, watch};
+
+/// Spawns one child process; returns `{ processId, pid }`.
+pub const CHILDPROCESS_SPAWN_METHOD: &str = "ora/childprocess/spawn";
+/// Writes bytes to one spawned process's stdin.
+pub const CHILDPROCESS_WRITE_METHOD: &str = "ora/childprocess/write";
+/// Signals EOF on one spawned process's stdin without killing it.
+pub const CHILDPROCESS_CLOSE_STDIN_METHOD: &str = "ora/childprocess/closeStdin";
+/// Requests best-effort tree-wide termination of one spawned process.
+pub const CHILDPROCESS_KILL_METHOD: &str = "ora/childprocess/kill";
+
+/// Host-pushed notification carrying one chunk of a spawned process's stdout.
+const CHILDPROCESS_STDOUT_METHOD: &str = "ora/childprocess/stdout";
+/// Host-pushed notification carrying one chunk of a spawned process's stderr.
+const CHILDPROCESS_STDERR_METHOD: &str = "ora/childprocess/stderr";
+/// Host-pushed notification announcing that a spawned process has exited.
+const CHILDPROCESS_EXIT_METHOD: &str = "ora/childprocess/exit";
+
+const INVALID_PARAMS_CODE: i64 = -32602;
+const NOT_FOUND_CODE: i64 = -32004;
+const IO_CODE: i64 = -32000;
+
+/// Chunk size used when pumping a spawned process's stdout or stderr into notifications.
+const READ_CHUNK_BYTES: usize = 32 * 1024;
+
+/// Stable classification of a child-process failure, serialized as `data.kind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChildProcessErrorKind {
+    /// The request params are malformed.
+    InvalidParams,
+    /// `command` parsed but was empty.
+    InvalidCommand,
+    /// `processId` does not name a process this handler is tracking.
+    NotFound,
+    /// Spawn failed because the OS could not resolve the executable.
+    ProgramNotFound,
+    /// Any other spawn, write, or kill failure.
+    Io,
+}
+
+impl ChildProcessErrorKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidParams => "invalid_params",
+            Self::InvalidCommand => "invalid_command",
+            Self::NotFound => "not_found",
+            Self::ProgramNotFound => "program_not_found",
+            Self::Io => "io",
+        }
+    }
+
+    fn code(self) -> i64 {
+        match self {
+            Self::InvalidParams | Self::InvalidCommand => INVALID_PARAMS_CODE,
+            Self::NotFound => NOT_FOUND_CODE,
+            Self::ProgramNotFound | Self::Io => IO_CODE,
+        }
+    }
+}
+
+/// One failed child-process call before it is rendered as a JSON-RPC error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChildProcessError {
+    kind: ChildProcessErrorKind,
+    message: String,
+}
+
+impl ChildProcessError {
+    fn new(kind: ChildProcessErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Classifies a spawn failure, distinguishing a missing executable from any other I/O fault.
+    fn from_spawn_io(error: io::Error) -> Self {
+        if error.kind() == io::ErrorKind::NotFound {
+            Self::new(ChildProcessErrorKind::ProgramNotFound, error.to_string())
+        } else {
+            Self::new(ChildProcessErrorKind::Io, error.to_string())
+        }
+    }
+}
+
+impl From<ChildProcessError> for HostRequestError {
+    fn from(error: ChildProcessError) -> Self {
+        HostRequestError::new(error.kind.code(), error.message)
+            .with_data(json!({ "kind": error.kind.as_str() }))
+    }
+}
+
+/// One command the plugin asked the host to send to a spawned process's stdin.
+enum StdinCommand {
+    Write(Vec<u8>),
+    Close,
+}
+
+/// One process this handler is tracking, keyed by its plugin-local `processId`.
+struct Tracked<P> {
+    process: Arc<P>,
+    stdin_tx: mpsc::Sender<StdinCommand>,
+}
+
+struct Inner<S: ProcessSpawner> {
+    plugin_id: String,
+    spawner: S,
+    next_id: AtomicU64,
+    tracked: StdMutex<HashMap<String, Tracked<S::Process>>>,
+    /// Filled in once by [`PluginProcessHost::attach_runtime`] after the plugin connection this
+    /// handler serves becomes ready; see the module docs for why this cannot be known upfront.
+    runtime: watch::Sender<Option<ProcessPluginRuntime>>,
+    /// Kept alive only so `runtime.send` above never observes zero receivers: `watch::Sender::send`
+    /// fails (and drops its value) once every receiver is gone, and every other receiver used here
+    /// is a short-lived `subscribe()` inside `push`. Never read directly.
+    _runtime_rx: watch::Receiver<Option<ProcessPluginRuntime>>,
+}
+
+/// Serves `ora/childprocess/*` for one plugin process, spawning through `S`.
+///
+/// Generic over [`ProcessSpawner`] for the same reason `DenoPluginRuntimeLauncher` is: production
+/// always uses [`ora_process::TokioProcessSpawner`], while tests inject a fake that never starts a
+/// real OS process.
+pub struct PluginProcessHost<S: ProcessSpawner>(Arc<Inner<S>>);
+
+impl<S: ProcessSpawner> Clone for PluginProcessHost<S> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+impl<S> PluginProcessHost<S>
+where
+    S: ProcessSpawner + Send + Sync + 'static,
+    S::Process: Send + Sync + 'static,
+{
+    /// Binds the handler to the plugin it serves and the spawner it spawns through.
+    pub fn new(plugin_id: impl Into<String>, spawner: S) -> Self {
+        let (runtime, runtime_rx) = watch::channel(None);
+        Self(Arc::new(Inner {
+            plugin_id: plugin_id.into(),
+            spawner,
+            next_id: AtomicU64::new(1),
+            tracked: StdMutex::new(HashMap::new()),
+            runtime,
+            _runtime_rx: runtime_rx,
+        }))
+    }
+
+    /// Supplies the plugin runtime handle used to push `stdout`/`stderr`/`exit` notifications.
+    ///
+    /// Called once, right after the launch that used this handler as its `host_requests`
+    /// returns: the handler must exist before that launch (it is passed into it), so the runtime
+    /// handle it needs in order to talk back to the plugin can only arrive after the fact.
+    pub fn attach_runtime(&self, runtime: ProcessPluginRuntime) {
+        let _ = self.0.runtime.send(Some(runtime));
+    }
+
+    /// Kills every process this handler is still tracking, best effort.
+    ///
+    /// Called once the plugin generation this handler serves has stopped for any reason —
+    /// intentional stop, uninstall, restart, or failure — so a host-spawned process never outlives
+    /// the plugin that asked for it.
+    pub async fn kill_all(&self) {
+        let processes: Vec<Arc<S::Process>> = self
+            .0
+            .tracked
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .values()
+            .map(|tracked| Arc::clone(&tracked.process))
+            .collect();
+        for process in processes {
+            if let Err(error) = process.kill().await {
+                ora_warn!(
+                    plugin_id = %self.0.plugin_id,
+                    error = %error,
+                    "failed to kill a host-managed child process during plugin teardown"
+                );
+            }
+        }
+    }
+
+    /// Pushes one notification to the plugin, waiting for `attach_runtime` if it has not run yet.
+    ///
+    /// The wait only ever blocks for the brief window between a launch returning and its caller
+    /// calling `attach_runtime`; once that call lands every later push observes it immediately.
+    async fn push(&self, method: &str, params: Value) {
+        let mut receiver = self.0.runtime.subscribe();
+        if receiver.borrow().is_none() && receiver.changed().await.is_err() {
+            return;
+        }
+        let runtime = receiver.borrow().clone();
+        if let Some(runtime) = runtime {
+            let _ = runtime.notify(method, params).await;
+        }
+    }
+
+    async fn handle_spawn(&self, params: Value) -> Result<Value, HostRequestError> {
+        let request = parse_spawn_params(&params)?;
+        let mut spec = ProcessSpec::new(request.command)
+            .args(request.args)
+            .stdin(ProcessStdio::Piped)
+            .stdout(ProcessStdio::Piped)
+            .stderr(ProcessStdio::Piped);
+        if let Some(cwd) = request.cwd {
+            spec = spec.cwd(cwd);
+        }
+        for (key, value) in request.env {
+            spec = spec.env(key, value);
+        }
+
+        let mut process = self
+            .0
+            .spawner
+            .spawn(spec)
+            .map_err(ChildProcessError::from_spawn_io)?;
+        let pid = process.id();
+        let stdio = (
+            process.take_stdin(),
+            process.take_stdout(),
+            process.take_stderr(),
+        );
+        let (Some(stdin), Some(stdout), Some(stderr)) = stdio else {
+            let _ = process.kill().await;
+            let _ = process.wait().await;
+            return Err(ChildProcessError::new(
+                ChildProcessErrorKind::Io,
+                "spawned process stdio is unavailable",
+            )
+            .into());
+        };
+
+        let process_id = self.0.next_id.fetch_add(1, Ordering::Relaxed).to_string();
+        let (stdin_tx, stdin_rx) = mpsc::channel(32);
+        tokio::spawn(run_stdin_writer(stdin, stdin_rx));
+
+        let process = Arc::new(process);
+        self.0
+            .tracked
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(
+                process_id.clone(),
+                Tracked {
+                    process: Arc::clone(&process),
+                    stdin_tx,
+                },
+            );
+
+        tokio::spawn(pump_output(
+            self.clone(),
+            process_id.clone(),
+            stdout,
+            CHILDPROCESS_STDOUT_METHOD,
+        ));
+        tokio::spawn(pump_output(
+            self.clone(),
+            process_id.clone(),
+            stderr,
+            CHILDPROCESS_STDERR_METHOD,
+        ));
+        tokio::spawn(watch_exit(self.clone(), process_id.clone(), process));
+
+        Ok(json!({ "processId": process_id, "pid": pid }))
+    }
+
+    async fn handle_write(&self, params: Value) -> Result<Value, HostRequestError> {
+        let process_id = required_process_id(&params)?;
+        let bytes_base64 = params
+            .get("bytesBase64")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ChildProcessError::new(
+                    ChildProcessErrorKind::InvalidParams,
+                    "missing string bytesBase64",
+                )
+            })?;
+        let bytes = BASE64.decode(bytes_base64).map_err(|error| {
+            ChildProcessError::new(
+                ChildProcessErrorKind::InvalidParams,
+                format!("bytesBase64 is not valid base64: {error}"),
+            )
+        })?;
+        self.send_stdin(&process_id, StdinCommand::Write(bytes))
+            .await?;
+        Ok(json!({}))
+    }
+
+    async fn handle_close_stdin(&self, params: Value) -> Result<Value, HostRequestError> {
+        let process_id = required_process_id(&params)?;
+        self.send_stdin(&process_id, StdinCommand::Close).await?;
+        Ok(json!({}))
+    }
+
+    async fn send_stdin(
+        &self,
+        process_id: &str,
+        command: StdinCommand,
+    ) -> Result<(), ChildProcessError> {
+        let stdin_tx = self
+            .0
+            .tracked
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(process_id)
+            .map(|tracked| tracked.stdin_tx.clone())
+            .ok_or_else(|| {
+                ChildProcessError::new(ChildProcessErrorKind::NotFound, "unknown processId")
+            })?;
+        stdin_tx.send(command).await.map_err(|_| {
+            ChildProcessError::new(ChildProcessErrorKind::Io, "process stdin is closed")
+        })
+    }
+
+    async fn handle_kill(&self, params: Value) -> Result<Value, HostRequestError> {
+        let process_id = required_process_id(&params)?;
+        let process = self
+            .0
+            .tracked
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&process_id)
+            .map(|tracked| Arc::clone(&tracked.process))
+            .ok_or_else(|| {
+                ChildProcessError::new(ChildProcessErrorKind::NotFound, "unknown processId")
+            })?;
+        process.kill().await.map_err(|error| {
+            ChildProcessError::new(ChildProcessErrorKind::Io, error.to_string())
+        })?;
+        Ok(json!({}))
+    }
+}
+
+impl<S> HostRequestHandler for PluginProcessHost<S>
+where
+    S: ProcessSpawner + Send + Sync + 'static,
+    S::Process: Send + Sync + 'static,
+{
+    async fn handle(&self, method: &str, params: Value) -> Result<Value, HostRequestError> {
+        match method {
+            CHILDPROCESS_SPAWN_METHOD => self.handle_spawn(params).await,
+            CHILDPROCESS_WRITE_METHOD => self.handle_write(params).await,
+            CHILDPROCESS_CLOSE_STDIN_METHOD => self.handle_close_stdin(params).await,
+            CHILDPROCESS_KILL_METHOD => self.handle_kill(params).await,
+            other => Err(HostRequestError::method_not_found(other)),
+        }
+    }
+}
+
+/// Feeds one spawned process's stdin from the channel `write`/`closeStdin` requests publish to.
+async fn run_stdin_writer<W: AsyncWrite + Unpin>(
+    mut stdin: W,
+    mut commands: mpsc::Receiver<StdinCommand>,
+) {
+    while let Some(command) = commands.recv().await {
+        match command {
+            StdinCommand::Write(bytes) => {
+                if stdin.write_all(&bytes).await.is_err() {
+                    return;
+                }
+            }
+            StdinCommand::Close => {
+                let _ = stdin.shutdown().await;
+                return;
+            }
+        }
+    }
+}
+
+/// Forwards every chunk read from one spawned process's stdout or stderr as a notification.
+async fn pump_output<S, R>(
+    host: PluginProcessHost<S>,
+    process_id: String,
+    mut reader: R,
+    method: &'static str,
+) where
+    S: ProcessSpawner + Send + Sync + 'static,
+    S::Process: Send + Sync + 'static,
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = [0_u8; READ_CHUNK_BYTES];
+    loop {
+        match reader.read(&mut buffer).await {
+            Ok(0) => return,
+            Ok(length) => {
+                host.push(
+                    method,
+                    json!({
+                        "processId": process_id,
+                        "bytesBase64": BASE64.encode(&buffer[..length]),
+                    }),
+                )
+                .await;
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+/// Waits for one spawned process to exit, then reports it and stops tracking it.
+async fn watch_exit<S>(host: PluginProcessHost<S>, process_id: String, process: Arc<S::Process>)
+where
+    S: ProcessSpawner + Send + Sync + 'static,
+    S::Process: Send + Sync + 'static,
+{
+    let status = process.wait().await;
+    host.0
+        .tracked
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .remove(&process_id);
+    if let Err(error) = &status {
+        ora_warn!(
+            plugin_id = %host.0.plugin_id,
+            error = %error,
+            "failed to wait for a host-managed child process"
+        );
+    }
+    let (code, signal) = exit_fields(status.as_ref());
+    host.push(
+        CHILDPROCESS_EXIT_METHOD,
+        json!({ "processId": process_id, "code": code, "signal": signal }),
+    )
+    .await;
+}
+
+/// Splits a process's final status into a wire-friendly exit code and, on Unix, a signal number.
+fn exit_fields(status: Result<&ExitStatus, &io::Error>) -> (Option<i32>, Option<i32>) {
+    let Ok(status) = status else {
+        return (None, None);
+    };
+    let code = status.code();
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    };
+    #[cfg(not(unix))]
+    let signal = None;
+    (code, signal)
+}
+
+/// One validated `spawn` request.
+struct SpawnParams {
+    command: String,
+    args: Vec<String>,
+    cwd: Option<PathBuf>,
+    env: Vec<(String, String)>,
+}
+
+/// Parses and validates the `spawn` params, rejecting anything not shaped like the documented
+/// `{ command, args?, cwd?, env? }`.
+fn parse_spawn_params(params: &Value) -> Result<SpawnParams, ChildProcessError> {
+    let object = params.as_object().ok_or_else(|| {
+        ChildProcessError::new(
+            ChildProcessErrorKind::InvalidParams,
+            "spawn params must be an object",
+        )
+    })?;
+    let command = object
+        .get("command")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ChildProcessError::new(
+                ChildProcessErrorKind::InvalidParams,
+                "missing string command",
+            )
+        })?;
+    if command.trim().is_empty() {
+        return Err(ChildProcessError::new(
+            ChildProcessErrorKind::InvalidCommand,
+            "command must not be empty",
+        ));
+    }
+    let args = match object.get("args") {
+        None | Some(Value::Null) => Vec::new(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .map(|item| {
+                item.as_str().map(str::to_owned).ok_or_else(|| {
+                    ChildProcessError::new(
+                        ChildProcessErrorKind::InvalidParams,
+                        "args must be strings",
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        Some(_) => {
+            return Err(ChildProcessError::new(
+                ChildProcessErrorKind::InvalidParams,
+                "args must be an array of strings",
+            ));
+        }
+    };
+    let cwd = match object.get("cwd") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(value)) => Some(PathBuf::from(value)),
+        Some(_) => {
+            return Err(ChildProcessError::new(
+                ChildProcessErrorKind::InvalidParams,
+                "cwd must be a string",
+            ));
+        }
+    };
+    let env = match object.get("env") {
+        None | Some(Value::Null) => Vec::new(),
+        Some(Value::Object(entries)) => entries
+            .iter()
+            .map(|(key, value)| {
+                value
+                    .as_str()
+                    .map(|value| (key.clone(), value.to_owned()))
+                    .ok_or_else(|| {
+                        ChildProcessError::new(
+                            ChildProcessErrorKind::InvalidParams,
+                            "env values must be strings",
+                        )
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        Some(_) => {
+            return Err(ChildProcessError::new(
+                ChildProcessErrorKind::InvalidParams,
+                "env must be an object of strings",
+            ));
+        }
+    };
+    Ok(SpawnParams {
+        command: command.to_owned(),
+        args,
+        cwd,
+        env,
+    })
+}
+
+/// Extracts and validates the `processId` param shared by `write`, `closeStdin`, and `kill`.
+fn required_process_id(params: &Value) -> Result<String, ChildProcessError> {
+    params
+        .get("processId")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            ChildProcessError::new(
+                ChildProcessErrorKind::InvalidParams,
+                "missing string processId",
+            )
+        })
+}

--- a/crates/plugin-lifecycle/src/childprocess_tests.rs
+++ b/crates/plugin-lifecycle/src/childprocess_tests.rs
@@ -1,0 +1,606 @@
+//! Tests for `ora/childprocess/*`: request handling and tracking lifecycle against a fake spawned
+//! process, plus one end-to-end check that stdout, stderr, and exit reach the plugin as
+//! notifications once a real `PluginRuntime` is attached.
+
+use std::ffi::OsStr;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use ora_plugin_runtime::{
+    HostRequestError, HostRequestHandler, NoHostRequests, PluginRuntime as ProcessPluginRuntime,
+    PluginRuntimeConfig,
+};
+use ora_process::{ManagedProcess, ProcessSpawner, ProcessSpec};
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tokio::sync::{mpsc, watch};
+use tokio::time::timeout;
+
+use crate::childprocess::{
+    CHILDPROCESS_CLOSE_STDIN_METHOD, CHILDPROCESS_KILL_METHOD, CHILDPROCESS_SPAWN_METHOD,
+    CHILDPROCESS_WRITE_METHOD, PluginProcessHost,
+};
+
+/// The `data.kind` classification of one failed call, as a plugin would branch on it.
+fn kind_of(error: &HostRequestError) -> String {
+    error.data()["kind"].as_str().unwrap_or_default().to_owned()
+}
+
+// ---------------------------------------------------------------------------------------------
+// Fake spawned child process: stands in for the OS process behind `ora/childprocess/spawn`.
+// ---------------------------------------------------------------------------------------------
+
+/// The test-facing peer of one spawned [`FakeChildProcess`]: the other end of every piped stream.
+struct FakeChildTestHandle {
+    stdin_peer: DuplexStream,
+    stdout_peer: DuplexStream,
+    #[allow(dead_code)]
+    stderr_peer: DuplexStream,
+    exit_tx: watch::Sender<Option<ExitStatus>>,
+    killed: Arc<AtomicBool>,
+}
+
+#[derive(Clone)]
+struct FakeChildSpawner(Arc<FakeChildSpawnerState>);
+
+struct FakeChildSpawnerState {
+    next_id: AtomicU32,
+    calls: StdMutex<Vec<ProcessSpec>>,
+    handles: StdMutex<Vec<FakeChildTestHandle>>,
+    force_next_error: StdMutex<Option<io::ErrorKind>>,
+}
+
+impl FakeChildSpawner {
+    fn new() -> Self {
+        Self(Arc::new(FakeChildSpawnerState {
+            next_id: AtomicU32::new(100),
+            calls: StdMutex::new(Vec::new()),
+            handles: StdMutex::new(Vec::new()),
+            force_next_error: StdMutex::new(None),
+        }))
+    }
+
+    /// Makes the next `spawn` call fail as if the OS could not start the process.
+    fn force_next_error(&self, kind: io::ErrorKind) {
+        *self
+            .0
+            .force_next_error
+            .lock()
+            .expect("lock force_next_error") = Some(kind);
+    }
+
+    /// The `ProcessSpec` passed to every `spawn` call so far, in order.
+    fn calls(&self) -> Vec<ProcessSpec> {
+        self.0.calls.lock().expect("lock calls").clone()
+    }
+
+    /// Takes the test-facing peer of the most recently spawned process.
+    fn last_handle(&self) -> FakeChildTestHandle {
+        self.0
+            .handles
+            .lock()
+            .expect("lock handles")
+            .pop()
+            .expect("a process was spawned")
+    }
+}
+
+impl ProcessSpawner for FakeChildSpawner {
+    type Process = FakeChildProcess;
+
+    fn spawn(&self, spec: ProcessSpec) -> io::Result<Self::Process> {
+        if let Some(kind) = self
+            .0
+            .force_next_error
+            .lock()
+            .expect("lock force_next_error")
+            .take()
+        {
+            return Err(io::Error::from(kind));
+        }
+        self.0.calls.lock().expect("lock calls").push(spec);
+        let id = self.0.next_id.fetch_add(1, Ordering::Relaxed);
+        let (stdin_host, stdin_peer) = tokio::io::duplex(8192);
+        let (stdout_peer, stdout_host) = tokio::io::duplex(8192);
+        let (stderr_peer, stderr_host) = tokio::io::duplex(8192);
+        let (exit_tx, _) = watch::channel(None);
+        let killed = Arc::new(AtomicBool::new(false));
+        self.0
+            .handles
+            .lock()
+            .expect("lock handles")
+            .push(FakeChildTestHandle {
+                stdin_peer,
+                stdout_peer,
+                stderr_peer,
+                exit_tx: exit_tx.clone(),
+                killed: Arc::clone(&killed),
+            });
+        Ok(FakeChildProcess {
+            id: Some(id),
+            stdin: Some(stdin_host),
+            stdout: Some(stdout_host),
+            stderr: Some(stderr_host),
+            exit_tx,
+            killed,
+        })
+    }
+}
+
+struct FakeChildProcess {
+    id: Option<u32>,
+    stdin: Option<DuplexStream>,
+    stdout: Option<DuplexStream>,
+    stderr: Option<DuplexStream>,
+    exit_tx: watch::Sender<Option<ExitStatus>>,
+    killed: Arc<AtomicBool>,
+}
+
+impl ManagedProcess for FakeChildProcess {
+    type Stdin = DuplexStream;
+    type Stdout = DuplexStream;
+    type Stderr = DuplexStream;
+
+    fn id(&self) -> Option<u32> {
+        self.id
+    }
+
+    fn take_stdin(&mut self) -> Option<Self::Stdin> {
+        self.stdin.take()
+    }
+
+    fn take_stdout(&mut self) -> Option<Self::Stdout> {
+        self.stdout.take()
+    }
+
+    fn take_stderr(&mut self) -> Option<Self::Stderr> {
+        self.stderr.take()
+    }
+
+    fn try_wait(&self) -> io::Result<Option<ExitStatus>> {
+        Ok(*self.exit_tx.borrow())
+    }
+
+    async fn wait(&self) -> io::Result<ExitStatus> {
+        let mut exited = self.exit_tx.subscribe();
+        loop {
+            if let Some(status) = *exited.borrow() {
+                return Ok(status);
+            }
+            exited
+                .changed()
+                .await
+                .map_err(|_| io::Error::other("fake process exit channel closed"))?;
+        }
+    }
+
+    async fn kill(&self) -> io::Result<()> {
+        self.killed.store(true, Ordering::Release);
+        self.exit_tx.send_replace(Some(exit_status(0)));
+        Ok(())
+    }
+}
+
+fn exit_status(code: i32) -> ExitStatus {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        ExitStatus::from_raw(code)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::ExitStatusExt;
+        ExitStatus::from_raw(code as u32)
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Handler behavior against the fake spawner: no runtime attached, so pushed notifications are
+// never observed here — see `pushes_stdout_stderr_and_exit_once_a_runtime_is_attached` below.
+// ---------------------------------------------------------------------------------------------
+
+#[tokio::test]
+async fn spawn_returns_process_id_and_forwards_command_args_cwd_env() {
+    let spawner = FakeChildSpawner::new();
+    let host = PluginProcessHost::new("plugin-a", spawner.clone());
+
+    let result = host
+        .handle(
+            CHILDPROCESS_SPAWN_METHOD,
+            json!({
+                "command": "opencode",
+                "args": ["acp", "--cwd", "/work"],
+                "cwd": "/work",
+                "env": { "FOO": "bar" },
+            }),
+        )
+        .await
+        .expect("spawn succeeds");
+
+    let calls = spawner.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].program(), OsStr::new("opencode"));
+    assert_eq!(
+        calls[0].args_iter().collect::<Vec<_>>(),
+        vec![OsStr::new("acp"), OsStr::new("--cwd"), OsStr::new("/work")]
+    );
+    assert_eq!(calls[0].cwd_path(), Some(Path::new("/work")));
+    assert_eq!(
+        calls[0].envs().collect::<Vec<_>>(),
+        vec![(OsStr::new("FOO"), OsStr::new("bar"))]
+    );
+    assert_eq!(result, json!({ "processId": "1", "pid": 100 }));
+}
+
+#[tokio::test]
+async fn spawn_rejects_an_empty_command() {
+    let host = PluginProcessHost::new("plugin-a", FakeChildSpawner::new());
+
+    let error = host
+        .handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "   " }))
+        .await
+        .expect_err("empty command is rejected");
+
+    assert_eq!(kind_of(&error), "invalid_command");
+}
+
+#[tokio::test]
+async fn spawn_maps_a_missing_executable_to_program_not_found() {
+    let spawner = FakeChildSpawner::new();
+    spawner.force_next_error(io::ErrorKind::NotFound);
+    let host = PluginProcessHost::new("plugin-a", spawner);
+
+    let error = host
+        .handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "missing" }))
+        .await
+        .expect_err("spawn fails");
+
+    assert_eq!(kind_of(&error), "program_not_found");
+}
+
+#[tokio::test]
+async fn spawn_maps_any_other_spawn_failure_to_io() {
+    let spawner = FakeChildSpawner::new();
+    spawner.force_next_error(io::ErrorKind::PermissionDenied);
+    let host = PluginProcessHost::new("plugin-a", spawner);
+
+    let error = host
+        .handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "opencode" }))
+        .await
+        .expect_err("spawn fails");
+
+    assert_eq!(kind_of(&error), "io");
+}
+
+#[tokio::test]
+async fn write_forwards_bytes_and_close_stdin_signals_eof() {
+    let spawner = FakeChildSpawner::new();
+    let host = PluginProcessHost::new("plugin-a", spawner.clone());
+    let spawned = host
+        .handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "opencode" }))
+        .await
+        .expect("spawn succeeds");
+    let process_id = spawned["processId"]
+        .as_str()
+        .expect("processId is a string")
+        .to_owned();
+    let mut test_handle = spawner.last_handle();
+
+    host.handle(
+        CHILDPROCESS_WRITE_METHOD,
+        json!({ "processId": process_id, "bytesBase64": BASE64.encode(b"hello\n") }),
+    )
+    .await
+    .expect("write succeeds");
+
+    let mut buffer = [0_u8; 16];
+    let read = timeout(
+        Duration::from_secs(1),
+        test_handle.stdin_peer.read(&mut buffer),
+    )
+    .await
+    .expect("stdin write arrives before timeout")
+    .expect("stdin read succeeds");
+    assert_eq!(&buffer[..read], b"hello\n");
+
+    host.handle(
+        CHILDPROCESS_CLOSE_STDIN_METHOD,
+        json!({ "processId": process_id }),
+    )
+    .await
+    .expect("close stdin succeeds");
+
+    let eof = timeout(
+        Duration::from_secs(1),
+        test_handle.stdin_peer.read(&mut buffer),
+    )
+    .await
+    .expect("eof arrives before timeout")
+    .expect("stdin read succeeds");
+    assert_eq!(eof, 0);
+}
+
+#[tokio::test]
+async fn operations_on_an_unknown_process_id_are_not_found() {
+    let host = PluginProcessHost::new("plugin-a", FakeChildSpawner::new());
+
+    for (method, params) in [
+        (
+            CHILDPROCESS_WRITE_METHOD,
+            json!({ "processId": "missing", "bytesBase64": "" }),
+        ),
+        (
+            CHILDPROCESS_CLOSE_STDIN_METHOD,
+            json!({ "processId": "missing" }),
+        ),
+        (CHILDPROCESS_KILL_METHOD, json!({ "processId": "missing" })),
+    ] {
+        let error = host.handle(method, params).await.expect_err(method);
+        assert_eq!(kind_of(&error), "not_found", "method {method}");
+    }
+}
+
+#[tokio::test]
+async fn kill_terminates_the_process_which_then_stops_being_tracked() {
+    let spawner = FakeChildSpawner::new();
+    let host = PluginProcessHost::new("plugin-a", spawner.clone());
+    let spawned = host
+        .handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "opencode" }))
+        .await
+        .expect("spawn succeeds");
+    let process_id = spawned["processId"]
+        .as_str()
+        .expect("processId is a string")
+        .to_owned();
+    let test_handle = spawner.last_handle();
+
+    host.handle(
+        CHILDPROCESS_KILL_METHOD,
+        json!({ "processId": process_id.clone() }),
+    )
+    .await
+    .expect("kill succeeds");
+    assert!(test_handle.killed.load(Ordering::Acquire));
+
+    // The exit-watcher task removes the tracking entry once `wait()` observes the exit `kill()`
+    // triggered; poll for that instead of sleeping a fixed duration.
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let result = host
+                .handle(CHILDPROCESS_KILL_METHOD, json!({ "processId": process_id }))
+                .await;
+            if matches!(&result, Err(error) if kind_of(error) == "not_found") {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("process becomes untracked once it has exited");
+}
+
+#[tokio::test]
+async fn kill_all_terminates_every_tracked_process() {
+    let spawner = FakeChildSpawner::new();
+    let host = PluginProcessHost::new("plugin-a", spawner.clone());
+    host.handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "one" }))
+        .await
+        .expect("spawn succeeds");
+    host.handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "two" }))
+        .await
+        .expect("spawn succeeds");
+    let second = spawner.last_handle();
+    let first = spawner.last_handle();
+
+    host.kill_all().await;
+
+    assert_eq!(
+        (
+            first.killed.load(Ordering::Acquire),
+            second.killed.load(Ordering::Acquire)
+        ),
+        (true, true)
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// End-to-end: stdout, stderr, and exit reach the plugin as `ora/childprocess/*` notifications
+// once a real `PluginRuntime` is attached, exercising `attach_runtime`'s late-binding wait.
+// ---------------------------------------------------------------------------------------------
+
+const JSON_RPC_FRAME_TYPE: u8 = 0x01;
+
+/// Writes one frame using the same length-delimited envelope `ora-plugin-runtime` speaks; this is
+/// a standalone reimplementation for the test's "fake plugin" side, not an import of the crate's
+/// private codec.
+async fn write_frame<W: tokio::io::AsyncWrite + Unpin>(writer: &mut W, payload: &[u8]) {
+    let length = u32::try_from(payload.len() + 1).expect("payload fits in a frame");
+    writer
+        .write_all(&length.to_be_bytes())
+        .await
+        .expect("write frame header");
+    writer
+        .write_all(&[JSON_RPC_FRAME_TYPE])
+        .await
+        .expect("write frame type");
+    writer
+        .write_all(payload)
+        .await
+        .expect("write frame payload");
+    writer.flush().await.expect("flush frame");
+}
+
+/// Reads one frame using the same envelope; returns `None` at a clean EOF.
+async fn read_frame<R: tokio::io::AsyncRead + Unpin>(reader: &mut R) -> Option<Vec<u8>> {
+    let mut header = [0_u8; 4];
+    if reader.read_exact(&mut header).await.is_err() {
+        return None;
+    }
+    let length = u32::from_be_bytes(header) as usize;
+    let mut frame = vec![0_u8; length];
+    reader
+        .read_exact(&mut frame)
+        .await
+        .expect("read frame body");
+    assert_eq!(frame[0], JSON_RPC_FRAME_TYPE);
+    Some(frame.split_off(1))
+}
+
+/// A `ManagedProcess` standing in for the plugin's own Deno process, so a real `PluginRuntime` can
+/// be constructed against a duplex pipe instead of a real subprocess.
+struct FakePluginProcess {
+    stdin: Option<DuplexStream>,
+    stdout: Option<DuplexStream>,
+    stderr: Option<DuplexStream>,
+}
+
+impl ManagedProcess for FakePluginProcess {
+    type Stdin = DuplexStream;
+    type Stdout = DuplexStream;
+    type Stderr = DuplexStream;
+
+    fn id(&self) -> Option<u32> {
+        Some(1)
+    }
+
+    fn take_stdin(&mut self) -> Option<Self::Stdin> {
+        self.stdin.take()
+    }
+
+    fn take_stdout(&mut self) -> Option<Self::Stdout> {
+        self.stdout.take()
+    }
+
+    fn take_stderr(&mut self) -> Option<Self::Stderr> {
+        self.stderr.take()
+    }
+
+    fn try_wait(&self) -> io::Result<Option<ExitStatus>> {
+        Ok(None)
+    }
+
+    async fn wait(&self) -> io::Result<ExitStatus> {
+        std::future::pending().await
+    }
+
+    async fn kill(&self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Spawns exactly one pre-built [`FakePluginProcess`], ignoring the `ProcessSpec`.
+struct SinglePluginProcessSpawner(StdMutex<Option<FakePluginProcess>>);
+
+impl ProcessSpawner for SinglePluginProcessSpawner {
+    type Process = FakePluginProcess;
+
+    fn spawn(&self, _spec: ProcessSpec) -> io::Result<Self::Process> {
+        Ok(self
+            .0
+            .lock()
+            .expect("lock plugin process")
+            .take()
+            .expect("spawn called once"))
+    }
+}
+
+#[tokio::test]
+async fn pushes_stdout_and_exit_once_a_runtime_is_attached() {
+    let entrypoint = tempfile::NamedTempFile::new().expect("create fake entrypoint file");
+
+    let (host_stdin, mut plugin_reads_from_host) = tokio::io::duplex(8192);
+    let (mut plugin_writes_to_host, host_stdout) = tokio::io::duplex(8192);
+    let (_plugin_stderr_peer, host_stderr) = tokio::io::duplex(8192);
+    let plugin_spawner = SinglePluginProcessSpawner(StdMutex::new(Some(FakePluginProcess {
+        stdin: Some(host_stdin),
+        stdout: Some(host_stdout),
+        stderr: Some(host_stderr),
+    })));
+
+    let (frames_tx, mut frames_rx) = mpsc::unbounded_channel::<Value>();
+    tokio::spawn(async move {
+        write_frame(
+            &mut plugin_writes_to_host,
+            br#"{"jsonrpc":"2.0","method":"ora/register","params":{"methods":[],"emits":[]}}"#,
+        )
+        .await;
+        while let Some(payload) = read_frame(&mut plugin_reads_from_host).await {
+            let value: Value = serde_json::from_slice(&payload).expect("host frame is valid JSON");
+            if frames_tx.send(value).is_err() {
+                return;
+            }
+        }
+    });
+
+    let (runtime, _notifications) = ProcessPluginRuntime::launch(
+        &plugin_spawner,
+        PluginRuntimeConfig {
+            plugin_id: "plugin-a".to_string(),
+            deno_path: PathBuf::from("deno"),
+            entrypoint: entrypoint.path().to_path_buf(),
+            permissions: Vec::new(),
+            cwd: None,
+            ready_timeout: Duration::from_secs(5),
+            call_timeout: Duration::from_secs(5),
+            shutdown_timeout: Duration::from_secs(5),
+        },
+        NoHostRequests,
+    )
+    .await
+    .expect("fake plugin runtime launches");
+
+    let child_spawner = FakeChildSpawner::new();
+    let processes = PluginProcessHost::new("plugin-a", child_spawner.clone());
+    processes.attach_runtime(runtime);
+
+    let spawned = processes
+        .handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "opencode" }))
+        .await
+        .expect("spawn succeeds");
+    let process_id = spawned["processId"]
+        .as_str()
+        .expect("processId is a string")
+        .to_owned();
+    let mut child_test_handle = child_spawner.last_handle();
+
+    child_test_handle
+        .stdout_peer
+        .write_all(b"chunk-one")
+        .await
+        .expect("write fake stdout chunk");
+
+    let stdout_notification = timeout(Duration::from_secs(2), frames_rx.recv())
+        .await
+        .expect("stdout notification arrives before timeout")
+        .expect("frame channel stays open");
+    assert_eq!(
+        stdout_notification,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "ora/childprocess/stdout",
+            "params": { "processId": process_id, "bytesBase64": BASE64.encode(b"chunk-one") },
+        })
+    );
+
+    child_test_handle.exit_tx.send_replace(Some(exit_status(0)));
+
+    let exit_notification = timeout(Duration::from_secs(2), frames_rx.recv())
+        .await
+        .expect("exit notification arrives before timeout")
+        .expect("frame channel stays open");
+    assert_eq!(
+        exit_notification,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "ora/childprocess/exit",
+            "params": { "processId": process_id, "code": 0, "signal": Value::Null },
+        })
+    );
+}

--- a/crates/plugin-lifecycle/src/childprocess_tests.rs
+++ b/crates/plugin-lifecycle/src/childprocess_tests.rs
@@ -25,7 +25,7 @@ use tokio::time::timeout;
 
 use crate::childprocess::{
     CHILDPROCESS_CLOSE_STDIN_METHOD, CHILDPROCESS_KILL_METHOD, CHILDPROCESS_SPAWN_METHOD,
-    CHILDPROCESS_WRITE_METHOD, PluginProcessHost,
+    CHILDPROCESS_WRITE_METHOD, MAX_WRITE_BYTES, PluginProcessHost,
 };
 
 /// The `data.kind` classification of one failed call, as a plugin would branch on it.
@@ -41,7 +41,6 @@ fn kind_of(error: &HostRequestError) -> String {
 struct FakeChildTestHandle {
     stdin_peer: DuplexStream,
     stdout_peer: DuplexStream,
-    #[allow(dead_code)]
     stderr_peer: DuplexStream,
     exit_tx: watch::Sender<Option<ExitStatus>>,
     killed: Arc<AtomicBool>,
@@ -328,6 +327,24 @@ async fn write_forwards_bytes_and_close_stdin_signals_eof() {
 }
 
 #[tokio::test]
+async fn write_rejects_a_payload_over_the_size_limit_before_decoding_it() {
+    let host = PluginProcessHost::new("plugin-a", FakeChildSpawner::new());
+    // Longer than any base64 string that could decode to `MAX_WRITE_BYTES`; the content does not
+    // need to be valid base64 because the size check runs before `BASE64.decode`.
+    let oversized = "A".repeat(MAX_WRITE_BYTES.div_ceil(3) * 4 + 4);
+
+    let error = host
+        .handle(
+            CHILDPROCESS_WRITE_METHOD,
+            json!({ "processId": "missing", "bytesBase64": oversized }),
+        )
+        .await
+        .expect_err("oversized payload is rejected");
+
+    assert_eq!(kind_of(&error), "invalid_params");
+}
+
+#[tokio::test]
 async fn operations_on_an_unknown_process_id_are_not_found() {
     let host = PluginProcessHost::new("plugin-a", FakeChildSpawner::new());
 
@@ -512,7 +529,7 @@ impl ProcessSpawner for SinglePluginProcessSpawner {
 }
 
 #[tokio::test]
-async fn pushes_stdout_and_exit_once_a_runtime_is_attached() {
+async fn pushes_stdout_before_exit_even_when_the_process_exits_immediately_after_writing() {
     let entrypoint = tempfile::NamedTempFile::new().expect("create fake entrypoint file");
 
     let (host_stdin, mut plugin_reads_from_host) = tokio::io::duplex(8192);
@@ -576,6 +593,22 @@ async fn pushes_stdout_and_exit_once_a_runtime_is_attached() {
         .await
         .expect("write fake stdout chunk");
 
+    // Fire the exit signal immediately after the write, without waiting for the stdout
+    // notification to be observed first: this is the interleaving that let `watch_exit`
+    // race ahead of `pump_output` and reorder the notifications before the join fix. A real OS
+    // process closes its stdout/stderr pipes as part of exiting, which is what lets
+    // `pump_output` observe EOF and finish; drop the fake's write ends the same way, or the exit
+    // notification would wait on `watch_exit`'s join forever.
+    let FakeChildTestHandle {
+        stdout_peer,
+        stderr_peer,
+        exit_tx,
+        ..
+    } = child_test_handle;
+    drop(stdout_peer);
+    drop(stderr_peer);
+    exit_tx.send_replace(Some(exit_status(0)));
+
     let stdout_notification = timeout(Duration::from_secs(2), frames_rx.recv())
         .await
         .expect("stdout notification arrives before timeout")
@@ -588,8 +621,6 @@ async fn pushes_stdout_and_exit_once_a_runtime_is_attached() {
             "params": { "processId": process_id, "bytesBase64": BASE64.encode(b"chunk-one") },
         })
     );
-
-    child_test_handle.exit_tx.send_replace(Some(exit_status(0)));
 
     let exit_notification = timeout(Duration::from_secs(2), frames_rx.recv())
         .await

--- a/crates/plugin-lifecycle/src/launch.rs
+++ b/crates/plugin-lifecycle/src/launch.rs
@@ -13,7 +13,7 @@ use crate::registration::validate_registration;
 use crate::state::ManagedPluginState;
 use crate::{PluginLifecycleInner, PluginNotificationSink};
 use ora_domain::PluginId;
-use ora_plugin_manager::InstalledPlugin as DiscoveredPlugin;
+use ora_plugin_manager::{InstalledPlugin as DiscoveredPlugin, PluginContribution};
 use ora_plugin_runtime::PluginNotification;
 use std::sync::{Arc, PoisonError};
 use std::time::Duration;
@@ -74,6 +74,7 @@ pub(crate) async fn complete_launch<RuntimeLauncher, StatusPublisher, Notificati
             entrypoint: plugin.package_root.join(entrypoint.to_path_buf()),
             package_root: plugin.package_root.clone(),
             permissions: permissions_for(&plugin.contributes),
+            allow_childprocess: matches!(plugin.contributes, PluginContribution::Agent(_)),
             data_dir,
         })
         .await;

--- a/crates/plugin-lifecycle/src/lib.rs
+++ b/crates/plugin-lifecycle/src/lib.rs
@@ -1,3 +1,4 @@
+mod childprocess;
 mod connection;
 mod data_dir;
 mod launch;
@@ -11,6 +12,10 @@ mod storage;
 mod surface_closer;
 mod uninstall;
 
+pub use childprocess::{
+    CHILDPROCESS_CLOSE_STDIN_METHOD, CHILDPROCESS_KILL_METHOD, CHILDPROCESS_SPAWN_METHOD,
+    CHILDPROCESS_WRITE_METHOD, PluginProcessHost,
+};
 pub use connection::{ConnectionError, PluginGenerationKey, PluginGenerationLease};
 pub use data_dir::PluginDataDirectories;
 pub use ora_plugin_runtime::{PluginNotification, PluginRegistration};
@@ -496,6 +501,8 @@ fn parse_request_id(plugin_id: &str) -> Result<PluginId, PluginLifecycleError> {
     })
 }
 
+#[cfg(test)]
+mod childprocess_tests;
 #[cfg(test)]
 mod data_plane_tests;
 #[cfg(test)]

--- a/crates/plugin-lifecycle/src/ports.rs
+++ b/crates/plugin-lifecycle/src/ports.rs
@@ -25,6 +25,14 @@ pub struct PluginLaunchRequest {
     /// The plugin's private data directory, already created; the launcher binds the
     /// `ora/storage/*` handler to it so the process can only ever reach its own data.
     pub data_dir: PathBuf,
+    /// Whether the launcher should bind `ora/childprocess/*` for this process.
+    ///
+    /// True only for agent plugins: they are the only kind whose Deno permissions include
+    /// `--allow-run` (see `permissions::agent_permissions`), so they are the only kind a
+    /// host-managed subprocess does not hand a new capability to. A workbench, webview, skill, or
+    /// MCP plugin runs with zero Deno permissions specifically so it cannot start a process; the
+    /// launcher must not let a host request reopen that door.
+    pub allow_childprocess: bool,
 }
 
 /// Preserves the reason a plugin process could not start or stopped unexpectedly.

--- a/crates/plugin-lifecycle/src/runtime.rs
+++ b/crates/plugin-lifecycle/src/runtime.rs
@@ -16,15 +16,22 @@ use std::time::Duration;
 /// Dispatches one plugin process's host requests to whichever handler owns the method's
 /// namespace. `ora-plugin-runtime` launches with exactly one [`HostRequestHandler`] per process,
 /// so this is the single place `ora/storage/*` and `ora/childprocess/*` combine.
+///
+/// `processes` is `None` for every non-agent plugin: those launch with zero Deno permissions
+/// specifically so they cannot start a process (see [`PluginLaunchRequest::allow_childprocess`]),
+/// and mounting the handler unconditionally would let a host request reopen that door.
 struct PluginHostRequests {
     storage: PluginStorage,
-    processes: PluginProcessHost<TokioProcessSpawner>,
+    processes: Option<PluginProcessHost<TokioProcessSpawner>>,
 }
 
 impl HostRequestHandler for PluginHostRequests {
     async fn handle(&self, method: &str, params: Value) -> Result<Value, HostRequestError> {
         if method.starts_with("ora/childprocess/") {
-            self.processes.handle(method, params).await
+            match &self.processes {
+                Some(processes) => processes.handle(method, params).await,
+                None => Err(HostRequestError::method_not_found(method)),
+            }
         } else {
             self.storage.handle(method, params).await
         }
@@ -103,8 +110,9 @@ impl PluginRuntimeLauncher for DenoPluginRuntimeLauncher {
                         .map_err(|error| PluginRuntimeFailure::new(error.to_string()))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let processes =
-                PluginProcessHost::new(request.plugin_id.to_string(), TokioProcessSpawner::new());
+            let processes = request.allow_childprocess.then(|| {
+                PluginProcessHost::new(request.plugin_id.to_string(), TokioProcessSpawner::new())
+            });
             let host_requests = PluginHostRequests {
                 storage: PluginStorage::new(request.data_dir),
                 processes: processes.clone(),
@@ -127,7 +135,9 @@ impl PluginRuntimeLauncher for DenoPluginRuntimeLauncher {
             .map_err(|error| PluginRuntimeFailure::new(error.to_string()))?;
             // The handler must exist before `launch` is called, so it can only learn how to push
             // notifications back to the plugin once `launch` has returned this handle.
-            processes.attach_runtime(runtime.clone());
+            if let Some(processes) = &processes {
+                processes.attach_runtime(runtime.clone());
+            }
             // Whatever ends this plugin generation — an intentional stop, uninstall, restart, or
             // failure — must also end every process it asked the host to spawn on its behalf; see
             // `PluginProcessHost::kill_all`.
@@ -136,7 +146,9 @@ impl PluginRuntimeLauncher for DenoPluginRuntimeLauncher {
                 let runtime = runtime.clone();
                 async move {
                     runtime.wait_for_exit().await;
-                    processes.kill_all().await;
+                    if let Some(processes) = processes {
+                        processes.kill_all().await;
+                    }
                 }
             });
             let registration = runtime.registration().await;
@@ -208,5 +220,36 @@ impl PluginRuntime for DenoPluginRuntime {
                 .await
                 .map_err(map_call_error)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PluginHostRequests;
+    use crate::childprocess::CHILDPROCESS_SPAWN_METHOD;
+    use crate::storage::PluginStorage;
+    use ora_plugin_runtime::{HostRequestError, HostRequestHandler};
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    /// A non-agent plugin's dispatcher has no `processes` handler mounted, so a spawn request
+    /// must fail the same way an entirely unknown method would rather than reach a spawner.
+    #[tokio::test]
+    async fn childprocess_methods_are_unknown_without_the_processes_handler() {
+        let host_requests = PluginHostRequests {
+            storage: PluginStorage::new(PathBuf::from(".")),
+            processes: None,
+        };
+
+        let error = host_requests
+            .handle(CHILDPROCESS_SPAWN_METHOD, json!({ "command": "opencode" }))
+            .await
+            .expect_err("spawn is refused without a processes handler");
+
+        assert_eq!(
+            error,
+            HostRequestError::method_not_found(CHILDPROCESS_SPAWN_METHOD)
+        );
     }
 }

--- a/crates/plugin-lifecycle/src/runtime.rs
+++ b/crates/plugin-lifecycle/src/runtime.rs
@@ -1,16 +1,35 @@
+use crate::childprocess::PluginProcessHost;
 use crate::ports::{
     LaunchedRuntime, PluginCallError, PluginLaunchRequest, PluginRuntime, PluginRuntimeExit,
     PluginRuntimeFailure, PluginRuntimeLauncher,
 };
 use crate::storage::PluginStorage;
 use ora_plugin_runtime::{
-    PluginProcessExit, PluginRegistration, PluginRuntime as ProcessPluginRuntime,
-    PluginRuntimeConfig, PluginRuntimeError,
+    HostRequestError, HostRequestHandler, PluginProcessExit, PluginRegistration,
+    PluginRuntime as ProcessPluginRuntime, PluginRuntimeConfig, PluginRuntimeError,
 };
 use ora_process::TokioProcessSpawner;
 use serde_json::Value;
 use std::future::Future;
 use std::time::Duration;
+
+/// Dispatches one plugin process's host requests to whichever handler owns the method's
+/// namespace. `ora-plugin-runtime` launches with exactly one [`HostRequestHandler`] per process,
+/// so this is the single place `ora/storage/*` and `ora/childprocess/*` combine.
+struct PluginHostRequests {
+    storage: PluginStorage,
+    processes: PluginProcessHost<TokioProcessSpawner>,
+}
+
+impl HostRequestHandler for PluginHostRequests {
+    async fn handle(&self, method: &str, params: Value) -> Result<Value, HostRequestError> {
+        if method.starts_with("ora/childprocess/") {
+            self.processes.handle(method, params).await
+        } else {
+            self.storage.handle(method, params).await
+        }
+    }
+}
 
 /// Configures bounded startup, invocation, and shutdown waits for real plugin processes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,6 +103,12 @@ impl PluginRuntimeLauncher for DenoPluginRuntimeLauncher {
                         .map_err(|error| PluginRuntimeFailure::new(error.to_string()))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
+            let processes =
+                PluginProcessHost::new(request.plugin_id.to_string(), TokioProcessSpawner::new());
+            let host_requests = PluginHostRequests {
+                storage: PluginStorage::new(request.data_dir),
+                processes: processes.clone(),
+            };
             let (runtime, notifications) = ProcessPluginRuntime::launch(
                 &TokioProcessSpawner::new(),
                 PluginRuntimeConfig {
@@ -96,10 +121,24 @@ impl PluginRuntimeLauncher for DenoPluginRuntimeLauncher {
                     call_timeout: timeouts.call,
                     shutdown_timeout: timeouts.shutdown,
                 },
-                PluginStorage::new(request.data_dir),
+                host_requests,
             )
             .await
             .map_err(|error| PluginRuntimeFailure::new(error.to_string()))?;
+            // The handler must exist before `launch` is called, so it can only learn how to push
+            // notifications back to the plugin once `launch` has returned this handle.
+            processes.attach_runtime(runtime.clone());
+            // Whatever ends this plugin generation — an intentional stop, uninstall, restart, or
+            // failure — must also end every process it asked the host to spawn on its behalf; see
+            // `PluginProcessHost::kill_all`.
+            tokio::spawn({
+                let processes = processes.clone();
+                let runtime = runtime.clone();
+                async move {
+                    runtime.wait_for_exit().await;
+                    processes.kill_all().await;
+                }
+            });
             let registration = runtime.registration().await;
             Ok(LaunchedRuntime {
                 runtime: DenoPluginRuntime {

--- a/crates/plugin-lifecycle/src/tests.rs
+++ b/crates/plugin-lifecycle/src/tests.rs
@@ -446,6 +446,7 @@ async fn activation_launches_the_plugin_and_publishes_each_transition() {
                 DenoPermission::AllowEnv,
                 DenoPermission::AllowNet,
             ],
+            allow_childprocess: true,
             data_dir: temp_dir
                 .path()
                 .join("plugins")

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -70,6 +70,36 @@ await storage.remove("index.json"); // file or directory tree
 Storage errors carry `kind` `invalid_path`, `not_found`, `too_large`, `io`, or
 `invalid_params`.
 
+## Host-managed child processes
+
+`createHostProcesses(plugin)` wraps `ora/childprocess/*`: instead of a plugin
+spawning its own subprocess (which on Deno needs `--allow-run`), it asks Ora to
+spawn, own, and best-effort kill one on its behalf. Ora tears down every process
+a plugin spawned this way the moment that plugin generation stops for any
+reason, on top of whatever a caller's own `kill()` requests.
+
+```ts
+import { createHostProcesses } from "@ora-space/plugin-sdk";
+
+const processes = createHostProcesses(plugin); // before plugin.run()
+const acp = await processes.spawn({
+  command: "opencode",
+  args: ["acp", "--cwd", cwd],
+  cwd,
+});
+acp.stdout; // ReadableStream<Uint8Array> — this plugin owns any line framing
+acp.stderr; // ReadableStream<Uint8Array>
+await acp.write(new TextEncoder().encode(line)); // to the process's stdin
+await acp.closeStdin(); // signals EOF without killing it
+await acp.kill(); // best-effort tree-wide termination
+const { code, signal } = await acp.exited;
+```
+
+`spawn` failures carry `kind` `invalid_command` (empty command),
+`program_not_found` (the OS could not resolve the executable — distinct from any
+other spawn failure, which is `io`), or `invalid_params`; `write`, `closeStdin`,
+and `kill` against an already-exited process's id fail with `not_found`.
+
 ## UI plugins
 
 `defineUiPlugin` builds a plugin that serves Ora's ui contract with the

--- a/packages/plugin-sdk/deno.json
+++ b/packages/plugin-sdk/deno.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "name": "@ora-space/plugin-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/mod.ts"

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ora-space/plugin-sdk",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Ora plugin development SDK",
   "type": "module",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
   "scripts": {
     "format": "deno fmt src tests deno.json package.json README.md",
     "format:check": "deno fmt --check src tests deno.json package.json README.md",
-    "lint": "deno lint src tests && deno check src/mod.ts tests/plugin.test.ts tests/agent.test.ts tests/storage.test.ts tests/workbench.test.ts",
+    "lint": "deno lint src tests && deno check src/mod.ts tests/plugin.test.ts tests/agent.test.ts tests/storage.test.ts tests/process.test.ts tests/workbench.test.ts",
     "test": "deno test tests"
   },
   "publishConfig": {

--- a/packages/plugin-sdk/src/mod.ts
+++ b/packages/plugin-sdk/src/mod.ts
@@ -12,6 +12,13 @@ export {
 } from "./agent.ts";
 export type { EffectSurfaceDeclaration } from "./plugin.ts";
 export {
+  createHostProcesses,
+  type HostChildProcess,
+  type HostChildProcessExit,
+  type HostChildProcessOptions,
+  type HostProcesses,
+} from "./process.ts";
+export {
   createPlugin,
   DEFAULT_HOST_REQUEST_TIMEOUT_MS,
   HostRequestError,

--- a/packages/plugin-sdk/src/process.ts
+++ b/packages/plugin-sdk/src/process.ts
@@ -1,0 +1,213 @@
+import type { Plugin } from "./plugin.ts";
+import type { JsonValue } from "./protocol.ts";
+import { decodeBase64, encodeBase64 } from "./storage.ts";
+
+const CHILDPROCESS_SPAWN_METHOD = "ora/childprocess/spawn";
+const CHILDPROCESS_WRITE_METHOD = "ora/childprocess/write";
+const CHILDPROCESS_CLOSE_STDIN_METHOD = "ora/childprocess/closeStdin";
+const CHILDPROCESS_KILL_METHOD = "ora/childprocess/kill";
+const CHILDPROCESS_STDOUT_METHOD = "ora/childprocess/stdout";
+const CHILDPROCESS_STDERR_METHOD = "ora/childprocess/stderr";
+const CHILDPROCESS_EXIT_METHOD = "ora/childprocess/exit";
+
+/** Options for one subprocess the host spawns on this plugin's behalf. */
+export interface HostChildProcessOptions {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+/** How one host-managed child process ended; `signal` is only ever set on Unix. */
+export interface HostChildProcessExit {
+  code: number | null;
+  signal: number | null;
+}
+
+/**
+ * One subprocess the host owns on this plugin's behalf instead of the plugin spawning it itself.
+ *
+ * The host, not this plugin's own sandboxed runtime, holds the OS process handle: it is killed,
+ * best effort, the moment this plugin generation stops for any reason, on top of whatever this
+ * object's own `kill()` requests.
+ */
+export interface HostChildProcess {
+  readonly pid: number | undefined;
+  readonly stdout: ReadableStream<Uint8Array>;
+  readonly stderr: ReadableStream<Uint8Array>;
+  readonly exited: Promise<HostChildProcessExit>;
+  /** Writes bytes to the process's stdin. */
+  write(bytes: Uint8Array): Promise<void>;
+  /** Signals EOF on the process's stdin without killing it. */
+  closeStdin(): Promise<void>;
+  /** Requests best-effort tree-wide termination of the process. */
+  kill(): Promise<void>;
+}
+
+/** Spawns subprocesses the host owns instead of this plugin's own sandboxed runtime. */
+export interface HostProcesses {
+  spawn(options: HostChildProcessOptions): Promise<HostChildProcess>;
+}
+
+/** One process's demultiplexed stdout/stderr sinks and its `exited` resolver. */
+interface TrackedProcess {
+  stdoutController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  stderrController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  resolveExit: (exit: HostChildProcessExit) => void;
+}
+
+/**
+ * Builds the client for `ora/childprocess/*`: the host spawns, owns, and best-effort kills a
+ * subprocess for this plugin instead of the plugin spawning one itself (which is what
+ * `opencode-agent` did directly with `Deno.Command` before this existed).
+ *
+ * Must be called before `plugin.run()`, like `createStorage`: it registers the notification
+ * handlers the host pushes, unprompted, for every process this client spawns — `stdout` and
+ * `stderr` as raw byte chunks (this plugin owns any line framing) and `exit` once — all
+ * demultiplexed by `processId`.
+ */
+export function createHostProcesses(plugin: Plugin): HostProcesses {
+  const processes = new Map<string, TrackedProcess>();
+
+  plugin.onNotification(CHILDPROCESS_STDOUT_METHOD, (params) => {
+    forwardChunk(processes, params, "stdoutController");
+  });
+  plugin.onNotification(CHILDPROCESS_STDERR_METHOD, (params) => {
+    forwardChunk(processes, params, "stderrController");
+  });
+  plugin.onNotification(CHILDPROCESS_EXIT_METHOD, (params) => {
+    const exit = parseExitNotification(params);
+    if (exit === undefined) {
+      return;
+    }
+    const tracked = processes.get(exit.processId);
+    if (tracked === undefined) {
+      return;
+    }
+    processes.delete(exit.processId);
+    tracked.stdoutController?.close();
+    tracked.stderrController?.close();
+    tracked.resolveExit({ code: exit.code, signal: exit.signal });
+  });
+
+  return {
+    async spawn(options) {
+      const result = await plugin.request(CHILDPROCESS_SPAWN_METHOD, {
+        command: options.command,
+        args: options.args ?? [],
+        cwd: options.cwd ?? null,
+        env: options.env ?? {},
+      } as JsonValue);
+      const spawned = parseSpawnResult(result);
+
+      let stdoutController:
+        | ReadableStreamDefaultController<Uint8Array>
+        | undefined;
+      const stdout = new ReadableStream<Uint8Array>({
+        start(controller) {
+          stdoutController = controller;
+        },
+      });
+      let stderrController:
+        | ReadableStreamDefaultController<Uint8Array>
+        | undefined;
+      const stderr = new ReadableStream<Uint8Array>({
+        start(controller) {
+          stderrController = controller;
+        },
+      });
+      const exited = new Promise<HostChildProcessExit>((resolveExit) => {
+        processes.set(spawned.processId, {
+          stdoutController,
+          stderrController,
+          resolveExit,
+        });
+      });
+
+      return {
+        pid: spawned.pid ?? undefined,
+        stdout,
+        stderr,
+        exited,
+        write: (bytes) =>
+          discardResult(plugin.request(CHILDPROCESS_WRITE_METHOD, {
+            processId: spawned.processId,
+            bytesBase64: encodeBase64(bytes),
+          })),
+        closeStdin: () =>
+          discardResult(
+            plugin.request(CHILDPROCESS_CLOSE_STDIN_METHOD, {
+              processId: spawned.processId,
+            }),
+          ),
+        kill: () =>
+          discardResult(
+            plugin.request(CHILDPROCESS_KILL_METHOD, {
+              processId: spawned.processId,
+            }),
+          ),
+      };
+    },
+  };
+}
+
+/** Decodes one `stdout`/`stderr` notification and enqueues it on the matching stream. */
+function forwardChunk(
+  processes: Map<string, TrackedProcess>,
+  params: JsonValue,
+  controllerField: "stdoutController" | "stderrController",
+): void {
+  if (
+    !isRecord(params) || typeof params.processId !== "string" ||
+    typeof params.bytesBase64 !== "string"
+  ) {
+    console.warn("Ignoring a malformed ora/childprocess output notification");
+    return;
+  }
+  const tracked = processes.get(params.processId);
+  // An unknown processId is not a defect: the process may already have exited and been
+  // untracked, with a trailing chunk still in flight.
+  tracked?.[controllerField]?.enqueue(decodeBase64(params.bytesBase64));
+}
+
+/** Validates one `exit` notification's shape. */
+function parseExitNotification(
+  params: JsonValue,
+):
+  | { processId: string; code: number | null; signal: number | null }
+  | undefined {
+  if (
+    !isRecord(params) || typeof params.processId !== "string" ||
+    (typeof params.code !== "number" && params.code !== null) ||
+    (typeof params.signal !== "number" && params.signal !== null)
+  ) {
+    console.warn("Ignoring a malformed ora/childprocess/exit notification");
+    return undefined;
+  }
+  return {
+    processId: params.processId,
+    code: params.code as number | null,
+    signal: params.signal as number | null,
+  };
+}
+
+/** Validates the wire shape of a `spawn` result. */
+function parseSpawnResult(
+  result: JsonValue,
+): { processId: string; pid: number | null } {
+  if (
+    !isRecord(result) || typeof result.processId !== "string" ||
+    (typeof result.pid !== "number" && result.pid !== null)
+  ) {
+    throw new Error(`${CHILDPROCESS_SPAWN_METHOD} returned an invalid result`);
+  }
+  return { processId: result.processId, pid: result.pid as number | null };
+}
+
+async function discardResult(result: Promise<JsonValue>): Promise<void> {
+  await result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/plugin-sdk/tests/process.test.ts
+++ b/packages/plugin-sdk/tests/process.test.ts
@@ -1,0 +1,288 @@
+import {
+  createHostProcesses,
+  createPlugin,
+  type JsonValue,
+} from "../src/mod.ts";
+import {
+  decodeFrames,
+  encodeFrame,
+  type PluginTransport,
+} from "../src/protocol.ts";
+
+/** Compares JSON-compatible values without a Node compatibility dependency. */
+function assertEquals(actual: unknown, expected: unknown): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`Expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+/** Creates paired in-memory streams for exercising the SDK without global stdio. */
+function createTransportHarness(): {
+  transport: PluginTransport;
+  send: (message: JsonValue) => Promise<void>;
+  responses: AsyncGenerator<unknown>;
+} {
+  const hostInput = new TransformStream<Uint8Array>();
+  // Unbounded queuing lets a plugin await a request frame write before the harness reads it,
+  // the way a real stdio pipe would.
+  const pluginOutput = new TransformStream<Uint8Array>(
+    undefined,
+    undefined,
+    new CountQueuingStrategy({ highWaterMark: Infinity }),
+  );
+  const inputWriter = hostInput.writable.getWriter();
+  return {
+    transport: {
+      readable: hostInput.readable,
+      writable: pluginOutput.writable,
+      redirectConsole: false,
+    },
+    send: (message) => inputWriter.write(encodeFrame(message)),
+    responses: decodeFrames(pluginOutput.readable),
+  };
+}
+
+/** Base64 of `"hi"`, used across tests as one arbitrary chunk of process output. */
+const HI_BASE64 = "aGk=";
+
+Deno.test(
+  "spawn sends command/args/cwd/env and resolves pid from the host result",
+  async () => {
+    const plugin = createPlugin();
+    const processes = createHostProcesses(plugin);
+    const harness = createTransportHarness();
+    const run = plugin.run(harness.transport);
+    await harness.responses.next();
+
+    const spawned = processes.spawn({
+      command: "opencode",
+      args: ["acp", "--cwd", "/work"],
+      cwd: "/work",
+      env: { FOO: "bar" },
+    });
+
+    assertEquals((await harness.responses.next()).value, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ora/childprocess/spawn",
+      params: {
+        command: "opencode",
+        args: ["acp", "--cwd", "/work"],
+        cwd: "/work",
+        env: { FOO: "bar" },
+      },
+    });
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { processId: "1", pid: 4242 },
+    });
+
+    const process = await spawned;
+    assertEquals(process.pid, 4242);
+
+    await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+    await run;
+  },
+);
+
+Deno.test(
+  "spawn omits args/cwd/env with the documented defaults",
+  async () => {
+    const plugin = createPlugin();
+    const processes = createHostProcesses(plugin);
+    const harness = createTransportHarness();
+    const run = plugin.run(harness.transport);
+    await harness.responses.next();
+
+    const spawned = processes.spawn({ command: "opencode" }).catch(
+      (error) => error,
+    );
+
+    assertEquals((await harness.responses.next()).value, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ora/childprocess/spawn",
+      params: { command: "opencode", args: [], cwd: null, env: {} },
+    });
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { processId: "1", pid: null },
+    });
+
+    const process = await spawned;
+    assertEquals(process.pid, undefined);
+
+    await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+    await run;
+  },
+);
+
+Deno.test(
+  "write, closeStdin, and kill send the process's id and base64 bytes",
+  async () => {
+    const plugin = createPlugin();
+    const processes = createHostProcesses(plugin);
+    const harness = createTransportHarness();
+    const run = plugin.run(harness.transport);
+    await harness.responses.next();
+
+    const spawned = processes.spawn({ command: "opencode" });
+    await harness.responses.next();
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { processId: "7", pid: 1 },
+    });
+    const process = await spawned;
+
+    const wrote = process.write(new TextEncoder().encode("hi"));
+    assertEquals((await harness.responses.next()).value, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "ora/childprocess/write",
+      params: { processId: "7", bytesBase64: HI_BASE64 },
+    });
+    await harness.send({ jsonrpc: "2.0", id: 2, result: {} });
+    await wrote;
+
+    const closed = process.closeStdin();
+    assertEquals((await harness.responses.next()).value, {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "ora/childprocess/closeStdin",
+      params: { processId: "7" },
+    });
+    await harness.send({ jsonrpc: "2.0", id: 3, result: {} });
+    await closed;
+
+    const killed = process.kill();
+    assertEquals((await harness.responses.next()).value, {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "ora/childprocess/kill",
+      params: { processId: "7" },
+    });
+    await harness.send({ jsonrpc: "2.0", id: 4, result: {} });
+    await killed;
+
+    await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+    await run;
+  },
+);
+
+Deno.test(
+  "stdout and stderr notifications are demultiplexed by processId, and exit closes both streams",
+  async () => {
+    const plugin = createPlugin();
+    const processes = createHostProcesses(plugin);
+    const harness = createTransportHarness();
+    const run = plugin.run(harness.transport);
+    await harness.responses.next();
+
+    // Two concurrent processes, spawned in one order but resolved out of order, prove
+    // demultiplexing is by processId rather than by spawn call order.
+    const first = processes.spawn({ command: "one" });
+    const second = processes.spawn({ command: "two" });
+    await harness.responses.next();
+    await harness.responses.next();
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { processId: "second", pid: 2 },
+    });
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { processId: "first", pid: 1 },
+    });
+    const firstProcess = await first;
+    const secondProcess = await second;
+
+    await harness.send({
+      jsonrpc: "2.0",
+      method: "ora/childprocess/stdout",
+      params: { processId: "second", bytesBase64: HI_BASE64 },
+    });
+    await harness.send({
+      jsonrpc: "2.0",
+      method: "ora/childprocess/stderr",
+      params: { processId: "first", bytesBase64: HI_BASE64 },
+    });
+
+    const secondStdoutReader = secondProcess.stdout.getReader();
+    assertEquals(
+      [...(await secondStdoutReader.read()).value ?? []],
+      [104, 105],
+    );
+    const firstStderrReader = firstProcess.stderr.getReader();
+    assertEquals(
+      [...(await firstStderrReader.read()).value ?? []],
+      [104, 105],
+    );
+
+    // Neither process has exited yet: reads beyond the single enqueued chunk must not resolve.
+    const firstStdoutReader = firstProcess.stdout.getReader();
+    const pendingRead = firstStdoutReader.read().then(() => "resolved");
+    const raced = await Promise.race([
+      pendingRead,
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 20)),
+    ]);
+    assertEquals(raced, "pending");
+
+    await harness.send({
+      jsonrpc: "2.0",
+      method: "ora/childprocess/exit",
+      params: { processId: "first", code: 0, signal: null },
+    });
+    assertEquals(await firstProcess.exited, { code: 0, signal: null });
+    assertEquals(await pendingRead, "resolved");
+    assertEquals((await firstStdoutReader.read()).done, true);
+
+    await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+    await run;
+  },
+);
+
+Deno.test(
+  "an exit or output notification for an unknown processId is ignored rather than crashing the plugin",
+  async () => {
+    const plugin = createPlugin();
+    createHostProcesses(plugin);
+    const harness = createTransportHarness();
+    const run = plugin.run(harness.transport);
+    await harness.responses.next();
+
+    await harness.send({
+      jsonrpc: "2.0",
+      method: "ora/childprocess/stdout",
+      params: { processId: "ghost", bytesBase64: HI_BASE64 },
+    });
+    await harness.send({
+      jsonrpc: "2.0",
+      method: "ora/childprocess/exit",
+      params: { processId: "ghost", code: 0, signal: null },
+    });
+
+    // The connection is still alive: a normal request still round-trips.
+    const list = plugin.request("ora/storage/list", { path: "" });
+    assertEquals((await harness.responses.next()).value, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ora/storage/list",
+      params: { path: "" },
+    });
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { entries: [] },
+    });
+    assertEquals(await list, { entries: [] });
+
+    await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+    await run;
+  },
+);


### PR DESCRIPTION
## 背景

目前 opencode-agent 这类 Agent 插件是在自己的 Deno 沙箱进程里，用 `Deno.Command` 直接拉起并管理它自己的 ACP server 子进程。这样做需要插件持有 `--allow-run`，并且这个子进程的操作系统生命周期完全脱离了 Ora 自己的进程树监管（`ora-process` 的 Job Object / 进程组整树终止能力），只依赖插件自己在 Deno 里做的那点清理。

这次改动把"拉起 / 停止子进程"这件事移交给 Ora host（Rust 端）来做，并且把这个能力做成 `plugin-sdk` 里的通用接口（不绑定 ACP，任何 agent/workbench 插件都能用），而不是只服务 opencode-agent 一个插件。

## 改动内容

- `ora-plugin-lifecycle` 新增 `ora/childprocess/{spawn,write,closeStdin,kill}` 四个 host request 方法（`crates/plugin-lifecycle/src/childprocess.rs`），底层复用 `ora-process` 现成的进程树级终止能力（Windows Job Object / Unix 进程组），不重复造轮子。
- stdout / stderr / exit 通过 host→plugin 的通知推回插件，采用延迟绑定（`attach_runtime`）：因为这个 handler 必须在对应的 `PluginRuntime` 句柄存在之前就先构造出来（它本身是 launch 的入参），而推送通知恰好需要那个句柄，只能等 launch 返回之后再补上。
- 接入 `runtime.rs`：每个进程只能有一个 `HostRequestHandler`，所以用一个很小的 `PluginHostRequests` 分发器把新能力和已有的 `PluginStorage` 组合起来；插件这一代进程无论以什么方式结束（正常 stop、卸载、restart、还是崩溃），只要它的 `wait_for_exit()` 返回，就会统一触发 `kill_all()` 清理它拉起的所有子进程 —— 这就是"不管 Ora 以什么方式停止，都要 best effort 停掉这些子进程"的落地方式。
- `packages/plugin-sdk` 新增对称的 `createHostProcesses(plugin)` 客户端（和现有的 `createStorage` 是同一个层级），已导出、有文档、有测试。

## 测试

- Rust 侧新增 9 个测试，其中一个专门构造了一个基于 duplex pipe 的"假插件进程"来跑通真实的 `PluginRuntime`，验证通知确实能端到端送达 —— 这个测试在写完之后就抓到了一个真实 bug（`watch::Sender::send` 在没有存活接收端时会静默丢弃值，导致进程被提前判定为已退出）。
- `cargo test / clippy / fmt` 对 `ora-plugin-lifecycle` 全部通过。
- Plugin SDK 侧新增 5 个测试，`deno test / lint / fmt` 全部通过。
- 用改造后的 `opencode-agent`（对应的 opencode-agent 仓库那边的 PR）对着真实安装的 `opencode` CLI 跑了一遍完整流程（`agent/start` → ACP 会话 → `effect/restart` 触发 kill+respawn → `agent/stop`），全部符合预期。

## 有意没动的部分

- `ora-plugin-lifecycle` 里 agent 插件的 Deno 权限集合（`agent_permissions` / `permissions_for`）没有收紧，`--allow-run` 还是保留的 —— 这是所有 agent 插件共享的权限策略，AGENTS.md 里已经写明权限收紧是后续单独要做的事，这次只是新增能力，不改变现有插件的运行方式。