### PR TITLE
fix(workflow): keep task runs under their task

### DIFF
--- a/packages/app-shell/src/features/workflow-run/run-workflow-dialog.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-workflow-dialog.tsx
@@ -21,7 +21,7 @@ import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selecti
 interface RunWorkflowDialogProps {
   open: boolean;
   workflow: { id: string; name: string } | null;
-  target: { projectId: string; workspaceId: string } | null;
+  target: { projectId: string; workspaceId: string; taskId?: string } | null;
   onOpenChange: (open: boolean) => void;
 }
 
@@ -74,7 +74,7 @@ export function RunWorkflowDialog({
         name: resolvedRunName,
       });
       useUiStore.getState().expandProject(target.projectId);
-      selectWorkflowRun(result.run.id, target.projectId);
+      selectWorkflowRun(result.run.id, target.projectId, target.taskId);
       onOpenChange(false);
       resetLocalState();
     } catch (cause) {

--- a/packages/app-shell/src/features/workspace/sidebar-create-menu.tsx
+++ b/packages/app-shell/src/features/workspace/sidebar-create-menu.tsx
@@ -23,6 +23,8 @@ interface SidebarCreateMenuProps {
   projectId: string;
   /** Exact Workspace that owns chats and workflow execution created from this row. */
   workspaceId: string | null;
+  /** Task row owning the workspace, when this menu is rendered under a task. */
+  taskId?: string;
   scope: "project" | "task";
   onNewTask: () => void;
 }
@@ -40,6 +42,7 @@ const ITEM_CLASS =
 export function SidebarCreateMenu({
   projectId,
   workspaceId,
+  taskId,
   scope,
   onNewTask,
 }: SidebarCreateMenuProps) {
@@ -252,6 +255,7 @@ export function SidebarCreateMenu({
                       kind: "runWorkflow",
                       projectId,
                       workspaceId,
+                      ...(taskId !== undefined ? { taskId } : {}),
                       workflowId: workflow.id,
                       workflowName: workflow.name,
                     });

--- a/packages/app-shell/src/features/workspace/workspace-dialogs.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-dialogs.tsx
@@ -74,6 +74,7 @@ export function WorkspaceDialogs() {
             ? {
                 projectId: runWorkflowDialog.projectId,
                 workspaceId: runWorkflowDialog.workspaceId,
+                taskId: runWorkflowDialog.taskId,
               }
             : null
         }

--- a/packages/app-shell/src/features/workspace/workspace-project-tree-node.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-project-tree-node.tsx
@@ -185,6 +185,8 @@ export const ProjectTreeNode = memo(function ProjectTreeNode({
       <TreeBranch expanded={projectOpen} retainWhenCollapsed={!forceExpanded}>
         <ProjectWorkflowRunRows
           projectId={project.id}
+          workspaceId={mainWorkspaceId}
+          depth={1}
           listEnabled={projectOpen}
           activeRunId={activeRunId}
           onSelectRun={(runId) =>
@@ -269,6 +271,9 @@ const WorktreeTaskNode = memo(function WorktreeTaskNode({
       s.selection.taskId === task.id &&
       (s.selection.sessionId !== null || s.selection.draftId !== null),
   );
+  const activeRunId = useWorkspaceSelectionStore((s) =>
+    s.selection.taskId === task.id ? s.selection.workflowRunId : null,
+  );
   const taskCreateFocused = useWorkspaceSelectionStore((s) => {
     const { createFocus, selection } = s;
     return (
@@ -305,6 +310,7 @@ const WorktreeTaskNode = memo(function WorktreeTaskNode({
           <SidebarCreateMenu
             projectId={projectId}
             workspaceId={task.workspaceId}
+            taskId={task.id}
             scope="task"
             onNewTask={() =>
               startSessionDraft({
@@ -331,6 +337,26 @@ const WorktreeTaskNode = memo(function WorktreeTaskNode({
         ]}
       />
       <TreeBranch expanded={taskOpen} retainWhenCollapsed={!forceExpanded}>
+        <ProjectWorkflowRunRows
+          projectId={projectId}
+          workspaceId={task.workspaceId}
+          depth={2}
+          listEnabled={taskOpen}
+          activeRunId={activeRunId}
+          onSelectRun={(runId) =>
+            useWorkspaceSelectionStore
+              .getState()
+              .selectWorkflowRun(runId, projectId, task.id)
+          }
+          onDeleteRun={(run) =>
+            useUiStore.getState().setDeleteTarget({
+              kind: "workflowRun",
+              id: run.id,
+              name: run.name,
+              projectId,
+            })
+          }
+        />
         {drafts.map((draft) => (
           <DraftSessionTreeRow key={draft.id} draftId={draft.id} depth={2} />
         ))}

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
@@ -765,7 +765,7 @@ describe("WorkspaceSidebar", () => {
         snapshotId: "snap1",
         name: "Review bot",
         status: "pending",
-        workspaceId: "workspace-wt1",
+        workspaceId: "workspace-p1",
         createdAt: 0n,
         updatedAt: 0n,
       },
@@ -779,6 +779,43 @@ describe("WorkspaceSidebar", () => {
     expect(
       within(runRow).getByRole("button", { name: /归档|Archive/ }),
     ).not.toBeNull();
+  });
+
+  it("places task workflow runs under the owning task", async () => {
+    const state = workspaceWithOneSession();
+    state.workflowRuns = [
+      {
+        id: "run-task",
+        projectId: PROJECT.id,
+        workflowId: "wf-task",
+        snapshotId: "snap-task",
+        name: "Task workflow",
+        status: "pending",
+        workspaceId: TASK.workspaceId,
+        createdAt: 0n,
+        updatedAt: 0n,
+      },
+      {
+        id: "run-project",
+        projectId: PROJECT.id,
+        workflowId: "wf-project",
+        snapshotId: "snap-project",
+        name: "Project workflow",
+        status: "pending",
+        workspaceId: "workspace-p1",
+        createdAt: 0n,
+        updatedAt: 0n,
+      },
+    ];
+    renderSidebar(state);
+
+    await waitFor(() => {
+      expect(treeRow("Task workflow")).not.toBeNull();
+      expect(treeRow("Project workflow")).not.toBeNull();
+    });
+
+    expect(treeRow("Task workflow")!.style.paddingLeft).toBe("44px");
+    expect(treeRow("Project workflow")!.style.paddingLeft).toBe("26px");
   });
 
   it("opens delete confirmation from the session context menu", async () => {
@@ -865,6 +902,7 @@ describe("WorkspaceSidebar", () => {
       kind: "runWorkflow",
       projectId: PROJECT.id,
       workspaceId: TASK.workspaceId,
+      taskId: TASK.id,
       workflowId: "wf1",
       workflowName: "Task review",
     });

--- a/packages/app-shell/src/features/workspace/workspace-tree-row.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-tree-row.tsx
@@ -310,15 +310,19 @@ function runStatusClass(status: GraphWorkflowRunStatus): string {
   }
 }
 
-/** Per-project run list so each row can call useGraphWorkflowRuns without hook-in-loop. */
+/** Renders workflow runs belonging to one workspace within a project run query. */
 export const ProjectWorkflowRunRows = memo(function ProjectWorkflowRunRows({
   projectId,
+  workspaceId,
+  depth,
   activeRunId,
   onSelectRun,
   onDeleteRun,
   listEnabled = true,
 }: {
   projectId: string;
+  workspaceId: string | null;
+  depth: 1 | 2;
   activeRunId: string | null;
   onSelectRun: (runId: string) => void;
   onDeleteRun: (run: { id: string; name: string }) => void;
@@ -330,7 +334,9 @@ export const ProjectWorkflowRunRows = memo(function ProjectWorkflowRunRows({
     enabled: listEnabled,
   });
   const renameWorkflowRun = useRenameWorkflowRun();
-  const runs = runsQuery.data ?? [];
+  const runs = (runsQuery.data ?? []).filter(
+    (run) => run.workspaceId === workspaceId,
+  );
   return (
     <>
       {runs.map((run) => {
@@ -341,7 +347,7 @@ export const ProjectWorkflowRunRows = memo(function ProjectWorkflowRunRows({
         return (
           <TreeRow
             key={run.id}
-            depth={1}
+            depth={depth}
             active={activeRunId === run.id}
             icon={
               <span className="relative flex size-[18px] items-center justify-center">

--- a/packages/app-shell/src/state/stores/ui-store.ts
+++ b/packages/app-shell/src/state/stores/ui-store.ts
@@ -12,6 +12,7 @@ export type DialogState =
       kind: "runWorkflow";
       projectId: string;
       workspaceId: string;
+      taskId?: string;
       workflowId: string;
       workflowName: string;
     };

--- a/packages/app-shell/src/state/stores/workspace-selection-store.ts
+++ b/packages/app-shell/src/state/stores/workspace-selection-store.ts
@@ -69,8 +69,12 @@ interface WorkspaceSelectionState {
     taskId: string | null,
     projectId: string,
   ) => void;
-  /** Selects a graph workflow run under a project (clears task/session). */
-  selectWorkflowRun: (workflowRunId: string, projectId: string) => void;
+  /** Selects a graph workflow run under its project and optional task workspace. */
+  selectWorkflowRun: (
+    workflowRunId: string,
+    projectId: string,
+    taskId?: string,
+  ) => void;
   /** Clears the entire selection. */
   clearSelection: () => void;
   /** Clears only the session leg (used after the selected session is deleted). */
@@ -249,10 +253,10 @@ export const useWorkspaceSelectionStore = create<WorkspaceSelectionState>()(
             draftId,
           });
         },
-        selectWorkflowRun: (workflowRunId, projectId) => {
+        selectWorkflowRun: (workflowRunId, projectId, taskId) => {
           replaceSelection({
             projectId,
-            taskId: null,
+            taskId: taskId ?? null,
             sessionId: null,
             workflowRunId,
             draftId: null,


### PR DESCRIPTION
## 修复内容

修复从 task 下创建 workflow run 后，运行记录错误显示在项目级列表中的问题。

现在 workflow run 会根据所属 workspace 正确分层：从 task 发起的 run 显示在对应 task 下，项目级发起的 run 继续显示在项目下。同时修复了 task run 创建后选中状态丢失 task 归属的问题，并增加了侧边栏回归测试。

## 验证

- 侧边栏测试通过（57/57）
- 相关 workflow、dialog、store 测试通过（57/57）
- TypeScript 类型检查通过