### PR TITLE
feat(plugins): 显示并保持插件市场下载进度

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -8,10 +8,23 @@ use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tauri::State;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::ipc::Channel;
+use tauri::{AppHandle, Emitter, State};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
+
+const PLUGIN_INSTALL_PROGRESS_EVENT: &str = "plugin-install-progress";
+const PLUGIN_PROGRESS_EVENT_INTERVAL: u64 = 1024 * 1024;
+
+/// Carries byte-level marketplace package progress to the plugin card that started the install.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PluginInstallProgressEvent {
+    plugin_id: String,
+    downloaded: u64,
+    total: Option<u64>,
+}
 
 /// Executes one synchronous backend operation on the runtime's blocking executor.
 async fn run_backend<Request, Response>(
@@ -1124,13 +1137,43 @@ async_backend_command!(
     uninstall_plugin,
     "Stops and removes one installed plugin."
 );
-async_backend_command!(
-    install_plugin,
-    InstallPluginRequest,
-    InstallPluginResponse,
-    install_plugin,
-    "Installs one marketplace plugin by downloading, verifying, and extracting it."
-);
+/// Installs one marketplace plugin and emits throttled byte-level download progress.
+#[tauri::command]
+pub async fn install_plugin(
+    state: State<'_, DesktopState>,
+    app: AppHandle,
+    request: InstallPluginRequest,
+) -> Result<InstallPluginResponse, CommandError> {
+    let plugin_id = request.plugin_id.clone();
+    let last_emitted = Arc::new(AtomicU64::new(0));
+    let progress = Arc::new(move |progress: ora_utils::http::Progress| {
+        let previous = last_emitted.load(Ordering::Relaxed);
+        let complete = progress.total == Some(progress.bytes);
+        if previous != 0
+            && progress.bytes < previous.saturating_add(PLUGIN_PROGRESS_EVENT_INTERVAL)
+            && !complete
+        {
+            return;
+        }
+        last_emitted.store(progress.bytes, Ordering::Relaxed);
+        let event = PluginInstallProgressEvent {
+            plugin_id: plugin_id.clone(),
+            downloaded: progress.bytes,
+            total: progress.total,
+        };
+        if let Err(error) = app.emit(PLUGIN_INSTALL_PROGRESS_EVENT, event) {
+            ora_logging::ora_warn!(message = "Failed to emit plugin install progress", error = %error);
+        }
+    });
+
+    run_async_backend(
+        "install_plugin",
+        state
+            .backend
+            .install_plugin_with_progress(request, progress),
+    )
+    .await
+}
 async_backend_command!(
     update_plugin,
     UpdatePluginRequest,

--- a/apps/desktop/web/tauri-platform-adapter.test.ts
+++ b/apps/desktop/web/tauri-platform-adapter.test.ts
@@ -109,6 +109,39 @@ describe("TauriPlatformAdapter", () => {
     expect(stop).toHaveBeenCalledOnce();
   });
 
+  it("forwards marketplace install progress and stops listening on unsubscribe", async () => {
+    const stop = vi.fn();
+    const listener = vi.fn();
+    let forward: ((event: { payload: unknown }) => void) | undefined;
+    listenMock.mockImplementation(async (_event, handler) => {
+      forward = handler as (event: { payload: unknown }) => void;
+      return stop;
+    });
+    const adapter = createTauriPlatformAdapter();
+
+    const unsubscribe =
+      await adapter.pluginMarketplace.onInstallProgress(listener);
+    forward?.({
+      payload: {
+        pluginId: "official/weather",
+        downloaded: 4,
+        total: 10,
+      },
+    });
+    unsubscribe();
+
+    expect(listenMock).toHaveBeenCalledWith(
+      "plugin-install-progress",
+      expect.any(Function),
+    );
+    expect(listener).toHaveBeenCalledWith({
+      pluginId: "official/weather",
+      downloaded: 4,
+      total: 10,
+    });
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("reads and updates the desktop worktree root through Tauri commands", async () => {
     invokeMock.mockResolvedValueOnce({ worktreeRoot: "/home/ora/worktrees" });
     const adapter = createTauriPlatformAdapter();

--- a/apps/desktop/web/tauri-platform-adapter.ts
+++ b/apps/desktop/web/tauri-platform-adapter.ts
@@ -9,6 +9,8 @@ import {
   type DesktopUpdateStatus,
   type LocationTarget,
   type PlatformAdapter,
+  type PluginInstallProgress,
+  type PluginMarketplaceCapability,
   type SelectPathOptions,
   type SaveTextFileOptions,
   type SelectSavePathOptions,
@@ -26,6 +28,7 @@ import {
 
 const SURFACE_EVENT = "surface://event";
 const DESKTOP_UPDATE_EVENT = "desktop-update-status-changed";
+const PLUGIN_INSTALL_PROGRESS_EVENT = "plugin-install-progress";
 
 /** Reads the host OS from the webview user agent without an async Tauri call. */
 function detectWindowManagerOs(): WindowManagerOs | null {
@@ -103,6 +106,16 @@ function createTauriUpdates(): DesktopUpdateCapability {
   };
 }
 
+/** Wires marketplace package transfer progress into the shared settings UI. */
+function createTauriPluginMarketplace(): PluginMarketplaceCapability {
+  return {
+    onInstallProgress: (listener) =>
+      listen<PluginInstallProgress>(PLUGIN_INSTALL_PROGRESS_EVENT, (event) => {
+        listener(event.payload);
+      }),
+  };
+}
+
 /** Wires the plugin surface commands and lifecycle event stream exposed by the Desktop runtime. */
 function createTauriSurfaces(): SurfaceCapability {
   return {
@@ -157,6 +170,9 @@ export class TauriPlatformAdapter implements PlatformAdapter {
   readonly surfaces: SurfaceCapability = createTauriSurfaces();
 
   readonly updates: DesktopUpdateCapability = createTauriUpdates();
+
+  readonly pluginMarketplace: PluginMarketplaceCapability =
+    createTauriPluginMarketplace();
 
   readonly worktreeStorage = {
     getRoot: async (): Promise<string> => {

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -25,6 +25,7 @@ use ora_db::SqliteWorkflowRunEngineRepository;
 use ora_db::{DatabaseBootstrapper, DatabaseLocation, RepositoryPool, default_migration_catalog};
 use ora_logging::{ora_error, ora_warn};
 use ora_scheduler::Scheduler;
+use ora_utils::http::ProgressCallback;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -428,6 +429,17 @@ impl Backend {
         request: InstallPluginRequest,
     ) -> Result<InstallPluginResponse, BackendError> {
         let response = self.plugin.install(request).await?;
+        self.agent_runtime.sync_plugin_agents();
+        Ok(response)
+    }
+
+    /// Installs a marketplace plugin while forwarding download progress to a host callback.
+    pub async fn install_plugin_with_progress(
+        &self,
+        request: InstallPluginRequest,
+        progress: ProgressCallback,
+    ) -> Result<InstallPluginResponse, BackendError> {
+        let response = self.plugin.install_with_progress(request, progress).await?;
         self.agent_runtime.sync_plugin_agents();
         Ok(response)
     }

--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -39,7 +39,7 @@ use ora_plugin_manager::{
 };
 use ora_plugin_manifest::PluginManifest;
 use ora_plugin_registry::{RegistryEntry, RegistryError, RegistryIndex, RegistrySync};
-use ora_utils::http::{ProxyConfig, ReqwestDownloader};
+use ora_utils::http::{ProgressCallback, ProxyConfig, ReqwestDownloader};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, PoisonError};
@@ -622,6 +622,24 @@ impl PluginApi {
         &self,
         request: InstallPluginRequest,
     ) -> Result<InstallPluginResponse, BackendError> {
+        self.install_package(request, /*progress*/ None).await
+    }
+
+    /// Installs a marketplace plugin and forwards network transfer progress to the host shell.
+    pub(crate) async fn install_with_progress(
+        &self,
+        request: InstallPluginRequest,
+        progress: ProgressCallback,
+    ) -> Result<InstallPluginResponse, BackendError> {
+        self.install_package(request, Some(progress)).await
+    }
+
+    /// Keeps release resolution and finalization identical for observed and unobserved installs.
+    async fn install_package(
+        &self,
+        request: InstallPluginRequest,
+        progress: Option<ProgressCallback>,
+    ) -> Result<InstallPluginResponse, BackendError> {
         let (manifest, use_proxy) = self.resolve_marketplace_release(&request.plugin_id)?;
         let release_source = self.select_marketplace_release(&manifest)?;
         match release_source.download() {
@@ -633,10 +651,25 @@ impl PluginApi {
             }
         }
         let download_proxy = self.download_proxy_for(use_proxy)?;
-        Installer::new(ReqwestDownloader::new(download_proxy))
-            .install(&manifest, release_source, &self.data_directory)
-            .await
-            .map_err(|error| self.map_install_error("failed to install plugin", error))?;
+        let installer = Installer::new(ReqwestDownloader::new(download_proxy));
+        match progress {
+            Some(progress) => {
+                installer
+                    .install_with_progress(
+                        &manifest,
+                        release_source,
+                        &self.data_directory,
+                        progress,
+                    )
+                    .await
+            }
+            None => {
+                installer
+                    .install(&manifest, release_source, &self.data_directory)
+                    .await
+            }
+        }
+        .map_err(|error| self.map_install_error("failed to install plugin", error))?;
         let outcome = self.finalize_new_install(&request.plugin_id).await?;
         ora_info!(plugin_id = %request.plugin_id, outcome = ?outcome, "installed marketplace plugin");
         Ok(InstallPluginResponse {

--- a/crates/plugin-manager/src/install.rs
+++ b/crates/plugin-manager/src/install.rs
@@ -5,7 +5,9 @@ use crate::limits::package_extract_limits;
 use ora_plugin_manifest::{HookTarget, PluginKind, PluginManifest, PluginReleaseSource};
 use ora_utils::archive::{ArchiveFormat, extract_archive};
 use ora_utils::hash;
-use ora_utils::http::{Checksum, DownloadOptions, DownloadRequest, DownloadSource, HttpDownload};
+use ora_utils::http::{
+    Checksum, DownloadOptions, DownloadRequest, DownloadSource, HttpDownload, ProgressCallback,
+};
 use semver::Version;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -274,8 +276,32 @@ where
         source: ResolvedReleaseSource,
         data_dir: &Path,
     ) -> Result<PathBuf, InstallError> {
+        self.install_package(manifest, source, data_dir, /*progress*/ None)
+            .await
+    }
+
+    /// Installs a release while forwarding byte-level network download progress to the caller.
+    pub async fn install_with_progress(
+        &self,
+        manifest: &PluginManifest,
+        source: ResolvedReleaseSource,
+        data_dir: &Path,
+        progress: ProgressCallback,
+    ) -> Result<PathBuf, InstallError> {
+        self.install_package(manifest, source, data_dir, Some(progress))
+            .await
+    }
+
+    /// Shares the atomic install path between callers that do and do not observe the transfer.
+    async fn install_package(
+        &self,
+        manifest: &PluginManifest,
+        source: ResolvedReleaseSource,
+        data_dir: &Path,
+        progress: Option<ProgressCallback>,
+    ) -> Result<PathBuf, InstallError> {
         let archive_path = self
-            .download_package(manifest, source.clone(), data_dir)
+            .download_package(manifest, source.clone(), data_dir, progress)
             .await?;
         let namespace = manifest.namespace();
         let name = manifest.name();
@@ -524,6 +550,7 @@ where
         manifest: &PluginManifest,
         source: ResolvedReleaseSource,
         data_dir: &Path,
+        progress: Option<ProgressCallback>,
     ) -> Result<PathBuf, InstallError> {
         let digest = source.sha256();
         let cache_dir = data_dir.join("plugins").join(CACHE_ROOT);
@@ -543,7 +570,7 @@ where
             destination: archive_path.clone(),
             checksum: Some(Checksum::sha256(digest.to_vec())),
             options: DownloadOptions::default(),
-            progress: None,
+            progress,
             cancel: None,
         };
         self.downloader.download(request).await?;

--- a/packages/app-shell/src/app-shell.tsx
+++ b/packages/app-shell/src/app-shell.tsx
@@ -19,6 +19,7 @@ import { WorkspaceSidebar } from "./features/workspace/workspace-sidebar";
 import { WorkspaceView } from "./features/workspace/workspace-view";
 import { WorkspaceDialogs } from "./features/workspace/workspace-dialogs";
 import { SettingsDialog } from "./features/settings/settings-dialog";
+import { PluginOperationEventBridge } from "./features/settings/plugin-operation-event-bridge";
 import { SurfaceDownloadPrompt } from "./features/surface/surface-download-prompt";
 import { SurfaceDownloadToaster } from "./features/surface/surface-download-toaster";
 import { SurfaceEventBridge } from "./features/surface/surface-event-bridge";
@@ -196,6 +197,7 @@ function AppShellContent({
                 </ResizablePanel>
               </ResizablePanelGroup>
               <SettingsDialog />
+              <PluginOperationEventBridge />
               <SurfaceEventBridge />
               <SurfaceDownloadToaster />
               <SurfaceDownloadPrompt />

--- a/packages/app-shell/src/features/settings/plugin-operation-event-bridge.test.tsx
+++ b/packages/app-shell/src/features/settings/plugin-operation-event-bridge.test.tsx
@@ -1,0 +1,49 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PlatformProvider, type PluginInstallProgress } from "../../platform";
+import { createStubPlatform } from "../../test/stub-platform";
+import { usePluginOperationStore } from "../../state/stores/plugin-operation-store";
+import { PluginOperationEventBridge } from "./plugin-operation-event-bridge";
+
+afterEach(() => {
+  usePluginOperationStore.setState({ activities: {} });
+});
+
+it("records install progress independently of the marketplace page lifecycle", async () => {
+  let report: ((progress: PluginInstallProgress) => void) | undefined;
+  const stop = vi.fn();
+  const platform = {
+    ...createStubPlatform(),
+    pluginMarketplace: {
+      onInstallProgress: vi.fn(async (listener) => {
+        report = listener;
+        return stop;
+      }),
+    },
+  };
+  usePluginOperationStore.getState().begin("official/weather", "install");
+  const view = render(
+    <PlatformProvider adapter={platform}>
+      <PluginOperationEventBridge />
+    </PlatformProvider>,
+  );
+  await act(async () => Promise.resolve());
+
+  act(() => {
+    report?.({ pluginId: "official/weather", downloaded: 40, total: 100 });
+  });
+
+  expect(usePluginOperationStore.getState().activities).toEqual({
+    "official/weather": {
+      state: "pending",
+      kind: "install",
+      progress: {
+        pluginId: "official/weather",
+        downloaded: 40,
+        total: 100,
+      },
+    },
+  });
+  view.unmount();
+  expect(stop).toHaveBeenCalledOnce();
+});

--- a/packages/app-shell/src/features/settings/plugin-operation-event-bridge.test.tsx
+++ b/packages/app-shell/src/features/settings/plugin-operation-event-bridge.test.tsx
@@ -6,7 +6,7 @@ import { usePluginOperationStore } from "../../state/stores/plugin-operation-sto
 import { PluginOperationEventBridge } from "./plugin-operation-event-bridge";
 
 afterEach(() => {
-  usePluginOperationStore.setState({ activities: {} });
+  act(() => usePluginOperationStore.setState({ activities: {} }));
 });
 
 it("records install progress independently of the marketplace page lifecycle", async () => {

--- a/packages/app-shell/src/features/settings/plugin-operation-event-bridge.tsx
+++ b/packages/app-shell/src/features/settings/plugin-operation-event-bridge.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { usePlatform } from "../../platform";
+import { usePluginOperationStore } from "../../state/stores/plugin-operation-store";
+
+/** Keeps native plugin transfer progress alive when the settings dialog or plugin page unmounts. */
+export function PluginOperationEventBridge() {
+  const { pluginMarketplace } = usePlatform();
+
+  useEffect(() => {
+    if (pluginMarketplace === undefined) return;
+    let disposed = false;
+    let unsubscribe: (() => void) | undefined;
+    void pluginMarketplace
+      .onInstallProgress((progress) => {
+        if (!disposed) {
+          usePluginOperationStore.getState().reportInstallProgress(progress);
+        }
+      })
+      .then((stop) => {
+        if (disposed) stop();
+        else unsubscribe = stop;
+      })
+      .catch(() => undefined);
+
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
+  }, [pluginMarketplace]);
+
+  return null;
+}

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { expect, it, vi } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import type { ContractsClient, InstalledPlugin } from "@ora/contracts";
 import { toast } from "@ora/ui";
 import { AppI18nProvider } from "../../i18n/i18n";
@@ -9,14 +9,20 @@ import { appI18n } from "../../i18n/i18n-instance";
 import { ContractsClientContext } from "../../contracts-client-context";
 import { PlatformProvider, type PlatformAdapter } from "../../platform";
 import { createStubPlatform } from "../../test/stub-platform";
+import { usePluginOperationStore } from "../../state/stores/plugin-operation-store";
 import {
   createMockClient,
   createMockClientState,
 } from "../../test/mock-client";
+import { PluginOperationEventBridge } from "./plugin-operation-event-bridge";
 import { PluginsSettings } from "./plugins-settings";
 
 // Keep this test worker responsible for initializing the instance used by useTranslation.
 void appI18n;
+
+afterEach(() => {
+  usePluginOperationStore.setState({ activities: {} });
+});
 
 /** Renders plugin settings with isolated query, contracts-client, and platform state. */
 function renderSettings(
@@ -31,6 +37,7 @@ function renderSettings(
       <ContractsClientContext.Provider value={client}>
         <PlatformProvider adapter={platform}>
           <AppI18nProvider>
+            <PluginOperationEventBridge />
             <PluginsSettings />
           </AppI18nProvider>
         </PlatformProvider>

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { expect, it, vi } from "vitest";
@@ -139,6 +139,16 @@ it("renders marketplace plugins from the registry index", async () => {
 
   expect(await screen.findByText("Weather")).toBeInTheDocument();
   expect(screen.getByText("Weather plugin")).toBeInTheDocument();
+  const installButton = screen.getByRole("button", { name: /安装|Install/ });
+  expect(
+    installButton.querySelector(".tabler-icon-download"),
+  ).toBeInTheDocument();
+  expect(installButton).toHaveClass("border-border");
+  expect(
+    screen.getByRole("button", {
+      name: /查看 Weather 的 README|View Weather README/,
+    }),
+  ).toHaveClass("items-center");
 });
 
 /** Installing goes through the backend and refreshes the installed surface. */
@@ -157,9 +167,61 @@ it("installs a marketplace plugin through the backend", async () => {
     displayName: "weather",
     version: "1.2.0",
   });
+  const installedButton = await screen.findByRole("button", {
+    name: /已安装|Installed/,
+  });
+  expect(installedButton).not.toHaveClass("border-border");
+  const completed = installedButton.querySelector(
+    '[data-slot="plugin-install-complete"]',
+  );
+  expect(completed).toHaveClass("size-6");
+  expect(completed).toHaveAttribute("data-animated", "true");
+  expect(completed?.querySelector(".tabler-icon-check")).toHaveClass(
+    "zoom-in-0",
+  );
+});
+
+/** Marketplace cards expose native byte progress while a package download is pending. */
+it("shows marketplace plugin download progress", async () => {
+  const user = userEvent.setup();
+  const { client } = clientWithWeather();
+  vi.spyOn(client.plugin, "install").mockImplementation(
+    () => new Promise<never>(() => undefined),
+  );
+  let reportProgress:
+    | ((progress: {
+        pluginId: string;
+        downloaded: number;
+        total: number | null;
+      }) => void)
+    | undefined;
+  const platform: PlatformAdapter = {
+    ...createStubPlatform(),
+    pluginMarketplace: {
+      onInstallProgress: async (listener) => {
+        reportProgress = listener;
+        return () => undefined;
+      },
+    },
+  };
+  renderSettings(client, platform);
+
+  await user.click(await screen.findByRole("button", { name: /安装|Install/ }));
+  act(() => {
+    reportProgress?.({
+      pluginId: "official/weather",
+      downloaded: 4,
+      total: 10,
+    });
+  });
+
   expect(
-    await screen.findByRole("button", { name: /已安装|Installed/ }),
-  ).toBeInTheDocument();
+    await screen.findByRole("progressbar", {
+      name: /插件下载进度|Plugin download progress/,
+    }),
+  ).toHaveAttribute("aria-valuenow", "40");
+  expect(screen.queryByText("40%")).not.toBeInTheDocument();
+  expect(document.querySelector('[data-slot="progress"]')).toBeNull();
 });
 
 /** A sync control pulls the marketplace source through the backend. */

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -21,7 +21,7 @@ import { PluginsSettings } from "./plugins-settings";
 void appI18n;
 
 afterEach(() => {
-  usePluginOperationStore.setState({ activities: {} });
+  act(() => usePluginOperationStore.setState({ activities: {} }));
 });
 
 /** Renders plugin settings with isolated query, contracts-client, and platform state. */

--- a/packages/app-shell/src/features/settings/plugins-settings.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.tsx
@@ -465,7 +465,10 @@ function AvailablePluginCard({
             className="shrink-0"
             aria-label={t("settings.plugins.installed")}
           >
-            <CompletedInstallIcon animate={install.isSuccess} />
+            <CompletedInstallIcon
+              animate={install.completionId !== null}
+              onAnimationComplete={install.consumeCompletion}
+            />
           </Button>
         )}
       </span>
@@ -474,7 +477,13 @@ function AvailablePluginCard({
 }
 
 /** Matches the download ring's footprint and lets a newly installed check spring into place. */
-function CompletedInstallIcon({ animate }: { animate: boolean }) {
+function CompletedInstallIcon({
+  animate,
+  onAnimationComplete,
+}: {
+  animate: boolean;
+  onAnimationComplete: () => void;
+}) {
   return (
     <span
       data-slot="plugin-install-complete"
@@ -489,6 +498,7 @@ function CompletedInstallIcon({ animate }: { animate: boolean }) {
         }
       />
       <IconCheck
+        onAnimationEnd={animate ? onAnimationComplete : undefined}
         className={
           animate
             ? "size-3.5 stroke-[2.5] animate-in fade-in-0 zoom-in-0 delay-100 duration-300 fill-mode-both ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:animate-none"

--- a/packages/app-shell/src/features/settings/plugins-settings.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.tsx
@@ -17,9 +17,9 @@ import {
 } from "@ora/ui";
 import {
   IconArrowBigUpLines,
-  IconCircleCheck,
+  IconCheck,
+  IconDownload,
   IconLoader2,
-  IconPlus,
   IconProgressDown,
   IconRefresh,
   IconSearch,
@@ -264,7 +264,7 @@ export function PluginsSettings({
             />
           </div>
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
             className="shrink-0 min-w-32"
             disabled={sync.isPending}
@@ -337,7 +337,17 @@ function AvailablePluginCard({
   const { t } = useTranslation();
   const install = useInstallPlugin(plugin.id);
   const update = useUpdatePlugin(plugin.id);
-  const busy = install.isPending || update.isPending;
+  const downloadPercentage =
+    install.progress?.total !== null &&
+    install.progress?.total !== undefined &&
+    install.progress.total > 0
+      ? Math.min(
+          100,
+          Math.round(
+            (install.progress.downloaded / install.progress.total) * 100,
+          ),
+        )
+      : null;
   const hasUpdate = plugin.version !== installed?.version;
   const incompatible = plugin.compatibility === "incompatible";
 
@@ -375,7 +385,7 @@ function AvailablePluginCard({
           onSelect(plugin);
         }
       }}
-      className="flex cursor-pointer items-start gap-3 rounded-lg border border-border p-3 outline-none transition-colors hover:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring"
+      className="flex cursor-pointer items-center gap-3 rounded-lg border border-border p-3 outline-none transition-colors hover:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring"
     >
       <PluginLogo logo={plugin.logo} />
       <span className="min-w-0 flex-1">
@@ -394,24 +404,33 @@ function AvailablePluginCard({
         )}
       </span>
       <span className="flex shrink-0 items-center">
-        {busy ? (
+        {install.isPending ? (
           <Button
-            variant="outline"
-            size="icon-sm"
+            variant="ghost"
+            size="icon"
+            disabled
+            className="shrink-0 disabled:opacity-100"
+            aria-label={t("settings.plugins.installing")}
+          >
+            <CircularDownloadProgress
+              value={downloadPercentage}
+              label={t("settings.plugins.downloadProgress")}
+            />
+          </Button>
+        ) : update.isPending ? (
+          <Button
+            variant="ghost"
+            size="icon"
             disabled
             className="shrink-0"
-            aria-label={t(
-              update.isPending
-                ? "settings.plugins.updating"
-                : "settings.plugins.installing",
-            )}
+            aria-label={t("settings.plugins.updating")}
           >
             <IconProgressDown />
           </Button>
         ) : installed === undefined ? (
           <Button
             variant="outline"
-            size="icon-sm"
+            size="icon"
             className="shrink-0"
             disabled={incompatible}
             aria-label={t("settings.plugins.install")}
@@ -423,12 +442,12 @@ function AvailablePluginCard({
               );
             }}
           >
-            <IconPlus />
+            <IconDownload />
           </Button>
         ) : hasUpdate ? (
           <Button
-            variant="outline"
-            size="icon-sm"
+            variant="ghost"
+            size="icon"
             className="shrink-0"
             aria-label={t("settings.plugins.update")}
             onClick={(event) => {
@@ -440,17 +459,100 @@ function AvailablePluginCard({
           </Button>
         ) : (
           <Button
-            variant="outline"
-            size="icon-sm"
+            variant="ghost"
+            size="icon"
             disabled
             className="shrink-0"
             aria-label={t("settings.plugins.installed")}
           >
-            <IconCircleCheck />
+            <CompletedInstallIcon animate={install.isSuccess} />
           </Button>
         )}
       </span>
     </div>
+  );
+}
+
+/** Matches the download ring's footprint and lets a newly installed check spring into place. */
+function CompletedInstallIcon({ animate }: { animate: boolean }) {
+  return (
+    <span
+      data-slot="plugin-install-complete"
+      data-animated={animate}
+      className="relative grid size-6 place-items-center"
+    >
+      <span
+        className={
+          animate
+            ? "absolute inset-0 rounded-full border-2 border-current animate-in fade-in-0 zoom-in-75 duration-200 motion-reduce:animate-none"
+            : "absolute inset-0 rounded-full border-2 border-current"
+        }
+      />
+      <IconCheck
+        className={
+          animate
+            ? "size-3.5 stroke-[2.5] animate-in fade-in-0 zoom-in-0 delay-100 duration-300 fill-mode-both ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:animate-none"
+            : "size-3.5 stroke-[2.5]"
+        }
+      />
+    </span>
+  );
+}
+
+/** Renders determinate or indeterminate package progress inside the marketplace action button. */
+function CircularDownloadProgress({
+  value,
+  label,
+}: {
+  value: number | null;
+  label: string;
+}) {
+  const radius = 11;
+  const circumference = 2 * Math.PI * radius;
+  const offset =
+    value === null ? 0 : circumference * (1 - Math.max(0, value) / 100);
+
+  return (
+    <span
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={value ?? undefined}
+      className="relative grid size-7 place-items-center"
+    >
+      <svg
+        viewBox="0 0 28 28"
+        aria-hidden="true"
+        className={
+          value === null
+            ? "size-7 -rotate-90 animate-spin"
+            : "size-7 -rotate-90"
+        }
+      >
+        <circle
+          cx="14"
+          cy="14"
+          r={radius}
+          fill="none"
+          strokeWidth="2.5"
+          className="stroke-muted"
+        />
+        <circle
+          cx="14"
+          cy="14"
+          r={radius}
+          fill="none"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeDasharray={
+            value === null ? `18 ${circumference}` : circumference
+          }
+          strokeDashoffset={offset}
+          className="stroke-primary transition-[stroke-dashoffset] duration-300 ease-out"
+        />
+      </svg>
+    </span>
   );
 }
 

--- a/packages/app-shell/src/i18n/i18n-instance.ts
+++ b/packages/app-shell/src/i18n/i18n-instance.ts
@@ -861,6 +861,7 @@ export const translationResources = {
       "插件进程会先停止，然后移除已安装的代码。",
     "settings.plugins.deleteConfigurationData": "同时删除配置数据（推荐）",
     "settings.plugins.installing": "安装中",
+    "settings.plugins.downloadProgress": "插件下载进度",
     "settings.plugins.cancel": "取消",
     "settings.plugins.installFailed": "安装失败",
     "settings.plugins.installSuccess": "插件已安装。",
@@ -2428,6 +2429,7 @@ export const translationResources = {
     "settings.plugins.deleteConfigurationData":
       "Also delete configuration data (recommended)",
     "settings.plugins.installing": "Installing",
+    "settings.plugins.downloadProgress": "Plugin download progress",
     "settings.plugins.cancel": "Cancel",
     "settings.plugins.installFailed": "Install failed",
     "settings.plugins.installSuccess": "Plugin installed.",

--- a/packages/app-shell/src/platform/index.ts
+++ b/packages/app-shell/src/platform/index.ts
@@ -5,6 +5,8 @@ export {
   type LocationActionsCapability,
   type DesktopUpdateCapability,
   type DesktopUpdateStatus,
+  type PluginInstallProgress,
+  type PluginMarketplaceCapability,
   type ManualUpdateReason,
   type LocationTarget,
   type PathSelectionKind,

--- a/packages/app-shell/src/platform/types.ts
+++ b/packages/app-shell/src/platform/types.ts
@@ -99,6 +99,20 @@ export interface DesktopUpdateCapability {
   ): Promise<() => void>;
 }
 
+/** Byte-level progress for one marketplace package download. */
+export interface PluginInstallProgress {
+  pluginId: string;
+  downloaded: number;
+  total: number | null;
+}
+
+/** Exposes native marketplace transfer events without coupling shared UI to Tauri. */
+export interface PluginMarketplaceCapability {
+  onInstallProgress(
+    listener: (progress: PluginInstallProgress) => void,
+  ): Promise<() => void>;
+}
+
 /** Where a plugin surface renders: docked into the right panel or in its own native window. */
 export type SurfaceTarget = "embedded" | "windowed";
 
@@ -223,6 +237,7 @@ export interface PlatformAdapter {
   readonly locationActions: LocationActionsCapability;
   readonly surfaces: SurfaceCapability;
   readonly updates?: DesktopUpdateCapability;
+  readonly pluginMarketplace?: PluginMarketplaceCapability;
   selectPath(options: SelectPathOptions): Promise<string | null>;
   /** Opens the native save dialog and returns the chosen path, or null when dismissed. */
   selectSavePath(options: SelectSavePathOptions): Promise<string | null>;

--- a/packages/app-shell/src/state/hooks/use-install-plugin.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-install-plugin.test.tsx
@@ -12,7 +12,7 @@ import { usePluginOperationStore } from "../stores/plugin-operation-store";
 import { useInstallPlugin } from "./use-install-plugin";
 
 afterEach(() => {
-  usePluginOperationStore.setState({ activities: {} });
+  act(() => usePluginOperationStore.setState({ activities: {} }));
 });
 
 describe("useInstallPlugin", () => {

--- a/packages/app-shell/src/state/hooks/use-install-plugin.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-install-plugin.test.tsx
@@ -1,11 +1,19 @@
 import { act, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createMockClient,
   createMockClientState,
 } from "../../test/mock-client";
-import { renderHookWithClient } from "../../test/hook-harness";
+import {
+  createTestQueryClient,
+  renderHookWithClient,
+} from "../../test/hook-harness";
+import { usePluginOperationStore } from "../stores/plugin-operation-store";
 import { useInstallPlugin } from "./use-install-plugin";
+
+afterEach(() => {
+  usePluginOperationStore.setState({ activities: {} });
+});
 
 describe("useInstallPlugin", () => {
   it("installs a marketplace plugin and refreshes the installed surface", async () => {
@@ -39,5 +47,46 @@ describe("useInstallPlugin", () => {
       displayName: "weather",
       version: "1.2.0",
     });
+  });
+
+  it("keeps an install pending across unmount and rejects a duplicate start", async () => {
+    const client = createMockClient(createMockClientState());
+    let resolveInstall:
+      | ((response: Awaited<ReturnType<typeof client.plugin.install>>) => void)
+      | undefined;
+    const install = vi.spyOn(client.plugin, "install").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveInstall = resolve;
+        }),
+    );
+    const queryClient = createTestQueryClient();
+    const first = renderHookWithClient(
+      () => useInstallPlugin("official/weather"),
+      client,
+      queryClient,
+    );
+
+    act(() => first.result.current.mutate({}));
+    await waitFor(() => expect(install).toHaveBeenCalledOnce());
+    expect(first.result.current.isPending).toBe(true);
+    first.unmount();
+
+    const second = renderHookWithClient(
+      () => useInstallPlugin("official/weather"),
+      client,
+      queryClient,
+    );
+    expect(second.result.current.isPending).toBe(true);
+    act(() => second.result.current.mutate({}));
+    expect(install).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      resolveInstall?.({
+        pluginId: "official/weather",
+        outcome: { state: "installed" },
+      });
+    });
+    await waitFor(() => expect(second.result.current.isPending).toBe(false));
   });
 });

--- a/packages/app-shell/src/state/hooks/use-install-plugin.ts
+++ b/packages/app-shell/src/state/hooks/use-install-plugin.ts
@@ -50,6 +50,15 @@ export function useInstallPlugin(pluginId: string) {
   const installing =
     activity?.state === "pending" && activity.kind === "install";
   const progress = installing ? activity.progress : null;
+  const completionId =
+    activity?.state === "install_completed" ? activity.completionId : null;
+  const consumeCompletion = () => {
+    if (completionId !== null) {
+      usePluginOperationStore
+        .getState()
+        .consumeInstallCompletion(pluginId, completionId);
+    }
+  };
   return {
     ...mutation,
     isPending: installing,
@@ -57,5 +66,7 @@ export function useInstallPlugin(pluginId: string) {
     mutate,
     mutateAsync,
     progress,
+    completionId,
+    consumeCompletion,
   };
 }

--- a/packages/app-shell/src/state/hooks/use-install-plugin.ts
+++ b/packages/app-shell/src/state/hooks/use-install-plugin.ts
@@ -1,5 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { useContractsClient } from "../../contracts-client-context";
+import {
+  useOptionalPlatform,
+  type PluginInstallProgress,
+} from "../../platform";
 import { queryKeys } from "./query-keys";
 
 /**
@@ -9,16 +14,46 @@ import { queryKeys } from "./query-keys";
  */
 export function useInstallPlugin(pluginId: string) {
   const client = useContractsClient();
+  const platform = useOptionalPlatform();
   const queryClient = useQueryClient();
+  const [progress, setProgress] = useState<PluginInstallProgress | null>(null);
   const invalidate = () =>
     Promise.all([
       queryClient.invalidateQueries({ queryKey: queryKeys.installedPlugins }),
       queryClient.invalidateQueries({ queryKey: queryKeys.availablePlugins }),
     ]);
 
-  return useMutation({
+  const mutation = useMutation({
     mutationFn: ({ signal }: { signal?: AbortSignal } = {}) =>
       client.plugin.install({ pluginId }, { signal }),
     onSettled: invalidate,
   });
+
+  useEffect(() => {
+    let active = true;
+    let unsubscribe: (() => void) | undefined;
+    void platform?.pluginMarketplace
+      ?.onInstallProgress((next) => {
+        if (active && next.pluginId === pluginId) setProgress(next);
+      })
+      .then((stop) => {
+        if (active) unsubscribe = stop;
+        else stop();
+      });
+    return () => {
+      active = false;
+      unsubscribe?.();
+    };
+  }, [platform?.pluginMarketplace, pluginId]);
+
+  const mutate = (...args: Parameters<typeof mutation.mutate>) => {
+    setProgress(null);
+    mutation.mutate(...args);
+  };
+  const mutateAsync = (...args: Parameters<typeof mutation.mutateAsync>) => {
+    setProgress(null);
+    return mutation.mutateAsync(...args);
+  };
+
+  return { ...mutation, mutate, mutateAsync, progress };
 }

--- a/packages/app-shell/src/state/hooks/use-install-plugin.ts
+++ b/packages/app-shell/src/state/hooks/use-install-plugin.ts
@@ -1,10 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
 import { useContractsClient } from "../../contracts-client-context";
-import {
-  useOptionalPlatform,
-  type PluginInstallProgress,
-} from "../../platform";
+import { usePluginOperationStore } from "../stores/plugin-operation-store";
 import { queryKeys } from "./query-keys";
 
 /**
@@ -14,9 +10,10 @@ import { queryKeys } from "./query-keys";
  */
 export function useInstallPlugin(pluginId: string) {
   const client = useContractsClient();
-  const platform = useOptionalPlatform();
   const queryClient = useQueryClient();
-  const [progress, setProgress] = useState<PluginInstallProgress | null>(null);
+  const activity = usePluginOperationStore(
+    (state) => state.activities[pluginId],
+  );
   const invalidate = () =>
     Promise.all([
       queryClient.invalidateQueries({ queryKey: queryKeys.installedPlugins }),
@@ -26,34 +23,39 @@ export function useInstallPlugin(pluginId: string) {
   const mutation = useMutation({
     mutationFn: ({ signal }: { signal?: AbortSignal } = {}) =>
       client.plugin.install({ pluginId }, { signal }),
-    onSettled: invalidate,
+    onSettled: async (_response, error) => {
+      try {
+        await invalidate();
+      } finally {
+        const operations = usePluginOperationStore.getState();
+        if (error === null) operations.completeInstall(pluginId);
+        else operations.clear(pluginId);
+      }
+    },
   });
 
-  useEffect(() => {
-    let active = true;
-    let unsubscribe: (() => void) | undefined;
-    void platform?.pluginMarketplace
-      ?.onInstallProgress((next) => {
-        if (active && next.pluginId === pluginId) setProgress(next);
-      })
-      .then((stop) => {
-        if (active) unsubscribe = stop;
-        else stop();
-      });
-    return () => {
-      active = false;
-      unsubscribe?.();
-    };
-  }, [platform?.pluginMarketplace, pluginId]);
-
   const mutate = (...args: Parameters<typeof mutation.mutate>) => {
-    setProgress(null);
+    if (!usePluginOperationStore.getState().begin(pluginId, "install")) return;
     mutation.mutate(...args);
   };
   const mutateAsync = (...args: Parameters<typeof mutation.mutateAsync>) => {
-    setProgress(null);
+    if (!usePluginOperationStore.getState().begin(pluginId, "install")) {
+      return Promise.reject(
+        new Error(`plugin operation already pending: ${pluginId}`),
+      );
+    }
     return mutation.mutateAsync(...args);
   };
 
-  return { ...mutation, mutate, mutateAsync, progress };
+  const installing =
+    activity?.state === "pending" && activity.kind === "install";
+  const progress = installing ? activity.progress : null;
+  return {
+    ...mutation,
+    isPending: installing,
+    isSuccess: mutation.isSuccess || activity?.state === "install_completed",
+    mutate,
+    mutateAsync,
+    progress,
+  };
 }

--- a/packages/app-shell/src/state/hooks/use-plugin-mutations.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-plugin-mutations.test.tsx
@@ -1,6 +1,6 @@
 import { act, waitFor } from "@testing-library/react";
 import { useQuery } from "@tanstack/react-query";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockClient,
   createMockClientState,
@@ -10,6 +10,7 @@ import {
   renderHookWithClient,
 } from "../../test/hook-harness";
 import { useAgentModelStore } from "../stores/agent-model-store";
+import { usePluginOperationStore } from "../stores/plugin-operation-store";
 import { queryKeys } from "./query-keys";
 import { usePluginMutations } from "./use-plugin-mutations";
 
@@ -19,6 +20,10 @@ const TARGET = { type: "workspace" as const, workspaceId: "workspace-1" };
 
 beforeEach(() => {
   useAgentModelStore.setState({ known: {} });
+});
+
+afterEach(() => {
+  usePluginOperationStore.setState({ activities: {} });
 });
 
 describe("usePluginMutations", () => {
@@ -98,5 +103,50 @@ describe("usePluginMutations", () => {
     );
     expect(useAgentModelStore.getState().known[AGENT_REF]).toBeUndefined();
     expect(loadModels).toHaveBeenCalledOnce();
+  });
+
+  it("keeps uninstall pending across unmount and rejects a duplicate operation", async () => {
+    const client = createMockClient(createMockClientState());
+    let resolveUninstall:
+      | ((
+          response: Awaited<ReturnType<typeof client.plugin.uninstall>>,
+        ) => void)
+      | undefined;
+    const uninstall = vi.spyOn(client.plugin, "uninstall").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUninstall = resolve;
+        }),
+    );
+    const stop = vi.spyOn(client.plugin, "stop");
+    const queryClient = createTestQueryClient();
+    const first = renderHookWithClient(
+      () => usePluginMutations(PLUGIN_ID),
+      client,
+      queryClient,
+    );
+
+    act(() => first.result.current.uninstall.mutate("delete"));
+    await waitFor(() => expect(uninstall).toHaveBeenCalledOnce());
+    expect(first.result.current.uninstall.isPending).toBe(true);
+    first.unmount();
+
+    const second = renderHookWithClient(
+      () => usePluginMutations(PLUGIN_ID),
+      client,
+      queryClient,
+    );
+    expect(second.result.current.uninstall.isPending).toBe(true);
+    act(() => second.result.current.stop.mutate());
+    act(() => second.result.current.uninstall.mutate("delete"));
+    expect(uninstall).toHaveBeenCalledOnce();
+    expect(stop).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveUninstall?.({ pluginId: PLUGIN_ID });
+    });
+    await waitFor(() =>
+      expect(second.result.current.uninstall.isPending).toBe(false),
+    );
   });
 });

--- a/packages/app-shell/src/state/hooks/use-plugin-mutations.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-plugin-mutations.test.tsx
@@ -23,7 +23,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  usePluginOperationStore.setState({ activities: {} });
+  act(() => usePluginOperationStore.setState({ activities: {} }));
 });
 
 describe("usePluginMutations", () => {

--- a/packages/app-shell/src/state/hooks/use-plugin-mutations.ts
+++ b/packages/app-shell/src/state/hooks/use-plugin-mutations.ts
@@ -2,6 +2,7 @@ import type { InstalledPlugin, PluginDataDisposition } from "@ora/contracts";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useContractsClient } from "../../contracts-client-context";
 import { useAgentModelStore } from "../stores/agent-model-store";
+import { usePluginOperationStore } from "../stores/plugin-operation-store";
 import { queryKeys } from "./query-keys";
 import { invalidatePluginQueries } from "./plugin-invalidation";
 
@@ -9,6 +10,9 @@ import { invalidatePluginQueries } from "./plugin-invalidation";
 export function usePluginMutations(pluginId: string, agentRef?: string) {
   const client = useContractsClient();
   const queryClient = useQueryClient();
+  const activity = usePluginOperationStore(
+    (state) => state.activities[pluginId],
+  );
   const invalidate = () => invalidatePluginQueries(queryClient);
   const refreshAgent = (agentRef: string, scope: "availability" | "models") => {
     // Every lifecycle change invalidates availability and its display cache.
@@ -38,12 +42,24 @@ export function usePluginMutations(pluginId: string, agentRef?: string) {
   const activate = useMutation({
     mutationFn: () => client.plugin.activate({ pluginId }),
     onSuccess: ({ plugin }) => refreshPluginAgent(plugin, "models"),
-    onSettled: invalidate,
+    onSettled: async () => {
+      try {
+        await invalidate();
+      } finally {
+        usePluginOperationStore.getState().clear(pluginId);
+      }
+    },
   });
   const stop = useMutation({
     mutationFn: () => client.plugin.stop({ pluginId }),
     onSuccess: ({ plugin }) => refreshPluginAgent(plugin, "availability"),
-    onSettled: invalidate,
+    onSettled: async () => {
+      try {
+        await invalidate();
+      } finally {
+        usePluginOperationStore.getState().clear(pluginId);
+      }
+    },
   });
   const uninstall = useMutation({
     mutationFn: (dataDisposition?: PluginDataDisposition) =>
@@ -60,8 +76,75 @@ export function usePluginMutations(pluginId: string, agentRef?: string) {
             queryKey: queryKeys.agentRuntimeStatus,
           })
         : refreshAgent(agentRef, "availability"),
-    onSettled: invalidate,
+    onSettled: async () => {
+      try {
+        await invalidate();
+      } finally {
+        usePluginOperationStore.getState().clear(pluginId);
+      }
+    },
   });
 
-  return { activate, stop, uninstall };
+  const activateMutate = (...args: Parameters<typeof activate.mutate>) => {
+    if (!usePluginOperationStore.getState().begin(pluginId, "activate")) return;
+    activate.mutate(...args);
+  };
+  const activateMutateAsync = (
+    ...args: Parameters<typeof activate.mutateAsync>
+  ) => {
+    if (!usePluginOperationStore.getState().begin(pluginId, "activate")) {
+      return Promise.reject(
+        new Error(`plugin operation already pending: ${pluginId}`),
+      );
+    }
+    return activate.mutateAsync(...args);
+  };
+  const stopMutate = (...args: Parameters<typeof stop.mutate>) => {
+    if (!usePluginOperationStore.getState().begin(pluginId, "stop")) return;
+    stop.mutate(...args);
+  };
+  const stopMutateAsync = (...args: Parameters<typeof stop.mutateAsync>) => {
+    if (!usePluginOperationStore.getState().begin(pluginId, "stop")) {
+      return Promise.reject(
+        new Error(`plugin operation already pending: ${pluginId}`),
+      );
+    }
+    return stop.mutateAsync(...args);
+  };
+  const uninstallMutate = (...args: Parameters<typeof uninstall.mutate>) => {
+    if (!usePluginOperationStore.getState().begin(pluginId, "uninstall"))
+      return;
+    uninstall.mutate(...args);
+  };
+  const uninstallMutateAsync = (
+    ...args: Parameters<typeof uninstall.mutateAsync>
+  ) => {
+    if (!usePluginOperationStore.getState().begin(pluginId, "uninstall")) {
+      return Promise.reject(
+        new Error(`plugin operation already pending: ${pluginId}`),
+      );
+    }
+    return uninstall.mutateAsync(...args);
+  };
+
+  return {
+    activate: {
+      ...activate,
+      isPending: activity?.state === "pending" && activity.kind === "activate",
+      mutate: activateMutate,
+      mutateAsync: activateMutateAsync,
+    },
+    stop: {
+      ...stop,
+      isPending: activity?.state === "pending" && activity.kind === "stop",
+      mutate: stopMutate,
+      mutateAsync: stopMutateAsync,
+    },
+    uninstall: {
+      ...uninstall,
+      isPending: activity?.state === "pending" && activity.kind === "uninstall",
+      mutate: uninstallMutate,
+      mutateAsync: uninstallMutateAsync,
+    },
+  };
 }

--- a/packages/app-shell/src/state/hooks/use-update-plugin.ts
+++ b/packages/app-shell/src/state/hooks/use-update-plugin.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useContractsClient } from "../../contracts-client-context";
+import { usePluginOperationStore } from "../stores/plugin-operation-store";
 import { queryKeys } from "./query-keys";
 
 /**
@@ -10,15 +11,43 @@ import { queryKeys } from "./query-keys";
 export function useUpdatePlugin(pluginId: string) {
   const client = useContractsClient();
   const queryClient = useQueryClient();
+  const activity = usePluginOperationStore(
+    (state) => state.activities[pluginId],
+  );
   const invalidate = () =>
     Promise.all([
       queryClient.invalidateQueries({ queryKey: queryKeys.installedPlugins }),
       queryClient.invalidateQueries({ queryKey: queryKeys.availablePlugins }),
     ]);
 
-  return useMutation({
+  const mutation = useMutation({
     mutationFn: ({ signal }: { signal?: AbortSignal } = {}) =>
       client.plugin.update({ pluginId }, { signal }),
-    onSettled: invalidate,
+    onSettled: async () => {
+      try {
+        await invalidate();
+      } finally {
+        usePluginOperationStore.getState().clear(pluginId);
+      }
+    },
   });
+  const mutate = (...args: Parameters<typeof mutation.mutate>) => {
+    if (!usePluginOperationStore.getState().begin(pluginId, "update")) return;
+    mutation.mutate(...args);
+  };
+  const mutateAsync = (...args: Parameters<typeof mutation.mutateAsync>) => {
+    if (!usePluginOperationStore.getState().begin(pluginId, "update")) {
+      return Promise.reject(
+        new Error(`plugin operation already pending: ${pluginId}`),
+      );
+    }
+    return mutation.mutateAsync(...args);
+  };
+
+  return {
+    ...mutation,
+    isPending: activity?.state === "pending" && activity.kind === "update",
+    mutate,
+    mutateAsync,
+  };
 }

--- a/packages/app-shell/src/state/stores/plugin-operation-store.ts
+++ b/packages/app-shell/src/state/stores/plugin-operation-store.ts
@@ -20,11 +20,12 @@ interface PluginOperationState {
   reportInstallProgress: (progress: PluginInstallProgress) => void;
   /** Briefly records install success so the completion glyph can animate after query refresh. */
   completeInstall: (pluginId: string) => void;
+  /** Clears the exact completion after its glyph animation ends. */
+  consumeInstallCompletion: (pluginId: string, completionId: number) => void;
   /** Clears a settled operation so another lifecycle action can begin. */
   clear: (pluginId: string) => void;
 }
 
-const COMPLETION_ANIMATION_MS = 700;
 let nextCompletionId = 1;
 
 /** Owns plugin lifecycle activity independently of any settings row or card lifecycle. */
@@ -64,16 +65,15 @@ export const usePluginOperationStore = create<PluginOperationState>(
           [pluginId]: { state: "install_completed", completionId },
         },
       }));
-      // Completion is transitional UI state, not durable installation truth; queries own that.
-      setTimeout(() => {
-        const activity = get().activities[pluginId];
-        if (
-          activity?.state === "install_completed" &&
-          activity.completionId === completionId
-        ) {
-          get().clear(pluginId);
-        }
-      }, COMPLETION_ANIMATION_MS);
+    },
+    consumeInstallCompletion: (pluginId, completionId) => {
+      const activity = get().activities[pluginId];
+      if (
+        activity?.state === "install_completed" &&
+        activity.completionId === completionId
+      ) {
+        get().clear(pluginId);
+      }
     },
     clear: (pluginId) => {
       set((state) => {

--- a/packages/app-shell/src/state/stores/plugin-operation-store.ts
+++ b/packages/app-shell/src/state/stores/plugin-operation-store.ts
@@ -1,0 +1,86 @@
+import type { PluginInstallProgress } from "../../platform";
+import { create } from "zustand";
+
+export type PluginOperationKind =
+  "install" | "update" | "activate" | "stop" | "uninstall";
+
+export type PluginOperationActivity =
+  | {
+      state: "pending";
+      kind: PluginOperationKind;
+      progress: PluginInstallProgress | null;
+    }
+  | { state: "install_completed"; completionId: number };
+
+interface PluginOperationState {
+  activities: Record<string, PluginOperationActivity>;
+  /** Starts an operation only when the same plugin has no conflicting work in flight. */
+  begin: (pluginId: string, kind: PluginOperationKind) => boolean;
+  /** Retains native install transfer progress across settings-page navigation. */
+  reportInstallProgress: (progress: PluginInstallProgress) => void;
+  /** Briefly records install success so the completion glyph can animate after query refresh. */
+  completeInstall: (pluginId: string) => void;
+  /** Clears a settled operation so another lifecycle action can begin. */
+  clear: (pluginId: string) => void;
+}
+
+const COMPLETION_ANIMATION_MS = 700;
+let nextCompletionId = 1;
+
+/** Owns plugin lifecycle activity independently of any settings row or card lifecycle. */
+export const usePluginOperationStore = create<PluginOperationState>(
+  (set, get) => ({
+    activities: {},
+    begin: (pluginId, kind) => {
+      if (get().activities[pluginId]?.state === "pending") return false;
+      set((state) => ({
+        activities: {
+          ...state.activities,
+          [pluginId]: { state: "pending", kind, progress: null },
+        },
+      }));
+      return true;
+    },
+    reportInstallProgress: (progress) => {
+      const activity = get().activities[progress.pluginId];
+      if (activity?.state !== "pending" || activity.kind !== "install") return;
+      set((state) => ({
+        activities: {
+          ...state.activities,
+          [progress.pluginId]: {
+            state: "pending",
+            kind: "install",
+            progress,
+          },
+        },
+      }));
+    },
+    completeInstall: (pluginId) => {
+      const completionId = nextCompletionId;
+      nextCompletionId += 1;
+      set((state) => ({
+        activities: {
+          ...state.activities,
+          [pluginId]: { state: "install_completed", completionId },
+        },
+      }));
+      // Completion is transitional UI state, not durable installation truth; queries own that.
+      setTimeout(() => {
+        const activity = get().activities[pluginId];
+        if (
+          activity?.state === "install_completed" &&
+          activity.completionId === completionId
+        ) {
+          get().clear(pluginId);
+        }
+      }, COMPLETION_ANIMATION_MS);
+    },
+    clear: (pluginId) => {
+      set((state) => {
+        const activities = { ...state.activities };
+        delete activities[pluginId];
+        return { activities };
+      });
+    },
+  }),
+);


### PR DESCRIPTION
## 概要

- 将 Rust 下载器的真实插件包下载进度通过节流后的 Tauri 事件上报到前端
- 将安装入口改为 outline 下载按钮，并在原位置展示确定或不确定状态的圆环进度
- 安装完成后为完成勾添加弹出动画，同时适配系统的“减少动态效果”偏好
- 使用按插件隔离的共享状态管理安装、更新、卸载、启动和停止操作，避免切换页面后忙碌状态丢失或重复发起冲突操作
- 在 App Shell 层统一监听安装进度，使插件设置页面卸载后仍能持续更新进度

## 行为变化

- 离开插件市场后再返回，可以恢复最新的下载进度
- 不同插件的操作状态和下载进度相互独立
- 同一插件在当前操作结束前，不允许发起其他冲突操作
- 安装完成后先刷新已安装插件和可用插件的权威查询，再清理临时操作状态

## 验证

- pnpm --filter @ora/app-shell test（125 个测试文件，1227 项测试）
- pnpm --filter @ora/app-shell lint
- cargo check -p ora-plugin-manager -p ora-backend -p ora-desktop
- cargo clippy -p ora-plugin-manager -p ora-backend -p ora-desktop --no-deps -- -D warnings
- git diff --check