### PR TITLE
[Agent MCP 01] Expand Agent Target Effect persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,3 @@ packages/contracts/.test-dist/
 /specs
 /memories
 
-# Local Agent MCP design notes used during development; do not commit
-CONTEXT.md
-docs/adr/
-docs/agents/
-docs/agent-mcp-config-research.md
-docs/agent-mcp-configuration-spec.md
-

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ packages/contracts/.test-dist/
 /specs
 /memories
 
+# Local Agent MCP design notes used during development; do not commit
+CONTEXT.md
+docs/adr/
+docs/agents/
+docs/agent-mcp-config-research.md
+docs/agent-mcp-configuration-spec.md
+

--- a/crates/db/src/agent_target_repository_tests.rs
+++ b/crates/db/src/agent_target_repository_tests.rs
@@ -2,16 +2,20 @@ use crate::{
     DatabaseBootstrapper, DatabaseLocation, MigrationCatalog, RepositoryPool,
     SqliteEffectRepository, TimestampSource, default_migration_catalog,
 };
-use ora_domain::WorkspaceId;
+use ora_domain::{Namespace, WorkspaceId};
 use ora_effect::{
-    AgentCapabilityRevision, AgentPluginId, AgentTargetCondition, AgentTargetConditionReason,
-    AgentTargetConditionSubject, AgentTargetIdentity, AgentTargetLifecycle, AgentTargetPhase,
-    AgentTargetRepository, AgentTargetWakeReason, ConditionImpact, EffectRepository, Generation,
+    AgentCapabilityRevision, AgentPluginId, AgentTargetCondition, AgentTargetConditionAttachment,
+    AgentTargetConditionReason, AgentTargetConditionSubject, AgentTargetIdentity,
+    AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileRequest, AgentTargetReconcileState,
+    AgentTargetRecord, AgentTargetRepository, AgentTargetStatus, AgentTargetWakeReason,
+    ConditionImpact, ConsumerId, EffectRepository, Generation, ManagedIdentity, SkillName,
+    SkillSelectionKey, SourceKind, SurfaceKey, WorkspaceEffect, WorkspaceEffectSpec,
     initial_agent_target_status,
 };
 use ora_logging::with_trace_logging;
 use pretty_assertions::assert_eq;
 use rusqlite::{Connection, params};
+use std::collections::BTreeMap;
 use tempfile::TempDir;
 
 #[derive(Clone, Copy, Debug)]
@@ -139,10 +143,18 @@ fn seed_surface_requests(connection: &Connection, workspace_id: &WorkspaceId) {
                  id, surface_id, consumer_id, subject_kind, subject_id, reason,
                  failed_generation, message, first_observed_at, last_observed_at
              ) VALUES
-             ('cond-surface', 'surface-a', NULL, 'surface', '{\"kind\":\"surface\"}',
+             ('cond-surface', 'surface-a', NULL, 'surface',
+              '{\"kind\":\"surface\",\"surface_key\":\"surface-a\"}',
               'path_unsafe', 3, 'unsafe path', 10, 20),
-             ('cond-consumer', 'surface-b', 'opencode', 'consumer', '{\"kind\":\"consumer\"}',
-              'waiting_for_idle', 5, 'waiting', 30, 40)",
+             ('cond-desired', 'surface-a', NULL, 'desired_item',
+              '{\"kind\":\"desired_skill\",\"selection_key\":{\"source_kind\":\"plugin\",\"namespace\":\"ora\",\"name\":\"demo\"}}',
+              'desired_collision', 4, 'collision', 11, 21),
+             ('cond-consumer', 'surface-b', 'opencode', 'consumer',
+              '{\"kind\":\"consumer\",\"consumer_id\":\"opencode\"}',
+              'waiting_for_idle', 5, 'waiting', 30, 40),
+             ('cond-managed', 'surface-b', 'opencode', 'managed_item',
+              '{\"kind\":\"managed_skill\",\"managed_identity\":\"managed-1\"}',
+              'ownership_conflict', 6, 'owned', 31, 41)",
             [],
         )
         .unwrap_or_else(|error| panic!("insert conditions: {error}"));
@@ -257,7 +269,7 @@ fn upgrades_old_schema_and_backfills_target_requests_deterministically() {
         .connection()
         .query_row(
             "SELECT requests.requested_generation, requests.not_before_at, requests.requested_at,
-                    status.desired_generation, status.ready_generation
+                    status.desired_generation, status.ready_generation, status.phase
              FROM effect_agent_targets targets
              JOIN effect_agent_target_reconcile_requests requests
                ON requests.agent_target_id = targets.id
@@ -272,11 +284,12 @@ fn upgrades_old_schema_and_backfills_target_requests_deterministically() {
                     row.get::<_, i64>(2)?,
                     row.get::<_, i64>(3)?,
                     row.get::<_, i64>(4)?,
+                    row.get::<_, String>(5)?,
                 ))
             },
         )
         .unwrap_or_else(|error| panic!("load opencode backfill: {error}"));
-    assert_eq!(opencode, (9, 200, 100, 7, 4));
+    assert_eq!(opencode, (9, 200, 100, 7, 4, "pending".to_string()));
 
     let condition_count: i64 = upgraded
         .connection()
@@ -287,8 +300,9 @@ fn upgrades_old_schema_and_backfills_target_requests_deterministically() {
             |row| row.get(0),
         )
         .unwrap();
-    // surface-scoped fans out to opencode on surface-a; consumer-scoped keeps opencode on surface-b.
-    assert_eq!(condition_count, 2);
+    // surface-scoped fans out to opencode on surface-a (surface + desired_item);
+    // consumer-scoped keeps opencode on surface-b (consumer + managed_item).
+    assert_eq!(condition_count, 4);
     drop(upgraded);
 
     let pool = RepositoryPool::new(&location)
@@ -299,13 +313,95 @@ fn upgrades_old_schema_and_backfills_target_requests_deterministically() {
         .load_agent_target_status(&identity)
         .unwrap_or_else(|error| panic!("load backfilled status: {error}"))
         .expect("opencode target status");
-    assert_eq!(status.conditions.len(), 2);
-    assert!(
-        status
-            .conditions
-            .iter()
-            .all(|condition| condition.impact == ConditionImpact::Blocking)
-    );
+    let mut actual = status;
+    actual
+        .conditions
+        .sort_by_key(|condition| format!("{:?}", condition.subject));
+    for condition in &mut actual.conditions {
+        condition.id.clear();
+    }
+    let surface_a = AgentTargetConditionAttachment {
+        surface_key: SurfaceKey::new("surface-a"),
+        consumer_id: Some(ConsumerId::new("opencode")),
+    };
+    let surface_b = AgentTargetConditionAttachment {
+        surface_key: SurfaceKey::new("surface-b"),
+        consumer_id: Some(ConsumerId::new("opencode")),
+    };
+    let mut expected = AgentTargetStatus {
+        agent_target_id: actual.agent_target_id.clone(),
+        identity: identity.clone(),
+        desired_generation: Generation::new(7),
+        observed_generation: Generation::new(6),
+        applied_generation: Generation::new(5),
+        ready_generation: Generation::new(4),
+        phase: AgentTargetPhase::Pending,
+        status_version: 1,
+        created_at: 10,
+        updated_at: 11,
+        conditions: vec![
+            AgentTargetCondition {
+                id: String::new(),
+                subject: AgentTargetConditionSubject::Consumer {
+                    consumer_id: ConsumerId::new("opencode"),
+                },
+                reason: AgentTargetConditionReason::WaitingForIdle,
+                impact: ConditionImpact::Blocking,
+                message: "waiting".to_string(),
+                first_observed_at: 30,
+                last_observed_at: 40,
+                failed_generation: Some(Generation::new(5)),
+                attachment: Some(surface_b.clone()),
+            },
+            AgentTargetCondition {
+                id: String::new(),
+                subject: AgentTargetConditionSubject::DesiredSkill {
+                    selection_key: SkillSelectionKey::new(
+                        SourceKind::Plugin,
+                        Namespace::new("ora").expect("namespace"),
+                        SkillName::parse("demo").expect("skill name"),
+                    ),
+                },
+                reason: AgentTargetConditionReason::DesiredCollision,
+                impact: ConditionImpact::Blocking,
+                message: "collision".to_string(),
+                first_observed_at: 11,
+                last_observed_at: 21,
+                failed_generation: Some(Generation::new(4)),
+                attachment: Some(surface_a.clone()),
+            },
+            AgentTargetCondition {
+                id: String::new(),
+                subject: AgentTargetConditionSubject::ManagedSkill {
+                    managed_identity: ManagedIdentity::new("managed-1"),
+                },
+                reason: AgentTargetConditionReason::OwnershipConflict,
+                impact: ConditionImpact::Blocking,
+                message: "owned".to_string(),
+                first_observed_at: 31,
+                last_observed_at: 41,
+                failed_generation: Some(Generation::new(6)),
+                attachment: Some(surface_b),
+            },
+            AgentTargetCondition {
+                id: String::new(),
+                subject: AgentTargetConditionSubject::Surface {
+                    surface_key: SurfaceKey::new("surface-a"),
+                },
+                reason: AgentTargetConditionReason::PathUnsafe,
+                impact: ConditionImpact::Blocking,
+                message: "unsafe path".to_string(),
+                first_observed_at: 10,
+                last_observed_at: 20,
+                failed_generation: Some(Generation::new(3)),
+                attachment: Some(surface_a),
+            },
+        ],
+    };
+    expected
+        .conditions
+        .sort_by_key(|condition| format!("{:?}", condition.subject));
+    assert_eq!(actual, expected);
 }
 
 #[test]
@@ -391,11 +487,12 @@ fn typed_repository_round_trips_complete_agent_target_record() {
             &identity,
             &AgentCapabilityRevision::new("cap-1"),
             AgentTargetLifecycle::Active,
-            50,
+            /*updated_at*/ 50,
         )
         .unwrap_or_else(|error| panic!("upsert target: {error}"));
 
-    let mut status = initial_agent_target_status(target.id.clone(), identity.clone(), 50);
+    let mut status =
+        initial_agent_target_status(target.id.clone(), identity.clone(), /*now*/ 50);
     status.desired_generation = Generation::new(4);
     status.observed_generation = Generation::new(3);
     status.applied_generation = Generation::new(2);
@@ -405,15 +502,16 @@ fn typed_repository_round_trips_complete_agent_target_record() {
     status.updated_at = 60;
     status.conditions = vec![AgentTargetCondition {
         id: "condition-1".to_string(),
-        subject: AgentTargetConditionSubject::AgentTarget,
+        subject: AgentTargetConditionSubject::Mcp {
+            managed_identity: ManagedIdentity::new("mcp-1"),
+        },
         reason: AgentTargetConditionReason::UnsupportedByAgent,
         impact: ConditionImpact::NonBlocking,
         message: "stdio unsupported".to_string(),
         first_observed_at: 55,
         last_observed_at: 60,
         failed_generation: Some(Generation::new(4)),
-        surface_key: None,
-        consumer_id: None,
+        attachment: None,
     }];
     repository
         .save_agent_target_status(&status)
@@ -424,35 +522,44 @@ fn typed_repository_round_trips_complete_agent_target_record() {
             &identity,
             Generation::new(4),
             AgentTargetWakeReason::DesiredChanged,
-            80,
-            70,
+            /*not_before_at*/ 80,
+            /*updated_at*/ 70,
         )
         .unwrap_or_else(|error| panic!("upsert request: {error}"));
+    let expected_request = AgentTargetReconcileRequest {
+        agent_target_id: target.id.clone(),
+        identity: identity.clone(),
+        requested_generation: Generation::new(6),
+        request_token: request.request_token.clone(),
+        state: AgentTargetReconcileState::Pending,
+        wake_reason: AgentTargetWakeReason::CapabilityChanged,
+        attempt_count: 0,
+        requested_at: 65,
+        not_before_at: 65,
+        updated_at: 90,
+    };
     let coalesced = repository
         .upsert_agent_target_reconcile_request(
             &identity,
             Generation::new(6),
             AgentTargetWakeReason::CapabilityChanged,
-            65,
-            90,
+            /*not_before_at*/ 65,
+            /*updated_at*/ 90,
         )
         .unwrap_or_else(|error| panic!("coalesce request: {error}"));
-    assert_eq!(coalesced.requested_generation, Generation::new(6));
-    assert_eq!(coalesced.not_before_at, 65);
-    assert_eq!(coalesced.request_token, request.request_token);
+    assert_eq!(coalesced, expected_request);
 
     let loaded = repository
         .load_agent_target_record(&identity)
         .unwrap_or_else(|error| panic!("load record: {error}"))
         .expect("record present");
-    assert_eq!(loaded.target, target);
-    assert_eq!(loaded.status, status);
     assert_eq!(
-        loaded
-            .reconcile_request
-            .expect("request present")
-            .requested_generation,
-        Generation::new(6)
+        loaded,
+        AgentTargetRecord {
+            target,
+            status,
+            reconcile_request: Some(expected_request),
+        }
     );
 }
 
@@ -463,8 +570,16 @@ fn surface_keyed_skill_effect_apis_remain_available() {
     let effect = repository
         .load_workspace_effect(&workspace_id)
         .unwrap_or_else(|error| panic!("load workspace effect: {error}"));
-    assert_eq!(effect.workspace_id, workspace_id);
-    assert_eq!(effect.generation, Generation::default());
+    assert_eq!(
+        effect,
+        WorkspaceEffect {
+            workspace_id,
+            generation: Generation::default(),
+            spec: WorkspaceEffectSpec {
+                skills: BTreeMap::new(),
+            },
+        }
+    );
 
     let surface_table_exists: i64 = pool
         .with_connection(|connection| {

--- a/crates/db/src/agent_target_repository_tests.rs
+++ b/crates/db/src/agent_target_repository_tests.rs
@@ -1,0 +1,495 @@
+use crate::{
+    DatabaseBootstrapper, DatabaseLocation, MigrationCatalog, RepositoryPool,
+    SqliteEffectRepository, TimestampSource, default_migration_catalog,
+};
+use ora_domain::WorkspaceId;
+use ora_effect::{
+    AgentCapabilityRevision, AgentPluginId, AgentTargetCondition, AgentTargetConditionReason,
+    AgentTargetConditionSubject, AgentTargetIdentity, AgentTargetLifecycle, AgentTargetPhase,
+    AgentTargetRepository, AgentTargetWakeReason, ConditionImpact, EffectRepository, Generation,
+    initial_agent_target_status,
+};
+use ora_logging::with_trace_logging;
+use pretty_assertions::assert_eq;
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy, Debug)]
+struct FixedTimestamp;
+
+impl TimestampSource for FixedTimestamp {
+    fn current_timestamp_millis(&self) -> i64 {
+        1_700_000_000_000
+    }
+}
+
+/// Bootstraps a file-backed pool with one Workspace Effect aggregate.
+fn fixture() -> (TempDir, RepositoryPool, WorkspaceId) {
+    let directory = TempDir::new().unwrap_or_else(|error| panic!("create database dir: {error}"));
+    let location = DatabaseLocation::path(directory.path().join("ora.sqlite"));
+    let pool = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestamp)
+            .bootstrap_repository_pool(
+                &location,
+                &default_migration_catalog()
+                    .unwrap_or_else(|error| panic!("build catalog: {error}")),
+            )
+            .unwrap_or_else(|error| panic!("bootstrap pool: {error}"))
+    });
+    let workspace_id = WorkspaceId::new("workspace-1");
+    pool.with_connection(|connection| {
+        connection.execute(
+            "INSERT INTO projects (
+                 id, name, repository_kind, created_at, updated_at, is_deleted
+             ) VALUES ('project-1', 'Demo', 'git', 1, 1, 0)",
+            [],
+        )?;
+        connection.execute(
+            "INSERT INTO workspace_locations (
+                 id, location_kind, locator_version, locator_json, created_at, updated_at
+             ) VALUES ('location-1', 'local_filesystem', 1, '{}', 1, 1)",
+            [],
+        )?;
+        connection.execute(
+            "INSERT INTO workspaces (
+                 id, project_id, workspace_kind, location_id, lifecycle,
+                 created_at, updated_at, is_deleted
+             ) VALUES (?1, 'project-1', 'main', 'location-1', 'active', 1, 1, 0)",
+            params![workspace_id.as_ref()],
+        )?;
+        Ok(())
+    })
+    .unwrap_or_else(|error| panic!("insert Workspace fixture: {error}"));
+    (directory, pool, workspace_id)
+}
+
+/// Builds a catalog that stops before Agent Target Expand so upgrade backfill can be tested.
+fn catalog_before_agent_targets() -> MigrationCatalog {
+    let full = default_migration_catalog().unwrap_or_else(|error| panic!("build catalog: {error}"));
+    MigrationCatalog::with_target_versions(
+        full.migrations().to_vec(),
+        vec!["0001", "0002", "0003", "0004", "0005", "0006"],
+    )
+    .unwrap_or_else(|error| panic!("prefix catalog: {error}"))
+}
+
+/// Inserts two surface reconcile requests that share one Agent Plugin consumer.
+fn seed_surface_requests(connection: &Connection, workspace_id: &WorkspaceId) {
+    connection
+        .execute(
+            "INSERT INTO effect_surfaces (
+                 id, workspace_id, adapter_kind, locator_key, locator_json, format_kind,
+                 lifecycle, created_at, updated_at
+             ) VALUES
+             ('surface-a', ?1, 'filesystem_skill', '.agents/skills', '{}', 'skill_directory.v1',
+              'active', 10, 10),
+             ('surface-b', ?1, 'filesystem_skill', '.claude/skills', '{}', 'skill_directory.v1',
+              'active', 10, 10)",
+            params![workspace_id.as_ref()],
+        )
+        .unwrap_or_else(|error| panic!("insert surfaces: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_surface_consumers (
+                 surface_id, consumer_id, coordination_kind, created_at, updated_at
+             ) VALUES
+             ('surface-a', 'opencode', 'wait_for_idle_and_restart', 10, 10),
+             ('surface-b', 'opencode', 'wait_for_idle_and_restart', 11, 11),
+             ('surface-b', 'codex', 'wait_for_idle_and_restart', 12, 12)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert consumers: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_surface_status (
+                 surface_id, desired_generation, observed_generation, applied_generation,
+                 phase, status_version, created_at, updated_at
+             ) VALUES
+             ('surface-a', 5, 4, 3, 'pending', 1, 10, 10),
+             ('surface-b', 7, 6, 5, 'pending', 1, 10, 10)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert surface status: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_consumer_status (
+                 surface_id, consumer_id, ready_generation, phase, status_version,
+                 created_at, updated_at
+             ) VALUES
+             ('surface-a', 'opencode', 2, 'current', 1, 10, 10),
+             ('surface-b', 'opencode', 4, 'current', 1, 10, 10),
+             ('surface-b', 'codex', 1, 'current', 1, 10, 10)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert consumer status: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_reconcile_requests (
+                 surface_id, requested_generation, request_token, state, wake_reason,
+                 attempt_count, requested_at, not_before_at, updated_at
+             ) VALUES
+             ('surface-a', 4, 'token-a', 'pending', 'desired_changed', 0, 100, 250, 100),
+             ('surface-b', 9, 'token-b', 'pending', 'desired_changed', 0, 110, 200, 110)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert surface requests: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_conditions (
+                 id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES
+             ('cond-surface', 'surface-a', NULL, 'surface', '{\"kind\":\"surface\"}',
+              'path_unsafe', 3, 'unsafe path', 10, 20),
+             ('cond-consumer', 'surface-b', 'opencode', 'consumer', '{\"kind\":\"consumer\"}',
+              'waiting_for_idle', 5, 'waiting', 30, 40)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert conditions: {error}"));
+}
+
+#[test]
+fn empty_database_bootstraps_agent_target_schema() {
+    let catalog = default_migration_catalog().expect("build migration catalog");
+    assert_eq!(
+        catalog.target_versions(),
+        ["0001", "0002", "0003", "0004", "0005", "0006", "0007"]
+    );
+
+    let database = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestamp)
+            .bootstrap(&DatabaseLocation::in_memory(), &catalog)
+            .expect("bootstrap database")
+    });
+
+    let tables = load_table_names(database.connection());
+    assert!(tables.iter().any(|name| name == "effect_agent_targets"));
+    assert!(
+        tables
+            .iter()
+            .any(|name| name == "effect_agent_target_status")
+    );
+    assert!(
+        tables
+            .iter()
+            .any(|name| name == "effect_agent_target_reconcile_requests")
+    );
+    assert!(
+        tables
+            .iter()
+            .any(|name| name == "effect_agent_target_conditions")
+    );
+    assert!(
+        tables
+            .iter()
+            .any(|name| name == "effect_reconcile_requests")
+    );
+}
+
+#[test]
+fn upgrades_old_schema_and_backfills_target_requests_deterministically() {
+    let directory = TempDir::new().unwrap_or_else(|error| panic!("create database dir: {error}"));
+    let location = DatabaseLocation::path(directory.path().join("ora.sqlite"));
+    let prefix = catalog_before_agent_targets();
+    let database = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestamp)
+            .bootstrap(&location, &prefix)
+            .unwrap_or_else(|error| panic!("bootstrap prefix: {error}"))
+    });
+    let workspace_id = WorkspaceId::new("workspace-1");
+    database
+        .connection()
+        .execute(
+            "INSERT INTO projects (
+                 id, name, repository_kind, created_at, updated_at, is_deleted
+             ) VALUES ('project-1', 'Demo', 'git', 1, 1, 0)",
+            [],
+        )
+        .unwrap();
+    database
+        .connection()
+        .execute(
+            "INSERT INTO workspace_locations (
+                 id, location_kind, locator_version, locator_json, created_at, updated_at
+             ) VALUES ('location-1', 'local_filesystem', 1, '{}', 1, 1)",
+            [],
+        )
+        .unwrap();
+    database
+        .connection()
+        .execute(
+            "INSERT INTO workspaces (
+                 id, project_id, workspace_kind, location_id, lifecycle,
+                 created_at, updated_at, is_deleted
+             ) VALUES (?1, 'project-1', 'main', 'location-1', 'active', 1, 1, 0)",
+            params![workspace_id.as_ref()],
+        )
+        .unwrap();
+    seed_surface_requests(database.connection(), &workspace_id);
+    drop(database);
+
+    let full = default_migration_catalog().expect("full catalog");
+    let upgraded = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestamp)
+            .bootstrap(&location, &full)
+            .unwrap_or_else(|error| panic!("upgrade to 0007: {error}"))
+    });
+
+    let surface_request_count: i64 = upgraded
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM effect_reconcile_requests",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(surface_request_count, 2);
+
+    let target_count: i64 = upgraded
+        .connection()
+        .query_row("SELECT COUNT(*) FROM effect_agent_targets", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(target_count, 2);
+
+    let opencode = upgraded
+        .connection()
+        .query_row(
+            "SELECT requests.requested_generation, requests.not_before_at, requests.requested_at,
+                    status.desired_generation, status.ready_generation
+             FROM effect_agent_targets targets
+             JOIN effect_agent_target_reconcile_requests requests
+               ON requests.agent_target_id = targets.id
+             JOIN effect_agent_target_status status
+               ON status.agent_target_id = targets.id
+             WHERE targets.workspace_id = ?1 AND targets.agent_plugin_id = 'opencode'",
+            params![workspace_id.as_ref()],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .unwrap_or_else(|error| panic!("load opencode backfill: {error}"));
+    assert_eq!(opencode, (9, 200, 100, 7, 4));
+
+    let condition_count: i64 = upgraded
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM effect_agent_target_conditions
+             WHERE impact = 'blocking'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    // surface-scoped fans out to opencode on surface-a; consumer-scoped keeps opencode on surface-b.
+    assert_eq!(condition_count, 2);
+    drop(upgraded);
+
+    let pool = RepositoryPool::new(&location)
+        .unwrap_or_else(|error| panic!("open upgraded pool: {error}"));
+    let repository = SqliteEffectRepository::new(pool);
+    let identity = AgentTargetIdentity::new(workspace_id.clone(), AgentPluginId::new("opencode"));
+    let status = repository
+        .load_agent_target_status(&identity)
+        .unwrap_or_else(|error| panic!("load backfilled status: {error}"))
+        .expect("opencode target status");
+    assert_eq!(status.conditions.len(), 2);
+    assert!(
+        status
+            .conditions
+            .iter()
+            .all(|condition| condition.impact == ConditionImpact::Blocking)
+    );
+}
+
+#[test]
+fn agent_target_uniqueness_and_generation_constraints() {
+    let (_directory, pool, workspace_id) = fixture();
+    pool.with_connection(|connection| {
+        connection
+            .execute(
+                "INSERT INTO effect_agent_targets (
+                     id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                     created_at, updated_at
+                 ) VALUES ('target-1', ?1, 'opencode', '', 'active', 1, 1)",
+                params![workspace_id.as_ref()],
+            )
+            .unwrap();
+        let duplicate = connection.execute(
+            "INSERT INTO effect_agent_targets (
+                 id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                 created_at, updated_at
+             ) VALUES ('target-2', ?1, 'opencode', '', 'active', 1, 1)",
+            params![workspace_id.as_ref()],
+        );
+        assert!(duplicate.is_err(), "duplicate Agent Target must fail");
+
+        connection
+            .execute(
+                "INSERT INTO effect_agent_target_status (
+                     agent_target_id, desired_generation, observed_generation,
+                     applied_generation, ready_generation, phase, status_version,
+                     created_at, updated_at
+                 ) VALUES ('target-1', 1, 1, 1, 1, 'current', 1, 1, 1)",
+                [],
+            )
+            .unwrap();
+        let illegal_order = connection.execute(
+            "UPDATE effect_agent_target_status
+             SET ready_generation = 2, applied_generation = 1
+             WHERE agent_target_id = 'target-1'",
+            [],
+        );
+        assert!(illegal_order.is_err(), "ready > applied must fail");
+
+        let illegal_phase = connection.execute(
+            "UPDATE effect_agent_target_status SET phase = 'unknown' WHERE agent_target_id = 'target-1'",
+            [],
+        );
+        assert!(illegal_phase.is_err(), "illegal phase must fail");
+
+        let illegal_impact = connection.execute(
+            "INSERT INTO effect_agent_target_conditions (
+                 id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 impact, failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES ('c1', 'target-1', NULL, NULL, 'agent_target', '{}', 'path_unsafe',
+                       'maybe', NULL, 'bad', 1, 1)",
+            [],
+        );
+        assert!(illegal_impact.is_err(), "illegal impact must fail");
+
+        let illegal_ownership = connection.execute(
+            "INSERT INTO effect_agent_target_conditions (
+                 id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 impact, failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES ('c2', 'target-1', NULL, 'opencode', 'consumer', '{}', 'waiting_for_idle',
+                       'blocking', NULL, 'bad ownership', 1, 1)",
+            [],
+        );
+        assert!(
+            illegal_ownership.is_err(),
+            "consumer without surface must fail"
+        );
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn typed_repository_round_trips_complete_agent_target_record() {
+    let (_directory, pool, workspace_id) = fixture();
+    let repository = SqliteEffectRepository::new(pool);
+    let identity = AgentTargetIdentity::new(workspace_id.clone(), AgentPluginId::new("opencode"));
+    let target = repository
+        .upsert_agent_target(
+            &identity,
+            &AgentCapabilityRevision::new("cap-1"),
+            AgentTargetLifecycle::Active,
+            50,
+        )
+        .unwrap_or_else(|error| panic!("upsert target: {error}"));
+
+    let mut status = initial_agent_target_status(target.id.clone(), identity.clone(), 50);
+    status.desired_generation = Generation::new(4);
+    status.observed_generation = Generation::new(3);
+    status.applied_generation = Generation::new(2);
+    status.ready_generation = Generation::new(1);
+    status.phase = AgentTargetPhase::ReadyWithIssues;
+    status.status_version = 2;
+    status.updated_at = 60;
+    status.conditions = vec![AgentTargetCondition {
+        id: "condition-1".to_string(),
+        subject: AgentTargetConditionSubject::AgentTarget,
+        reason: AgentTargetConditionReason::UnsupportedByAgent,
+        impact: ConditionImpact::NonBlocking,
+        message: "stdio unsupported".to_string(),
+        first_observed_at: 55,
+        last_observed_at: 60,
+        failed_generation: Some(Generation::new(4)),
+        surface_key: None,
+        consumer_id: None,
+    }];
+    repository
+        .save_agent_target_status(&status)
+        .unwrap_or_else(|error| panic!("save status: {error}"));
+
+    let request = repository
+        .upsert_agent_target_reconcile_request(
+            &identity,
+            Generation::new(4),
+            AgentTargetWakeReason::DesiredChanged,
+            80,
+            70,
+        )
+        .unwrap_or_else(|error| panic!("upsert request: {error}"));
+    let coalesced = repository
+        .upsert_agent_target_reconcile_request(
+            &identity,
+            Generation::new(6),
+            AgentTargetWakeReason::CapabilityChanged,
+            65,
+            90,
+        )
+        .unwrap_or_else(|error| panic!("coalesce request: {error}"));
+    assert_eq!(coalesced.requested_generation, Generation::new(6));
+    assert_eq!(coalesced.not_before_at, 65);
+    assert_eq!(coalesced.request_token, request.request_token);
+
+    let loaded = repository
+        .load_agent_target_record(&identity)
+        .unwrap_or_else(|error| panic!("load record: {error}"))
+        .expect("record present");
+    assert_eq!(loaded.target, target);
+    assert_eq!(loaded.status, status);
+    assert_eq!(
+        loaded
+            .reconcile_request
+            .expect("request present")
+            .requested_generation,
+        Generation::new(6)
+    );
+}
+
+#[test]
+fn surface_keyed_skill_effect_apis_remain_available() {
+    let (_directory, pool, workspace_id) = fixture();
+    let repository = SqliteEffectRepository::new(pool.clone());
+    let effect = repository
+        .load_workspace_effect(&workspace_id)
+        .unwrap_or_else(|error| panic!("load workspace effect: {error}"));
+    assert_eq!(effect.workspace_id, workspace_id);
+    assert_eq!(effect.generation, Generation::default());
+
+    let surface_table_exists: i64 = pool
+        .with_connection(|connection| {
+            connection
+                .query_row(
+                    "SELECT EXISTS(
+                     SELECT 1 FROM sqlite_master
+                     WHERE type = 'table' AND name = 'effect_reconcile_requests'
+                 )",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(Into::into)
+        })
+        .unwrap();
+    assert_eq!(surface_table_exists, 1);
+}
+
+fn load_table_names(connection: &Connection) -> Vec<String> {
+    let mut statement = connection
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+        .unwrap();
+    statement
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -6,6 +6,8 @@ mod repository;
 mod time;
 
 #[cfg(test)]
+mod agent_target_repository_tests;
+#[cfg(test)]
 mod effect_repository_tests;
 #[cfg(test)]
 mod git_cleanup_tests;

--- a/crates/db/src/migration/README.md
+++ b/crates/db/src/migration/README.md
@@ -7,7 +7,7 @@ This module owns Ora's linear, reversible SQLite schema history and reconciles a
 - `MigrationCatalog` requires unique, strictly increasing versions.
 - The active target must be a prefix of the complete catalog. This makes controlled rollback deterministic and rejects branch-shaped histories.
 - Every migration contains ordered up and down statements. Their trimmed, joined SQL is the stable executable snapshot used for comparison and rollback.
-- The default catalog contains six dependency-ordered modules: workspace core and application configuration, Agent/Skill catalog, workflows, Git lifecycle bookkeeping, Workspace Effect state, and durable plugin marketplace source configuration.
+- The default catalog contains seven dependency-ordered modules: workspace core and application configuration, Agent/Skill catalog, workflows, Git lifecycle bookkeeping, Workspace Effect state, durable plugin marketplace source configuration, and Agent Target Effect Expand persistence.
 - Skills, configurable agents, and workflows use `(namespace, name)` as their case-insensitive
   visible identity. Soft-deleted rows do not reserve that identity, and local resources use the
   `local` namespace.
@@ -18,6 +18,12 @@ This module owns Ora's linear, reversible SQLite schema history and reconciles a
   Artifacts; and append-only Audit events.
 - Migration `0006` stores plugin marketplace source configuration in SQLite: the duplicate-free
   URL, tracked branch, per-source `use_proxy` policy, and stable precedence position.
+- Migration `0007` expands Agent Target Effect persistence beside the surface-keyed Skill model:
+  `effect_agent_targets` uniquely keyed by Workspace plus Agent Plugin; target status with
+  desired/observed/applied/ready generations and phase; target-keyed reconcile requests; and
+  target-owned conditions with Blocking/NonBlocking impact. Existing surface request rows are
+  deterministically backfilled into one target request using the maximum requested generation and
+  earliest due time. Production workers continue to claim only surface-keyed requests.
 - A reconcile request carries its own scheduling state: `pending`, `claimed`, `blocked`, or
   `retry_scheduled`, plus the lease that proves who currently owns the surface and the
   `request_token` that fences that owner's writes. Only one worker can hold a surface, an expired

--- a/crates/db/src/migration/README.md
+++ b/crates/db/src/migration/README.md
@@ -23,7 +23,9 @@ This module owns Ora's linear, reversible SQLite schema history and reconciles a
   desired/observed/applied/ready generations and phase; target-keyed reconcile requests; and
   target-owned conditions with Blocking/NonBlocking impact. Existing surface request rows are
   deterministically backfilled into one target request using the maximum requested generation and
-  earliest due time. Production workers continue to claim only surface-keyed requests.
+  earliest due time. Status phase is `current` only when ready generation equals desired generation;
+  otherwise it is `pending`. Condition backfill preserves stored subject identity and records
+  existing rows as Blocking. Production workers continue to claim only surface-keyed requests.
 - A reconcile request carries its own scheduling state: `pending`, `claimed`, `blocked`, or
   `retry_scheduled`, plus the lease that proves who currently owns the surface and the
   `request_token` that fences that owner's writes. Only one worker can hold a surface, an expired

--- a/crates/db/src/migration/catalog.rs
+++ b/crates/db/src/migration/catalog.rs
@@ -84,6 +84,12 @@ impl MigrationCatalog {
         &self.target_versions
     }
 
+    /// Returns every migration definition owned by the catalog, including versions beyond the active target.
+    #[cfg(test)]
+    pub(crate) fn migrations(&self) -> &[Migration] {
+        &self.migrations
+    }
+
     /// Finds a migration definition by version so reconciliation can execute it.
     pub fn migration(&self, version: &str) -> Option<&Migration> {
         self.migrations_by_version

--- a/crates/db/src/migration/schema/mod.rs
+++ b/crates/db/src/migration/schema/mod.rs
@@ -6,6 +6,7 @@ mod schema_v0003;
 mod schema_v0004;
 mod schema_v0005;
 mod schema_v0006;
+mod schema_v0007;
 
 /// Returns the ordered schema migrations shipped with the database crate.
 pub(super) fn migrations() -> Vec<Migration> {
@@ -16,5 +17,6 @@ pub(super) fn migrations() -> Vec<Migration> {
         schema_v0004::migration(),
         schema_v0005::migration(),
         schema_v0006::migration(),
+        schema_v0007::migration(),
     ]
 }

--- a/crates/db/src/migration/schema/schema_v0007.rs
+++ b/crates/db/src/migration/schema/schema_v0007.rs
@@ -137,50 +137,64 @@ GROUP BY surfaces.workspace_id, consumers.consumer_id;
 "#,
     r#"
 -- Clamp independently maximized generations so Expand rows always satisfy ordering CHECKs.
+-- Current is the caught-up state; a target whose ready generation lags desired stays Pending.
 INSERT INTO effect_agent_target_status (
     agent_target_id, desired_generation, observed_generation, applied_generation,
     ready_generation, phase, status_version, created_at, updated_at
 )
 SELECT
-    targets.id,
-    MAX(COALESCE(surface_status.desired_generation, 0)),
-    MIN(
-        MAX(COALESCE(surface_status.desired_generation, 0)),
-        MAX(COALESCE(surface_status.observed_generation, 0))
-    ),
-    MIN(
+    agent_target_id,
+    desired_generation,
+    observed_generation,
+    applied_generation,
+    ready_generation,
+    CASE
+        WHEN ready_generation = desired_generation THEN 'current'
+        ELSE 'pending'
+    END,
+    1,
+    created_at,
+    updated_at
+FROM (
+    SELECT
+        targets.id AS agent_target_id,
+        MAX(COALESCE(surface_status.desired_generation, 0)) AS desired_generation,
         MIN(
             MAX(COALESCE(surface_status.desired_generation, 0)),
             MAX(COALESCE(surface_status.observed_generation, 0))
-        ),
-        MAX(COALESCE(surface_status.applied_generation, 0))
-    ),
-    MIN(
+        ) AS observed_generation,
         MIN(
             MIN(
                 MAX(COALESCE(surface_status.desired_generation, 0)),
                 MAX(COALESCE(surface_status.observed_generation, 0))
             ),
             MAX(COALESCE(surface_status.applied_generation, 0))
-        ),
-        MAX(COALESCE(consumer_status.ready_generation, 0))
-    ),
-    'current',
-    1,
-    targets.created_at,
-    targets.updated_at
-FROM effect_agent_targets targets
-JOIN effect_surfaces surfaces
-    ON surfaces.workspace_id = targets.workspace_id
-JOIN effect_surface_consumers consumers
-    ON consumers.surface_id = surfaces.id
-   AND consumers.consumer_id = targets.agent_plugin_id
-LEFT JOIN effect_surface_status surface_status
-    ON surface_status.surface_id = surfaces.id
-LEFT JOIN effect_consumer_status consumer_status
-    ON consumer_status.surface_id = surfaces.id
-   AND consumer_status.consumer_id = consumers.consumer_id
-GROUP BY targets.id;
+        ) AS applied_generation,
+        MIN(
+            MIN(
+                MIN(
+                    MAX(COALESCE(surface_status.desired_generation, 0)),
+                    MAX(COALESCE(surface_status.observed_generation, 0))
+                ),
+                MAX(COALESCE(surface_status.applied_generation, 0))
+            ),
+            MAX(COALESCE(consumer_status.ready_generation, 0))
+        ) AS ready_generation,
+        targets.created_at AS created_at,
+        targets.updated_at AS updated_at
+    FROM effect_agent_targets targets
+    JOIN effect_surfaces surfaces
+        ON surfaces.workspace_id = targets.workspace_id
+    JOIN effect_surface_consumers consumers
+        ON consumers.surface_id = surfaces.id
+       AND consumers.consumer_id = targets.agent_plugin_id
+    LEFT JOIN effect_surface_status surface_status
+        ON surface_status.surface_id = surfaces.id
+    LEFT JOIN effect_consumer_status consumer_status
+        ON consumer_status.surface_id = surfaces.id
+       AND consumer_status.consumer_id = consumers.consumer_id
+    GROUP BY targets.id
+);
 "#,
     r#"
 -- Merge every surface request that touches a target into one pending target request.
@@ -212,6 +226,7 @@ GROUP BY targets.id;
 "#,
     r#"
 -- Consumer-scoped surface conditions become Blocking target conditions on that plugin.
+-- Preserve the stored subject so desired_item / managed_item identities survive upgrade.
 INSERT INTO effect_agent_target_conditions (
     id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
     failed_generation, message, first_observed_at, last_observed_at
@@ -220,8 +235,8 @@ SELECT lower(hex(randomblob(16))),
        targets.id,
        conditions.surface_id,
        conditions.consumer_id,
-       'consumer',
-       json_object('kind', 'consumer', 'consumer_id', conditions.consumer_id),
+       conditions.subject_kind,
+       conditions.subject_id,
        conditions.reason,
        'blocking',
        conditions.failed_generation,
@@ -245,8 +260,8 @@ SELECT lower(hex(randomblob(16))),
        targets.id,
        conditions.surface_id,
        consumers.consumer_id,
-       'surface',
-       json_object('kind', 'surface', 'surface_key', conditions.surface_id),
+       conditions.subject_kind,
+       conditions.subject_id,
        conditions.reason,
        'blocking',
        conditions.failed_generation,

--- a/crates/db/src/migration/schema/schema_v0007.rs
+++ b/crates/db/src/migration/schema/schema_v0007.rs
@@ -1,0 +1,276 @@
+use super::Migration;
+
+const UP_STATEMENTS: &[&str] = &[
+    r#"
+-- Agent Target rows are the Expand-phase owner for future Skill+MCP convergence. Surface-keyed
+-- Skill tables remain authoritative for the live worker until a later Contract ticket.
+CREATE TABLE effect_agent_targets (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspace_effects(workspace_id) ON DELETE CASCADE,
+    agent_plugin_id TEXT NOT NULL,
+    capability_revision TEXT NOT NULL,
+    lifecycle TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    UNIQUE (workspace_id, agent_plugin_id),
+    CHECK (lifecycle IN ('active', 'retired')),
+    CHECK (updated_at >= created_at)
+);
+CREATE INDEX effect_agent_targets_workspace
+    ON effect_agent_targets(workspace_id, agent_plugin_id);
+"#,
+    r#"
+CREATE TABLE effect_agent_target_status (
+    agent_target_id TEXT PRIMARY KEY REFERENCES effect_agent_targets(id) ON DELETE CASCADE,
+    desired_generation INTEGER NOT NULL DEFAULT 0,
+    observed_generation INTEGER NOT NULL DEFAULT 0,
+    applied_generation INTEGER NOT NULL DEFAULT 0,
+    ready_generation INTEGER NOT NULL DEFAULT 0,
+    phase TEXT NOT NULL,
+    status_version INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    CHECK (desired_generation >= 0),
+    CHECK (observed_generation >= 0),
+    CHECK (applied_generation >= 0),
+    CHECK (ready_generation >= 0),
+    CHECK (applied_generation <= observed_generation),
+    CHECK (observed_generation <= desired_generation),
+    CHECK (ready_generation <= applied_generation),
+    CHECK (status_version > 0),
+    CHECK (phase IN (
+        'pending', 'waiting_for_idle', 'quiescing', 'applying', 'resuming',
+        'current', 'ready_with_issues', 'degraded', 'retiring', 'recovery_required'
+    )),
+    CHECK (updated_at >= created_at)
+);
+"#,
+    r#"
+-- Parallel to surface-keyed effect_reconcile_requests. Nothing in production claims this table yet.
+CREATE TABLE effect_agent_target_reconcile_requests (
+    agent_target_id TEXT PRIMARY KEY REFERENCES effect_agent_targets(id) ON DELETE CASCADE,
+    requested_generation INTEGER NOT NULL,
+    request_token TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    wake_reason TEXT NOT NULL DEFAULT 'desired_changed',
+    blocked_reason TEXT,
+    lease_owner TEXT,
+    lease_expires_at INTEGER,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    requested_at INTEGER NOT NULL,
+    not_before_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    CHECK (requested_generation >= 0),
+    CHECK (attempt_count >= 0),
+    CHECK (not_before_at >= requested_at),
+    CHECK (updated_at >= requested_at),
+    CHECK (state IN ('pending', 'claimed', 'blocked', 'retry_scheduled')),
+    CHECK ((state = 'claimed') = (lease_owner IS NOT NULL)),
+    CHECK ((state = 'claimed') = (lease_expires_at IS NOT NULL)),
+    CHECK ((state = 'blocked') = (blocked_reason IS NOT NULL)),
+    CHECK (wake_reason IN (
+        'desired_changed', 'capability_changed', 'retry', 'recovery', 'startup_repair'
+    ))
+);
+CREATE INDEX effect_agent_target_reconcile_requests_due
+    ON effect_agent_target_reconcile_requests(state, not_before_at, requested_at, agent_target_id);
+CREATE INDEX effect_agent_target_reconcile_requests_leases
+    ON effect_agent_target_reconcile_requests(lease_expires_at) WHERE state = 'claimed';
+"#,
+    r#"
+CREATE TABLE effect_agent_target_conditions (
+    id TEXT PRIMARY KEY,
+    agent_target_id TEXT NOT NULL
+        REFERENCES effect_agent_target_status(agent_target_id) ON DELETE CASCADE,
+    surface_id TEXT REFERENCES effect_surfaces(id) ON DELETE SET NULL,
+    consumer_id TEXT,
+    subject_kind TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    impact TEXT NOT NULL,
+    failed_generation INTEGER,
+    message TEXT NOT NULL,
+    first_observed_at INTEGER NOT NULL,
+    last_observed_at INTEGER NOT NULL,
+    CHECK (impact IN ('blocking', 'non_blocking')),
+    CHECK (subject_kind IN (
+        'agent_target', 'surface', 'consumer', 'desired_item', 'managed_item', 'mcp'
+    )),
+    CHECK (reason IN (
+        'no_consumers', 'incompatible_surface_declarations', 'desired_collision',
+        'preserved_conflict', 'ownership_conflict', 'drift_conflict', 'source_unavailable',
+        'path_unsafe', 'scan_failed', 'waiting_for_idle', 'consumer_resume_failed',
+        'materialization_failed', 'transient_io', 'recovery_required',
+        'unsupported_by_agent', 'capability_invalid'
+    )),
+    CHECK (failed_generation IS NULL OR failed_generation >= 0),
+    CHECK (last_observed_at >= first_observed_at),
+    CHECK (consumer_id IS NULL OR surface_id IS NOT NULL),
+    FOREIGN KEY (surface_id, consumer_id)
+        REFERENCES effect_surface_consumers(surface_id, consumer_id) ON DELETE SET NULL
+);
+CREATE UNIQUE INDEX effect_agent_target_conditions_unique
+    ON effect_agent_target_conditions(
+        agent_target_id,
+        subject_kind,
+        subject_id,
+        reason,
+        IFNULL(surface_id, ''),
+        IFNULL(consumer_id, '')
+    );
+"#,
+    r#"
+-- One Agent Target per historical surface consumer declaration.
+INSERT INTO effect_agent_targets (
+    id, workspace_id, agent_plugin_id, capability_revision, lifecycle, created_at, updated_at
+)
+SELECT lower(hex(randomblob(16))),
+       surfaces.workspace_id,
+       consumers.consumer_id,
+       '',
+       'active',
+       MIN(consumers.created_at),
+       MAX(consumers.updated_at)
+FROM effect_surface_consumers consumers
+JOIN effect_surfaces surfaces ON surfaces.id = consumers.surface_id
+GROUP BY surfaces.workspace_id, consumers.consumer_id;
+"#,
+    r#"
+-- Clamp independently maximized generations so Expand rows always satisfy ordering CHECKs.
+INSERT INTO effect_agent_target_status (
+    agent_target_id, desired_generation, observed_generation, applied_generation,
+    ready_generation, phase, status_version, created_at, updated_at
+)
+SELECT
+    targets.id,
+    MAX(COALESCE(surface_status.desired_generation, 0)),
+    MIN(
+        MAX(COALESCE(surface_status.desired_generation, 0)),
+        MAX(COALESCE(surface_status.observed_generation, 0))
+    ),
+    MIN(
+        MIN(
+            MAX(COALESCE(surface_status.desired_generation, 0)),
+            MAX(COALESCE(surface_status.observed_generation, 0))
+        ),
+        MAX(COALESCE(surface_status.applied_generation, 0))
+    ),
+    MIN(
+        MIN(
+            MIN(
+                MAX(COALESCE(surface_status.desired_generation, 0)),
+                MAX(COALESCE(surface_status.observed_generation, 0))
+            ),
+            MAX(COALESCE(surface_status.applied_generation, 0))
+        ),
+        MAX(COALESCE(consumer_status.ready_generation, 0))
+    ),
+    'current',
+    1,
+    targets.created_at,
+    targets.updated_at
+FROM effect_agent_targets targets
+JOIN effect_surfaces surfaces
+    ON surfaces.workspace_id = targets.workspace_id
+JOIN effect_surface_consumers consumers
+    ON consumers.surface_id = surfaces.id
+   AND consumers.consumer_id = targets.agent_plugin_id
+LEFT JOIN effect_surface_status surface_status
+    ON surface_status.surface_id = surfaces.id
+LEFT JOIN effect_consumer_status consumer_status
+    ON consumer_status.surface_id = surfaces.id
+   AND consumer_status.consumer_id = consumers.consumer_id
+GROUP BY targets.id;
+"#,
+    r#"
+-- Merge every surface request that touches a target into one pending target request.
+INSERT INTO effect_agent_target_reconcile_requests (
+    agent_target_id, requested_generation, request_token, state, wake_reason,
+    blocked_reason, lease_owner, lease_expires_at, attempt_count,
+    requested_at, not_before_at, updated_at
+)
+SELECT
+    targets.id,
+    MAX(requests.requested_generation),
+    lower(hex(randomblob(16))),
+    'pending',
+    'desired_changed',
+    NULL,
+    NULL,
+    NULL,
+    0,
+    MIN(requests.requested_at),
+    MAX(MIN(requests.not_before_at), MIN(requests.requested_at)),
+    MAX(requests.updated_at)
+FROM effect_reconcile_requests requests
+JOIN effect_surfaces surfaces ON surfaces.id = requests.surface_id
+JOIN effect_surface_consumers consumers ON consumers.surface_id = surfaces.id
+JOIN effect_agent_targets targets
+    ON targets.workspace_id = surfaces.workspace_id
+   AND targets.agent_plugin_id = consumers.consumer_id
+GROUP BY targets.id;
+"#,
+    r#"
+-- Consumer-scoped surface conditions become Blocking target conditions on that plugin.
+INSERT INTO effect_agent_target_conditions (
+    id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
+    failed_generation, message, first_observed_at, last_observed_at
+)
+SELECT lower(hex(randomblob(16))),
+       targets.id,
+       conditions.surface_id,
+       conditions.consumer_id,
+       'consumer',
+       json_object('kind', 'consumer', 'consumer_id', conditions.consumer_id),
+       conditions.reason,
+       'blocking',
+       conditions.failed_generation,
+       conditions.message,
+       conditions.first_observed_at,
+       conditions.last_observed_at
+FROM effect_conditions conditions
+JOIN effect_surfaces surfaces ON surfaces.id = conditions.surface_id
+JOIN effect_agent_targets targets
+    ON targets.workspace_id = surfaces.workspace_id
+   AND targets.agent_plugin_id = conditions.consumer_id
+WHERE conditions.consumer_id IS NOT NULL;
+"#,
+    r#"
+-- Surface-scoped conditions fan out to every Agent Target that consumes the surface.
+INSERT INTO effect_agent_target_conditions (
+    id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
+    failed_generation, message, first_observed_at, last_observed_at
+)
+SELECT lower(hex(randomblob(16))),
+       targets.id,
+       conditions.surface_id,
+       consumers.consumer_id,
+       'surface',
+       json_object('kind', 'surface', 'surface_key', conditions.surface_id),
+       conditions.reason,
+       'blocking',
+       conditions.failed_generation,
+       conditions.message,
+       conditions.first_observed_at,
+       conditions.last_observed_at
+FROM effect_conditions conditions
+JOIN effect_surface_consumers consumers ON consumers.surface_id = conditions.surface_id
+JOIN effect_surfaces surfaces ON surfaces.id = conditions.surface_id
+JOIN effect_agent_targets targets
+    ON targets.workspace_id = surfaces.workspace_id
+   AND targets.agent_plugin_id = consumers.consumer_id
+WHERE conditions.consumer_id IS NULL;
+"#,
+];
+
+const DOWN_STATEMENTS: &[&str] = &[r#"
+DROP TABLE IF EXISTS effect_agent_target_conditions;
+DROP TABLE IF EXISTS effect_agent_target_reconcile_requests;
+DROP TABLE IF EXISTS effect_agent_target_status;
+DROP TABLE IF EXISTS effect_agent_targets;
+"#];
+
+/// Builds Agent Target Effect persistence beside the surface-keyed Skill model.
+pub fn migration() -> Migration {
+    Migration::new("0007", UP_STATEMENTS, DOWN_STATEMENTS)
+}

--- a/crates/db/src/repository/README.md
+++ b/crates/db/src/repository/README.md
@@ -9,7 +9,9 @@ This module implements `ora-application` persistence ports on SQLite and exposes
   between SQL rows and application values.
 - `SqliteEffectRepository` stores normalized Desired selections, source state, surface descriptors,
   ownership ledgers, status, and durable operations. Desired replacement uses generation CAS;
-  operation finalization changes its ledger and journal phase in one immediate transaction.
+  operation finalization changes its ledger and journal phase in one immediate transaction. It also
+  implements the Expand-phase `AgentTargetRepository` port for target-keyed status and requests
+  without activating target claim loops.
 - Normal reads exclude soft-deleted rows. Soft deletion records timestamps rather than removing individual domain records physically.
 - `RepositoryPool` serializes access to its connection and gives repository operations a consistent error boundary.
 

--- a/crates/db/src/repository/effect/README.md
+++ b/crates/db/src/repository/effect/README.md
@@ -3,7 +3,8 @@
 This module implements the `ora-effect` persistence and source ports. The public adapter owns
 transaction boundaries for Desired CAS, source publication and propagation, surface lifecycle,
 operation finalization, and retry wakeups. `mapping` contains row validation, normalized inserts,
-enum encodings, and request-upsert helpers shared by those transactions.
+enum encodings, and request-upsert helpers shared by those transactions. `agent_target` implements
+the Expand-phase Agent Target repository port without switching the surface-keyed Skill worker.
 
 Desired replacement, source reference protection, and operation finalization use immediate write
 transactions so checks cannot race their corresponding writes. Observed and Preserved scans never

--- a/crates/db/src/repository/effect/agent_target/README.md
+++ b/crates/db/src/repository/effect/agent_target/README.md
@@ -1,0 +1,19 @@
+# Agent Target SQLite persistence
+
+This module implements `ora_effect::AgentTargetRepository` on `SqliteEffectRepository`. It owns
+typed reads and writes for Agent Target rows, status, target-owned conditions, and target-keyed
+reconcile requests introduced by migration `0007`.
+
+## Responsibilities
+
+- Upsert and load Agent Targets uniquely keyed by Workspace identity plus Agent Plugin identity.
+- Persist status generations (`desired` / `observed` / `applied` / `ready`), phase, status version,
+  and Blocking/NonBlocking conditions as whole objects.
+- Upsert target reconcile requests with max-generation and earliest-due coalescing.
+- Keep these APIs independent of the surface-keyed Skill claim loop.
+
+## Non-responsibilities
+
+- Claiming or completing target reconcile requests in production workers.
+- Dual-writing surface and target requests, compatibility views, or MCP materialization.
+- Mutating or retiring the existing `effect_reconcile_requests` / `effect_conditions` tables.

--- a/crates/db/src/repository/effect/agent_target/README.md
+++ b/crates/db/src/repository/effect/agent_target/README.md
@@ -11,9 +11,12 @@ reconcile requests introduced by migration `0007`.
   and Blocking/NonBlocking conditions as whole objects.
 - Upsert target reconcile requests with max-generation and earliest-due coalescing.
 - Keep these APIs independent of the surface-keyed Skill claim loop.
+- `encode` owns enum encodings and reuses Skill generation integer conversion. `rows` maps identity
+  and request rows. `conditions` loads and replaces target-owned conditions.
 
 ## Non-responsibilities
 
-- Claiming or completing target reconcile requests in production workers.
+- Claiming or completing target reconcile requests in production workers. Lease columns exist so a
+  later worker ticket can claim them without another schema migration.
 - Dual-writing surface and target requests, compatibility views, or MCP materialization.
 - Mutating or retiring the existing `effect_reconcile_requests` / `effect_conditions` tables.

--- a/crates/db/src/repository/effect/agent_target/conditions.rs
+++ b/crates/db/src/repository/effect/agent_target/conditions.rs
@@ -1,0 +1,151 @@
+//! Agent Target-owned condition load and replace.
+
+use super::encode::*;
+use crate::DatabaseError;
+use ora_effect::{
+    AgentTargetCondition, AgentTargetConditionAttachment, AgentTargetConditionSubject, ConsumerId,
+    SurfaceKey,
+};
+use rusqlite::params;
+use uuid::Uuid;
+
+/// Loads every condition owned by one target in a stable order for whole-object comparison.
+pub(super) fn load_target_conditions(
+    connection: &rusqlite::Connection,
+    agent_target_id: &str,
+) -> Result<Vec<AgentTargetCondition>, DatabaseError> {
+    let mut statement = connection.prepare(
+        "SELECT id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
+                failed_generation, message, first_observed_at, last_observed_at
+         FROM effect_agent_target_conditions
+         WHERE agent_target_id = ?1
+         ORDER BY subject_kind, subject_id, reason, IFNULL(surface_id, ''), IFNULL(consumer_id, '')",
+    )?;
+    let rows = statement.query_map(params![agent_target_id], |row| {
+        let subject_json: String = row.get(4)?;
+        let subject = serde_json::from_str::<AgentTargetConditionSubject>(&subject_json).map_err(
+            |error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    4,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+            },
+        )?;
+        let reason_raw: String = row.get(5)?;
+        let reason = parse_condition_reason(&reason_raw).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+        let impact = parse_impact(&row.get::<_, String>(6)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+        let failed_generation = match row.get::<_, Option<i64>>(7)? {
+            Some(value) => Some(generation_from_sql(value).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    7,
+                    rusqlite::types::Type::Integer,
+                    Box::new(error),
+                )
+            })?),
+            None => None,
+        };
+        let surface_id: Option<String> = row.get(1)?;
+        let consumer_id: Option<String> = row.get(2)?;
+        let attachment = match (surface_id, consumer_id) {
+            (Some(surface_key), consumer_id) => Some(AgentTargetConditionAttachment {
+                surface_key: SurfaceKey::new(surface_key),
+                consumer_id: consumer_id.map(ConsumerId::new),
+            }),
+            (None, None) => None,
+            (None, Some(_)) => {
+                return Err(rusqlite::Error::FromSqlConversionFailure(
+                    2,
+                    rusqlite::types::Type::Text,
+                    Box::new(DatabaseError::CorruptEffectState(
+                        "condition consumer attachment is missing its surface".to_string(),
+                    )),
+                ));
+            }
+        };
+        Ok(AgentTargetCondition {
+            id: row.get(0)?,
+            subject,
+            reason,
+            impact,
+            message: row.get(8)?,
+            first_observed_at: row.get(9)?,
+            last_observed_at: row.get(10)?,
+            failed_generation,
+            attachment,
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+/// Replaces the complete condition set so a status write cannot leave a mixed generation.
+pub(super) fn replace_target_conditions(
+    transaction: &rusqlite::Transaction<'_>,
+    agent_target_id: &str,
+    conditions: &[AgentTargetCondition],
+) -> Result<(), DatabaseError> {
+    transaction.execute(
+        "DELETE FROM effect_agent_target_conditions WHERE agent_target_id = ?1",
+        params![agent_target_id],
+    )?;
+    for condition in conditions {
+        let subject_kind = match &condition.subject {
+            AgentTargetConditionSubject::AgentTarget => "agent_target",
+            AgentTargetConditionSubject::Surface { .. } => "surface",
+            AgentTargetConditionSubject::Consumer { .. } => "consumer",
+            AgentTargetConditionSubject::DesiredSkill { .. } => "desired_item",
+            AgentTargetConditionSubject::ManagedSkill { .. } => "managed_item",
+            AgentTargetConditionSubject::Mcp { .. } => "mcp",
+        };
+        let subject_id = serde_json::to_string(&condition.subject)
+            .map_err(|error| DatabaseError::CorruptEffectState(error.to_string()))?;
+        let id = if condition.id.is_empty() {
+            Uuid::new_v4().to_string()
+        } else {
+            condition.id.clone()
+        };
+        let (surface_id, consumer_id) = match &condition.attachment {
+            Some(attachment) => (
+                Some(attachment.surface_key.as_str()),
+                attachment.consumer_id.as_ref().map(ConsumerId::as_str),
+            ),
+            None => (None, None),
+        };
+        transaction.execute(
+            "INSERT INTO effect_agent_target_conditions (
+                 id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 impact, failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                id,
+                agent_target_id,
+                surface_id,
+                consumer_id,
+                subject_kind,
+                subject_id,
+                condition_reason_value(condition.reason),
+                impact_value(condition.impact),
+                condition
+                    .failed_generation
+                    .map(generation_to_sql)
+                    .transpose()?,
+                &condition.message,
+                condition.first_observed_at,
+                condition.last_observed_at,
+            ],
+        )?;
+    }
+    Ok(())
+}

--- a/crates/db/src/repository/effect/agent_target/encode.rs
+++ b/crates/db/src/repository/effect/agent_target/encode.rs
@@ -1,0 +1,235 @@
+//! Enum and numeric encodings shared by Agent Target SQLite persistence.
+
+use crate::DatabaseError;
+use ora_effect::{
+    AgentTargetConditionReason, AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileState,
+    AgentTargetRepositoryError, AgentTargetWakeReason, ConditionImpact, Generation,
+};
+pub(super) fn map_db_error(error: DatabaseError) -> AgentTargetRepositoryError {
+    match error {
+        DatabaseError::CorruptEffectState(message) => AgentTargetRepositoryError::corrupt(message),
+        other => AgentTargetRepositoryError::storage(other),
+    }
+}
+
+pub(super) fn generation_to_sql(generation: Generation) -> Result<i64, DatabaseError> {
+    i64::try_from(generation.value()).map_err(|_| {
+        DatabaseError::CorruptEffectState("generation exceeds SQLite integer range".to_string())
+    })
+}
+
+pub(super) fn generation_from_sql(value: i64) -> Result<Generation, DatabaseError> {
+    u64::try_from(value)
+        .map(Generation::new)
+        .map_err(|_| DatabaseError::CorruptEffectState("negative generation".to_string()))
+}
+
+pub(super) fn generation_from_row(
+    row: &rusqlite::Row<'_>,
+    index: usize,
+) -> Result<Generation, rusqlite::Error> {
+    let value: i64 = row.get(index)?;
+    generation_from_sql(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Integer,
+            Box::new(error),
+        )
+    })
+}
+
+pub(super) fn u64_to_sql(value: u64, field: &str) -> Result<i64, DatabaseError> {
+    i64::try_from(value).map_err(|_| {
+        DatabaseError::CorruptEffectState(format!("{field} exceeds SQLite integer range"))
+    })
+}
+
+pub(super) fn u64_from_row(row: &rusqlite::Row<'_>, index: usize) -> Result<u64, rusqlite::Error> {
+    let value: i64 = row.get(index)?;
+    u64::try_from(value).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Integer,
+            Box::new(DatabaseError::CorruptEffectState(
+                "negative status version".to_string(),
+            )),
+        )
+    })
+}
+
+pub(super) fn u32_from_row(row: &rusqlite::Row<'_>, index: usize) -> Result<u32, rusqlite::Error> {
+    let value: i64 = row.get(index)?;
+    u32::try_from(value).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Integer,
+            Box::new(DatabaseError::CorruptEffectState(
+                "invalid attempt count".to_string(),
+            )),
+        )
+    })
+}
+
+pub(super) fn lifecycle_value(lifecycle: AgentTargetLifecycle) -> &'static str {
+    match lifecycle {
+        AgentTargetLifecycle::Active => "active",
+        AgentTargetLifecycle::Retired => "retired",
+    }
+}
+
+pub(super) fn parse_lifecycle(value: &str) -> Result<AgentTargetLifecycle, DatabaseError> {
+    match value {
+        "active" => Ok(AgentTargetLifecycle::Active),
+        "retired" => Ok(AgentTargetLifecycle::Retired),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target lifecycle".to_string(),
+        )),
+    }
+}
+
+pub(super) fn phase_value(phase: AgentTargetPhase) -> &'static str {
+    match phase {
+        AgentTargetPhase::Pending => "pending",
+        AgentTargetPhase::WaitingForIdle => "waiting_for_idle",
+        AgentTargetPhase::Quiescing => "quiescing",
+        AgentTargetPhase::Applying => "applying",
+        AgentTargetPhase::Resuming => "resuming",
+        AgentTargetPhase::Current => "current",
+        AgentTargetPhase::ReadyWithIssues => "ready_with_issues",
+        AgentTargetPhase::Degraded => "degraded",
+        AgentTargetPhase::Retiring => "retiring",
+        AgentTargetPhase::RecoveryRequired => "recovery_required",
+    }
+}
+
+pub(super) fn parse_phase(value: &str) -> Result<AgentTargetPhase, DatabaseError> {
+    match value {
+        "pending" => Ok(AgentTargetPhase::Pending),
+        "waiting_for_idle" => Ok(AgentTargetPhase::WaitingForIdle),
+        "quiescing" => Ok(AgentTargetPhase::Quiescing),
+        "applying" => Ok(AgentTargetPhase::Applying),
+        "resuming" => Ok(AgentTargetPhase::Resuming),
+        "current" => Ok(AgentTargetPhase::Current),
+        "ready_with_issues" => Ok(AgentTargetPhase::ReadyWithIssues),
+        "degraded" => Ok(AgentTargetPhase::Degraded),
+        "retiring" => Ok(AgentTargetPhase::Retiring),
+        "recovery_required" => Ok(AgentTargetPhase::RecoveryRequired),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target phase".to_string(),
+        )),
+    }
+}
+
+pub(super) fn impact_value(impact: ConditionImpact) -> &'static str {
+    match impact {
+        ConditionImpact::Blocking => "blocking",
+        ConditionImpact::NonBlocking => "non_blocking",
+    }
+}
+
+pub(super) fn parse_impact(value: &str) -> Result<ConditionImpact, DatabaseError> {
+    match value {
+        "blocking" => Ok(ConditionImpact::Blocking),
+        "non_blocking" => Ok(ConditionImpact::NonBlocking),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown condition impact".to_string(),
+        )),
+    }
+}
+
+pub(super) fn reconcile_state_value(state: AgentTargetReconcileState) -> &'static str {
+    match state {
+        AgentTargetReconcileState::Pending => "pending",
+        AgentTargetReconcileState::Claimed => "claimed",
+        AgentTargetReconcileState::Blocked => "blocked",
+        AgentTargetReconcileState::RetryScheduled => "retry_scheduled",
+    }
+}
+
+pub(super) fn parse_reconcile_state(
+    value: &str,
+) -> Result<AgentTargetReconcileState, DatabaseError> {
+    match value {
+        "pending" => Ok(AgentTargetReconcileState::Pending),
+        "claimed" => Ok(AgentTargetReconcileState::Claimed),
+        "blocked" => Ok(AgentTargetReconcileState::Blocked),
+        "retry_scheduled" => Ok(AgentTargetReconcileState::RetryScheduled),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target reconcile state".to_string(),
+        )),
+    }
+}
+
+pub(super) fn wake_reason_value(reason: AgentTargetWakeReason) -> &'static str {
+    match reason {
+        AgentTargetWakeReason::DesiredChanged => "desired_changed",
+        AgentTargetWakeReason::CapabilityChanged => "capability_changed",
+        AgentTargetWakeReason::Retry => "retry",
+        AgentTargetWakeReason::Recovery => "recovery",
+        AgentTargetWakeReason::StartupRepair => "startup_repair",
+    }
+}
+
+pub(super) fn parse_wake_reason(value: &str) -> Result<AgentTargetWakeReason, DatabaseError> {
+    match value {
+        "desired_changed" => Ok(AgentTargetWakeReason::DesiredChanged),
+        "capability_changed" => Ok(AgentTargetWakeReason::CapabilityChanged),
+        "retry" => Ok(AgentTargetWakeReason::Retry),
+        "recovery" => Ok(AgentTargetWakeReason::Recovery),
+        "startup_repair" => Ok(AgentTargetWakeReason::StartupRepair),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target wake reason".to_string(),
+        )),
+    }
+}
+
+pub(super) fn condition_reason_value(reason: AgentTargetConditionReason) -> &'static str {
+    match reason {
+        AgentTargetConditionReason::NoConsumers => "no_consumers",
+        AgentTargetConditionReason::IncompatibleSurfaceDeclarations => {
+            "incompatible_surface_declarations"
+        }
+        AgentTargetConditionReason::DesiredCollision => "desired_collision",
+        AgentTargetConditionReason::PreservedConflict => "preserved_conflict",
+        AgentTargetConditionReason::OwnershipConflict => "ownership_conflict",
+        AgentTargetConditionReason::DriftConflict => "drift_conflict",
+        AgentTargetConditionReason::SourceUnavailable => "source_unavailable",
+        AgentTargetConditionReason::PathUnsafe => "path_unsafe",
+        AgentTargetConditionReason::ScanFailed => "scan_failed",
+        AgentTargetConditionReason::WaitingForIdle => "waiting_for_idle",
+        AgentTargetConditionReason::ConsumerResumeFailed => "consumer_resume_failed",
+        AgentTargetConditionReason::MaterializationFailed => "materialization_failed",
+        AgentTargetConditionReason::TransientIo => "transient_io",
+        AgentTargetConditionReason::RecoveryRequired => "recovery_required",
+        AgentTargetConditionReason::UnsupportedByAgent => "unsupported_by_agent",
+        AgentTargetConditionReason::CapabilityInvalid => "capability_invalid",
+    }
+}
+
+pub(super) fn parse_condition_reason(
+    value: &str,
+) -> Result<AgentTargetConditionReason, DatabaseError> {
+    match value {
+        "no_consumers" => Ok(AgentTargetConditionReason::NoConsumers),
+        "incompatible_surface_declarations" => {
+            Ok(AgentTargetConditionReason::IncompatibleSurfaceDeclarations)
+        }
+        "desired_collision" => Ok(AgentTargetConditionReason::DesiredCollision),
+        "preserved_conflict" => Ok(AgentTargetConditionReason::PreservedConflict),
+        "ownership_conflict" => Ok(AgentTargetConditionReason::OwnershipConflict),
+        "drift_conflict" => Ok(AgentTargetConditionReason::DriftConflict),
+        "source_unavailable" => Ok(AgentTargetConditionReason::SourceUnavailable),
+        "path_unsafe" => Ok(AgentTargetConditionReason::PathUnsafe),
+        "scan_failed" => Ok(AgentTargetConditionReason::ScanFailed),
+        "waiting_for_idle" => Ok(AgentTargetConditionReason::WaitingForIdle),
+        "consumer_resume_failed" => Ok(AgentTargetConditionReason::ConsumerResumeFailed),
+        "materialization_failed" => Ok(AgentTargetConditionReason::MaterializationFailed),
+        "transient_io" => Ok(AgentTargetConditionReason::TransientIo),
+        "recovery_required" => Ok(AgentTargetConditionReason::RecoveryRequired),
+        "unsupported_by_agent" => Ok(AgentTargetConditionReason::UnsupportedByAgent),
+        "capability_invalid" => Ok(AgentTargetConditionReason::CapabilityInvalid),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target condition reason".to_string(),
+        )),
+    }
+}

--- a/crates/db/src/repository/effect/agent_target/encode.rs
+++ b/crates/db/src/repository/effect/agent_target/encode.rs
@@ -1,10 +1,17 @@
-//! Enum and numeric encodings shared by Agent Target SQLite persistence.
+//! Enum encodings shared by Agent Target SQLite persistence.
+//!
+//! Generation and unsigned integer conversions live in `mapping` so Skill and Agent Target rows
+//! cannot drift onto different overflow rules.
 
 use crate::DatabaseError;
 use ora_effect::{
     AgentTargetConditionReason, AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileState,
     AgentTargetRepositoryError, AgentTargetWakeReason, ConditionImpact, Generation,
 };
+
+pub(super) use super::super::mapping::{generation_from_sql, generation_to_sql, u64_to_sql};
+
+/// Maps repository-facing failures without leaking rusqlite types across the Effect port.
 pub(super) fn map_db_error(error: DatabaseError) -> AgentTargetRepositoryError {
     match error {
         DatabaseError::CorruptEffectState(message) => AgentTargetRepositoryError::corrupt(message),
@@ -12,18 +19,7 @@ pub(super) fn map_db_error(error: DatabaseError) -> AgentTargetRepositoryError {
     }
 }
 
-pub(super) fn generation_to_sql(generation: Generation) -> Result<i64, DatabaseError> {
-    i64::try_from(generation.value()).map_err(|_| {
-        DatabaseError::CorruptEffectState("generation exceeds SQLite integer range".to_string())
-    })
-}
-
-pub(super) fn generation_from_sql(value: i64) -> Result<Generation, DatabaseError> {
-    u64::try_from(value)
-        .map(Generation::new)
-        .map_err(|_| DatabaseError::CorruptEffectState("negative generation".to_string()))
-}
-
+/// Reads a generation by ordinal so Agent Target SELECT lists can stay positional.
 pub(super) fn generation_from_row(
     row: &rusqlite::Row<'_>,
     index: usize,
@@ -38,12 +34,7 @@ pub(super) fn generation_from_row(
     })
 }
 
-pub(super) fn u64_to_sql(value: u64, field: &str) -> Result<i64, DatabaseError> {
-    i64::try_from(value).map_err(|_| {
-        DatabaseError::CorruptEffectState(format!("{field} exceeds SQLite integer range"))
-    })
-}
-
+/// Reads an unsigned counter by ordinal; SQLite cannot store the domain's unsigned type.
 pub(super) fn u64_from_row(row: &rusqlite::Row<'_>, index: usize) -> Result<u64, rusqlite::Error> {
     let value: i64 = row.get(index)?;
     u64::try_from(value).map_err(|_| {
@@ -57,6 +48,7 @@ pub(super) fn u64_from_row(row: &rusqlite::Row<'_>, index: usize) -> Result<u64,
     })
 }
 
+/// Reads an attempt counter by ordinal; negative values cannot be a legal retry count.
 pub(super) fn u32_from_row(row: &rusqlite::Row<'_>, index: usize) -> Result<u32, rusqlite::Error> {
     let value: i64 = row.get(index)?;
     u32::try_from(value).map_err(|_| {
@@ -70,6 +62,7 @@ pub(super) fn u32_from_row(row: &rusqlite::Row<'_>, index: usize) -> Result<u32,
     })
 }
 
+/// Writes the CHECK-accepted lifecycle token so domain and schema cannot drift.
 pub(super) fn lifecycle_value(lifecycle: AgentTargetLifecycle) -> &'static str {
     match lifecycle {
         AgentTargetLifecycle::Active => "active",
@@ -77,6 +70,7 @@ pub(super) fn lifecycle_value(lifecycle: AgentTargetLifecycle) -> &'static str {
     }
 }
 
+/// Rejects lifecycle strings the CHECK constraint should already have excluded.
 pub(super) fn parse_lifecycle(value: &str) -> Result<AgentTargetLifecycle, DatabaseError> {
     match value {
         "active" => Ok(AgentTargetLifecycle::Active),
@@ -87,6 +81,7 @@ pub(super) fn parse_lifecycle(value: &str) -> Result<AgentTargetLifecycle, Datab
     }
 }
 
+/// Writes the CHECK-accepted phase token so domain and schema cannot drift.
 pub(super) fn phase_value(phase: AgentTargetPhase) -> &'static str {
     match phase {
         AgentTargetPhase::Pending => "pending",
@@ -102,6 +97,7 @@ pub(super) fn phase_value(phase: AgentTargetPhase) -> &'static str {
     }
 }
 
+/// Rejects phase strings the CHECK constraint should already have excluded.
 pub(super) fn parse_phase(value: &str) -> Result<AgentTargetPhase, DatabaseError> {
     match value {
         "pending" => Ok(AgentTargetPhase::Pending),
@@ -120,6 +116,7 @@ pub(super) fn parse_phase(value: &str) -> Result<AgentTargetPhase, DatabaseError
     }
 }
 
+/// Writes the CHECK-accepted impact token so domain and schema cannot drift.
 pub(super) fn impact_value(impact: ConditionImpact) -> &'static str {
     match impact {
         ConditionImpact::Blocking => "blocking",
@@ -127,6 +124,7 @@ pub(super) fn impact_value(impact: ConditionImpact) -> &'static str {
     }
 }
 
+/// Rejects impact strings the CHECK constraint should already have excluded.
 pub(super) fn parse_impact(value: &str) -> Result<ConditionImpact, DatabaseError> {
     match value {
         "blocking" => Ok(ConditionImpact::Blocking),
@@ -137,29 +135,52 @@ pub(super) fn parse_impact(value: &str) -> Result<ConditionImpact, DatabaseError
     }
 }
 
-pub(super) fn reconcile_state_value(state: AgentTargetReconcileState) -> &'static str {
+/// Splits the state machine into the four columns SQLite CHECKs as functions of `state`.
+pub(super) fn reconcile_state_sql(
+    state: &AgentTargetReconcileState,
+) -> (&'static str, Option<&str>, Option<&str>, Option<i64>) {
     match state {
-        AgentTargetReconcileState::Pending => "pending",
-        AgentTargetReconcileState::Claimed => "claimed",
-        AgentTargetReconcileState::Blocked => "blocked",
-        AgentTargetReconcileState::RetryScheduled => "retry_scheduled",
+        AgentTargetReconcileState::Pending => ("pending", None, None, None),
+        AgentTargetReconcileState::RetryScheduled => ("retry_scheduled", None, None, None),
+        AgentTargetReconcileState::Claimed {
+            lease_owner,
+            lease_expires_at,
+        } => (
+            "claimed",
+            None,
+            Some(lease_owner.as_str()),
+            Some(*lease_expires_at),
+        ),
+        AgentTargetReconcileState::Blocked { reason } => {
+            ("blocked", Some(reason.as_str()), None, None)
+        }
     }
 }
 
+/// Rebuilds the domain state machine so illegal column combinations cannot enter memory.
 pub(super) fn parse_reconcile_state(
     value: &str,
+    blocked_reason: Option<String>,
+    lease_owner: Option<String>,
+    lease_expires_at: Option<i64>,
 ) -> Result<AgentTargetReconcileState, DatabaseError> {
-    match value {
-        "pending" => Ok(AgentTargetReconcileState::Pending),
-        "claimed" => Ok(AgentTargetReconcileState::Claimed),
-        "blocked" => Ok(AgentTargetReconcileState::Blocked),
-        "retry_scheduled" => Ok(AgentTargetReconcileState::RetryScheduled),
+    match (value, blocked_reason, lease_owner, lease_expires_at) {
+        ("pending", None, None, None) => Ok(AgentTargetReconcileState::Pending),
+        ("retry_scheduled", None, None, None) => Ok(AgentTargetReconcileState::RetryScheduled),
+        ("claimed", None, Some(lease_owner), Some(lease_expires_at)) => {
+            Ok(AgentTargetReconcileState::Claimed {
+                lease_owner,
+                lease_expires_at,
+            })
+        }
+        ("blocked", Some(reason), None, None) => Ok(AgentTargetReconcileState::Blocked { reason }),
         _ => Err(DatabaseError::CorruptEffectState(
-            "unknown agent target reconcile state".to_string(),
+            "agent target reconcile state columns are inconsistent".to_string(),
         )),
     }
 }
 
+/// Writes the CHECK-accepted wake-reason token so domain and schema cannot drift.
 pub(super) fn wake_reason_value(reason: AgentTargetWakeReason) -> &'static str {
     match reason {
         AgentTargetWakeReason::DesiredChanged => "desired_changed",
@@ -170,6 +191,7 @@ pub(super) fn wake_reason_value(reason: AgentTargetWakeReason) -> &'static str {
     }
 }
 
+/// Rejects wake-reason strings the CHECK constraint should already have excluded.
 pub(super) fn parse_wake_reason(value: &str) -> Result<AgentTargetWakeReason, DatabaseError> {
     match value {
         "desired_changed" => Ok(AgentTargetWakeReason::DesiredChanged),
@@ -183,6 +205,7 @@ pub(super) fn parse_wake_reason(value: &str) -> Result<AgentTargetWakeReason, Da
     }
 }
 
+/// Writes the CHECK-accepted condition-reason token so domain and schema cannot drift.
 pub(super) fn condition_reason_value(reason: AgentTargetConditionReason) -> &'static str {
     match reason {
         AgentTargetConditionReason::NoConsumers => "no_consumers",
@@ -206,6 +229,7 @@ pub(super) fn condition_reason_value(reason: AgentTargetConditionReason) -> &'st
     }
 }
 
+/// Rejects condition-reason strings the CHECK constraint should already have excluded.
 pub(super) fn parse_condition_reason(
     value: &str,
 ) -> Result<AgentTargetConditionReason, DatabaseError> {

--- a/crates/db/src/repository/effect/agent_target/mod.rs
+++ b/crates/db/src/repository/effect/agent_target/mod.rs
@@ -3,19 +3,22 @@
 //! These APIs coexist with the surface-keyed Skill repository. Production workers must not claim
 //! target reconcile requests until a later Contract ticket switches ownership.
 
+mod conditions;
 mod encode;
+mod rows;
 
 use super::SqliteEffectRepository;
 use crate::DatabaseError;
+use conditions::replace_target_conditions;
 use encode::*;
 use ora_domain::WorkspaceId;
 use ora_effect::{
-    AgentCapabilityRevision, AgentPluginId, AgentTarget, AgentTargetCondition,
-    AgentTargetConditionSubject, AgentTargetId, AgentTargetIdentity, AgentTargetLifecycle,
-    AgentTargetReconcileRequest, AgentTargetReconcileState, AgentTargetRecord,
-    AgentTargetRepository, AgentTargetRepositoryError, AgentTargetStatus, AgentTargetWakeReason,
-    ConsumerId, Generation, SurfaceKey,
+    AgentCapabilityRevision, AgentTarget, AgentTargetCondition, AgentTargetId, AgentTargetIdentity,
+    AgentTargetLifecycle, AgentTargetReconcileRequest, AgentTargetReconcileState,
+    AgentTargetRecord, AgentTargetRepository, AgentTargetRepositoryError, AgentTargetStatus,
+    AgentTargetWakeReason, Generation,
 };
+use rows::*;
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 use uuid::Uuid;
 
@@ -31,7 +34,7 @@ impl AgentTargetRepository for SqliteEffectRepository {
             .with_connection_mut(|connection| {
                 let transaction =
                     connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-                ensure_workspace_effect(&transaction, &identity.workspace_id, updated_at)?;
+                ensure_workspace_effect(&transaction, &identity.workspace_id)?;
                 let existing = transaction
                     .query_row(
                         "SELECT id, created_at FROM effect_agent_targets
@@ -256,18 +259,15 @@ impl AgentTargetRepository for SqliteEffectRepository {
                     let wake_requested_at = updated_at.min(not_before_at);
                     let requested_at = existing.requested_at.min(wake_requested_at);
                     let due_at = existing.not_before_at.min(not_before_at).max(requested_at);
-                    let (state, blocked_reason, lease_owner, lease_expires_at) =
-                        if existing.state == AgentTargetReconcileState::Claimed {
-                            (
-                                existing.state,
-                                existing.blocked_reason,
-                                existing.lease_owner,
-                                existing.lease_expires_at,
-                            )
+                    let state =
+                        if matches!(existing.state, AgentTargetReconcileState::Claimed { .. }) {
+                            existing.state
                         } else {
-                            (AgentTargetReconcileState::Pending, None, None, None)
+                            AgentTargetReconcileState::Pending
                         };
                     let updated_at = updated_at.max(existing.updated_at);
+                    let (state_sql, blocked_reason, lease_owner, lease_expires_at) =
+                        reconcile_state_sql(&state);
                     transaction.execute(
                         "UPDATE effect_agent_target_reconcile_requests
                          SET requested_generation = ?1, state = ?2, wake_reason = ?3,
@@ -276,10 +276,10 @@ impl AgentTargetRepository for SqliteEffectRepository {
                          WHERE agent_target_id = ?10",
                         params![
                             generation_to_sql(requested_generation)?,
-                            reconcile_state_value(state),
+                            state_sql,
                             wake_reason_value(wake_reason),
-                            blocked_reason.as_deref(),
-                            lease_owner.as_deref(),
+                            blocked_reason,
+                            lease_owner,
                             lease_expires_at,
                             requested_at,
                             due_at,
@@ -294,9 +294,6 @@ impl AgentTargetRepository for SqliteEffectRepository {
                         request_token: existing.request_token,
                         state,
                         wake_reason,
-                        blocked_reason,
-                        lease_owner,
-                        lease_expires_at,
                         attempt_count: existing.attempt_count,
                         requested_at,
                         not_before_at: due_at,
@@ -329,9 +326,6 @@ impl AgentTargetRepository for SqliteEffectRepository {
                         request_token: token,
                         state: AgentTargetReconcileState::Pending,
                         wake_reason,
-                        blocked_reason: None,
-                        lease_owner: None,
-                        lease_expires_at: None,
                         attempt_count: 0,
                         requested_at,
                         not_before_at: due_at,
@@ -433,7 +427,6 @@ impl AgentTargetRepository for SqliteEffectRepository {
 fn ensure_workspace_effect(
     transaction: &rusqlite::Transaction<'_>,
     workspace_id: &WorkspaceId,
-    _now: i64,
 ) -> Result<(), DatabaseError> {
     let exists: bool = transaction.query_row(
         "SELECT EXISTS(SELECT 1 FROM workspace_effects WHERE workspace_id = ?1)",
@@ -447,267 +440,4 @@ fn ensure_workspace_effect(
         "workspace effect missing for {}",
         workspace_id.as_ref()
     )))
-}
-
-fn load_status_for_target(
-    connection: &rusqlite::Connection,
-    target: &AgentTarget,
-) -> Result<AgentTargetStatus, DatabaseError> {
-    let mut status = connection.query_row(
-        "SELECT desired_generation, observed_generation, applied_generation, ready_generation,
-                phase, status_version, created_at, updated_at
-         FROM effect_agent_target_status
-         WHERE agent_target_id = ?1",
-        params![target.id.as_str()],
-        |row| {
-            Ok(AgentTargetStatus {
-                agent_target_id: target.id.clone(),
-                identity: target.identity.clone(),
-                desired_generation: generation_from_row(row, 0)?,
-                observed_generation: generation_from_row(row, 1)?,
-                applied_generation: generation_from_row(row, 2)?,
-                ready_generation: generation_from_row(row, 3)?,
-                phase: parse_phase(&row.get::<_, String>(4)?).map_err(|error| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        4,
-                        rusqlite::types::Type::Text,
-                        Box::new(error),
-                    )
-                })?,
-                status_version: u64_from_row(row, 5)?,
-                created_at: row.get(6)?,
-                updated_at: row.get(7)?,
-                conditions: Vec::new(),
-            })
-        },
-    )?;
-    status.conditions = load_target_conditions(connection, target.id.as_str())?;
-    Ok(status)
-}
-
-fn load_target_conditions(
-    connection: &rusqlite::Connection,
-    agent_target_id: &str,
-) -> Result<Vec<AgentTargetCondition>, DatabaseError> {
-    let mut statement = connection.prepare(
-        "SELECT id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
-                failed_generation, message, first_observed_at, last_observed_at
-         FROM effect_agent_target_conditions
-         WHERE agent_target_id = ?1
-         ORDER BY subject_kind, subject_id, reason, IFNULL(surface_id, ''), IFNULL(consumer_id, '')",
-    )?;
-    let rows = statement.query_map(params![agent_target_id], |row| {
-        let subject_json: String = row.get(4)?;
-        let subject = serde_json::from_str::<AgentTargetConditionSubject>(&subject_json).map_err(
-            |error| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    4,
-                    rusqlite::types::Type::Text,
-                    Box::new(error),
-                )
-            },
-        )?;
-        let reason_raw: String = row.get(5)?;
-        let reason = parse_condition_reason(&reason_raw).map_err(|error| {
-            rusqlite::Error::FromSqlConversionFailure(
-                5,
-                rusqlite::types::Type::Text,
-                Box::new(error),
-            )
-        })?;
-        let impact = parse_impact(&row.get::<_, String>(6)?).map_err(|error| {
-            rusqlite::Error::FromSqlConversionFailure(
-                6,
-                rusqlite::types::Type::Text,
-                Box::new(error),
-            )
-        })?;
-        let failed_generation = match row.get::<_, Option<i64>>(7)? {
-            Some(value) => Some(generation_from_sql(value).map_err(|error| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    7,
-                    rusqlite::types::Type::Integer,
-                    Box::new(error),
-                )
-            })?),
-            None => None,
-        };
-        let surface_id: Option<String> = row.get(1)?;
-        let consumer_id: Option<String> = row.get(2)?;
-        Ok(AgentTargetCondition {
-            id: row.get(0)?,
-            subject,
-            reason,
-            impact,
-            message: row.get(8)?,
-            first_observed_at: row.get(9)?,
-            last_observed_at: row.get(10)?,
-            failed_generation,
-            surface_key: surface_id.map(SurfaceKey::new),
-            consumer_id: consumer_id.map(ConsumerId::new),
-        })
-    })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-}
-
-fn replace_target_conditions(
-    transaction: &rusqlite::Transaction<'_>,
-    agent_target_id: &str,
-    conditions: &[AgentTargetCondition],
-) -> Result<(), DatabaseError> {
-    transaction.execute(
-        "DELETE FROM effect_agent_target_conditions WHERE agent_target_id = ?1",
-        params![agent_target_id],
-    )?;
-    for condition in conditions {
-        let subject_kind = match &condition.subject {
-            AgentTargetConditionSubject::AgentTarget => "agent_target",
-            AgentTargetConditionSubject::Surface { .. } => "surface",
-            AgentTargetConditionSubject::Consumer { .. } => "consumer",
-            AgentTargetConditionSubject::DesiredSkill { .. } => "desired_item",
-            AgentTargetConditionSubject::ManagedSkill { .. } => "managed_item",
-            AgentTargetConditionSubject::Mcp { .. } => "mcp",
-        };
-        let subject_id = serde_json::to_string(&condition.subject)
-            .map_err(|error| DatabaseError::CorruptEffectState(error.to_string()))?;
-        let id = if condition.id.is_empty() {
-            Uuid::new_v4().to_string()
-        } else {
-            condition.id.clone()
-        };
-        transaction.execute(
-            "INSERT INTO effect_agent_target_conditions (
-                 id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason,
-                 impact, failed_generation, message, first_observed_at, last_observed_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
-            params![
-                id,
-                agent_target_id,
-                condition.surface_key.as_ref().map(SurfaceKey::as_str),
-                condition.consumer_id.as_ref().map(ConsumerId::as_str),
-                subject_kind,
-                subject_id,
-                condition_reason_value(condition.reason),
-                impact_value(condition.impact),
-                condition
-                    .failed_generation
-                    .map(generation_to_sql)
-                    .transpose()?,
-                &condition.message,
-                condition.first_observed_at,
-                condition.last_observed_at,
-            ],
-        )?;
-    }
-    Ok(())
-}
-
-fn map_agent_target_row(row: &rusqlite::Row<'_>) -> Result<AgentTarget, rusqlite::Error> {
-    Ok(AgentTarget {
-        id: AgentTargetId::new(row.get::<_, String>(0)?),
-        identity: AgentTargetIdentity::new(
-            WorkspaceId::new(row.get::<_, String>(1)?),
-            AgentPluginId::new(row.get::<_, String>(2)?),
-        ),
-        capability_revision: AgentCapabilityRevision::new(row.get::<_, String>(3)?),
-        lifecycle: parse_lifecycle(&row.get::<_, String>(4)?).map_err(|error| {
-            rusqlite::Error::FromSqlConversionFailure(
-                4,
-                rusqlite::types::Type::Text,
-                Box::new(error),
-            )
-        })?,
-        created_at: row.get(5)?,
-        updated_at: row.get(6)?,
-    })
-}
-
-struct RequestColumns {
-    requested_generation: Generation,
-    request_token: String,
-    state: AgentTargetReconcileState,
-    blocked_reason: Option<String>,
-    lease_owner: Option<String>,
-    lease_expires_at: Option<i64>,
-    attempt_count: u32,
-    requested_at: i64,
-    not_before_at: i64,
-    updated_at: i64,
-}
-
-fn map_request_columns(row: &rusqlite::Row<'_>) -> Result<RequestColumns, rusqlite::Error> {
-    // Validate wake_reason even though coalescing replaces it with the newest wake.
-    let _: AgentTargetWakeReason =
-        parse_wake_reason(&row.get::<_, String>(3)?).map_err(|error| {
-            rusqlite::Error::FromSqlConversionFailure(
-                3,
-                rusqlite::types::Type::Text,
-                Box::new(error),
-            )
-        })?;
-    Ok(RequestColumns {
-        requested_generation: generation_from_row(row, 0)?,
-        request_token: row.get(1)?,
-        state: parse_reconcile_state(&row.get::<_, String>(2)?).map_err(|error| {
-            rusqlite::Error::FromSqlConversionFailure(
-                2,
-                rusqlite::types::Type::Text,
-                Box::new(error),
-            )
-        })?,
-        blocked_reason: row.get(4)?,
-        lease_owner: row.get(5)?,
-        lease_expires_at: row.get(6)?,
-        attempt_count: u32_from_row(row, 7)?,
-        requested_at: row.get(8)?,
-        not_before_at: row.get(9)?,
-        updated_at: row.get(10)?,
-    })
-}
-
-fn map_full_request_row(
-    row: &rusqlite::Row<'_>,
-) -> Result<AgentTargetReconcileRequest, rusqlite::Error> {
-    Ok(AgentTargetReconcileRequest {
-        agent_target_id: AgentTargetId::new(row.get::<_, String>(0)?),
-        identity: AgentTargetIdentity::new(
-            WorkspaceId::new(row.get::<_, String>(1)?),
-            AgentPluginId::new(row.get::<_, String>(2)?),
-        ),
-        requested_generation: generation_from_row(row, 3)?,
-        request_token: row.get(4)?,
-        state: parse_reconcile_state(&row.get::<_, String>(5)?).map_err(|error| {
-            rusqlite::Error::FromSqlConversionFailure(
-                5,
-                rusqlite::types::Type::Text,
-                Box::new(error),
-            )
-        })?,
-        wake_reason: parse_wake_reason(&row.get::<_, String>(6)?).map_err(|error| {
-            rusqlite::Error::FromSqlConversionFailure(
-                6,
-                rusqlite::types::Type::Text,
-                Box::new(error),
-            )
-        })?,
-        blocked_reason: row.get(7)?,
-        lease_owner: row.get(8)?,
-        lease_expires_at: row.get(9)?,
-        attempt_count: u32_from_row(row, 10)?,
-        requested_at: row.get(11)?,
-        not_before_at: row.get(12)?,
-        updated_at: row.get(13)?,
-    })
-}
-
-fn validate_generation_order(status: &AgentTargetStatus) -> Result<(), AgentTargetRepositoryError> {
-    if status.applied_generation > status.observed_generation
-        || status.observed_generation > status.desired_generation
-        || status.ready_generation > status.applied_generation
-    {
-        return Err(AgentTargetRepositoryError::corrupt(
-            "agent target generation ordering is illegal",
-        ));
-    }
-    Ok(())
 }

--- a/crates/db/src/repository/effect/agent_target/mod.rs
+++ b/crates/db/src/repository/effect/agent_target/mod.rs
@@ -1,0 +1,713 @@
+//! Typed SQLite persistence for Agent Target Expand-phase Effect state.
+//!
+//! These APIs coexist with the surface-keyed Skill repository. Production workers must not claim
+//! target reconcile requests until a later Contract ticket switches ownership.
+
+mod encode;
+
+use super::SqliteEffectRepository;
+use crate::DatabaseError;
+use encode::*;
+use ora_domain::WorkspaceId;
+use ora_effect::{
+    AgentCapabilityRevision, AgentPluginId, AgentTarget, AgentTargetCondition,
+    AgentTargetConditionSubject, AgentTargetId, AgentTargetIdentity, AgentTargetLifecycle,
+    AgentTargetReconcileRequest, AgentTargetReconcileState, AgentTargetRecord,
+    AgentTargetRepository, AgentTargetRepositoryError, AgentTargetStatus, AgentTargetWakeReason,
+    ConsumerId, Generation, SurfaceKey,
+};
+use rusqlite::{OptionalExtension, TransactionBehavior, params};
+use uuid::Uuid;
+
+impl AgentTargetRepository for SqliteEffectRepository {
+    fn upsert_agent_target(
+        &self,
+        identity: &AgentTargetIdentity,
+        capability_revision: &AgentCapabilityRevision,
+        lifecycle: AgentTargetLifecycle,
+        updated_at: i64,
+    ) -> Result<AgentTarget, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection_mut(|connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                ensure_workspace_effect(&transaction, &identity.workspace_id, updated_at)?;
+                let existing = transaction
+                    .query_row(
+                        "SELECT id, created_at FROM effect_agent_targets
+                         WHERE workspace_id = ?1 AND agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+                    )
+                    .optional()?;
+                let (id, created_at) = if let Some((id, created_at)) = existing {
+                    transaction.execute(
+                        "UPDATE effect_agent_targets
+                         SET capability_revision = ?1, lifecycle = ?2, updated_at = ?3
+                         WHERE id = ?4",
+                        params![
+                            capability_revision.as_str(),
+                            lifecycle_value(lifecycle),
+                            updated_at,
+                            &id
+                        ],
+                    )?;
+                    (id, created_at)
+                } else {
+                    let id = Uuid::new_v4().to_string();
+                    transaction.execute(
+                        "INSERT INTO effect_agent_targets (
+                             id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                             created_at, updated_at
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+                        params![
+                            &id,
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str(),
+                            capability_revision.as_str(),
+                            lifecycle_value(lifecycle),
+                            updated_at,
+                        ],
+                    )?;
+                    transaction.execute(
+                        "INSERT INTO effect_agent_target_status (
+                             agent_target_id, desired_generation, observed_generation,
+                             applied_generation, ready_generation, phase, status_version,
+                             created_at, updated_at
+                         ) VALUES (?1, 0, 0, 0, 0, 'current', 1, ?2, ?2)",
+                        params![&id, updated_at],
+                    )?;
+                    (id, updated_at)
+                };
+                transaction.commit()?;
+                Ok(AgentTarget {
+                    id: AgentTargetId::new(id),
+                    identity: identity.clone(),
+                    capability_revision: capability_revision.clone(),
+                    lifecycle,
+                    created_at,
+                    updated_at,
+                })
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTarget>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                connection
+                    .query_row(
+                        "SELECT id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                                created_at, updated_at
+                         FROM effect_agent_targets
+                         WHERE workspace_id = ?1 AND agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        map_agent_target_row,
+                    )
+                    .optional()
+                    .map_err(Into::into)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target_by_id(
+        &self,
+        agent_target_id: &AgentTargetId,
+    ) -> Result<Option<AgentTarget>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                connection
+                    .query_row(
+                        "SELECT id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                                created_at, updated_at
+                         FROM effect_agent_targets
+                         WHERE id = ?1",
+                        params![agent_target_id.as_str()],
+                        map_agent_target_row,
+                    )
+                    .optional()
+                    .map_err(Into::into)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn save_agent_target_status(
+        &self,
+        status: &AgentTargetStatus,
+    ) -> Result<(), AgentTargetRepositoryError> {
+        validate_generation_order(status)?;
+        self.pool
+            .with_connection_mut(|connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let updated = transaction.execute(
+                    "UPDATE effect_agent_target_status
+                     SET desired_generation = ?1, observed_generation = ?2,
+                         applied_generation = ?3, ready_generation = ?4, phase = ?5,
+                         status_version = ?6, updated_at = ?7
+                     WHERE agent_target_id = ?8",
+                    params![
+                        generation_to_sql(status.desired_generation)?,
+                        generation_to_sql(status.observed_generation)?,
+                        generation_to_sql(status.applied_generation)?,
+                        generation_to_sql(status.ready_generation)?,
+                        phase_value(status.phase),
+                        u64_to_sql(status.status_version, "status_version")?,
+                        status.updated_at,
+                        status.agent_target_id.as_str(),
+                    ],
+                )?;
+                if updated == 0 {
+                    return Err(DatabaseError::CorruptEffectState(
+                        "agent target status row is missing".to_string(),
+                    ));
+                }
+                replace_target_conditions(
+                    &transaction,
+                    status.agent_target_id.as_str(),
+                    &status.conditions,
+                )?;
+                transaction.commit()?;
+                Ok(())
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target_status(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetStatus>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                let Some(target) = connection
+                    .query_row(
+                        "SELECT id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                                created_at, updated_at
+                         FROM effect_agent_targets
+                         WHERE workspace_id = ?1 AND agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        map_agent_target_row,
+                    )
+                    .optional()?
+                else {
+                    return Ok(None);
+                };
+                load_status_for_target(connection, &target).map(Some)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn upsert_agent_target_reconcile_request(
+        &self,
+        identity: &AgentTargetIdentity,
+        requested_generation: Generation,
+        wake_reason: AgentTargetWakeReason,
+        not_before_at: i64,
+        updated_at: i64,
+    ) -> Result<AgentTargetReconcileRequest, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection_mut(|connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let target_id: String = transaction
+                    .query_row(
+                        "SELECT id FROM effect_agent_targets
+                         WHERE workspace_id = ?1 AND agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        |row| row.get(0),
+                    )
+                    .map_err(|_| {
+                        DatabaseError::CorruptEffectState(format!(
+                            "agent target missing for workspace {} and plugin {}",
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ))
+                    })?;
+                let existing = transaction
+                    .query_row(
+                        "SELECT requested_generation, request_token, state, wake_reason,
+                                blocked_reason, lease_owner, lease_expires_at, attempt_count,
+                                requested_at, not_before_at, updated_at
+                         FROM effect_agent_target_reconcile_requests
+                         WHERE agent_target_id = ?1",
+                        params![&target_id],
+                        map_request_columns,
+                    )
+                    .optional()?;
+                let request = if let Some(existing) = existing {
+                    // Keep the highest requested generation and the earliest due time across wakes.
+                    let requested_generation =
+                        existing.requested_generation.max(requested_generation);
+                    let wake_requested_at = updated_at.min(not_before_at);
+                    let requested_at = existing.requested_at.min(wake_requested_at);
+                    let due_at = existing.not_before_at.min(not_before_at).max(requested_at);
+                    let (state, blocked_reason, lease_owner, lease_expires_at) =
+                        if existing.state == AgentTargetReconcileState::Claimed {
+                            (
+                                existing.state,
+                                existing.blocked_reason,
+                                existing.lease_owner,
+                                existing.lease_expires_at,
+                            )
+                        } else {
+                            (AgentTargetReconcileState::Pending, None, None, None)
+                        };
+                    let updated_at = updated_at.max(existing.updated_at);
+                    transaction.execute(
+                        "UPDATE effect_agent_target_reconcile_requests
+                         SET requested_generation = ?1, state = ?2, wake_reason = ?3,
+                             blocked_reason = ?4, lease_owner = ?5, lease_expires_at = ?6,
+                             requested_at = ?7, not_before_at = ?8, updated_at = ?9
+                         WHERE agent_target_id = ?10",
+                        params![
+                            generation_to_sql(requested_generation)?,
+                            reconcile_state_value(state),
+                            wake_reason_value(wake_reason),
+                            blocked_reason.as_deref(),
+                            lease_owner.as_deref(),
+                            lease_expires_at,
+                            requested_at,
+                            due_at,
+                            updated_at,
+                            &target_id,
+                        ],
+                    )?;
+                    AgentTargetReconcileRequest {
+                        agent_target_id: AgentTargetId::new(target_id),
+                        identity: identity.clone(),
+                        requested_generation,
+                        request_token: existing.request_token,
+                        state,
+                        wake_reason,
+                        blocked_reason,
+                        lease_owner,
+                        lease_expires_at,
+                        attempt_count: existing.attempt_count,
+                        requested_at,
+                        not_before_at: due_at,
+                        updated_at,
+                    }
+                } else {
+                    let token = Uuid::new_v4().to_string();
+                    let requested_at = updated_at.min(not_before_at);
+                    let due_at = not_before_at.max(requested_at);
+                    transaction.execute(
+                        "INSERT INTO effect_agent_target_reconcile_requests (
+                             agent_target_id, requested_generation, request_token, state,
+                             wake_reason, blocked_reason, lease_owner, lease_expires_at,
+                             attempt_count, requested_at, not_before_at, updated_at
+                         ) VALUES (?1, ?2, ?3, 'pending', ?4, NULL, NULL, NULL, 0, ?5, ?6, ?7)",
+                        params![
+                            &target_id,
+                            generation_to_sql(requested_generation)?,
+                            &token,
+                            wake_reason_value(wake_reason),
+                            requested_at,
+                            due_at,
+                            updated_at,
+                        ],
+                    )?;
+                    AgentTargetReconcileRequest {
+                        agent_target_id: AgentTargetId::new(target_id),
+                        identity: identity.clone(),
+                        requested_generation,
+                        request_token: token,
+                        state: AgentTargetReconcileState::Pending,
+                        wake_reason,
+                        blocked_reason: None,
+                        lease_owner: None,
+                        lease_expires_at: None,
+                        attempt_count: 0,
+                        requested_at,
+                        not_before_at: due_at,
+                        updated_at,
+                    }
+                };
+                transaction.commit()?;
+                Ok(request)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target_reconcile_request(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetReconcileRequest>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                connection
+                    .query_row(
+                        "SELECT targets.id, targets.workspace_id, targets.agent_plugin_id,
+                                requests.requested_generation, requests.request_token,
+                                requests.state, requests.wake_reason, requests.blocked_reason,
+                                requests.lease_owner, requests.lease_expires_at,
+                                requests.attempt_count, requests.requested_at,
+                                requests.not_before_at, requests.updated_at
+                         FROM effect_agent_target_reconcile_requests requests
+                         JOIN effect_agent_targets targets
+                           ON targets.id = requests.agent_target_id
+                         WHERE targets.workspace_id = ?1 AND targets.agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        map_full_request_row,
+                    )
+                    .optional()
+                    .map_err(Into::into)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn replace_agent_target_conditions(
+        &self,
+        agent_target_id: &AgentTargetId,
+        conditions: &[AgentTargetCondition],
+    ) -> Result<(), AgentTargetRepositoryError> {
+        self.pool
+            .with_connection_mut(|connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                replace_target_conditions(&transaction, agent_target_id.as_str(), conditions)?;
+                transaction.commit()?;
+                Ok(())
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target_record(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetRecord>, AgentTargetRepositoryError> {
+        let Some(target) = self.load_agent_target(identity)? else {
+            return Ok(None);
+        };
+        let status = self.load_agent_target_status(identity)?.ok_or_else(|| {
+            AgentTargetRepositoryError::corrupt("agent target status row is missing")
+        })?;
+        let reconcile_request = self.load_agent_target_reconcile_request(identity)?;
+        Ok(Some(AgentTargetRecord {
+            target,
+            status,
+            reconcile_request,
+        }))
+    }
+
+    fn list_agent_targets_for_workspace(
+        &self,
+        workspace_id: &WorkspaceId,
+    ) -> Result<Vec<AgentTarget>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                let mut statement = connection.prepare(
+                    "SELECT id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                            created_at, updated_at
+                     FROM effect_agent_targets
+                     WHERE workspace_id = ?1
+                     ORDER BY agent_plugin_id",
+                )?;
+                let rows =
+                    statement.query_map(params![workspace_id.as_ref()], map_agent_target_row)?;
+                rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+            })
+            .map_err(map_db_error)
+    }
+}
+
+/// Refuses to create an Agent Target without the Workspace Effect aggregate that owns generations.
+fn ensure_workspace_effect(
+    transaction: &rusqlite::Transaction<'_>,
+    workspace_id: &WorkspaceId,
+    _now: i64,
+) -> Result<(), DatabaseError> {
+    let exists: bool = transaction.query_row(
+        "SELECT EXISTS(SELECT 1 FROM workspace_effects WHERE workspace_id = ?1)",
+        params![workspace_id.as_ref()],
+        |row| row.get(0),
+    )?;
+    if exists {
+        return Ok(());
+    }
+    Err(DatabaseError::CorruptEffectState(format!(
+        "workspace effect missing for {}",
+        workspace_id.as_ref()
+    )))
+}
+
+fn load_status_for_target(
+    connection: &rusqlite::Connection,
+    target: &AgentTarget,
+) -> Result<AgentTargetStatus, DatabaseError> {
+    let mut status = connection.query_row(
+        "SELECT desired_generation, observed_generation, applied_generation, ready_generation,
+                phase, status_version, created_at, updated_at
+         FROM effect_agent_target_status
+         WHERE agent_target_id = ?1",
+        params![target.id.as_str()],
+        |row| {
+            Ok(AgentTargetStatus {
+                agent_target_id: target.id.clone(),
+                identity: target.identity.clone(),
+                desired_generation: generation_from_row(row, 0)?,
+                observed_generation: generation_from_row(row, 1)?,
+                applied_generation: generation_from_row(row, 2)?,
+                ready_generation: generation_from_row(row, 3)?,
+                phase: parse_phase(&row.get::<_, String>(4)?).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        4,
+                        rusqlite::types::Type::Text,
+                        Box::new(error),
+                    )
+                })?,
+                status_version: u64_from_row(row, 5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+                conditions: Vec::new(),
+            })
+        },
+    )?;
+    status.conditions = load_target_conditions(connection, target.id.as_str())?;
+    Ok(status)
+}
+
+fn load_target_conditions(
+    connection: &rusqlite::Connection,
+    agent_target_id: &str,
+) -> Result<Vec<AgentTargetCondition>, DatabaseError> {
+    let mut statement = connection.prepare(
+        "SELECT id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
+                failed_generation, message, first_observed_at, last_observed_at
+         FROM effect_agent_target_conditions
+         WHERE agent_target_id = ?1
+         ORDER BY subject_kind, subject_id, reason, IFNULL(surface_id, ''), IFNULL(consumer_id, '')",
+    )?;
+    let rows = statement.query_map(params![agent_target_id], |row| {
+        let subject_json: String = row.get(4)?;
+        let subject = serde_json::from_str::<AgentTargetConditionSubject>(&subject_json).map_err(
+            |error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    4,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+            },
+        )?;
+        let reason_raw: String = row.get(5)?;
+        let reason = parse_condition_reason(&reason_raw).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+        let impact = parse_impact(&row.get::<_, String>(6)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+        let failed_generation = match row.get::<_, Option<i64>>(7)? {
+            Some(value) => Some(generation_from_sql(value).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    7,
+                    rusqlite::types::Type::Integer,
+                    Box::new(error),
+                )
+            })?),
+            None => None,
+        };
+        let surface_id: Option<String> = row.get(1)?;
+        let consumer_id: Option<String> = row.get(2)?;
+        Ok(AgentTargetCondition {
+            id: row.get(0)?,
+            subject,
+            reason,
+            impact,
+            message: row.get(8)?,
+            first_observed_at: row.get(9)?,
+            last_observed_at: row.get(10)?,
+            failed_generation,
+            surface_key: surface_id.map(SurfaceKey::new),
+            consumer_id: consumer_id.map(ConsumerId::new),
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+fn replace_target_conditions(
+    transaction: &rusqlite::Transaction<'_>,
+    agent_target_id: &str,
+    conditions: &[AgentTargetCondition],
+) -> Result<(), DatabaseError> {
+    transaction.execute(
+        "DELETE FROM effect_agent_target_conditions WHERE agent_target_id = ?1",
+        params![agent_target_id],
+    )?;
+    for condition in conditions {
+        let subject_kind = match &condition.subject {
+            AgentTargetConditionSubject::AgentTarget => "agent_target",
+            AgentTargetConditionSubject::Surface { .. } => "surface",
+            AgentTargetConditionSubject::Consumer { .. } => "consumer",
+            AgentTargetConditionSubject::DesiredSkill { .. } => "desired_item",
+            AgentTargetConditionSubject::ManagedSkill { .. } => "managed_item",
+            AgentTargetConditionSubject::Mcp { .. } => "mcp",
+        };
+        let subject_id = serde_json::to_string(&condition.subject)
+            .map_err(|error| DatabaseError::CorruptEffectState(error.to_string()))?;
+        let id = if condition.id.is_empty() {
+            Uuid::new_v4().to_string()
+        } else {
+            condition.id.clone()
+        };
+        transaction.execute(
+            "INSERT INTO effect_agent_target_conditions (
+                 id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 impact, failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                id,
+                agent_target_id,
+                condition.surface_key.as_ref().map(SurfaceKey::as_str),
+                condition.consumer_id.as_ref().map(ConsumerId::as_str),
+                subject_kind,
+                subject_id,
+                condition_reason_value(condition.reason),
+                impact_value(condition.impact),
+                condition
+                    .failed_generation
+                    .map(generation_to_sql)
+                    .transpose()?,
+                &condition.message,
+                condition.first_observed_at,
+                condition.last_observed_at,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn map_agent_target_row(row: &rusqlite::Row<'_>) -> Result<AgentTarget, rusqlite::Error> {
+    Ok(AgentTarget {
+        id: AgentTargetId::new(row.get::<_, String>(0)?),
+        identity: AgentTargetIdentity::new(
+            WorkspaceId::new(row.get::<_, String>(1)?),
+            AgentPluginId::new(row.get::<_, String>(2)?),
+        ),
+        capability_revision: AgentCapabilityRevision::new(row.get::<_, String>(3)?),
+        lifecycle: parse_lifecycle(&row.get::<_, String>(4)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                4,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        created_at: row.get(5)?,
+        updated_at: row.get(6)?,
+    })
+}
+
+struct RequestColumns {
+    requested_generation: Generation,
+    request_token: String,
+    state: AgentTargetReconcileState,
+    blocked_reason: Option<String>,
+    lease_owner: Option<String>,
+    lease_expires_at: Option<i64>,
+    attempt_count: u32,
+    requested_at: i64,
+    not_before_at: i64,
+    updated_at: i64,
+}
+
+fn map_request_columns(row: &rusqlite::Row<'_>) -> Result<RequestColumns, rusqlite::Error> {
+    // Validate wake_reason even though coalescing replaces it with the newest wake.
+    let _: AgentTargetWakeReason =
+        parse_wake_reason(&row.get::<_, String>(3)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+    Ok(RequestColumns {
+        requested_generation: generation_from_row(row, 0)?,
+        request_token: row.get(1)?,
+        state: parse_reconcile_state(&row.get::<_, String>(2)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                2,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        blocked_reason: row.get(4)?,
+        lease_owner: row.get(5)?,
+        lease_expires_at: row.get(6)?,
+        attempt_count: u32_from_row(row, 7)?,
+        requested_at: row.get(8)?,
+        not_before_at: row.get(9)?,
+        updated_at: row.get(10)?,
+    })
+}
+
+fn map_full_request_row(
+    row: &rusqlite::Row<'_>,
+) -> Result<AgentTargetReconcileRequest, rusqlite::Error> {
+    Ok(AgentTargetReconcileRequest {
+        agent_target_id: AgentTargetId::new(row.get::<_, String>(0)?),
+        identity: AgentTargetIdentity::new(
+            WorkspaceId::new(row.get::<_, String>(1)?),
+            AgentPluginId::new(row.get::<_, String>(2)?),
+        ),
+        requested_generation: generation_from_row(row, 3)?,
+        request_token: row.get(4)?,
+        state: parse_reconcile_state(&row.get::<_, String>(5)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        wake_reason: parse_wake_reason(&row.get::<_, String>(6)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        blocked_reason: row.get(7)?,
+        lease_owner: row.get(8)?,
+        lease_expires_at: row.get(9)?,
+        attempt_count: u32_from_row(row, 10)?,
+        requested_at: row.get(11)?,
+        not_before_at: row.get(12)?,
+        updated_at: row.get(13)?,
+    })
+}
+
+fn validate_generation_order(status: &AgentTargetStatus) -> Result<(), AgentTargetRepositoryError> {
+    if status.applied_generation > status.observed_generation
+        || status.observed_generation > status.desired_generation
+        || status.ready_generation > status.applied_generation
+    {
+        return Err(AgentTargetRepositoryError::corrupt(
+            "agent target generation ordering is illegal",
+        ));
+    }
+    Ok(())
+}

--- a/crates/db/src/repository/effect/agent_target/rows.rs
+++ b/crates/db/src/repository/effect/agent_target/rows.rs
@@ -1,0 +1,171 @@
+//! Row mapping for Agent Target identity, status, and reconcile requests.
+
+use super::conditions::load_target_conditions;
+use super::encode::*;
+use crate::DatabaseError;
+use ora_domain::WorkspaceId;
+use ora_effect::{
+    AgentCapabilityRevision, AgentPluginId, AgentTarget, AgentTargetId, AgentTargetIdentity,
+    AgentTargetReconcileRequest, AgentTargetReconcileState, AgentTargetRepositoryError,
+    AgentTargetStatus, AgentTargetWakeReason, Generation,
+};
+use rusqlite::params;
+
+/// Reconstructs an Agent Target identity row without scheduling state.
+pub(super) fn map_agent_target_row(
+    row: &rusqlite::Row<'_>,
+) -> Result<AgentTarget, rusqlite::Error> {
+    Ok(AgentTarget {
+        id: AgentTargetId::new(row.get::<_, String>(0)?),
+        identity: AgentTargetIdentity::new(
+            WorkspaceId::new(row.get::<_, String>(1)?),
+            AgentPluginId::new(row.get::<_, String>(2)?),
+        ),
+        capability_revision: AgentCapabilityRevision::new(row.get::<_, String>(3)?),
+        lifecycle: parse_lifecycle(&row.get::<_, String>(4)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                4,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        created_at: row.get(5)?,
+        updated_at: row.get(6)?,
+    })
+}
+
+pub(super) struct RequestColumns {
+    pub requested_generation: Generation,
+    pub request_token: String,
+    pub state: AgentTargetReconcileState,
+    pub attempt_count: u32,
+    pub requested_at: i64,
+    pub not_before_at: i64,
+    pub updated_at: i64,
+}
+
+/// Validates wake_reason even though coalescing replaces it with the newest wake.
+pub(super) fn map_request_columns(
+    row: &rusqlite::Row<'_>,
+) -> Result<RequestColumns, rusqlite::Error> {
+    let _: AgentTargetWakeReason =
+        parse_wake_reason(&row.get::<_, String>(3)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+    Ok(RequestColumns {
+        requested_generation: generation_from_row(row, 0)?,
+        request_token: row.get(1)?,
+        state: parse_reconcile_state(
+            &row.get::<_, String>(2)?,
+            row.get(4)?,
+            row.get(5)?,
+            row.get(6)?,
+        )
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                2,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        attempt_count: u32_from_row(row, 7)?,
+        requested_at: row.get(8)?,
+        not_before_at: row.get(9)?,
+        updated_at: row.get(10)?,
+    })
+}
+
+/// Reconstructs a complete request including the target identity join columns.
+pub(super) fn map_full_request_row(
+    row: &rusqlite::Row<'_>,
+) -> Result<AgentTargetReconcileRequest, rusqlite::Error> {
+    Ok(AgentTargetReconcileRequest {
+        agent_target_id: AgentTargetId::new(row.get::<_, String>(0)?),
+        identity: AgentTargetIdentity::new(
+            WorkspaceId::new(row.get::<_, String>(1)?),
+            AgentPluginId::new(row.get::<_, String>(2)?),
+        ),
+        requested_generation: generation_from_row(row, 3)?,
+        request_token: row.get(4)?,
+        state: parse_reconcile_state(
+            &row.get::<_, String>(5)?,
+            row.get(7)?,
+            row.get(8)?,
+            row.get(9)?,
+        )
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        wake_reason: parse_wake_reason(&row.get::<_, String>(6)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        attempt_count: u32_from_row(row, 10)?,
+        requested_at: row.get(11)?,
+        not_before_at: row.get(12)?,
+        updated_at: row.get(13)?,
+    })
+}
+
+/// Loads status then attaches owned conditions so callers never observe a half-read target.
+pub(super) fn load_status_for_target(
+    connection: &rusqlite::Connection,
+    target: &AgentTarget,
+) -> Result<AgentTargetStatus, DatabaseError> {
+    let mut status = connection.query_row(
+        "SELECT desired_generation, observed_generation, applied_generation, ready_generation,
+                phase, status_version, created_at, updated_at
+         FROM effect_agent_target_status
+         WHERE agent_target_id = ?1",
+        params![target.id.as_str()],
+        |row| {
+            Ok(AgentTargetStatus {
+                agent_target_id: target.id.clone(),
+                identity: target.identity.clone(),
+                desired_generation: generation_from_row(row, 0)?,
+                observed_generation: generation_from_row(row, 1)?,
+                applied_generation: generation_from_row(row, 2)?,
+                ready_generation: generation_from_row(row, 3)?,
+                phase: parse_phase(&row.get::<_, String>(4)?).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        4,
+                        rusqlite::types::Type::Text,
+                        Box::new(error),
+                    )
+                })?,
+                status_version: u64_from_row(row, 5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+                conditions: Vec::new(),
+            })
+        },
+    )?;
+    status.conditions = load_target_conditions(connection, target.id.as_str())?;
+    Ok(status)
+}
+
+/// Enforces generation order in the domain so a CHECK-less write path cannot persist an illegal tuple.
+pub(super) fn validate_generation_order(
+    status: &AgentTargetStatus,
+) -> Result<(), AgentTargetRepositoryError> {
+    if status.applied_generation > status.observed_generation
+        || status.observed_generation > status.desired_generation
+        || status.ready_generation > status.applied_generation
+    {
+        return Err(AgentTargetRepositoryError::corrupt(
+            "agent target generation ordering is illegal",
+        ));
+    }
+    Ok(())
+}

--- a/crates/db/src/repository/effect/mapping.rs
+++ b/crates/db/src/repository/effect/mapping.rs
@@ -842,17 +842,17 @@ pub(super) fn parse_surface_phase(value: &str) -> Result<SurfacePhase, DatabaseE
 }
 
 /// Converts the unsigned domain value into SQLite's signed integer without truncation.
-pub(super) fn generation_to_sql(generation: Generation) -> Result<i64, DatabaseError> {
+pub(crate) fn generation_to_sql(generation: Generation) -> Result<i64, DatabaseError> {
     u64_to_sql(generation.value(), "generation")
 }
 
-pub(super) fn u64_to_sql(value: u64, field: &str) -> Result<i64, DatabaseError> {
+pub(crate) fn u64_to_sql(value: u64, field: &str) -> Result<i64, DatabaseError> {
     i64::try_from(value).map_err(|_| {
         DatabaseError::CorruptEffectState(format!("{field} exceeds SQLite integer range"))
     })
 }
 
-pub(super) fn generation_from_sql(value: i64) -> Result<Generation, DatabaseError> {
+pub(crate) fn generation_from_sql(value: i64) -> Result<Generation, DatabaseError> {
     u64::try_from(value)
         .map(Generation::new)
         .map_err(|_| DatabaseError::CorruptEffectState("negative generation".to_string()))

--- a/crates/db/src/repository/effect/mod.rs
+++ b/crates/db/src/repository/effect/mod.rs
@@ -1,3 +1,4 @@
+mod agent_target;
 mod mapping;
 
 use crate::{DatabaseError, RepositoryPool};

--- a/crates/db/src/tests.rs
+++ b/crates/db/src/tests.rs
@@ -29,7 +29,7 @@ fn bootstraps_the_current_workspace_schema() {
     let catalog = default_migration_catalog().expect("build migration catalog");
     assert_eq!(
         catalog.target_versions(),
-        ["0001", "0002", "0003", "0004", "0005", "0006"]
+        ["0001", "0002", "0003", "0004", "0005", "0006", "0007"]
     );
 
     let database = with_trace_logging(|| {
@@ -44,6 +44,10 @@ fn bootstraps_the_current_workspace_schema() {
         load_table_names(database.connection()),
         vec![
             "agents",
+            "effect_agent_target_conditions",
+            "effect_agent_target_reconcile_requests",
+            "effect_agent_target_status",
+            "effect_agent_targets",
             "effect_audit_events",
             "effect_conditions",
             "effect_consumer_status",

--- a/crates/effect/README.md
+++ b/crates/effect/README.md
@@ -1,12 +1,15 @@
 # ora-effect
 
 `ora-effect` owns Ora's workspace-scoped declarative Skill State and the machinery that safely
-projects it onto consumer-declared filesystem surfaces.
+projects it onto consumer-declared filesystem surfaces. It also defines the Agent Target domain
+types and persistence port used by the Expand-phase target-keyed Effect schema.
 
 ## Responsibilities
 
 - Strong identities for selections, exact source states, managed ownership, surfaces, operations,
   and generations.
+- Agent Target identity (Workspace × Agent Plugin), target status generations, target-owned
+  conditions with Blocking/NonBlocking impact, and target reconcile-request shapes.
 - A pure planner that separates desired, managed, observed, and preserved state and never grants
   ownership from disk contents alone.
 - Consumer descriptor merging, structured conditions, retry policy, and per-consumer readiness.
@@ -24,4 +27,6 @@ all materialized content except the ownership marker.
 
 Reconciliation plans a complete surface before mutation, serializes one physical surface at a
 time through its repository request, and treats watcher payloads only as wakeups. Different
-surfaces may be driven concurrently by the host.
+surfaces may be driven concurrently by the host. Agent Target persistence types coexist with the
+surface-keyed Skill worker; runtime cutover to target-keyed claims is out of scope for this crate's
+domain layer alone.

--- a/crates/effect/src/agent_target/README.md
+++ b/crates/effect/src/agent_target/README.md
@@ -1,0 +1,19 @@
+# Agent Target domain
+
+This module defines the Agent Target-shaped Effect persistence vocabulary used by the Expand
+migration and typed repository APIs. An Agent Target is uniquely identified by Workspace identity
+plus Agent Plugin identity. Status, reconcile requests, and conditions are owned by the target, not
+by a physical Skill surface.
+
+## Responsibilities
+
+- Strong identities for Agent Targets, capability revisions, and target-owned conditions.
+- Closed enums for target phase, condition impact, reconcile state, and wake reason.
+- The `AgentTargetRepository` port for typed persistence without activating target-keyed workers.
+- Complete record shapes suitable for whole-object repository round-trips.
+
+## Non-responsibilities
+
+- SQLite schema, backfill SQL, or repository transactions.
+- Target-keyed worker claim loops, admission gates, MCP resolution, or OpenCode materialization.
+- Compatibility views that hide the temporary coexistence of surface-keyed and target-keyed tables.

--- a/crates/effect/src/agent_target/README.md
+++ b/crates/effect/src/agent_target/README.md
@@ -8,7 +8,10 @@ by a physical Skill surface.
 ## Responsibilities
 
 - Strong identities for Agent Targets, capability revisions, and target-owned conditions.
-- Closed enums for target phase, condition impact, reconcile state, and wake reason.
+- Closed enums for target phase, condition impact, reconcile progress, and wake reason.
+- Reconcile progress as a state machine (`Pending` / `Claimed` / `Blocked` / `RetryScheduled`) so
+  lease and blocked-reason data cannot appear on the wrong state.
+- Optional condition attachments as `surface + optional consumer`, never a consumer without a surface.
 - The `AgentTargetRepository` port for typed persistence without activating target-keyed workers.
 - Complete record shapes suitable for whole-object repository round-trips.
 

--- a/crates/effect/src/agent_target/mod.rs
+++ b/crates/effect/src/agent_target/mod.rs
@@ -129,7 +129,9 @@ pub struct AgentTarget {
 
 /// High-level progression of one Agent Target reconciliation state machine.
 ///
-/// ReadyWithIssues is target-owned: Skill surfaces never express that phase.
+/// `ReadyWithIssues` is the caught-up state that still exposes NonBlocking conditions. `Degraded`
+/// is the spec's distinct retryable-failure phase (Ready Generation is kept, backoff continues);
+/// it is not a synonym for Ready with Issues. Skill surfaces never express ReadyWithIssues.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentTargetPhase {
@@ -162,10 +164,13 @@ pub enum AgentTargetConditionSubject {
     Consumer { consumer_id: ConsumerId },
     DesiredSkill { selection_key: SkillSelectionKey },
     ManagedSkill { managed_identity: ManagedIdentity },
-    Mcp { managed_identity: String },
+    Mcp { managed_identity: ManagedIdentity },
 }
 
 /// Stable machine-readable reasons for an Agent Target not being fully ready.
+///
+/// `UnsupportedByAgent` is a NonBlocking, target-specific transport issue (ADR 0003). It is not
+/// a synonym for plugin-level Needs Configuration, which never reaches this table.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentTargetConditionReason {
@@ -187,6 +192,17 @@ pub enum AgentTargetConditionReason {
     CapabilityInvalid,
 }
 
+/// Optional Skill-surface attachment for diagnostics.
+///
+/// A consumer id without a surface is unrepresentable because the SQLite foreign key names the
+/// `(surface, consumer)` pair. Subject identity stays in `AgentTargetConditionSubject`; this
+/// attachment is the optional physical association the spec allows beside that subject.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetConditionAttachment {
+    pub surface_key: SurfaceKey,
+    pub consumer_id: Option<ConsumerId>,
+}
+
 /// A current, structured explanation owned by one Agent Target.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AgentTargetCondition {
@@ -198,10 +214,7 @@ pub struct AgentTargetCondition {
     pub first_observed_at: i64,
     pub last_observed_at: i64,
     pub failed_generation: Option<Generation>,
-    /// Optional physical surface association retained for Skill diagnostics.
-    pub surface_key: Option<SurfaceKey>,
-    /// Optional consumer association retained when the condition is consumer-scoped.
-    pub consumer_id: Option<ConsumerId>,
+    pub attachment: Option<AgentTargetConditionAttachment>,
 }
 
 /// Current status of one Agent Target, including readiness generations and conditions.
@@ -221,12 +234,20 @@ pub struct AgentTargetStatus {
 }
 
 /// Scheduling state for a durable Agent Target reconcile request.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
+///
+/// Associated data matches the SQLite CHECK constraints: a claim always carries its lease, a
+/// blocked row always carries a reason, and the other states carry neither.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AgentTargetReconcileState {
     Pending,
-    Claimed,
-    Blocked,
+    Claimed {
+        lease_owner: String,
+        lease_expires_at: i64,
+    },
+    Blocked {
+        reason: String,
+    },
     RetryScheduled,
 }
 
@@ -250,9 +271,6 @@ pub struct AgentTargetReconcileRequest {
     pub request_token: String,
     pub state: AgentTargetReconcileState,
     pub wake_reason: AgentTargetWakeReason,
-    pub blocked_reason: Option<String>,
-    pub lease_owner: Option<String>,
-    pub lease_expires_at: Option<i64>,
     pub attempt_count: u32,
     pub requested_at: i64,
     pub not_before_at: i64,

--- a/crates/effect/src/agent_target/mod.rs
+++ b/crates/effect/src/agent_target/mod.rs
@@ -1,0 +1,268 @@
+//! Agent Target identity, status, conditions, and reconcile-request domain types.
+//!
+//! These types define the target-keyed Effect persistence shape introduced beside the existing
+//! surface-keyed Skill worker. Runtime cutover is intentionally out of scope for this module.
+
+mod ports;
+
+pub use ports::{AgentTargetRepository, AgentTargetRepositoryError, initial_agent_target_status};
+
+use crate::{ConsumerId, Generation, ManagedIdentity, SkillSelectionKey, SurfaceKey};
+use ora_domain::WorkspaceId;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display, Formatter};
+use uuid::Uuid;
+
+/// Opaque primary key for one persisted Agent Target row.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AgentTargetId(String);
+
+impl AgentTargetId {
+    /// Wraps an already-persisted identity without inventing a new one.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Allocates a random identity so targets cannot be inferred from Workspace paths.
+    pub fn random() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+
+    /// Returns the persistence representation.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for AgentTargetId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Canonical Agent Plugin identity used as half of an Agent Target unique key.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AgentPluginId(String);
+
+impl AgentPluginId {
+    /// Accepts the stable plugin identity string already used by surface consumers.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Returns the persistence representation.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for AgentPluginId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl From<ConsumerId> for AgentPluginId {
+    /// Surface consumers already carry the Agent Plugin identity string.
+    fn from(value: ConsumerId) -> Self {
+        Self::new(value.as_str())
+    }
+}
+
+/// Digest of the Agent Plugin version and its declared configuration capabilities.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AgentCapabilityRevision(String);
+
+impl AgentCapabilityRevision {
+    /// Accepts an opaque revision token; empty means "not yet negotiated" during Expand.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Returns the persistence representation.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for AgentCapabilityRevision {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Whether an Agent Target still participates in Desired convergence.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetLifecycle {
+    Active,
+    Retired,
+}
+
+/// Unique natural key for one Agent Target: Workspace × Agent Plugin.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AgentTargetIdentity {
+    pub workspace_id: WorkspaceId,
+    pub agent_plugin_id: AgentPluginId,
+}
+
+impl AgentTargetIdentity {
+    /// Builds the only legal Agent Target identity shape.
+    pub fn new(workspace_id: WorkspaceId, agent_plugin_id: AgentPluginId) -> Self {
+        Self {
+            workspace_id,
+            agent_plugin_id,
+        }
+    }
+}
+
+/// Durable Agent Target row without runtime scheduling state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTarget {
+    pub id: AgentTargetId,
+    pub identity: AgentTargetIdentity,
+    pub capability_revision: AgentCapabilityRevision,
+    pub lifecycle: AgentTargetLifecycle,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// High-level progression of one Agent Target reconciliation state machine.
+///
+/// ReadyWithIssues is target-owned: Skill surfaces never express that phase.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetPhase {
+    Pending,
+    WaitingForIdle,
+    Quiescing,
+    Applying,
+    Resuming,
+    Current,
+    ReadyWithIssues,
+    Degraded,
+    Retiring,
+    RecoveryRequired,
+}
+
+/// Whether a condition blocks readiness or only remains visible after Ready.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConditionImpact {
+    Blocking,
+    NonBlocking,
+}
+
+/// Identifies the precise subject of an Agent Target-owned condition.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentTargetConditionSubject {
+    AgentTarget,
+    Surface { surface_key: SurfaceKey },
+    Consumer { consumer_id: ConsumerId },
+    DesiredSkill { selection_key: SkillSelectionKey },
+    ManagedSkill { managed_identity: ManagedIdentity },
+    Mcp { managed_identity: String },
+}
+
+/// Stable machine-readable reasons for an Agent Target not being fully ready.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetConditionReason {
+    NoConsumers,
+    IncompatibleSurfaceDeclarations,
+    DesiredCollision,
+    PreservedConflict,
+    OwnershipConflict,
+    DriftConflict,
+    SourceUnavailable,
+    PathUnsafe,
+    ScanFailed,
+    WaitingForIdle,
+    ConsumerResumeFailed,
+    MaterializationFailed,
+    TransientIo,
+    RecoveryRequired,
+    UnsupportedByAgent,
+    CapabilityInvalid,
+}
+
+/// A current, structured explanation owned by one Agent Target.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetCondition {
+    pub id: String,
+    pub subject: AgentTargetConditionSubject,
+    pub reason: AgentTargetConditionReason,
+    pub impact: ConditionImpact,
+    pub message: String,
+    pub first_observed_at: i64,
+    pub last_observed_at: i64,
+    pub failed_generation: Option<Generation>,
+    /// Optional physical surface association retained for Skill diagnostics.
+    pub surface_key: Option<SurfaceKey>,
+    /// Optional consumer association retained when the condition is consumer-scoped.
+    pub consumer_id: Option<ConsumerId>,
+}
+
+/// Current status of one Agent Target, including readiness generations and conditions.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetStatus {
+    pub agent_target_id: AgentTargetId,
+    pub identity: AgentTargetIdentity,
+    pub desired_generation: Generation,
+    pub observed_generation: Generation,
+    pub applied_generation: Generation,
+    pub ready_generation: Generation,
+    pub phase: AgentTargetPhase,
+    pub status_version: u64,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub conditions: Vec<AgentTargetCondition>,
+}
+
+/// Scheduling state for a durable Agent Target reconcile request.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetReconcileState {
+    Pending,
+    Claimed,
+    Blocked,
+    RetryScheduled,
+}
+
+/// Why a target was woken; kept as a closed set so workers cannot invent opaque strings.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetWakeReason {
+    DesiredChanged,
+    CapabilityChanged,
+    Retry,
+    Recovery,
+    StartupRepair,
+}
+
+/// Durable Agent Target reconcile request used by later target-keyed workers.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetReconcileRequest {
+    pub agent_target_id: AgentTargetId,
+    pub identity: AgentTargetIdentity,
+    pub requested_generation: Generation,
+    pub request_token: String,
+    pub state: AgentTargetReconcileState,
+    pub wake_reason: AgentTargetWakeReason,
+    pub blocked_reason: Option<String>,
+    pub lease_owner: Option<String>,
+    pub lease_expires_at: Option<i64>,
+    pub attempt_count: u32,
+    pub requested_at: i64,
+    pub not_before_at: i64,
+    pub updated_at: i64,
+}
+
+/// Complete persisted Agent Target snapshot returned by repository round-trips.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetRecord {
+    pub target: AgentTarget,
+    pub status: AgentTargetStatus,
+    pub reconcile_request: Option<AgentTargetReconcileRequest>,
+}

--- a/crates/effect/src/agent_target/ports.rs
+++ b/crates/effect/src/agent_target/ports.rs
@@ -91,11 +91,6 @@ pub trait AgentTargetRepository {
 pub enum AgentTargetRepositoryError {
     #[error("agent target repository error: {0}")]
     Storage(String),
-    #[error("agent target not found for workspace `{workspace_id}` and plugin `{agent_plugin_id}`")]
-    NotFound {
-        workspace_id: String,
-        agent_plugin_id: String,
-    },
     #[error("corrupt agent target state: {0}")]
     Corrupt(String),
 }

--- a/crates/effect/src/agent_target/ports.rs
+++ b/crates/effect/src/agent_target/ports.rs
@@ -1,0 +1,134 @@
+//! Persistence port for Agent Target-shaped Effect state.
+//!
+//! Implementations must keep this shape independent of the surface-keyed Skill worker so Expand
+//! can land without switching runtime claim loops.
+
+use super::{
+    AgentCapabilityRevision, AgentTarget, AgentTargetCondition, AgentTargetId, AgentTargetIdentity,
+    AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileRequest, AgentTargetRecord,
+    AgentTargetStatus, AgentTargetWakeReason,
+};
+use crate::Generation;
+use ora_domain::WorkspaceId;
+use thiserror::Error;
+
+/// Loads and mutates Agent Target persistence without activating target-keyed workers.
+///
+/// Callers during Expand may exercise these methods in tests and migration verification. Production
+/// Skill reconciliation must continue to use the surface-keyed Effect repository APIs.
+pub trait AgentTargetRepository {
+    /// Creates or refreshes the durable Agent Target row for one Workspace × Agent Plugin pair.
+    fn upsert_agent_target(
+        &self,
+        identity: &AgentTargetIdentity,
+        capability_revision: &AgentCapabilityRevision,
+        lifecycle: AgentTargetLifecycle,
+        updated_at: i64,
+    ) -> Result<AgentTarget, AgentTargetRepositoryError>;
+
+    /// Loads one Agent Target by its natural identity when present.
+    fn load_agent_target(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTarget>, AgentTargetRepositoryError>;
+
+    /// Loads one Agent Target by opaque primary key when present.
+    fn load_agent_target_by_id(
+        &self,
+        agent_target_id: &AgentTargetId,
+    ) -> Result<Option<AgentTarget>, AgentTargetRepositoryError>;
+
+    /// Replaces status generations, phase, version, and owned conditions atomically.
+    fn save_agent_target_status(
+        &self,
+        status: &AgentTargetStatus,
+    ) -> Result<(), AgentTargetRepositoryError>;
+
+    /// Loads status plus owned conditions for one Agent Target identity.
+    fn load_agent_target_status(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetStatus>, AgentTargetRepositoryError>;
+
+    /// Upserts a durable target reconcile request using max-generation / earliest-due semantics.
+    fn upsert_agent_target_reconcile_request(
+        &self,
+        identity: &AgentTargetIdentity,
+        requested_generation: Generation,
+        wake_reason: AgentTargetWakeReason,
+        not_before_at: i64,
+        updated_at: i64,
+    ) -> Result<AgentTargetReconcileRequest, AgentTargetRepositoryError>;
+
+    /// Loads the durable request for one Agent Target when present.
+    fn load_agent_target_reconcile_request(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetReconcileRequest>, AgentTargetRepositoryError>;
+
+    /// Replaces the complete condition set owned by one Agent Target.
+    fn replace_agent_target_conditions(
+        &self,
+        agent_target_id: &AgentTargetId,
+        conditions: &[AgentTargetCondition],
+    ) -> Result<(), AgentTargetRepositoryError>;
+
+    /// Loads the complete persisted record for repository round-trip assertions.
+    fn load_agent_target_record(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetRecord>, AgentTargetRepositoryError>;
+
+    /// Lists every Agent Target belonging to one Workspace.
+    fn list_agent_targets_for_workspace(
+        &self,
+        workspace_id: &WorkspaceId,
+    ) -> Result<Vec<AgentTarget>, AgentTargetRepositoryError>;
+}
+
+/// Reports Agent Target persistence failures without leaking SQLite details to domain callers.
+#[derive(Debug, Error)]
+pub enum AgentTargetRepositoryError {
+    #[error("agent target repository error: {0}")]
+    Storage(String),
+    #[error("agent target not found for workspace `{workspace_id}` and plugin `{agent_plugin_id}`")]
+    NotFound {
+        workspace_id: String,
+        agent_plugin_id: String,
+    },
+    #[error("corrupt agent target state: {0}")]
+    Corrupt(String),
+}
+
+impl AgentTargetRepositoryError {
+    /// Wraps a storage failure while preserving the original display text.
+    pub fn storage(error: impl ToString) -> Self {
+        Self::Storage(error.to_string())
+    }
+
+    /// Wraps a corrupt-row failure discovered while decoding persisted state.
+    pub fn corrupt(error: impl ToString) -> Self {
+        Self::Corrupt(error.to_string())
+    }
+}
+
+/// Initial status used when an Agent Target is first materialized without prior surface history.
+pub fn initial_agent_target_status(
+    agent_target_id: AgentTargetId,
+    identity: AgentTargetIdentity,
+    now: i64,
+) -> AgentTargetStatus {
+    AgentTargetStatus {
+        agent_target_id,
+        identity,
+        desired_generation: Generation::default(),
+        observed_generation: Generation::default(),
+        applied_generation: Generation::default(),
+        ready_generation: Generation::default(),
+        phase: AgentTargetPhase::Current,
+        status_version: 1,
+        created_at: now,
+        updated_at: now,
+        conditions: Vec::new(),
+    }
+}

--- a/crates/effect/src/lib.rs
+++ b/crates/effect/src/lib.rs
@@ -14,10 +14,11 @@ mod tests;
 
 pub use agent_target::{
     AgentCapabilityRevision, AgentPluginId, AgentTarget, AgentTargetCondition,
-    AgentTargetConditionReason, AgentTargetConditionSubject, AgentTargetId, AgentTargetIdentity,
-    AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileRequest, AgentTargetReconcileState,
-    AgentTargetRecord, AgentTargetRepository, AgentTargetRepositoryError, AgentTargetStatus,
-    AgentTargetWakeReason, ConditionImpact, initial_agent_target_status,
+    AgentTargetConditionAttachment, AgentTargetConditionReason, AgentTargetConditionSubject,
+    AgentTargetId, AgentTargetIdentity, AgentTargetLifecycle, AgentTargetPhase,
+    AgentTargetReconcileRequest, AgentTargetReconcileState, AgentTargetRecord,
+    AgentTargetRepository, AgentTargetRepositoryError, AgentTargetStatus, AgentTargetWakeReason,
+    ConditionImpact, initial_agent_target_status,
 };
 pub use filesystem::{
     FilesystemEffectError, FilesystemSurfaceAdapter, MARKER_FILE_NAME, ManagedSkillMarker,

--- a/crates/effect/src/lib.rs
+++ b/crates/effect/src/lib.rs
@@ -1,5 +1,6 @@
 //! Workspace-scoped declarative Skill State and safe filesystem reconciliation.
 
+mod agent_target;
 mod filesystem;
 mod identity;
 mod planner;
@@ -11,6 +12,13 @@ mod surface;
 #[cfg(test)]
 mod tests;
 
+pub use agent_target::{
+    AgentCapabilityRevision, AgentPluginId, AgentTarget, AgentTargetCondition,
+    AgentTargetConditionReason, AgentTargetConditionSubject, AgentTargetId, AgentTargetIdentity,
+    AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileRequest, AgentTargetReconcileState,
+    AgentTargetRecord, AgentTargetRepository, AgentTargetRepositoryError, AgentTargetStatus,
+    AgentTargetWakeReason, ConditionImpact, initial_agent_target_status,
+};
 pub use filesystem::{
     FilesystemEffectError, FilesystemSurfaceAdapter, MARKER_FILE_NAME, ManagedSkillMarker,
     OperationPaths, RecoveryDecision, ScanDiagnostic, SurfaceScan,

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -12,15 +12,13 @@ Ora keeps SQLite migration definitions in Rust code inside `ora-db` rather than 
 
 ## Shipped catalog
 
-| Version | Adds                                                                                                                                                                                                                                                                                                      |
-| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0001`  | User configuration, projects, workspace locations and provisioning, workspaces, worktrees, task labels, and workspace-owned sessions.                                                                                                                                                                     |
-| `0002`  | Namespaced skills and configurable agents.                                                                                                                                                                                                                                                                |
-| `0003`  | Workflow definitions, snapshots, workspace-owned runs, and node runs.                                                                                                                                                                                                                                     |
-| `0004`  | Durable Git cleanup jobs and worktree provisioning leases.                                                                                                                                                                                                                                                |
-| `0005`  | Workspace Effect source state, normalized Desired selections, surface descriptors, ownership ledgers, status, file-operation journals, and durable reconcile/propagation requests.                                                                                                                        |
-| `0006`  | Durable plugin marketplace source configuration (URL, branch, proxy policy, precedence).                                                                                                                                                                                                                  |
-| `0007`  | Agent Target Effect Expand: target rows, status with ready generation, target-keyed reconcile requests, target-owned conditions with impact; deterministic surface-request backfill (max generation, earliest due); status phase is current only when ready equals desired; condition subjects preserved. |
+| Version | Adds                                                                                                                                                                               |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0001`  | User configuration, projects, workspace locations and provisioning, workspaces, worktrees, task labels, and workspace-owned sessions.                                              |
+| `0002`  | Namespaced skills and configurable agents.                                                                                                                                         |
+| `0003`  | Workflow definitions, snapshots, workspace-owned runs, and node runs.                                                                                                              |
+| `0004`  | Durable Git cleanup jobs and worktree provisioning leases.                                                                                                                         |
+| `0005`  | Workspace Effect source state, normalized Desired selections, surface descriptors, ownership ledgers, status, file-operation journals, and durable reconcile/propagation requests. |
 
 `default_migration_catalog()` returns all migrations with every version as the active target.
 

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -12,15 +12,15 @@ Ora keeps SQLite migration definitions in Rust code inside `ora-db` rather than 
 
 ## Shipped catalog
 
-| Version | Adds                                                                                                                                                                                 |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `0001`  | User configuration, projects, workspace locations and provisioning, workspaces, worktrees, task labels, and workspace-owned sessions.                                                |
-| `0002`  | Namespaced skills and configurable agents.                                                                                                                                           |
-| `0003`  | Workflow definitions, snapshots, workspace-owned runs, and node runs.                                                                                                                |
-| `0004`  | Durable Git cleanup jobs and worktree provisioning leases.                                                                                                                           |
-| `0005`  | Workspace Effect source state, normalized Desired selections, surface descriptors, ownership ledgers, status, file-operation journals, and durable reconcile/propagation requests.   |
-| `0006`  | Durable plugin marketplace source configuration (URL, branch, proxy policy, precedence).                                                                                             |
-| `0007`  | Agent Target Effect Expand: target rows, status with ready generation, target-keyed reconcile requests, target-owned conditions with impact; deterministic surface-request backfill. |
+| Version | Adds                                                                                                                                                                                                                                                                                                      |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0001`  | User configuration, projects, workspace locations and provisioning, workspaces, worktrees, task labels, and workspace-owned sessions.                                                                                                                                                                     |
+| `0002`  | Namespaced skills and configurable agents.                                                                                                                                                                                                                                                                |
+| `0003`  | Workflow definitions, snapshots, workspace-owned runs, and node runs.                                                                                                                                                                                                                                     |
+| `0004`  | Durable Git cleanup jobs and worktree provisioning leases.                                                                                                                                                                                                                                                |
+| `0005`  | Workspace Effect source state, normalized Desired selections, surface descriptors, ownership ledgers, status, file-operation journals, and durable reconcile/propagation requests.                                                                                                                        |
+| `0006`  | Durable plugin marketplace source configuration (URL, branch, proxy policy, precedence).                                                                                                                                                                                                                  |
+| `0007`  | Agent Target Effect Expand: target rows, status with ready generation, target-keyed reconcile requests, target-owned conditions with impact; deterministic surface-request backfill (max generation, earliest due); status phase is current only when ready equals desired; condition subjects preserved. |
 
 `default_migration_catalog()` returns all migrations with every version as the active target.
 

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -12,13 +12,15 @@ Ora keeps SQLite migration definitions in Rust code inside `ora-db` rather than 
 
 ## Shipped catalog
 
-| Version | Adds                                                                                                                                                                               |
-| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0001`  | User configuration, projects, workspace locations and provisioning, workspaces, worktrees, task labels, and workspace-owned sessions.                                              |
-| `0002`  | Namespaced skills and configurable agents.                                                                                                                                         |
-| `0003`  | Workflow definitions, snapshots, workspace-owned runs, and node runs.                                                                                                              |
-| `0004`  | Durable Git cleanup jobs and worktree provisioning leases.                                                                                                                         |
-| `0005`  | Workspace Effect source state, normalized Desired selections, surface descriptors, ownership ledgers, status, file-operation journals, and durable reconcile/propagation requests. |
+| Version | Adds                                                                                                                                                                                 |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `0001`  | User configuration, projects, workspace locations and provisioning, workspaces, worktrees, task labels, and workspace-owned sessions.                                                |
+| `0002`  | Namespaced skills and configurable agents.                                                                                                                                           |
+| `0003`  | Workflow definitions, snapshots, workspace-owned runs, and node runs.                                                                                                                |
+| `0004`  | Durable Git cleanup jobs and worktree provisioning leases.                                                                                                                           |
+| `0005`  | Workspace Effect source state, normalized Desired selections, surface descriptors, ownership ledgers, status, file-operation journals, and durable reconcile/propagation requests.   |
+| `0006`  | Durable plugin marketplace source configuration (URL, branch, proxy policy, precedence).                                                                                             |
+| `0007`  | Agent Target Effect Expand: target rows, status with ready generation, target-keyed reconcile requests, target-owned conditions with impact; deterministic surface-request backfill. |
 
 `default_migration_catalog()` returns all migrations with every version as the active target.
 


### PR DESCRIPTION
﻿## 摘要

本 PR 交付 [#484](https://github.com/ora-space/desktop/issues/484) 的 **Expand** 阶段：在现有 Skill Surface 工作路径旁边，增加 **Agent Target** 形状的持久化模型、确定性回填、数据库约束和强类型仓库接口。线上 Skill 安装、传播与调和仍走旧的 Surface 请求路径，尚未切换运行时。

**Agent Target** 指「一个 Agent Workspace × 一个 Agent 插件」的配对，是后续 Skill 与 MCP 共同收敛的边界。**Generation** 是 Workspace 期望状态的单调版本号，用来判断某一代配置是否已经应用完毕。

## 解决了什么问题

父议题 #479 要把市场安装的 MCP 真正送进 Agent 对话。如果一次性把「请求所有权」和「条件归属」从 Surface 改到 Agent Target，现有 Skill 调和会在迁移当天一起变红。#484 要求先把新表和新 API 铺好，旧表继续服务生产 worker。

具体落地：

- 新增 `effect_agent_targets` / `effect_agent_target_status` / `effect_agent_target_reconcile_requests` / `effect_agent_target_conditions`。
- 身份由 Workspace 身份 + Agent 插件身份唯一确定。
- 升级时把同一目标上的旧 Surface 请求合并为 **最大 requested generation + 最早到期时间**（到期时间即「不早于何时可以再跑」的 `not_before_at`）。
- 条件回填保留原来的 subject 身份（含 `desired_item` / `managed_item`），并一律记为 Blocking。
- 状态回填：只有 ready generation 等于 desired generation 时才标 `current`（已追平）；否则为 `pending`（还有工作没做完）。
- 数据库 CHECK / UNIQUE / 外键约束 generation 顺序、枚举合法性、目标唯一性和条件归属。

## 为什么这样解决

这是 Expand/Contract 迁移里的 Expand：新旧形状暂时共存，但 **不做双写、也不做兼容视图**。

- **双写** 指同一业务变更同时写入旧表和新表。两边一旦不一致，排障会非常痛苦。
- **兼容视图** 指用 SQL VIEW 把新表伪装成旧表。本仓库明确禁止「以防万一」的兼容层。
- 生产 worker 继续 claim 旧的 `effect_reconcile_requests`。新表的 lease（租约：哪一个 worker 正在处理该请求、何时过期）列已经建好，留给后续 #489 切换，避免再做一次 schema 变更。

领域类型把调度状态做成带关联数据的枚举：只有 `Claimed` 才带租约，只有 `Blocked` 才带原因。条件的物理附件是「surface + 可选 consumer」，不能出现「有 consumer 却没有 surface」。MCP 的 managed identity 使用与 Skill 相同的 `ManagedIdentity` 新类型，避免用裸字符串冒充领域概念。

## 考虑与权衡

1. **不在本票切换 worker、admission 门禁、MCP 解析或 OpenCode 物化。** 那些属于 #486 / #487 / #489 / #490。本票只保证后续切换有一张对的表。
2. **保留 `Degraded` 与 `UnsupportedByAgent` 这两个名字。** 规格状态机把 `Degraded` 定义为可重试失败相，不是 Ready with Issues 的别名；`UnsupportedByAgent` 是目标级非阻塞问题（ADR 0003），不是插件级 Needs Configuration。CONTEXT.md 的 Avoid 列表禁止的是混用，而不是删除这两个独立状态。
3. **不把 claim/complete API 提前做进仓库。** Schema 有列、领域能表达，但生产路径仍由 Surface worker 占用。否则会变成提前 cutover。
4. **仓库模块按职责拆成 `encode` / `rows` / `conditions`。** 避免单个文件超过 AGENTS.md 的 500 行目标，同时不把只用一次的琐碎函数抽出去。
5. **generation 的 SQLite 整数转换与 Skill 共用 `mapping`。** 避免两套溢出规则。
6. **分支上同时带上 MCP 配置交付的设计基线文档**（规格、CONTEXT、ADR、研究证据）以及 agent 技能索引。它们是本票的权威输入，不是运行时行为。

## 测试

- 临时 SQLite 升级：旧 schema 种子 Surface 请求与多种 subject 的条件，断言回填 generation、到期时间、phase、完整 status 对象。
- CHECK 约束：重复目标、非法 generation 顺序、非法 phase/impact、consumer 无 surface。
- 仓库整对象 round-trip（含请求 coalesce）。
- 既有 Skill Effect API 与 Surface 请求表仍然可用。

本地已跑：`cargo test -p ora-db -p ora-effect`，`cargo clippy -p ora-db -p ora-effect -- -D warnings`。

Closes #484
