### PR TITLE
[Agent MCP 03] 通过 Host 与 SDK 协商 MCP Configuration Capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,17 @@ keep that await inside `act` so restore that still updates React stays covered.
 # TypeScript/packages
 
 - A test that renders anything calling `useTranslation` must import `appI18n` itself: react-i18next keeps its instance in a `node_modules` module that Vitest loads once per worker, so a file relying on an earlier file in the same worker to have initialized it passes locally and fails on CI, where a different worker split leaves it first and the missing-instance warning trips the clean-stderr gate on an otherwise green run.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub issues. The repo is a fork of `ora-space/desktop`; Ora-project issues go upstream, fork-specific work stays on `origin`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles, label strings equal to role names: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,77 @@
+# Ora Agent Effects
+
+This context describes how Ora makes installed capabilities available to an Agent within a Workspace while preserving target-specific Agent behavior.
+
+## Language
+
+**Agent Workspace**:
+The authoritative working directory shared by an Agent instance and its Sessions. It is either a project's main checkout or a Task's isolated worktree.
+_Avoid_: Agent working directory, plugin data directory, Agent process directory
+
+**MCP Package**:
+An installed, immutable package that describes one MCP server and its configuration requirements without running an Ora plugin process.
+_Avoid_: MCP process, MCP Agent plugin
+
+**Resolved MCP**:
+The target-independent, use-time MCP description produced for one exact installed package version and one Agent Workspace after required configuration has been resolved.
+_Avoid_: Raw MCP config, Agent config
+
+**Default-enabled MCP**:
+An installed MCP Package that is intended to join every Agent Workspace automatically whenever it is Ready. The intent remains while the package Needs Configuration, so it can join again without another user selection.
+_Avoid_: Selected MCP, active MCP
+
+**Workspace MCP Desired Set**:
+The complete set of Ready MCP Packages that Ora intends to make available in an Agent Workspace. Every Default-enabled MCP joins this set for all existing and future Agent Workspaces when it becomes Ready.
+_Avoid_: Installed MCP catalog, Session MCP selection
+
+**MCP Source**:
+The stable Effect identity of one MCP Package across package and configuration versions.
+_Avoid_: MCP package version, resolved configuration
+
+**MCP Source Revision**:
+An immutable snapshot binding an MCP Source to one exact package version, descriptor content, configuration-store revision, and resolved-state digest.
+_Avoid_: MCP version, mutable settings
+
+**Agent Target**:
+The pairing of one Agent Workspace and one Agent Plugin that forms an independent configuration convergence boundary.
+_Avoid_: Agent instance, Session
+
+**Agent Target Ready Generation**:
+The latest Workspace generation for which every required Skill and MCP operation has been processed and the Agent Target can accept new turns. Non-blocking target-specific issues may remain visible at this generation.
+_Avoid_: Desired generation, applied file generation
+
+**MCP Configuration Capability**:
+A versioned, negotiated Agent Plugin declaration that it can materialize specified MCP transports for its target Agent and coordinate configuration changes with active Sessions. Its absence means the Agent does not support MCP materialization without invalidating the Agent's baseline conversation capability.
+_Avoid_: MCP support flag, MCP filesystem surface
+
+**Agent Capability Revision**:
+The identity of an Agent Plugin version and its declared configuration capabilities whose change requires affected Agent Targets to be reconciled again.
+_Avoid_: Plugin ID, process generation
+
+**MCP Configuration Snapshot**:
+The complete Resolved MCP set for one Agent Target and one Workspace generation. It is the idempotent input to MCP Materialization rather than an incremental add or remove event.
+_Avoid_: MCP update event, config fragment
+
+**MCP Materialization**:
+The Agent Plugin-owned transformation of a complete Resolved MCP set into the target Agent's native configuration while preserving resources not managed by Ora.
+_Avoid_: MCP installation, host rendering
+
+**Managed MCP Entry**:
+An MCP entry in a target Agent configuration whose ownership is proven by Ora's state for the current Agent Target.
+_Avoid_: Installed MCP, matching MCP name
+
+**Managed Agent Configuration Document**:
+A target-native configuration document exclusively generated for one Agent Target and owned as a whole through a durable locator and fingerprint.
+_Avoid_: User configuration file, config fragment
+
+**MCP Materialization Conflict**:
+A state in which the observed target configuration no longer matches the fingerprint previously applied by Ora, so ownership cannot justify another automatic write.
+_Avoid_: Configuration update, overwrite permission
+
+**Ready with Issues**:
+An Agent Target state in which the complete MCP Configuration Snapshot has been processed and supported MCPs are available, while one or more target-specific, non-blocking MCP issues remain visible.
+_Avoid_: Degraded, partially reconciled
+
+**Needs Configuration**:
+An installed MCP state in which required configuration is incomplete or unavailable, so the MCP remains Default-enabled but does not belong to any Workspace MCP Desired Set.
+_Avoid_: Installation failure, Unsupported by Agent

--- a/crates/backend/src/agent_runtime/connection.rs
+++ b/crates/backend/src/agent_runtime/connection.rs
@@ -785,15 +785,26 @@ async fn spawn_plugin_connection(
         .attach_agent(plugin_id)
         .await
         .map_err(plugin_attach_error)?;
+    let Some(plugin_version) = plugin_host
+        .installed_plugin_version(plugin_id)
+        .filter(|version| !version.is_empty())
+    else {
+        stop_plugin_runtime(plugin_host, plugin_id).await;
+        return Err(StartFailure::Terminal(runtime_internal(
+            "agent_start_failed",
+            "installed plugin version is unavailable",
+        )));
+    };
     let LaunchedPluginAgent {
         runtime,
         messages,
-        effect_surfaces,
+        effect_declaration,
     } = match plugin_agent::attach(
         attachment,
         &plugin_id.canonical(),
         home_directory,
         env!("CARGO_PKG_VERSION"),
+        &plugin_version,
     )
     .await
     {
@@ -804,7 +815,7 @@ async fn spawn_plugin_connection(
         }
     };
     plugin_host
-        .replace_agent_effect_surfaces(plugin_id.clone(), effect_surfaces)
+        .replace_agent_plugin_declaration(plugin_id.clone(), effect_declaration)
         .map_err(|error| {
             StartFailure::Terminal(runtime_internal("agent_start_failed", error.to_string()))
         })?;

--- a/crates/backend/src/agent_runtime/plugin_agent/README.md
+++ b/crates/backend/src/agent_runtime/plugin_agent/README.md
@@ -62,7 +62,7 @@ transports, or unknown capability fields disable MCP materialization and record
 Older plugins that omit the field are `UnsupportedByAgent` for every Ready MCP. Host snapshot
 requests carry operation identity, Agent Target identity, Workspace root, generation, and the
 supported Resolved MCP list only. Receipts that miss, duplicate, extra-cover, or mismatch
-generation, locator bounds, source revision, or fingerprint are rejected and cannot advance
+generation, locator bounds, native key uniqueness, source revision, or fingerprint are rejected and cannot advance
 Ready Generation. Agent Capability Revision binds the exact plugin version to the canonical
 capability digest. JSON-RPC diagnostics, stderr, timeout errors, and traces never include header
 values, environment values, document bytes, or Authorization material.

--- a/crates/backend/src/agent_runtime/plugin_agent/README.md
+++ b/crates/backend/src/agent_runtime/plugin_agent/README.md
@@ -13,6 +13,8 @@ sees a `RuntimeConnection` and cannot tell which kind of provider produced it.
 - Attach to one lifecycle-owned plugin process and read the notifications of that one generation.
 - Reject, at handshake time, any plugin whose registration does not cover `agent/start`,
   `agent/stop`, `agent/listModels`, and the emitted `agent/acp`.
+- Negotiate the optional `mcpConfiguration` capability independently of that baseline contract.
+  Missing, malformed, unpaired, or unsupported declarations disable MCP materialization only.
 - Call `agent/start` and confirm the plugin will speak a protocol version this host understands.
 - Read the plugin's pre-session model list through `agent/listModels`.
 - Relay ACP messages in both directions as `agent/acp` notifications.
@@ -52,6 +54,18 @@ failing agent rather than as a failure in the middle of someone's turn. That fai
 the supervisor publishes `Failing` and abandons the agent for the rest of the process instead of
 retrying, because the same plugin will fail identically every time and retrying only produces a
 warning per backoff interval.
+
+MCP configuration is additive. `mcpConfiguration` plus `agent/configureWorkspace` are negotiated
+as one optional capability; either side missing, an unknown protocol version, duplicate
+transports, or unknown capability fields disable MCP materialization and record
+`mcp_capability_invalid` / `mcp_capability_version_unsupported` without failing `agent/start`.
+Older plugins that omit the field are `UnsupportedByAgent` for every Ready MCP. Host snapshot
+requests carry operation identity, Agent Target identity, Workspace root, generation, and the
+supported Resolved MCP list only. Receipts that miss, duplicate, extra-cover, or mismatch
+generation, locator bounds, source revision, or fingerprint are rejected and cannot advance
+Ready Generation. Agent Capability Revision binds the exact plugin version to the canonical
+capability digest. JSON-RPC diagnostics, stderr, timeout errors, and traces never include header
+values, environment values, document bytes, or Authorization material.
 
 `agent/start` failures split in two. `-32001` means the agent CLI the plugin wraps is absent from
 this machine; that is an expected local configuration, so it is reported as `agent_not_installed`

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/README.md
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/README.md
@@ -12,7 +12,10 @@ strict receipt validation, and Agent Capability Revision binding.
   root, generation, and supported Resolved MCP values only.
 - Exclude unsupported transports before the plugin call and represent them as target-level
   NonBlocking `UnsupportedByAgent` conditions.
-- Reject receipts that do not exactly cover the supported Desired set.
+- Reject receipts that do not exactly cover the supported Desired set, including duplicate
+  native keys.
+- Surface `mcp_configuration_failed` / `mcp_configuration_response_invalid` as stable public
+  codes; Display text is diagnostic only.
 - Bind Agent Capability Revision to the exact plugin version and canonical capability digest.
 - Keep header values, environment values, document bytes, and API keys out of diagnostics.
 

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/README.md
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/README.md
@@ -1,0 +1,31 @@
+# mcp_configuration
+
+This module owns the Host wire adapter for the optional MCP Configuration Capability:
+capability/handler pairing, full-snapshot request construction, transport exclusion,
+strict receipt validation, and Agent Capability Revision binding.
+
+## Responsibilities
+
+- Negotiate `mcpConfiguration` against `agent/configureWorkspace` without invalidating the
+  baseline Agent conversation contract.
+- Build a complete snapshot that carries operation identity, Agent Target identity, Workspace
+  root, generation, and supported Resolved MCP values only.
+- Exclude unsupported transports before the plugin call and represent them as target-level
+  NonBlocking `UnsupportedByAgent` conditions.
+- Reject receipts that do not exactly cover the supported Desired set.
+- Bind Agent Capability Revision to the exact plugin version and canonical capability digest.
+- Keep header values, environment values, document bytes, and API keys out of diagnostics.
+
+## Non-responsibilities
+
+- Effect worker cutover, admission gating, and persistence of conditions (`#489`).
+- OpenCode-native document rendering (`#488`).
+- MCP Source publication and Desired Set membership (`#486`).
+- Publishing the plugin SDK (`#495`).
+
+## Invariants
+
+- Missing, malformed, duplicate, or unpaired capability disables MCP materialization only.
+- Snapshot JSON never includes raw manifests, configuration stores, database paths, or
+  unrelated plugin paths.
+- JSON-RPC timeout errors and Host traces name the method, never the payload.

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/invoke.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/invoke.rs
@@ -1,0 +1,87 @@
+//! Invokes `agent/configureWorkspace` without logging snapshot secrets.
+
+#![allow(dead_code)] // First production caller is the Agent Target worker in #489.
+
+use super::{
+    ExpectedReceiptCoverage, McpConfigurationReceipt, PreparedMcpConfiguration,
+    ReceiptValidationError, parse_mcp_configuration_receipt, snapshot_request_json,
+    validate_mcp_configuration_receipt,
+};
+use ora_logging::{ErrorReport, ora_info};
+use ora_plugin_runtime::{CONFIGURE_WORKSPACE_METHOD, PluginRuntime, PluginRuntimeError};
+use serde_json::Value;
+use std::future::Future;
+use thiserror::Error;
+
+/// Abstracts one plugin invoke so snapshot/receipt protocol tests do not need a Deno process.
+///
+/// Implementations must return the JSON-RPC result only. Logging the params would put header and
+/// environment values into Host traces.
+pub(crate) trait ConfigureWorkspaceRuntime {
+    /// Invokes one registered plugin method and returns its JSON result.
+    fn invoke(
+        &self,
+        method: &str,
+        params: Value,
+    ) -> impl Future<Output = Result<Value, PluginRuntimeError>> + Send;
+}
+
+impl ConfigureWorkspaceRuntime for PluginRuntime {
+    /// Delegates to the process runtime without logging params, so header values stay off traces.
+    async fn invoke(&self, method: &str, params: Value) -> Result<Value, PluginRuntimeError> {
+        PluginRuntime::invoke(self, method, params).await
+    }
+}
+
+/// Why configure failed without becoming a Ready generation.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub(crate) enum ConfigureWorkspaceError {
+    #[error("agent plugin did not register agent/configureWorkspace")]
+    MethodNotRegistered,
+    #[error("agent plugin configure call timed out")]
+    TimedOut,
+    #[error("agent plugin configure failed: {0}")]
+    Failed(String),
+    #[error("agent plugin configure receipt is invalid: {0}")]
+    InvalidReceipt(ReceiptValidationError),
+}
+
+impl From<PluginRuntimeError> for ConfigureWorkspaceError {
+    fn from(error: PluginRuntimeError) -> Self {
+        match error {
+            PluginRuntimeError::MethodNotRegistered(_) => Self::MethodNotRegistered,
+            PluginRuntimeError::CallTimeout => Self::TimedOut,
+            PluginRuntimeError::MissingEntrypoint(_)
+            | PluginRuntimeError::Spawn(_)
+            | PluginRuntimeError::MissingStdio
+            | PluginRuntimeError::ReadyTimeout
+            | PluginRuntimeError::Unavailable(_)
+            | PluginRuntimeError::RequestChannelClosed
+            | PluginRuntimeError::Remote { .. } => {
+                Self::Failed(ErrorReport::sanitize_text(&error.to_string()))
+            }
+        }
+    }
+}
+
+/// Sends one complete snapshot, then accepts the receipt only when coverage is exact.
+pub(crate) async fn configure_workspace<R: ConfigureWorkspaceRuntime>(
+    runtime: &R,
+    prepared: &PreparedMcpConfiguration,
+    expected: &ExpectedReceiptCoverage,
+) -> Result<McpConfigurationReceipt, ConfigureWorkspaceError> {
+    ora_info!(
+        message = "agent configure workspace",
+        operation_id = %prepared.operation_id,
+        agent_target_id = %prepared.agent_target_id,
+        generation = prepared.generation.value(),
+    );
+    let result = runtime
+        .invoke(CONFIGURE_WORKSPACE_METHOD, snapshot_request_json(prepared))
+        .await?;
+    let receipt =
+        parse_mcp_configuration_receipt(result).map_err(ConfigureWorkspaceError::InvalidReceipt)?;
+    validate_mcp_configuration_receipt(&receipt, expected)
+        .map_err(ConfigureWorkspaceError::InvalidReceipt)?;
+    Ok(receipt)
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/invoke.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/invoke.rs
@@ -46,6 +46,18 @@ pub(crate) enum ConfigureWorkspaceError {
     InvalidReceipt(ReceiptValidationError),
 }
 
+impl ConfigureWorkspaceError {
+    /// Stable public code; the Display message is diagnostic only and must not drive control flow.
+    pub(crate) fn error_code(&self) -> &'static str {
+        match self {
+            Self::InvalidReceipt(_) => "mcp_configuration_response_invalid",
+            Self::MethodNotRegistered | Self::TimedOut | Self::Failed(_) => {
+                "mcp_configuration_failed"
+            }
+        }
+    }
+}
+
 impl From<PluginRuntimeError> for ConfigureWorkspaceError {
     fn from(error: PluginRuntimeError) -> Self {
         match error {

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/mod.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/mod.rs
@@ -94,7 +94,28 @@ impl NegotiatedMcpConfiguration {
 pub(crate) struct AgentPluginEffectDeclaration {
     pub skill_surfaces: Vec<ora_effect::FilesystemSkillSurface>,
     pub mcp_configuration: NegotiatedMcpConfiguration,
-    pub capability_revision: AgentCapabilityRevision,
+    pub capability_revision: Option<AgentCapabilityRevision>,
+}
+
+impl AgentPluginEffectDeclaration {
+    /// Skill-only Expand declaration: no MCP negotiation and no bound capability revision.
+    pub(crate) fn skill_only(skill_surfaces: Vec<ora_effect::FilesystemSkillSurface>) -> Self {
+        Self {
+            skill_surfaces,
+            mcp_configuration: NegotiatedMcpConfiguration::Unsupported,
+            capability_revision: None,
+        }
+    }
+
+    /// True when uninstall (or an empty Skill-only write) should drop this plugin from the snapshot.
+    pub(crate) fn is_absent(&self) -> bool {
+        self.skill_surfaces.is_empty()
+            && matches!(
+                self.mcp_configuration,
+                NegotiatedMcpConfiguration::Unsupported
+            )
+            && self.capability_revision.is_none()
+    }
 }
 
 /// Pairs capability and handler without failing the baseline Agent conversation contract.

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/mod.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/mod.rs
@@ -1,0 +1,136 @@
+//! Host-side MCP Configuration Capability negotiation, snapshot protocol, and receipt checks.
+
+mod invoke;
+mod receipt;
+mod snapshot;
+
+#[cfg(test)]
+mod tests;
+
+// Snapshot, receipt, and invoke are the Host wire adapter. The Effect worker (#489) is the first
+// runtime caller; this ticket keeps that cutover out of scope, so lib clippy would otherwise treat
+// a complete protocol as dead code.
+#[cfg_attr(not(test), allow(dead_code, unused_imports))]
+pub(crate) use invoke::{ConfigureWorkspaceError, ConfigureWorkspaceRuntime, configure_workspace};
+#[cfg_attr(not(test), allow(dead_code, unused_imports))]
+pub(crate) use receipt::{
+    ExpectedManagedMcp, ExpectedReceiptCoverage, McpConfigurationReceipt, ReceiptValidationError,
+    parse_mcp_configuration_receipt, validate_mcp_configuration_receipt,
+};
+#[cfg_attr(not(test), allow(dead_code, unused_imports))]
+pub(crate) use snapshot::{
+    DesiredResolvedMcp, PreparedMcpConfiguration, ResolvedMcpTransport, SnapshotRequestError,
+    UnsupportedMcp, prepare_mcp_configuration_snapshot, snapshot_request_json,
+};
+
+use ora_effect::{AgentCapabilityRevision, Digest};
+use ora_plugin_runtime::{
+    CONFIGURE_WORKSPACE_METHOD, McpConfigurationCapability, McpConfigurationCapabilityIssue,
+    McpConfigurationRegistration, PluginRegistration,
+};
+
+/// Outcome of pairing a registration capability with `agent/configureWorkspace`.
+///
+/// `Unsupported` is the older-plugin case: every Ready MCP is target-specific Unsupported.
+/// `Disabled` keeps conversation available while refusing MCP materialization.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum NegotiatedMcpConfiguration {
+    Unsupported,
+    Disabled {
+        reason: McpConfigurationDisableReason,
+    },
+    Enabled(McpConfigurationCapability),
+}
+
+/// Why a present or partial MCP declaration cannot be used for materialization.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum McpConfigurationDisableReason {
+    Invalid(McpConfigurationCapabilityIssue),
+    CapabilityWithoutHandler,
+    HandlerWithoutCapability,
+}
+
+impl McpConfigurationDisableReason {
+    /// Stable public error code that never includes capability payload bytes.
+    pub(crate) fn error_code(&self) -> &'static str {
+        match self {
+            Self::Invalid(issue) => issue.error_code(),
+            Self::CapabilityWithoutHandler | Self::HandlerWithoutCapability => {
+                "mcp_capability_invalid"
+            }
+        }
+    }
+}
+
+impl NegotiatedMcpConfiguration {
+    /// Returns whether the Host may send `agent/configureWorkspace`.
+    pub(crate) fn enables_materialization(&self) -> bool {
+        matches!(self, Self::Enabled(_))
+    }
+
+    /// Returns the enabled capability when MCP materialization is available.
+    ///
+    /// The Agent Target worker (#489) is the first runtime caller of this accessor; attach already
+    /// stores the full negotiation outcome on the declaration snapshot.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn capability(&self) -> Option<&McpConfigurationCapability> {
+        match self {
+            Self::Enabled(capability) => Some(capability),
+            Self::Unsupported | Self::Disabled { .. } => None,
+        }
+    }
+
+    /// Returns the stable disable code when materialization is refused.
+    pub(crate) fn disable_error_code(&self) -> Option<&'static str> {
+        match self {
+            Self::Disabled { reason } => Some(reason.error_code()),
+            Self::Unsupported | Self::Enabled(_) => None,
+        }
+    }
+}
+
+/// Process-local Agent Effect declaration stored in the single convergence snapshot.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct AgentPluginEffectDeclaration {
+    pub skill_surfaces: Vec<ora_effect::FilesystemSkillSurface>,
+    pub mcp_configuration: NegotiatedMcpConfiguration,
+    pub capability_revision: AgentCapabilityRevision,
+}
+
+/// Pairs capability and handler without failing the baseline Agent conversation contract.
+pub(crate) fn negotiate_mcp_configuration(
+    registration: &PluginRegistration,
+) -> NegotiatedMcpConfiguration {
+    let has_handler = registration.methods.contains(CONFIGURE_WORKSPACE_METHOD);
+    match &registration.mcp_configuration {
+        McpConfigurationRegistration::Absent if has_handler => {
+            NegotiatedMcpConfiguration::Disabled {
+                reason: McpConfigurationDisableReason::HandlerWithoutCapability,
+            }
+        }
+        McpConfigurationRegistration::Absent => NegotiatedMcpConfiguration::Unsupported,
+        McpConfigurationRegistration::Invalid(issue) => NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::Invalid(issue.clone()),
+        },
+        McpConfigurationRegistration::Declared(capability) if has_handler => {
+            NegotiatedMcpConfiguration::Enabled(capability.clone())
+        }
+        McpConfigurationRegistration::Declared(_) => NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::CapabilityWithoutHandler,
+        },
+    }
+}
+
+/// Binds the exact plugin version to the canonical digest of the declared capability.
+///
+/// Version-only and digest-only changes each produce a new revision so later workers can wake
+/// every Agent Target after an upgrade or a repaired declaration.
+pub(crate) fn agent_capability_revision(
+    plugin_version: &str,
+    registration: &McpConfigurationRegistration,
+) -> AgentCapabilityRevision {
+    AgentCapabilityRevision::bind(
+        plugin_version,
+        &Digest::sha256(&registration.canonical_declaration_bytes()),
+    )
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/receipt.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/receipt.rs
@@ -1,0 +1,168 @@
+//! Strict Host validation of `agent/configureWorkspace` success receipts.
+
+#![allow(dead_code)] // First production caller is the Agent Target worker in #489.
+
+use ora_effect::{Digest, Generation};
+use ora_utils::path::{PortableRelativePath, PortableRelativePathError};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use thiserror::Error;
+
+/// One managed MCP entry the plugin claims to have applied.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct McpEntryReceipt {
+    pub managed_identity: String,
+    pub native_key: String,
+    pub entry_fingerprint: Digest,
+    pub source_revision_id: String,
+}
+
+/// Durably applied document the Host records after a successful configure call.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct McpConfigurationReceipt {
+    pub applied_generation: Generation,
+    pub document_locator: PortableRelativePath,
+    pub document_fingerprint: Digest,
+    pub entries: Vec<McpEntryReceipt>,
+}
+
+/// Supported Desired entries the receipt must cover exactly.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ExpectedManagedMcp {
+    pub managed_identity: String,
+    pub source_revision_id: String,
+}
+
+/// Coverage the Host requires before treating a receipt as Ready-eligible.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ExpectedReceiptCoverage {
+    pub generation: Generation,
+    pub desired: Vec<ExpectedManagedMcp>,
+}
+
+/// Why a plugin receipt cannot advance applied or Ready generation.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub(crate) enum ReceiptValidationError {
+    #[error("configure receipt is not a JSON object")]
+    NotAnObject,
+    #[error("configure receipt does not match protocol v1")]
+    InvalidStructure,
+    #[error("configure receipt generation does not match the request")]
+    GenerationMismatch,
+    #[error("configure receipt locator is outside the Workspace")]
+    LocatorOutOfBounds,
+    #[error("configure receipt is missing a managed identity")]
+    MissingManagedIdentity,
+    #[error("configure receipt contains a duplicate managed identity")]
+    DuplicateManagedIdentity,
+    #[error("configure receipt contains an extra managed identity")]
+    ExtraManagedIdentity,
+    #[error("configure receipt source revision does not match Desired")]
+    SourceRevisionMismatch,
+    #[error("configure receipt fingerprint is not a SHA-256 digest")]
+    IllegalFingerprint,
+}
+
+/// Parses a plugin result before coverage checks so unknown fields cannot sneak in.
+pub(crate) fn parse_mcp_configuration_receipt(
+    value: Value,
+) -> Result<McpConfigurationReceipt, ReceiptValidationError> {
+    if !value.is_object() {
+        return Err(ReceiptValidationError::NotAnObject);
+    }
+    let wire: WireReceipt =
+        serde_json::from_value(value).map_err(|_| ReceiptValidationError::InvalidStructure)?;
+    let document_locator = PortableRelativePath::parse(&wire.document_locator).map_err(
+        |error: PortableRelativePathError| match error {
+            PortableRelativePathError::ParentTraversal
+            | PortableRelativePathError::Rooted
+            | PortableRelativePathError::WindowsPrefix => {
+                ReceiptValidationError::LocatorOutOfBounds
+            }
+            PortableRelativePathError::NulByte | PortableRelativePathError::WindowsReservedName => {
+                ReceiptValidationError::InvalidStructure
+            }
+        },
+    )?;
+    if document_locator.is_root() {
+        return Err(ReceiptValidationError::LocatorOutOfBounds);
+    }
+    let document_fingerprint = Digest::parse(wire.document_fingerprint)
+        .map_err(|_| ReceiptValidationError::IllegalFingerprint)?;
+    let mut entries = Vec::with_capacity(wire.entries.len());
+    for entry in wire.entries {
+        if entry.managed_identity.is_empty() || entry.native_key.is_empty() {
+            return Err(ReceiptValidationError::InvalidStructure);
+        }
+        let entry_fingerprint = Digest::parse(entry.entry_fingerprint)
+            .map_err(|_| ReceiptValidationError::IllegalFingerprint)?;
+        entries.push(McpEntryReceipt {
+            managed_identity: entry.managed_identity,
+            native_key: entry.native_key,
+            entry_fingerprint,
+            source_revision_id: entry.source_revision_id,
+        });
+    }
+    Ok(McpConfigurationReceipt {
+        applied_generation: Generation::new(wire.applied_generation),
+        document_locator,
+        document_fingerprint,
+        entries,
+    })
+}
+
+/// Rejects receipts that would let an incomplete plugin result be marked Ready.
+pub(crate) fn validate_mcp_configuration_receipt(
+    receipt: &McpConfigurationReceipt,
+    expected: &ExpectedReceiptCoverage,
+) -> Result<(), ReceiptValidationError> {
+    if receipt.applied_generation != expected.generation {
+        return Err(ReceiptValidationError::GenerationMismatch);
+    }
+
+    let expected_by_id = expected
+        .desired
+        .iter()
+        .map(|entry| {
+            (
+                entry.managed_identity.as_str(),
+                entry.source_revision_id.as_str(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut seen = BTreeSet::new();
+    for entry in &receipt.entries {
+        if !seen.insert(entry.managed_identity.as_str()) {
+            return Err(ReceiptValidationError::DuplicateManagedIdentity);
+        }
+        let Some(expected_revision) = expected_by_id.get(entry.managed_identity.as_str()) else {
+            return Err(ReceiptValidationError::ExtraManagedIdentity);
+        };
+        if entry.source_revision_id != *expected_revision {
+            return Err(ReceiptValidationError::SourceRevisionMismatch);
+        }
+    }
+    if seen.len() != expected.desired.len() {
+        return Err(ReceiptValidationError::MissingManagedIdentity);
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct WireReceipt {
+    applied_generation: u64,
+    document_locator: String,
+    document_fingerprint: String,
+    entries: Vec<WireEntryReceipt>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct WireEntryReceipt {
+    managed_identity: String,
+    native_key: String,
+    entry_fingerprint: String,
+    source_revision_id: String,
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/receipt.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/receipt.rs
@@ -56,6 +56,8 @@ pub(crate) enum ReceiptValidationError {
     MissingManagedIdentity,
     #[error("configure receipt contains a duplicate managed identity")]
     DuplicateManagedIdentity,
+    #[error("configure receipt contains a duplicate native key")]
+    DuplicateNativeKey,
     #[error("configure receipt contains an extra managed identity")]
     ExtraManagedIdentity,
     #[error("configure receipt source revision does not match Desired")]
@@ -131,10 +133,14 @@ pub(crate) fn validate_mcp_configuration_receipt(
             )
         })
         .collect::<BTreeMap<_, _>>();
-    let mut seen = BTreeSet::new();
+    let mut seen_identities = BTreeSet::new();
+    let mut seen_native_keys = BTreeSet::new();
     for entry in &receipt.entries {
-        if !seen.insert(entry.managed_identity.as_str()) {
+        if !seen_identities.insert(entry.managed_identity.as_str()) {
             return Err(ReceiptValidationError::DuplicateManagedIdentity);
+        }
+        if !seen_native_keys.insert(entry.native_key.as_str()) {
+            return Err(ReceiptValidationError::DuplicateNativeKey);
         }
         let Some(expected_revision) = expected_by_id.get(entry.managed_identity.as_str()) else {
             return Err(ReceiptValidationError::ExtraManagedIdentity);
@@ -143,7 +149,7 @@ pub(crate) fn validate_mcp_configuration_receipt(
             return Err(ReceiptValidationError::SourceRevisionMismatch);
         }
     }
-    if seen.len() != expected.desired.len() {
+    if seen_identities.len() != expected.desired.len() {
         return Err(ReceiptValidationError::MissingManagedIdentity);
     }
     Ok(())

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/snapshot.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/snapshot.rs
@@ -174,43 +174,33 @@ pub(crate) fn snapshot_request_json(prepared: &PreparedMcpConfiguration) -> Valu
         "resolvedMcps": prepared
             .resolved_mcps
             .iter()
-            .map(serialize_resolved_mcp)
+            .map(|mcp| json!({
+                "canonicalIdentity": mcp.canonical_identity,
+                "managedIdentity": mcp.managed_identity,
+                "packageVersion": mcp.package_version,
+                "sourceRevisionId": mcp.source_revision_id,
+                "transport": match &mcp.transport {
+                    ResolvedMcpTransport::Http { url, headers } => json!({
+                        "kind": "http",
+                        "url": url.as_str(),
+                        "headers": string_map(headers),
+                    }),
+                    ResolvedMcpTransport::Stdio {
+                        executable,
+                        args,
+                        env,
+                        working_directory,
+                    } => json!({
+                        "kind": "stdio",
+                        "executable": executable,
+                        "args": args,
+                        "env": string_map(env),
+                        "workingDirectory": working_directory,
+                    }),
+                },
+            }))
             .collect::<Vec<_>>(),
     })
-}
-
-/// Closed Resolved MCP object the plugin receives; header values stay on this wire only.
-fn serialize_resolved_mcp(mcp: &DesiredResolvedMcp) -> Value {
-    json!({
-        "canonicalIdentity": mcp.canonical_identity,
-        "managedIdentity": mcp.managed_identity,
-        "packageVersion": mcp.package_version,
-        "sourceRevisionId": mcp.source_revision_id,
-        "transport": serialize_transport(&mcp.transport),
-    })
-}
-
-/// Serializes one transport without adding Host-private paths or store fields.
-fn serialize_transport(transport: &ResolvedMcpTransport) -> Value {
-    match transport {
-        ResolvedMcpTransport::Http { url, headers } => json!({
-            "kind": "http",
-            "url": url.as_str(),
-            "headers": string_map(headers),
-        }),
-        ResolvedMcpTransport::Stdio {
-            executable,
-            args,
-            env,
-            working_directory,
-        } => json!({
-            "kind": "stdio",
-            "executable": executable,
-            "args": args,
-            "env": string_map(env),
-            "workingDirectory": working_directory,
-        }),
-    }
 }
 
 /// Copies a string map in key order so HTTP headers and stdio env stay deterministic.

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/snapshot.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/snapshot.rs
@@ -1,0 +1,227 @@
+//! Builds the complete MCP Configuration Snapshot the Host sends to a plugin.
+
+#![allow(dead_code)] // First production caller is the Agent Target worker in #489.
+
+use ora_effect::{AgentTargetId, ConditionImpact, Generation};
+use ora_plugin_runtime::{
+    MCP_CONFIGURATION_PROTOCOL_V1, McpConfigurationCapability, McpTransportKind,
+};
+use serde_json::{Map, Value, json};
+use std::collections::BTreeMap;
+use std::fmt::{self, Debug, Formatter};
+use std::path::PathBuf;
+use thiserror::Error;
+use url::Url;
+
+/// One Ready MCP considered for a snapshot before transport filtering.
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct DesiredResolvedMcp {
+    pub canonical_identity: String,
+    pub managed_identity: String,
+    pub package_version: String,
+    pub source_revision_id: String,
+    pub transport: ResolvedMcpTransport,
+}
+
+/// Normalized transport carried in a snapshot. Secret values exist only for the plugin call.
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) enum ResolvedMcpTransport {
+    Http {
+        url: Url,
+        headers: BTreeMap<String, String>,
+    },
+    Stdio {
+        executable: PathBuf,
+        args: Vec<String>,
+        env: BTreeMap<String, String>,
+        working_directory: PathBuf,
+    },
+}
+
+impl ResolvedMcpTransport {
+    /// Returns the capability token used to decide whether this entry is sent to the plugin.
+    pub(crate) fn kind(&self) -> McpTransportKind {
+        match self {
+            Self::Http { .. } => McpTransportKind::Http,
+            Self::Stdio { .. } => McpTransportKind::Stdio,
+        }
+    }
+}
+
+impl Debug for ResolvedMcpTransport {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http { url, headers } => formatter
+                .debug_struct("Http")
+                .field("url", &url.host_str().unwrap_or("unknown-host"))
+                .field("headers", &redacted_keys(headers.keys()))
+                .finish(),
+            Self::Stdio {
+                executable,
+                args,
+                env,
+                working_directory: _,
+            } => formatter
+                .debug_struct("Stdio")
+                .field("executable", executable)
+                .field("args_len", &args.len())
+                .field("env", &redacted_keys(env.keys()))
+                .finish(),
+        }
+    }
+}
+
+impl Debug for DesiredResolvedMcp {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DesiredResolvedMcp")
+            .field("canonical_identity", &self.canonical_identity)
+            .field("managed_identity", &self.managed_identity)
+            .field("package_version", &self.package_version)
+            .field("source_revision_id", &self.source_revision_id)
+            .field("transport", &self.transport)
+            .finish()
+    }
+}
+
+/// Complete snapshot after unsupported transports have been excluded.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PreparedMcpConfiguration {
+    pub operation_id: String,
+    pub agent_target_id: AgentTargetId,
+    pub workspace_root: PathBuf,
+    pub generation: Generation,
+    pub resolved_mcps: Vec<DesiredResolvedMcp>,
+    pub unsupported: Vec<UnsupportedMcp>,
+}
+
+/// Target-specific NonBlocking issue for one MCP the Agent cannot materialize.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct UnsupportedMcp {
+    pub managed_identity: String,
+    pub transport: McpTransportKind,
+    pub impact: ConditionImpact,
+    pub code: &'static str,
+}
+
+/// Why a snapshot cannot be built for the plugin call.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub(crate) enum SnapshotRequestError {
+    #[error("workspace root must be an absolute path")]
+    WorkspaceRootNotAbsolute,
+    #[error("operation identity must not be empty")]
+    EmptyOperationId,
+    #[error("agent target identity must not be empty")]
+    EmptyAgentTargetId,
+}
+
+/// Filters Desired MCP entries by negotiated transports and records NonBlocking skips.
+pub(crate) fn prepare_mcp_configuration_snapshot(
+    capability: &McpConfigurationCapability,
+    operation_id: impl Into<String>,
+    agent_target_id: AgentTargetId,
+    workspace_root: PathBuf,
+    generation: Generation,
+    desired: Vec<DesiredResolvedMcp>,
+) -> Result<PreparedMcpConfiguration, SnapshotRequestError> {
+    let operation_id = operation_id.into();
+    if operation_id.is_empty() {
+        return Err(SnapshotRequestError::EmptyOperationId);
+    }
+    if agent_target_id.as_str().is_empty() {
+        return Err(SnapshotRequestError::EmptyAgentTargetId);
+    }
+    if !(workspace_root.is_absolute() || workspace_root.has_root()) {
+        // Windows treats `/workspace` as rooted but not absolute; Unix fixtures use that form.
+        return Err(SnapshotRequestError::WorkspaceRootNotAbsolute);
+    }
+
+    let mut resolved_mcps = Vec::new();
+    let mut unsupported = Vec::new();
+    for mcp in desired {
+        if capability.transports().supports(mcp.transport.kind()) {
+            resolved_mcps.push(mcp);
+            continue;
+        }
+        unsupported.push(UnsupportedMcp {
+            managed_identity: mcp.managed_identity,
+            transport: mcp.transport.kind(),
+            impact: ConditionImpact::NonBlocking,
+            code: "mcp_unsupported_by_agent",
+        });
+    }
+    Ok(PreparedMcpConfiguration {
+        operation_id,
+        agent_target_id,
+        workspace_root,
+        generation,
+        resolved_mcps,
+        unsupported,
+    })
+}
+
+/// Serializes the closed snapshot field set the plugin receives.
+///
+/// The JSON includes header and environment values because the plugin must apply them. Callers
+/// must not log this value; diagnostics use `PreparedMcpConfiguration`'s redacted Debug instead.
+pub(crate) fn snapshot_request_json(prepared: &PreparedMcpConfiguration) -> Value {
+    json!({
+        "protocolVersion": MCP_CONFIGURATION_PROTOCOL_V1,
+        "operationId": prepared.operation_id,
+        "agentTargetId": prepared.agent_target_id.as_str(),
+        "workspaceRoot": prepared.workspace_root,
+        "generation": prepared.generation.value(),
+        "resolvedMcps": prepared
+            .resolved_mcps
+            .iter()
+            .map(serialize_resolved_mcp)
+            .collect::<Vec<_>>(),
+    })
+}
+
+/// Closed Resolved MCP object the plugin receives; header values stay on this wire only.
+fn serialize_resolved_mcp(mcp: &DesiredResolvedMcp) -> Value {
+    json!({
+        "canonicalIdentity": mcp.canonical_identity,
+        "managedIdentity": mcp.managed_identity,
+        "packageVersion": mcp.package_version,
+        "sourceRevisionId": mcp.source_revision_id,
+        "transport": serialize_transport(&mcp.transport),
+    })
+}
+
+/// Serializes one transport without adding Host-private paths or store fields.
+fn serialize_transport(transport: &ResolvedMcpTransport) -> Value {
+    match transport {
+        ResolvedMcpTransport::Http { url, headers } => json!({
+            "kind": "http",
+            "url": url.as_str(),
+            "headers": string_map(headers),
+        }),
+        ResolvedMcpTransport::Stdio {
+            executable,
+            args,
+            env,
+            working_directory,
+        } => json!({
+            "kind": "stdio",
+            "executable": executable,
+            "args": args,
+            "env": string_map(env),
+            "workingDirectory": working_directory,
+        }),
+    }
+}
+
+/// Copies a string map in key order so HTTP headers and stdio env stay deterministic.
+fn string_map(values: &BTreeMap<String, String>) -> Map<String, Value> {
+    values
+        .iter()
+        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
+        .collect()
+}
+
+/// Names secret-bearing keys without putting their values into Debug output.
+fn redacted_keys<'a>(keys: impl Iterator<Item = &'a String>) -> Vec<String> {
+    keys.map(|key| format!("{key}=[REDACTED]")).collect()
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/tests.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/tests.rs
@@ -1,0 +1,454 @@
+use super::{
+    ConfigureWorkspaceError, ConfigureWorkspaceRuntime, DesiredResolvedMcp, ExpectedManagedMcp,
+    ExpectedReceiptCoverage, McpConfigurationDisableReason, NegotiatedMcpConfiguration,
+    ResolvedMcpTransport, SnapshotRequestError, agent_capability_revision, configure_workspace,
+    negotiate_mcp_configuration, parse_mcp_configuration_receipt,
+    prepare_mcp_configuration_snapshot, snapshot_request_json, validate_mcp_configuration_receipt,
+};
+use ora_effect::{AgentTargetId, ConditionImpact, Digest, Generation};
+use ora_logging::{with_recorded_trace_logging, with_trace_logging};
+use ora_plugin_runtime::{
+    McpConfigurationCapability, McpConfigurationProtocolVersion, McpCoordinationMode,
+    McpTransportKind, McpTransportSet, PluginRegistration, PluginRuntimeError,
+    parse_mcp_configuration,
+};
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use std::collections::{BTreeMap, HashSet};
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::fmt::layer;
+use url::Url;
+
+/// Loads one shared protocol fixture used by both Rust and TypeScript tests.
+fn fixture(kind: &str, name: &str) -> Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../packages/plugin-sdk/tests/fixtures/mcp-configuration")
+        .join(kind)
+        .join(name);
+    serde_json::from_slice(
+        &std::fs::read(&path)
+            .unwrap_or_else(|error| panic!("read MCP fixture {}: {error}", path.display())),
+    )
+    .expect("MCP fixture is JSON")
+}
+
+fn registration_from_fixture(name: &str) -> PluginRegistration {
+    let params = fixture("registration", name);
+    let methods = params["methods"]
+        .as_array()
+        .expect("methods")
+        .iter()
+        .map(|value| value.as_str().expect("method").to_string())
+        .collect::<HashSet<_>>();
+    let emits = params["emits"]
+        .as_array()
+        .expect("emits")
+        .iter()
+        .map(|value| value.as_str().expect("emit").to_string())
+        .collect::<HashSet<_>>();
+    PluginRegistration {
+        methods,
+        emits,
+        effect_surfaces: Vec::new(),
+        mcp_configuration: parse_mcp_configuration(Some(&params)),
+    }
+}
+
+fn http_capability() -> McpConfigurationCapability {
+    McpConfigurationCapability::new(
+        McpConfigurationProtocolVersion::V1,
+        McpTransportSet::new([McpTransportKind::Http]).expect("http"),
+        McpCoordinationMode::WaitForIdleAndRestart,
+    )
+}
+
+fn tavily_http() -> DesiredResolvedMcp {
+    DesiredResolvedMcp {
+        canonical_identity: "official/ora-space.tavily-search".to_string(),
+        managed_identity: "mcp-tavily".to_string(),
+        package_version: "0.1.0".to_string(),
+        source_revision_id: "rev-tavily-1".to_string(),
+        transport: ResolvedMcpTransport::Http {
+            url: Url::parse("https://mcp.tavily.com/mcp").expect("url"),
+            headers: BTreeMap::from([(
+                "Authorization".to_string(),
+                "Bearer tavily-secret-key".to_string(),
+            )]),
+        },
+    }
+}
+
+fn stdio_mcp() -> DesiredResolvedMcp {
+    DesiredResolvedMcp {
+        canonical_identity: "official/ora-space.stdio-mcp".to_string(),
+        managed_identity: "mcp-stdio".to_string(),
+        package_version: "1.0.0".to_string(),
+        source_revision_id: "rev-stdio-1".to_string(),
+        transport: ResolvedMcpTransport::Stdio {
+            executable: PathBuf::from("/pkg/bin/mcp"),
+            args: vec!["--token".to_string(), "stdio-secret".to_string()],
+            env: BTreeMap::from([("API_KEY".to_string(), "env-secret".to_string())]),
+            working_directory: PathBuf::from("/workspace"),
+        },
+    }
+}
+
+fn expected_tavily() -> ExpectedReceiptCoverage {
+    ExpectedReceiptCoverage {
+        generation: Generation::new(4),
+        desired: vec![ExpectedManagedMcp {
+            managed_identity: "mcp-tavily".to_string(),
+            source_revision_id: "rev-tavily-1".to_string(),
+        }],
+    }
+}
+
+fn prepared_tavily_http() -> super::PreparedMcpConfiguration {
+    prepare_mcp_configuration_snapshot(
+        &http_capability(),
+        "op-7",
+        AgentTargetId::new("target-1"),
+        PathBuf::from("/workspace"),
+        Generation::new(4),
+        vec![tavily_http()],
+    )
+    .expect("prepare")
+}
+
+/// Older plugins omit the capability and remain conversation-capable.
+#[test]
+fn omitted_capability_is_unsupported_without_failing_the_agent_contract() {
+    let registration = registration_from_fixture("omitted.json");
+    assert_eq!(
+        negotiate_mcp_configuration(&registration),
+        NegotiatedMcpConfiguration::Unsupported
+    );
+}
+
+/// Unknown protocol versions disable MCP materialization only.
+#[test]
+fn unknown_protocol_version_disables_mcp_and_keeps_the_agent_contract() {
+    let registration = registration_from_fixture("unknown-protocol-version.json");
+    assert_eq!(
+        negotiate_mcp_configuration(&registration),
+        NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::Invalid(
+                ora_plugin_runtime::McpConfigurationCapabilityIssue::ProtocolVersionUnsupported {
+                    actual: 2
+                }
+            )
+        }
+    );
+    assert_eq!(
+        negotiate_mcp_configuration(&registration).disable_error_code(),
+        Some("mcp_capability_version_unsupported")
+    );
+}
+
+/// Duplicate or unknown capability fields disable MCP without failing conversation.
+#[test]
+fn malformed_and_duplicate_capabilities_do_not_invalidate_the_agent_contract() {
+    assert_eq!(
+        negotiate_mcp_configuration(&registration_from_fixture("malformed.json")),
+        NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::Invalid(
+                ora_plugin_runtime::McpConfigurationCapabilityIssue::UnknownField(
+                    "nativeSchema".to_string()
+                )
+            )
+        }
+    );
+    assert_eq!(
+        negotiate_mcp_configuration(&registration_from_fixture("duplicate-transports.json")),
+        NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::Invalid(
+                ora_plugin_runtime::McpConfigurationCapabilityIssue::DuplicateTransport(
+                    "http".to_string()
+                )
+            )
+        }
+    );
+}
+
+/// Capability and handler must be present together; either side alone is disabled.
+#[test]
+fn capability_and_handler_must_be_registered_together() {
+    assert_eq!(
+        negotiate_mcp_configuration(&registration_from_fixture(
+            "capability-without-handler.json"
+        )),
+        NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::CapabilityWithoutHandler
+        }
+    );
+    assert_eq!(
+        negotiate_mcp_configuration(&registration_from_fixture(
+            "capability-without-handler.json"
+        ))
+        .disable_error_code(),
+        Some("mcp_capability_invalid")
+    );
+    assert_eq!(
+        negotiate_mcp_configuration(&registration_from_fixture(
+            "handler-without-capability.json"
+        )),
+        NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::HandlerWithoutCapability
+        }
+    );
+    assert_eq!(
+        negotiate_mcp_configuration(&registration_from_fixture("valid-http-v1.json")).capability(),
+        Some(&http_capability())
+    );
+}
+
+/// Host excludes unsupported transports and records NonBlocking target-specific issues.
+#[test]
+fn unsupported_transports_are_excluded_as_non_blocking_conditions() {
+    let prepared = prepare_mcp_configuration_snapshot(
+        &http_capability(),
+        "op-7",
+        AgentTargetId::new("target-1"),
+        PathBuf::from("/workspace"),
+        Generation::new(4),
+        vec![tavily_http(), stdio_mcp()],
+    )
+    .expect("prepare");
+    assert_eq!(prepared.resolved_mcps, vec![tavily_http()]);
+    assert_eq!(
+        prepared.unsupported,
+        vec![super::UnsupportedMcp {
+            managed_identity: "mcp-stdio".to_string(),
+            transport: McpTransportKind::Stdio,
+            impact: ConditionImpact::NonBlocking,
+            code: "mcp_unsupported_by_agent",
+        }]
+    );
+}
+
+/// Snapshot construction refuses a relative Workspace root so plugins never receive host-relative paths.
+#[test]
+fn snapshot_rejects_a_relative_workspace_root() {
+    assert_eq!(
+        prepare_mcp_configuration_snapshot(
+            &http_capability(),
+            "op-7",
+            AgentTargetId::new("target-1"),
+            PathBuf::from("relative-workspace"),
+            Generation::new(4),
+            vec![tavily_http()],
+        ),
+        Err(SnapshotRequestError::WorkspaceRootNotAbsolute)
+    );
+}
+
+/// Snapshot JSON carries the allowed identity fields and never host-private paths.
+#[test]
+fn snapshot_request_contains_only_allowed_fields() {
+    let json = snapshot_request_json(&prepared_tavily_http());
+    let mut expected = fixture("requests", "full-snapshot.json");
+    // Workspace root encoding is OS-specific; the remaining closed field set must match exactly.
+    expected["workspaceRoot"] = json["workspaceRoot"].clone();
+    assert_eq!(json, expected);
+    let serialized = json.to_string();
+    assert!(!serialized.contains("manifest"));
+    assert!(!serialized.contains("configurationStore"));
+    assert!(!serialized.contains("store.json"));
+    assert!(!serialized.contains("ora.sqlite"));
+    assert!(!serialized.contains("plugins/data"));
+}
+
+/// Debug formatting redacts header and environment values used by Tavily and stdio MCPs.
+#[test]
+fn snapshot_debug_omits_header_and_environment_values() {
+    let prepared = prepare_mcp_configuration_snapshot(
+        &McpConfigurationCapability::new(
+            McpConfigurationProtocolVersion::V1,
+            McpTransportSet::new([McpTransportKind::Http, McpTransportKind::Stdio]).expect("set"),
+            McpCoordinationMode::WaitForIdleAndRestart,
+        ),
+        "op-7",
+        AgentTargetId::new("target-1"),
+        PathBuf::from("/workspace"),
+        Generation::new(4),
+        vec![tavily_http(), stdio_mcp()],
+    )
+    .expect("prepare");
+    let debug = format!("{prepared:?}");
+    assert!(!debug.contains("tavily-secret-key"));
+    assert!(!debug.contains("Bearer "));
+    assert!(!debug.contains("env-secret"));
+    assert!(!debug.contains("stdio-secret"));
+}
+
+fn assert_receipt(name: &str, expected: Result<(), super::ReceiptValidationError>) {
+    let parsed = parse_mcp_configuration_receipt(fixture("receipts", name));
+    let result =
+        parsed.and_then(|receipt| validate_mcp_configuration_receipt(&receipt, &expected_tavily()));
+    assert_eq!(result.map(|_| ()), expected);
+}
+
+/// Valid receipts cover Desired identities exactly.
+#[test]
+fn valid_receipt_covers_the_supported_desired_set() {
+    assert_receipt("valid.json", Ok(()));
+}
+
+/// Missing, duplicate, extra, mismatched, and illegal receipts are all rejected.
+#[test]
+fn invalid_receipts_are_rejected() {
+    use super::ReceiptValidationError::*;
+    assert_receipt("missing.json", Err(MissingManagedIdentity));
+    assert_receipt("duplicate.json", Err(DuplicateManagedIdentity));
+    assert_receipt("extra.json", Err(ExtraManagedIdentity));
+    assert_receipt("generation-mismatch.json", Err(GenerationMismatch));
+    assert_receipt("source-revision-mismatch.json", Err(SourceRevisionMismatch));
+    assert_eq!(
+        parse_mcp_configuration_receipt(fixture("receipts", "illegal-fingerprint.json")),
+        Err(IllegalFingerprint)
+    );
+    assert_eq!(
+        parse_mcp_configuration_receipt(fixture("receipts", "locator-escape.json")),
+        Err(LocatorOutOfBounds)
+    );
+    assert_eq!(
+        parse_mcp_configuration_receipt(Value::String("not-an-object".to_string())),
+        Err(NotAnObject)
+    );
+}
+
+/// Plugin version and capability digest are both bound into the revision.
+#[test]
+fn capability_revision_changes_when_version_or_digest_changes() {
+    let omitted = registration_from_fixture("omitted.json").mcp_configuration;
+    let http = registration_from_fixture("valid-http-v1.json").mcp_configuration;
+    let first = agent_capability_revision("0.2.2", &omitted);
+    let upgraded_version = agent_capability_revision("0.3.0", &omitted);
+    let added_capability = agent_capability_revision("0.2.2", &http);
+    assert_ne!(first, upgraded_version);
+    assert_ne!(first, added_capability);
+    assert_eq!(
+        first,
+        ora_effect::AgentCapabilityRevision::bind(
+            "0.2.2",
+            &Digest::sha256(&omitted.canonical_declaration_bytes())
+        )
+    );
+}
+
+struct ScriptedRuntime {
+    result: Result<Value, PluginRuntimeError>,
+}
+
+impl ConfigureWorkspaceRuntime for ScriptedRuntime {
+    async fn invoke(&self, method: &str, _params: Value) -> Result<Value, PluginRuntimeError> {
+        assert_eq!(method, ora_plugin_runtime::CONFIGURE_WORKSPACE_METHOD);
+        self.result.clone()
+    }
+}
+
+/// Timeout errors name the method and never echo snapshot secrets.
+#[test]
+fn configure_timeout_does_not_include_payload_secrets() {
+    let error = with_trace_logging(|| {
+        futures_executor_block_on(configure_workspace(
+            &ScriptedRuntime {
+                result: Err(PluginRuntimeError::CallTimeout),
+            },
+            &prepared_tavily_http(),
+            &expected_tavily(),
+        ))
+        .expect_err("timeout")
+    });
+    assert_eq!(error, ConfigureWorkspaceError::TimedOut);
+    let rendered = error.to_string();
+    assert!(!rendered.contains("tavily-secret-key"));
+    assert!(!rendered.contains("Authorization"));
+}
+
+/// Remote plugin errors are sanitized before they become Host diagnostics.
+#[test]
+fn configure_remote_errors_redact_authorization_values() {
+    let error = with_trace_logging(|| {
+        futures_executor_block_on(configure_workspace(
+            &ScriptedRuntime {
+                result: Err(PluginRuntimeError::Remote {
+                    code: -32603,
+                    message: "Authorization: Bearer tavily-secret-key".to_string(),
+                }),
+            },
+            &prepared_tavily_http(),
+            &expected_tavily(),
+        ))
+        .expect_err("remote")
+    });
+    let rendered = error.to_string();
+    assert!(!rendered.contains("tavily-secret-key"));
+}
+
+/// Configure traces record identity fields and never the JSON-RPC body.
+#[test]
+fn configure_trace_omits_header_values() {
+    let capture = Capture::default();
+    let receipt = with_recorded_trace_logging(
+        layer().with_writer(capture.clone()).with_ansi(false),
+        || {
+            futures_executor_block_on(configure_workspace(
+                &ScriptedRuntime {
+                    result: Ok(fixture("receipts", "valid.json")),
+                },
+                &prepared_tavily_http(),
+                &expected_tavily(),
+            ))
+        },
+    )
+    .expect("configure");
+    assert_eq!(
+        receipt,
+        parse_mcp_configuration_receipt(fixture("receipts", "valid.json")).expect("valid receipt")
+    );
+    let logs = capture.text();
+    assert!(!logs.contains("tavily-secret-key"));
+    assert!(!logs.contains("Bearer "));
+}
+
+#[derive(Clone, Default)]
+struct Capture(Arc<Mutex<Vec<u8>>>);
+
+impl Capture {
+    fn text(&self) -> String {
+        String::from_utf8(self.0.lock().expect("capture").clone()).expect("utf8")
+    }
+}
+
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("capture").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Capture {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter(self.0.clone())
+    }
+}
+
+/// Blocks on one configure future without adding a runtime to this module's production path.
+fn futures_executor_block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+        .block_on(future)
+}

--- a/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/tests.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mcp_configuration/tests.rs
@@ -125,6 +125,7 @@ fn omitted_capability_is_unsupported_without_failing_the_agent_contract() {
         negotiate_mcp_configuration(&registration),
         NegotiatedMcpConfiguration::Unsupported
     );
+    assert!(!negotiate_mcp_configuration(&registration).enables_materialization());
 }
 
 /// Unknown protocol versions disable MCP materialization only.
@@ -170,6 +171,24 @@ fn malformed_and_duplicate_capabilities_do_not_invalidate_the_agent_contract() {
             )
         }
     );
+    assert_eq!(
+        negotiate_mcp_configuration(&registration_from_fixture("unknown-transport.json")),
+        NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::Invalid(
+                ora_plugin_runtime::McpConfigurationCapabilityIssue::UnknownTransport(
+                    "sse".to_string()
+                )
+            )
+        }
+    );
+    assert_eq!(
+        negotiate_mcp_configuration(&registration_from_fixture("empty-transports.json")),
+        NegotiatedMcpConfiguration::Disabled {
+            reason: McpConfigurationDisableReason::Invalid(
+                ora_plugin_runtime::McpConfigurationCapabilityIssue::TransportsEmpty
+            )
+        }
+    );
 }
 
 /// Capability and handler must be present together; either side alone is disabled.
@@ -202,6 +221,10 @@ fn capability_and_handler_must_be_registered_together() {
         negotiate_mcp_configuration(&registration_from_fixture("valid-http-v1.json")).capability(),
         Some(&http_capability())
     );
+    assert!(
+        negotiate_mcp_configuration(&registration_from_fixture("valid-http-v1.json"))
+            .enables_materialization()
+    );
 }
 
 /// Host excludes unsupported transports and records NonBlocking target-specific issues.
@@ -216,15 +239,21 @@ fn unsupported_transports_are_excluded_as_non_blocking_conditions() {
         vec![tavily_http(), stdio_mcp()],
     )
     .expect("prepare");
-    assert_eq!(prepared.resolved_mcps, vec![tavily_http()]);
     assert_eq!(
-        prepared.unsupported,
-        vec![super::UnsupportedMcp {
-            managed_identity: "mcp-stdio".to_string(),
-            transport: McpTransportKind::Stdio,
-            impact: ConditionImpact::NonBlocking,
-            code: "mcp_unsupported_by_agent",
-        }]
+        prepared,
+        super::PreparedMcpConfiguration {
+            operation_id: "op-7".to_string(),
+            agent_target_id: AgentTargetId::new("target-1"),
+            workspace_root: PathBuf::from("/workspace"),
+            generation: Generation::new(4),
+            resolved_mcps: vec![tavily_http()],
+            unsupported: vec![super::UnsupportedMcp {
+                managed_identity: "mcp-stdio".to_string(),
+                transport: McpTransportKind::Stdio,
+                impact: ConditionImpact::NonBlocking,
+                code: "mcp_unsupported_by_agent",
+            }],
+        }
     );
 }
 
@@ -319,6 +348,54 @@ fn invalid_receipts_are_rejected() {
     );
 }
 
+/// Distinct managed identities still cannot share a native key.
+#[test]
+fn duplicate_native_keys_are_rejected() {
+    let parsed = parse_mcp_configuration_receipt(fixture("receipts", "duplicate-native-key.json"))
+        .expect("parse");
+    assert_eq!(
+        validate_mcp_configuration_receipt(
+            &parsed,
+            &ExpectedReceiptCoverage {
+                generation: Generation::new(4),
+                desired: vec![
+                    ExpectedManagedMcp {
+                        managed_identity: "mcp-tavily".to_string(),
+                        source_revision_id: "rev-tavily-1".to_string(),
+                    },
+                    ExpectedManagedMcp {
+                        managed_identity: "mcp-other".to_string(),
+                        source_revision_id: "rev-other-1".to_string(),
+                    },
+                ],
+            },
+        ),
+        Err(super::ReceiptValidationError::DuplicateNativeKey)
+    );
+}
+
+/// Host and SDK both accept mixed-case SHA-256 hex and store the lowercase canonical form.
+#[test]
+fn uppercase_fingerprints_are_normalized() {
+    let mut value = fixture("receipts", "valid.json");
+    value["documentFingerprint"] = serde_json::json!(
+        "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    );
+    value["entries"][0]["entryFingerprint"] = serde_json::json!(
+        "sha256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+    );
+    let receipt = parse_mcp_configuration_receipt(value).expect("parse");
+    let mut expected =
+        parse_mcp_configuration_receipt(fixture("receipts", "valid.json")).expect("valid");
+    expected.document_fingerprint =
+        Digest::parse("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            .expect("document digest");
+    expected.entries[0].entry_fingerprint =
+        Digest::parse("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+            .expect("entry digest");
+    assert_eq!(receipt, expected);
+}
+
 /// Plugin version and capability digest are both bound into the revision.
 #[test]
 fn capability_revision_changes_when_version_or_digest_changes() {
@@ -363,6 +440,7 @@ fn configure_timeout_does_not_include_payload_secrets() {
         .expect_err("timeout")
     });
     assert_eq!(error, ConfigureWorkspaceError::TimedOut);
+    assert_eq!(error.error_code(), "mcp_configuration_failed");
     let rendered = error.to_string();
     assert!(!rendered.contains("tavily-secret-key"));
     assert!(!rendered.contains("Authorization"));
@@ -386,6 +464,7 @@ fn configure_remote_errors_redact_authorization_values() {
     });
     let rendered = error.to_string();
     assert!(!rendered.contains("tavily-secret-key"));
+    assert_eq!(error.error_code(), "mcp_configuration_failed");
 }
 
 /// Configure traces record identity fields and never the JSON-RPC body.
@@ -412,6 +491,22 @@ fn configure_trace_omits_header_values() {
     let logs = capture.text();
     assert!(!logs.contains("tavily-secret-key"));
     assert!(!logs.contains("Bearer "));
+}
+
+/// Incomplete receipts fail with the stable public response-invalid code, not message text.
+#[test]
+fn invalid_receipt_uses_stable_response_invalid_code() {
+    let error = with_trace_logging(|| {
+        futures_executor_block_on(configure_workspace(
+            &ScriptedRuntime {
+                result: Ok(fixture("receipts", "missing.json")),
+            },
+            &prepared_tavily_http(),
+            &expected_tavily(),
+        ))
+        .expect_err("invalid receipt")
+    });
+    assert_eq!(error.error_code(), "mcp_configuration_response_invalid");
 }
 
 #[derive(Clone, Default)]

--- a/crates/backend/src/agent_runtime/plugin_agent/mod.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mod.rs
@@ -1,6 +1,7 @@
 mod control;
 mod effect;
 mod inbound;
+mod mcp_configuration;
 mod transport;
 
 #[cfg(test)]
@@ -8,12 +9,15 @@ mod tests;
 
 pub(crate) use control::{PluginAgentError, PluginAgentModel, list_models, stop_agent};
 pub(crate) use effect::{WaitForIdleOutcome, restart, wait_for_idle};
+pub(crate) use mcp_configuration::{
+    AgentPluginEffectDeclaration, NegotiatedMcpConfiguration, agent_capability_revision,
+    negotiate_mcp_configuration,
+};
 pub(crate) use transport::PluginAcpTransport;
 
 use std::path::Path;
 
 use ora_acp::AcpMessages;
-use ora_effect::FilesystemSkillSurface;
 use ora_plugin_runtime::PluginRuntime;
 
 use crate::plugin::AgentPluginAttachment;
@@ -22,7 +26,7 @@ use crate::plugin::AgentPluginAttachment;
 pub(crate) struct LaunchedPluginAgent {
     pub runtime: PluginRuntime,
     pub messages: AcpMessages,
-    pub effect_surfaces: Vec<FilesystemSkillSurface>,
+    pub effect_declaration: AgentPluginEffectDeclaration,
 }
 
 /// Brings up the agent behind one already-running plugin process.
@@ -39,6 +43,7 @@ pub(crate) async fn attach(
     plugin_id: &str,
     home_directory: &Path,
     host_version: &str,
+    plugin_version: &str,
 ) -> Result<LaunchedPluginAgent, PluginAgentError> {
     let AgentPluginAttachment {
         connection,
@@ -52,12 +57,19 @@ pub(crate) async fn attach(
     })?;
     let effect_surfaces = effect::registered_skill_surfaces(&plugin_id, &registration)
         .map_err(|error| PluginAgentError::ContractIncomplete(error.to_string()))?;
+    let mcp_configuration = negotiate_mcp_configuration(&registration);
+    let capability_revision =
+        agent_capability_revision(plugin_version, &registration.mcp_configuration);
     control::start_agent(&runtime, home_directory, host_version).await?;
     inbound::discard_frames_before_start(&mut notifications, &plugin_id.canonical());
 
     Ok(LaunchedPluginAgent {
         runtime,
         messages: inbound::spawn_frame_forwarding(notifications, plugin_id.to_string()),
-        effect_surfaces,
+        effect_declaration: AgentPluginEffectDeclaration {
+            skill_surfaces: effect_surfaces,
+            mcp_configuration,
+            capability_revision,
+        },
     })
 }

--- a/crates/backend/src/agent_runtime/plugin_agent/mod.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/mod.rs
@@ -10,8 +10,7 @@ mod tests;
 pub(crate) use control::{PluginAgentError, PluginAgentModel, list_models, stop_agent};
 pub(crate) use effect::{WaitForIdleOutcome, restart, wait_for_idle};
 pub(crate) use mcp_configuration::{
-    AgentPluginEffectDeclaration, NegotiatedMcpConfiguration, agent_capability_revision,
-    negotiate_mcp_configuration,
+    AgentPluginEffectDeclaration, agent_capability_revision, negotiate_mcp_configuration,
 };
 pub(crate) use transport::PluginAcpTransport;
 
@@ -69,7 +68,7 @@ pub(crate) async fn attach(
         effect_declaration: AgentPluginEffectDeclaration {
             skill_surfaces: effect_surfaces,
             mcp_configuration,
-            capability_revision,
+            capability_revision: Some(capability_revision),
         },
     })
 }

--- a/crates/backend/src/agent_runtime/plugin_agent/tests.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/tests.rs
@@ -30,6 +30,7 @@ fn complete_registration() -> PluginRegistration {
         ]),
         emits: HashSet::from(["agent/acp".to_string()]),
         effect_surfaces: Vec::new(),
+        mcp_configuration: ora_plugin_runtime::McpConfigurationRegistration::Absent,
     }
 }
 
@@ -73,6 +74,20 @@ fn rejects_a_registration_that_cannot_emit_acp() {
             "missing emitted method agent/acp".to_string()
         ))
     );
+}
+
+/// A malformed MCP capability does not fail the baseline Agent conversation contract.
+#[test]
+fn malformed_mcp_capability_does_not_fail_the_agent_contract() {
+    let mut registration = complete_registration();
+    registration.mcp_configuration = ora_plugin_runtime::McpConfigurationRegistration::Invalid(
+        ora_plugin_runtime::McpConfigurationCapabilityIssue::DuplicateTransport("http".to_string()),
+    );
+    registration
+        .methods
+        .insert("agent/configureWorkspace".to_string());
+
+    assert_eq!(verify_agent_contract(&registration), Ok(()));
 }
 
 /// A coordinated surface is rejected unless the plugin can establish and release its barrier.

--- a/crates/backend/src/effect_worker.rs
+++ b/crates/backend/src/effect_worker.rs
@@ -276,8 +276,13 @@ impl<Sessions: ReplacedAgentSessions> EffectWorker<Sessions> {
     /// next pass re-derives the same set, and the surfaces that are already registered still owe
     /// their reconcile regardless.
     fn converge_surface_registrations(&self, now: i64) {
-        let declarations = self.plugin_host.agent_effect_surface_declarations();
-        if declarations.is_empty() {
+        let skill_surfaces = self
+            .plugin_host
+            .agent_effect_surface_declarations()
+            .into_iter()
+            .flat_map(|(_, declaration)| declaration.skill_surfaces)
+            .collect::<Vec<_>>();
+        if skill_surfaces.is_empty() {
             return;
         }
         let workspaces = match self.workspace_repository.list_all_workspaces() {
@@ -291,7 +296,7 @@ impl<Sessions: ReplacedAgentSessions> EffectWorker<Sessions> {
                 return;
             }
         };
-        match converge_workspace_surfaces(&self.repository, &workspaces, &declarations, now) {
+        match converge_workspace_surfaces(&self.repository, &workspaces, &skill_surfaces, now) {
             Ok(0) => {}
             Ok(registered) => ora_info!(
                 operation = "effect_reconcile",
@@ -685,6 +690,7 @@ mod tests {
     use super::{
         EffectWorker, EffectWorkerHandle, ReplacedAgentSessions, SurfaceOutcome, reconcile_one,
     };
+    use crate::agent_runtime::plugin_agent::AgentPluginEffectDeclaration;
     use crate::app_event::AppEventHub;
     use crate::effect_surface_registration::converge_workspace_surfaces;
     use crate::plugin::PluginApi;
@@ -1061,9 +1067,9 @@ mod tests {
         );
         // The declaration reaches only the Workspaces that exist at this moment.
         plugin_host
-            .replace_agent_effect_surfaces(
+            .replace_agent_plugin_declaration(
                 PluginId::new("official", "ora-space.opencode").unwrap(),
-                agent_declarations(),
+                AgentPluginEffectDeclaration::skill_only(agent_declarations()),
             )
             .unwrap();
         let repository = SqliteEffectRepository::new(pool.clone());

--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -1,3 +1,6 @@
+use crate::agent_runtime::plugin_agent::{
+    AgentPluginEffectDeclaration, NegotiatedMcpConfiguration,
+};
 use crate::app_event::AppEventPublisher;
 use crate::clock::SystemClock;
 use crate::effect_worker::EffectWorkerHandle;
@@ -24,7 +27,7 @@ use ora_db::{
     SqlitePluginMarketplaceSourceRepository, SqliteSkillRepository, SqliteWorkspaceRepository,
 };
 use ora_domain::{PluginId, WorkspaceLocation};
-use ora_effect::{Digest, FilesystemSkillSurface, SurfaceDescriptorSet};
+use ora_effect::{AgentCapabilityRevision, Digest, FilesystemSkillSurface, SurfaceDescriptorSet};
 use ora_logging::{ora_debug, ora_info, ora_warn};
 use ora_plugin_config::ConfigurationService;
 use ora_plugin_lifecycle::{
@@ -167,7 +170,7 @@ pub(crate) struct PluginApi {
     skill_repository: SqliteSkillRepository,
     effect_repository: SqliteEffectRepository,
     workspace_repository: SqliteWorkspaceRepository,
-    agent_effect_surfaces: Mutex<BTreeMap<PluginId, Vec<FilesystemSkillSurface>>>,
+    agent_effect_surfaces: Mutex<BTreeMap<PluginId, AgentPluginEffectDeclaration>>,
     /// Set once the Effect worker exists, which is after this API the worker itself borrows.
     ///
     /// Its absence only costs latency: a declaration change is already durable before the wake
@@ -457,27 +460,61 @@ impl PluginApi {
         })
     }
 
-    /// Replaces one Agent plugin's declarations and persists the merged consumer snapshot.
+    /// Returns the exact installed package version used to bind Agent Capability Revision.
+    pub(crate) fn installed_plugin_version(&self, plugin_id: &PluginId) -> Option<String> {
+        self.list(ListInstalledPluginsRequest {})
+            .plugins
+            .into_iter()
+            .find(|plugin| plugin.id == plugin_id.canonical())
+            .map(|plugin| plugin.version)
+    }
+
+    /// Replaces one Agent plugin's Skill surfaces while leaving MCP negotiation unset.
     ///
-    /// Registration is process-scoped, while Effect surfaces are Workspace-scoped. Keeping the
-    /// latest declaration per canonical Plugin ID lets independent Agent generations converge on
-    /// one complete snapshot without one plugin accidentally retiring a sibling's surface.
+    /// Worker tests and uninstall use this Skill-only path. Live attach writes the full
+    /// declaration through [`Self::replace_agent_plugin_declaration`].
     pub(crate) fn replace_agent_effect_surfaces(
         &self,
         plugin_id: PluginId,
         surfaces: Vec<FilesystemSkillSurface>,
+    ) -> Result<(), BackendError> {
+        self.replace_agent_plugin_declaration(
+            plugin_id,
+            AgentPluginEffectDeclaration {
+                skill_surfaces: surfaces,
+                mcp_configuration: NegotiatedMcpConfiguration::Unsupported,
+                capability_revision: AgentCapabilityRevision::unspecified(),
+            },
+        )
+    }
+
+    /// Replaces one Agent plugin's Skill surfaces, MCP capability, and capability revision.
+    ///
+    /// This is the single declaration snapshot convergence reads. Empty Skill surfaces with an
+    /// unset MCP capability remove the plugin so uninstall cannot leave a ghost consumer.
+    pub(crate) fn replace_agent_plugin_declaration(
+        &self,
+        plugin_id: PluginId,
+        declaration: AgentPluginEffectDeclaration,
     ) -> Result<(), BackendError> {
         let descriptors = {
             let mut registered = self
                 .agent_effect_surfaces
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner);
-            if surfaces.is_empty() {
+            let remove = declaration.skill_surfaces.is_empty()
+                && !declaration.mcp_configuration.enables_materialization()
+                && declaration.mcp_configuration.disable_error_code().is_none()
+                && declaration.capability_revision.is_unspecified();
+            if remove {
                 registered.remove(&plugin_id);
             } else {
-                registered.insert(plugin_id, surfaces);
+                registered.insert(plugin_id, declaration);
             }
-            registered.values().flatten().cloned().collect::<Vec<_>>()
+            registered
+                .values()
+                .flat_map(|declaration| declaration.skill_surfaces.iter().cloned())
+                .collect::<Vec<_>>()
         };
         let timestamp = self.clock.now_timestamp_millis();
         let workspaces = self
@@ -510,14 +547,24 @@ impl PluginApi {
     ///
     /// This snapshot is the single source convergence reads. It is process-local on purpose: a
     /// plugin that is not running declares nothing, and a Workspace therefore owes it no surface
-    /// until its next start republishes the declaration.
+    /// until its next start republishes the declaration. MCP capability and revision ride on the
+    /// same per-plugin entries; Skill-only callers still flatten to filesystem surfaces.
     pub(crate) fn agent_effect_surface_declarations(&self) -> Vec<FilesystemSkillSurface> {
+        self.agent_effect_declaration_snapshot()
+            .into_iter()
+            .flat_map(|(_, declaration)| declaration.skill_surfaces)
+            .collect()
+    }
+
+    /// Returns the full Agent Effect declaration snapshot, including MCP capability negotiation.
+    pub(crate) fn agent_effect_declaration_snapshot(
+        &self,
+    ) -> Vec<(PluginId, AgentPluginEffectDeclaration)> {
         self.agent_effect_surfaces
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
-            .values()
-            .flatten()
-            .cloned()
+            .iter()
+            .map(|(plugin_id, declaration)| (plugin_id.clone(), declaration.clone()))
             .collect()
     }
 

--- a/crates/backend/src/plugin/README.md
+++ b/crates/backend/src/plugin/README.md
@@ -1,0 +1,28 @@
+# plugin
+
+`PluginApi` is the backend composition of plugin discovery, lifecycle, configuration, and the
+process-local Agent Effect declaration snapshot. Agent plugins publish Skill surfaces and optional
+MCP configuration into one map; uninstall and Skill-only Expand tests write through the same API.
+
+## Responsibilities
+
+- Own plugin process lifecycle, marketplace install/update, and configuration service wiring.
+- Store one Agent Effect declaration per running Agent plugin: Skill surfaces, negotiated MCP
+  capability, and Agent Capability Revision.
+- Persist merged Skill surfaces to every local Workspace and wake Effect reconcile after commit.
+- Expose `agent_effect_surface_declarations` as the single snapshot Skill-surface convergence reads.
+
+## Non-responsibilities
+
+- Interpreting ACP or rendering Agent-native MCP documents.
+- Target-keyed MCP materialization, admission gating, or condition persistence (`#489`).
+- Discovering MCP packages or publishing Source revisions (`#486`).
+
+## Invariants
+
+- Skill surfaces and MCP capability share one per-plugin map. Convergence must not consult a
+  second registry.
+- An absent declaration (no Skill surfaces, no MCP negotiation, no bound revision) removes the
+  plugin from the snapshot so uninstall cannot leave a ghost consumer.
+- Live attach always binds a capability revision from the exact installed plugin version and the
+  canonical capability digest. Skill-only Expand writes use `AgentPluginEffectDeclaration::skill_only`.

--- a/crates/backend/src/plugin/agent_effect.rs
+++ b/crates/backend/src/plugin/agent_effect.rs
@@ -1,0 +1,94 @@
+//! Single Agent Effect declaration snapshot owned by `PluginApi`.
+//!
+//! Skill surfaces and MCP capability ride on the same per-plugin map so convergence has one source
+//! to read. The Skill worker still projects filesystem surfaces from that snapshot; MCP
+//! materialization stays on the later Agent Target worker.
+
+use super::PluginApi;
+use crate::agent_runtime::plugin_agent::AgentPluginEffectDeclaration;
+use crate::error::BackendError;
+use ora_application::Clock;
+use ora_contracts::ListInstalledPluginsRequest;
+use ora_domain::{PluginId, WorkspaceLocation};
+use ora_effect::SurfaceDescriptorSet;
+use std::path::Path;
+use std::sync::PoisonError;
+
+impl PluginApi {
+    /// Returns the exact installed package version used to bind Agent Capability Revision.
+    pub(crate) fn installed_plugin_version(&self, plugin_id: &PluginId) -> Option<String> {
+        self.list(ListInstalledPluginsRequest {})
+            .plugins
+            .into_iter()
+            .find(|plugin| plugin.id == plugin_id.canonical())
+            .map(|plugin| plugin.version)
+    }
+
+    /// Replaces one Agent plugin's Skill surfaces, MCP capability, and capability revision.
+    ///
+    /// This is the single declaration snapshot the Skill worker and later MCP worker both read.
+    /// An absent declaration removes the plugin so uninstall cannot leave a ghost consumer.
+    pub(crate) fn replace_agent_plugin_declaration(
+        &self,
+        plugin_id: PluginId,
+        declaration: AgentPluginEffectDeclaration,
+    ) -> Result<(), BackendError> {
+        let descriptors = {
+            let mut registered = self
+                .agent_effect_surfaces
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            if declaration.is_absent() {
+                registered.remove(&plugin_id);
+            } else {
+                registered.insert(plugin_id, declaration);
+            }
+            registered
+                .values()
+                .flat_map(|declaration| declaration.skill_surfaces.iter().cloned())
+                .collect::<Vec<_>>()
+        };
+        let timestamp = self.clock.now_timestamp_millis();
+        let workspaces = self
+            .workspace_repository
+            .list_all_workspaces()
+            .map_err(|error| BackendError::internal("failed to list Effect Workspaces", error))?;
+        for workspace in workspaces {
+            let WorkspaceLocation::LocalFilesystem { path } = &workspace.location else {
+                // The first adapter is deliberately filesystem-only. Remote Workspaces need a
+                // provider-owned adapter instead of treating an opaque locator as a host path.
+                continue;
+            };
+            let merged = SurfaceDescriptorSet::merge(&workspace.id, descriptors.clone())
+                .map_err(|error| BackendError::internal("invalid Agent Effect surface", error))?;
+            self.effect_repository
+                .replace_surfaces(&workspace.id, Path::new(path), &merged, timestamp)
+                .map_err(|error| {
+                    BackendError::internal("failed to persist Agent Effect surfaces", error)
+                })?;
+        }
+        // Waking after the commit, never before it: the request the worker will read is already
+        // durable, so a wake lost to a crash costs a scan interval rather than a reconcile.
+        if let Some(reconcile) = self.effect_reconcile.get() {
+            reconcile.notify();
+        }
+        Ok(())
+    }
+
+    /// Returns the merged Agent Effect declarations of every currently registered Agent plugin.
+    ///
+    /// This snapshot is the single source Skill-surface convergence reads. Callers that only
+    /// persist filesystem Skill surfaces flatten `skill_surfaces`; MCP capability and revision stay
+    /// on the same entries so a later worker cannot miss a second registry. The map is
+    /// process-local: a plugin that is not running declares nothing.
+    pub(crate) fn agent_effect_surface_declarations(
+        &self,
+    ) -> Vec<(PluginId, AgentPluginEffectDeclaration)> {
+        self.agent_effect_surfaces
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .iter()
+            .map(|(plugin_id, declaration)| (plugin_id.clone(), declaration.clone()))
+            .collect()
+    }
+}

--- a/crates/backend/src/plugin/mod.rs
+++ b/crates/backend/src/plugin/mod.rs
@@ -1,6 +1,4 @@
-use crate::agent_runtime::plugin_agent::{
-    AgentPluginEffectDeclaration, NegotiatedMcpConfiguration,
-};
+use crate::agent_runtime::plugin_agent::AgentPluginEffectDeclaration;
 use crate::app_event::AppEventPublisher;
 use crate::clock::SystemClock;
 use crate::effect_worker::EffectWorkerHandle;
@@ -26,8 +24,8 @@ use ora_db::{
     PluginSkillProjection, RepositoryPool, SqliteEffectRepository,
     SqlitePluginMarketplaceSourceRepository, SqliteSkillRepository, SqliteWorkspaceRepository,
 };
-use ora_domain::{PluginId, WorkspaceLocation};
-use ora_effect::{AgentCapabilityRevision, Digest, FilesystemSkillSurface, SurfaceDescriptorSet};
+use ora_domain::PluginId;
+use ora_effect::Digest;
 use ora_logging::{ora_debug, ora_info, ora_warn};
 use ora_plugin_config::ConfigurationService;
 use ora_plugin_lifecycle::{
@@ -44,6 +42,8 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
+
+mod agent_effect;
 
 /// The concrete lifecycle composition the backend runs.
 pub(crate) type BackendPluginLifecycle =
@@ -168,15 +168,15 @@ pub(crate) struct PluginApi {
     notifications: BroadcastNotificationSink,
     pub(crate) configuration: ConfigurationService,
     skill_repository: SqliteSkillRepository,
-    effect_repository: SqliteEffectRepository,
-    workspace_repository: SqliteWorkspaceRepository,
-    agent_effect_surfaces: Mutex<BTreeMap<PluginId, AgentPluginEffectDeclaration>>,
+    pub(super) effect_repository: SqliteEffectRepository,
+    pub(super) workspace_repository: SqliteWorkspaceRepository,
+    pub(super) agent_effect_surfaces: Mutex<BTreeMap<PluginId, AgentPluginEffectDeclaration>>,
     /// Set once the Effect worker exists, which is after this API the worker itself borrows.
     ///
     /// Its absence only costs latency: a declaration change is already durable before the wake
     /// would fire, so the worker's periodic scan still converges the surface.
-    effect_reconcile: OnceLock<EffectWorkerHandle>,
-    clock: SystemClock,
+    pub(super) effect_reconcile: OnceLock<EffectWorkerHandle>,
+    pub(super) clock: SystemClock,
 }
 
 impl PluginApi {
@@ -460,114 +460,6 @@ impl PluginApi {
         })
     }
 
-    /// Returns the exact installed package version used to bind Agent Capability Revision.
-    pub(crate) fn installed_plugin_version(&self, plugin_id: &PluginId) -> Option<String> {
-        self.list(ListInstalledPluginsRequest {})
-            .plugins
-            .into_iter()
-            .find(|plugin| plugin.id == plugin_id.canonical())
-            .map(|plugin| plugin.version)
-    }
-
-    /// Replaces one Agent plugin's Skill surfaces while leaving MCP negotiation unset.
-    ///
-    /// Worker tests and uninstall use this Skill-only path. Live attach writes the full
-    /// declaration through [`Self::replace_agent_plugin_declaration`].
-    pub(crate) fn replace_agent_effect_surfaces(
-        &self,
-        plugin_id: PluginId,
-        surfaces: Vec<FilesystemSkillSurface>,
-    ) -> Result<(), BackendError> {
-        self.replace_agent_plugin_declaration(
-            plugin_id,
-            AgentPluginEffectDeclaration {
-                skill_surfaces: surfaces,
-                mcp_configuration: NegotiatedMcpConfiguration::Unsupported,
-                capability_revision: AgentCapabilityRevision::unspecified(),
-            },
-        )
-    }
-
-    /// Replaces one Agent plugin's Skill surfaces, MCP capability, and capability revision.
-    ///
-    /// This is the single declaration snapshot convergence reads. Empty Skill surfaces with an
-    /// unset MCP capability remove the plugin so uninstall cannot leave a ghost consumer.
-    pub(crate) fn replace_agent_plugin_declaration(
-        &self,
-        plugin_id: PluginId,
-        declaration: AgentPluginEffectDeclaration,
-    ) -> Result<(), BackendError> {
-        let descriptors = {
-            let mut registered = self
-                .agent_effect_surfaces
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            let remove = declaration.skill_surfaces.is_empty()
-                && !declaration.mcp_configuration.enables_materialization()
-                && declaration.mcp_configuration.disable_error_code().is_none()
-                && declaration.capability_revision.is_unspecified();
-            if remove {
-                registered.remove(&plugin_id);
-            } else {
-                registered.insert(plugin_id, declaration);
-            }
-            registered
-                .values()
-                .flat_map(|declaration| declaration.skill_surfaces.iter().cloned())
-                .collect::<Vec<_>>()
-        };
-        let timestamp = self.clock.now_timestamp_millis();
-        let workspaces = self
-            .workspace_repository
-            .list_all_workspaces()
-            .map_err(|error| BackendError::internal("failed to list Effect Workspaces", error))?;
-        for workspace in workspaces {
-            let WorkspaceLocation::LocalFilesystem { path } = &workspace.location else {
-                // The first adapter is deliberately filesystem-only. Remote Workspaces need a
-                // provider-owned adapter instead of treating an opaque locator as a host path.
-                continue;
-            };
-            let merged = SurfaceDescriptorSet::merge(&workspace.id, descriptors.clone())
-                .map_err(|error| BackendError::internal("invalid Agent Effect surface", error))?;
-            self.effect_repository
-                .replace_surfaces(&workspace.id, Path::new(path), &merged, timestamp)
-                .map_err(|error| {
-                    BackendError::internal("failed to persist Agent Effect surfaces", error)
-                })?;
-        }
-        // Waking after the commit, never before it: the request the worker will read is already
-        // durable, so a wake lost to a crash costs a scan interval rather than a reconcile.
-        if let Some(reconcile) = self.effect_reconcile.get() {
-            reconcile.notify();
-        }
-        Ok(())
-    }
-
-    /// Returns the merged Effect surface declarations of every currently registered Agent plugin.
-    ///
-    /// This snapshot is the single source convergence reads. It is process-local on purpose: a
-    /// plugin that is not running declares nothing, and a Workspace therefore owes it no surface
-    /// until its next start republishes the declaration. MCP capability and revision ride on the
-    /// same per-plugin entries; Skill-only callers still flatten to filesystem surfaces.
-    pub(crate) fn agent_effect_surface_declarations(&self) -> Vec<FilesystemSkillSurface> {
-        self.agent_effect_declaration_snapshot()
-            .into_iter()
-            .flat_map(|(_, declaration)| declaration.skill_surfaces)
-            .collect()
-    }
-
-    /// Returns the full Agent Effect declaration snapshot, including MCP capability negotiation.
-    pub(crate) fn agent_effect_declaration_snapshot(
-        &self,
-    ) -> Vec<(PluginId, AgentPluginEffectDeclaration)> {
-        self.agent_effect_surfaces
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .iter()
-            .map(|(plugin_id, declaration)| (plugin_id.clone(), declaration.clone()))
-            .collect()
-    }
-
     /// Stops one plugin process while leaving the installed plugin available.
     pub(crate) async fn stop(
         &self,
@@ -588,7 +480,10 @@ impl PluginApi {
         self.skill_repository
             .remove_plugin_skills(&plugin_id, self.clock.now_timestamp_millis())
             .map_err(|error| BackendError::internal("failed to remove plugin Skills", error))?;
-        self.replace_agent_effect_surfaces(plugin_id, Vec::new())?;
+        self.replace_agent_plugin_declaration(
+            plugin_id,
+            AgentPluginEffectDeclaration::skill_only(Vec::new()),
+        )?;
         Ok(response)
     }
     /// Installs a marketplace plugin by resolving its release manifest from the synced sources and

--- a/crates/db/src/agent_target_repository_tests.rs
+++ b/crates/db/src/agent_target_repository_tests.rs
@@ -1,0 +1,495 @@
+use crate::{
+    DatabaseBootstrapper, DatabaseLocation, MigrationCatalog, RepositoryPool,
+    SqliteEffectRepository, TimestampSource, default_migration_catalog,
+};
+use ora_domain::WorkspaceId;
+use ora_effect::{
+    AgentCapabilityRevision, AgentPluginId, AgentTargetCondition, AgentTargetConditionReason,
+    AgentTargetConditionSubject, AgentTargetIdentity, AgentTargetLifecycle, AgentTargetPhase,
+    AgentTargetRepository, AgentTargetWakeReason, ConditionImpact, EffectRepository, Generation,
+    initial_agent_target_status,
+};
+use ora_logging::with_trace_logging;
+use pretty_assertions::assert_eq;
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy, Debug)]
+struct FixedTimestamp;
+
+impl TimestampSource for FixedTimestamp {
+    fn current_timestamp_millis(&self) -> i64 {
+        1_700_000_000_000
+    }
+}
+
+/// Bootstraps a file-backed pool with one Workspace Effect aggregate.
+fn fixture() -> (TempDir, RepositoryPool, WorkspaceId) {
+    let directory = TempDir::new().unwrap_or_else(|error| panic!("create database dir: {error}"));
+    let location = DatabaseLocation::path(directory.path().join("ora.sqlite"));
+    let pool = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestamp)
+            .bootstrap_repository_pool(
+                &location,
+                &default_migration_catalog()
+                    .unwrap_or_else(|error| panic!("build catalog: {error}")),
+            )
+            .unwrap_or_else(|error| panic!("bootstrap pool: {error}"))
+    });
+    let workspace_id = WorkspaceId::new("workspace-1");
+    pool.with_connection(|connection| {
+        connection.execute(
+            "INSERT INTO projects (
+                 id, name, repository_kind, created_at, updated_at, is_deleted
+             ) VALUES ('project-1', 'Demo', 'git', 1, 1, 0)",
+            [],
+        )?;
+        connection.execute(
+            "INSERT INTO workspace_locations (
+                 id, location_kind, locator_version, locator_json, created_at, updated_at
+             ) VALUES ('location-1', 'local_filesystem', 1, '{}', 1, 1)",
+            [],
+        )?;
+        connection.execute(
+            "INSERT INTO workspaces (
+                 id, project_id, workspace_kind, location_id, lifecycle,
+                 created_at, updated_at, is_deleted
+             ) VALUES (?1, 'project-1', 'main', 'location-1', 'active', 1, 1, 0)",
+            params![workspace_id.as_ref()],
+        )?;
+        Ok(())
+    })
+    .unwrap_or_else(|error| panic!("insert Workspace fixture: {error}"));
+    (directory, pool, workspace_id)
+}
+
+/// Builds a catalog that stops before Agent Target Expand so upgrade backfill can be tested.
+fn catalog_before_agent_targets() -> MigrationCatalog {
+    let full = default_migration_catalog().unwrap_or_else(|error| panic!("build catalog: {error}"));
+    MigrationCatalog::with_target_versions(
+        full.migrations().to_vec(),
+        vec!["0001", "0002", "0003", "0004", "0005", "0006"],
+    )
+    .unwrap_or_else(|error| panic!("prefix catalog: {error}"))
+}
+
+/// Inserts two surface reconcile requests that share one Agent Plugin consumer.
+fn seed_surface_requests(connection: &Connection, workspace_id: &WorkspaceId) {
+    connection
+        .execute(
+            "INSERT INTO effect_surfaces (
+                 id, workspace_id, adapter_kind, locator_key, locator_json, format_kind,
+                 lifecycle, created_at, updated_at
+             ) VALUES
+             ('surface-a', ?1, 'filesystem_skill', '.agents/skills', '{}', 'skill_directory.v1',
+              'active', 10, 10),
+             ('surface-b', ?1, 'filesystem_skill', '.claude/skills', '{}', 'skill_directory.v1',
+              'active', 10, 10)",
+            params![workspace_id.as_ref()],
+        )
+        .unwrap_or_else(|error| panic!("insert surfaces: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_surface_consumers (
+                 surface_id, consumer_id, coordination_kind, created_at, updated_at
+             ) VALUES
+             ('surface-a', 'opencode', 'wait_for_idle_and_restart', 10, 10),
+             ('surface-b', 'opencode', 'wait_for_idle_and_restart', 11, 11),
+             ('surface-b', 'codex', 'wait_for_idle_and_restart', 12, 12)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert consumers: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_surface_status (
+                 surface_id, desired_generation, observed_generation, applied_generation,
+                 phase, status_version, created_at, updated_at
+             ) VALUES
+             ('surface-a', 5, 4, 3, 'pending', 1, 10, 10),
+             ('surface-b', 7, 6, 5, 'pending', 1, 10, 10)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert surface status: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_consumer_status (
+                 surface_id, consumer_id, ready_generation, phase, status_version,
+                 created_at, updated_at
+             ) VALUES
+             ('surface-a', 'opencode', 2, 'current', 1, 10, 10),
+             ('surface-b', 'opencode', 4, 'current', 1, 10, 10),
+             ('surface-b', 'codex', 1, 'current', 1, 10, 10)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert consumer status: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_reconcile_requests (
+                 surface_id, requested_generation, request_token, state, wake_reason,
+                 attempt_count, requested_at, not_before_at, updated_at
+             ) VALUES
+             ('surface-a', 4, 'token-a', 'pending', 'desired_changed', 0, 100, 250, 100),
+             ('surface-b', 9, 'token-b', 'pending', 'desired_changed', 0, 110, 200, 110)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert surface requests: {error}"));
+    connection
+        .execute(
+            "INSERT INTO effect_conditions (
+                 id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES
+             ('cond-surface', 'surface-a', NULL, 'surface', '{\"kind\":\"surface\"}',
+              'path_unsafe', 3, 'unsafe path', 10, 20),
+             ('cond-consumer', 'surface-b', 'opencode', 'consumer', '{\"kind\":\"consumer\"}',
+              'waiting_for_idle', 5, 'waiting', 30, 40)",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("insert conditions: {error}"));
+}
+
+#[test]
+fn empty_database_bootstraps_agent_target_schema() {
+    let catalog = default_migration_catalog().expect("build migration catalog");
+    assert_eq!(
+        catalog.target_versions(),
+        ["0001", "0002", "0003", "0004", "0005", "0006", "0007"]
+    );
+
+    let database = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestamp)
+            .bootstrap(&DatabaseLocation::in_memory(), &catalog)
+            .expect("bootstrap database")
+    });
+
+    let tables = load_table_names(database.connection());
+    assert!(tables.iter().any(|name| name == "effect_agent_targets"));
+    assert!(
+        tables
+            .iter()
+            .any(|name| name == "effect_agent_target_status")
+    );
+    assert!(
+        tables
+            .iter()
+            .any(|name| name == "effect_agent_target_reconcile_requests")
+    );
+    assert!(
+        tables
+            .iter()
+            .any(|name| name == "effect_agent_target_conditions")
+    );
+    assert!(
+        tables
+            .iter()
+            .any(|name| name == "effect_reconcile_requests")
+    );
+}
+
+#[test]
+fn upgrades_old_schema_and_backfills_target_requests_deterministically() {
+    let directory = TempDir::new().unwrap_or_else(|error| panic!("create database dir: {error}"));
+    let location = DatabaseLocation::path(directory.path().join("ora.sqlite"));
+    let prefix = catalog_before_agent_targets();
+    let database = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestamp)
+            .bootstrap(&location, &prefix)
+            .unwrap_or_else(|error| panic!("bootstrap prefix: {error}"))
+    });
+    let workspace_id = WorkspaceId::new("workspace-1");
+    database
+        .connection()
+        .execute(
+            "INSERT INTO projects (
+                 id, name, repository_kind, created_at, updated_at, is_deleted
+             ) VALUES ('project-1', 'Demo', 'git', 1, 1, 0)",
+            [],
+        )
+        .unwrap();
+    database
+        .connection()
+        .execute(
+            "INSERT INTO workspace_locations (
+                 id, location_kind, locator_version, locator_json, created_at, updated_at
+             ) VALUES ('location-1', 'local_filesystem', 1, '{}', 1, 1)",
+            [],
+        )
+        .unwrap();
+    database
+        .connection()
+        .execute(
+            "INSERT INTO workspaces (
+                 id, project_id, workspace_kind, location_id, lifecycle,
+                 created_at, updated_at, is_deleted
+             ) VALUES (?1, 'project-1', 'main', 'location-1', 'active', 1, 1, 0)",
+            params![workspace_id.as_ref()],
+        )
+        .unwrap();
+    seed_surface_requests(database.connection(), &workspace_id);
+    drop(database);
+
+    let full = default_migration_catalog().expect("full catalog");
+    let upgraded = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestamp)
+            .bootstrap(&location, &full)
+            .unwrap_or_else(|error| panic!("upgrade to 0007: {error}"))
+    });
+
+    let surface_request_count: i64 = upgraded
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM effect_reconcile_requests",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(surface_request_count, 2);
+
+    let target_count: i64 = upgraded
+        .connection()
+        .query_row("SELECT COUNT(*) FROM effect_agent_targets", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(target_count, 2);
+
+    let opencode = upgraded
+        .connection()
+        .query_row(
+            "SELECT requests.requested_generation, requests.not_before_at, requests.requested_at,
+                    status.desired_generation, status.ready_generation
+             FROM effect_agent_targets targets
+             JOIN effect_agent_target_reconcile_requests requests
+               ON requests.agent_target_id = targets.id
+             JOIN effect_agent_target_status status
+               ON status.agent_target_id = targets.id
+             WHERE targets.workspace_id = ?1 AND targets.agent_plugin_id = 'opencode'",
+            params![workspace_id.as_ref()],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .unwrap_or_else(|error| panic!("load opencode backfill: {error}"));
+    assert_eq!(opencode, (9, 200, 100, 7, 4));
+
+    let condition_count: i64 = upgraded
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM effect_agent_target_conditions
+             WHERE impact = 'blocking'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    // surface-scoped fans out to opencode on surface-a; consumer-scoped keeps opencode on surface-b.
+    assert_eq!(condition_count, 2);
+    drop(upgraded);
+
+    let pool = RepositoryPool::new(&location)
+        .unwrap_or_else(|error| panic!("open upgraded pool: {error}"));
+    let repository = SqliteEffectRepository::new(pool);
+    let identity = AgentTargetIdentity::new(workspace_id.clone(), AgentPluginId::new("opencode"));
+    let status = repository
+        .load_agent_target_status(&identity)
+        .unwrap_or_else(|error| panic!("load backfilled status: {error}"))
+        .expect("opencode target status");
+    assert_eq!(status.conditions.len(), 2);
+    assert!(
+        status
+            .conditions
+            .iter()
+            .all(|condition| condition.impact == ConditionImpact::Blocking)
+    );
+}
+
+#[test]
+fn agent_target_uniqueness_and_generation_constraints() {
+    let (_directory, pool, workspace_id) = fixture();
+    pool.with_connection(|connection| {
+        connection
+            .execute(
+                "INSERT INTO effect_agent_targets (
+                     id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                     created_at, updated_at
+                 ) VALUES ('target-1', ?1, 'opencode', '', 'active', 1, 1)",
+                params![workspace_id.as_ref()],
+            )
+            .unwrap();
+        let duplicate = connection.execute(
+            "INSERT INTO effect_agent_targets (
+                 id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                 created_at, updated_at
+             ) VALUES ('target-2', ?1, 'opencode', '', 'active', 1, 1)",
+            params![workspace_id.as_ref()],
+        );
+        assert!(duplicate.is_err(), "duplicate Agent Target must fail");
+
+        connection
+            .execute(
+                "INSERT INTO effect_agent_target_status (
+                     agent_target_id, desired_generation, observed_generation,
+                     applied_generation, ready_generation, phase, status_version,
+                     created_at, updated_at
+                 ) VALUES ('target-1', 1, 1, 1, 1, 'current', 1, 1, 1)",
+                [],
+            )
+            .unwrap();
+        let illegal_order = connection.execute(
+            "UPDATE effect_agent_target_status
+             SET ready_generation = 2, applied_generation = 1
+             WHERE agent_target_id = 'target-1'",
+            [],
+        );
+        assert!(illegal_order.is_err(), "ready > applied must fail");
+
+        let illegal_phase = connection.execute(
+            "UPDATE effect_agent_target_status SET phase = 'unknown' WHERE agent_target_id = 'target-1'",
+            [],
+        );
+        assert!(illegal_phase.is_err(), "illegal phase must fail");
+
+        let illegal_impact = connection.execute(
+            "INSERT INTO effect_agent_target_conditions (
+                 id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 impact, failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES ('c1', 'target-1', NULL, NULL, 'agent_target', '{}', 'path_unsafe',
+                       'maybe', NULL, 'bad', 1, 1)",
+            [],
+        );
+        assert!(illegal_impact.is_err(), "illegal impact must fail");
+
+        let illegal_ownership = connection.execute(
+            "INSERT INTO effect_agent_target_conditions (
+                 id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 impact, failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES ('c2', 'target-1', NULL, 'opencode', 'consumer', '{}', 'waiting_for_idle',
+                       'blocking', NULL, 'bad ownership', 1, 1)",
+            [],
+        );
+        assert!(
+            illegal_ownership.is_err(),
+            "consumer without surface must fail"
+        );
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn typed_repository_round_trips_complete_agent_target_record() {
+    let (_directory, pool, workspace_id) = fixture();
+    let repository = SqliteEffectRepository::new(pool);
+    let identity = AgentTargetIdentity::new(workspace_id.clone(), AgentPluginId::new("opencode"));
+    let target = repository
+        .upsert_agent_target(
+            &identity,
+            &AgentCapabilityRevision::new("cap-1"),
+            AgentTargetLifecycle::Active,
+            50,
+        )
+        .unwrap_or_else(|error| panic!("upsert target: {error}"));
+
+    let mut status = initial_agent_target_status(target.id.clone(), identity.clone(), 50);
+    status.desired_generation = Generation::new(4);
+    status.observed_generation = Generation::new(3);
+    status.applied_generation = Generation::new(2);
+    status.ready_generation = Generation::new(1);
+    status.phase = AgentTargetPhase::ReadyWithIssues;
+    status.status_version = 2;
+    status.updated_at = 60;
+    status.conditions = vec![AgentTargetCondition {
+        id: "condition-1".to_string(),
+        subject: AgentTargetConditionSubject::AgentTarget,
+        reason: AgentTargetConditionReason::UnsupportedByAgent,
+        impact: ConditionImpact::NonBlocking,
+        message: "stdio unsupported".to_string(),
+        first_observed_at: 55,
+        last_observed_at: 60,
+        failed_generation: Some(Generation::new(4)),
+        surface_key: None,
+        consumer_id: None,
+    }];
+    repository
+        .save_agent_target_status(&status)
+        .unwrap_or_else(|error| panic!("save status: {error}"));
+
+    let request = repository
+        .upsert_agent_target_reconcile_request(
+            &identity,
+            Generation::new(4),
+            AgentTargetWakeReason::DesiredChanged,
+            80,
+            70,
+        )
+        .unwrap_or_else(|error| panic!("upsert request: {error}"));
+    let coalesced = repository
+        .upsert_agent_target_reconcile_request(
+            &identity,
+            Generation::new(6),
+            AgentTargetWakeReason::CapabilityChanged,
+            65,
+            90,
+        )
+        .unwrap_or_else(|error| panic!("coalesce request: {error}"));
+    assert_eq!(coalesced.requested_generation, Generation::new(6));
+    assert_eq!(coalesced.not_before_at, 65);
+    assert_eq!(coalesced.request_token, request.request_token);
+
+    let loaded = repository
+        .load_agent_target_record(&identity)
+        .unwrap_or_else(|error| panic!("load record: {error}"))
+        .expect("record present");
+    assert_eq!(loaded.target, target);
+    assert_eq!(loaded.status, status);
+    assert_eq!(
+        loaded
+            .reconcile_request
+            .expect("request present")
+            .requested_generation,
+        Generation::new(6)
+    );
+}
+
+#[test]
+fn surface_keyed_skill_effect_apis_remain_available() {
+    let (_directory, pool, workspace_id) = fixture();
+    let repository = SqliteEffectRepository::new(pool.clone());
+    let effect = repository
+        .load_workspace_effect(&workspace_id)
+        .unwrap_or_else(|error| panic!("load workspace effect: {error}"));
+    assert_eq!(effect.workspace_id, workspace_id);
+    assert_eq!(effect.generation, Generation::default());
+
+    let surface_table_exists: i64 = pool
+        .with_connection(|connection| {
+            connection
+                .query_row(
+                    "SELECT EXISTS(
+                     SELECT 1 FROM sqlite_master
+                     WHERE type = 'table' AND name = 'effect_reconcile_requests'
+                 )",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(Into::into)
+        })
+        .unwrap();
+    assert_eq!(surface_table_exists, 1);
+}
+
+fn load_table_names(connection: &Connection) -> Vec<String> {
+    let mut statement = connection
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+        .unwrap();
+    statement
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -6,6 +6,8 @@ mod repository;
 mod time;
 
 #[cfg(test)]
+mod agent_target_repository_tests;
+#[cfg(test)]
 mod effect_repository_tests;
 #[cfg(test)]
 mod git_cleanup_tests;

--- a/crates/db/src/migration/README.md
+++ b/crates/db/src/migration/README.md
@@ -7,7 +7,7 @@ This module owns Ora's linear, reversible SQLite schema history and reconciles a
 - `MigrationCatalog` requires unique, strictly increasing versions.
 - The active target must be a prefix of the complete catalog. This makes controlled rollback deterministic and rejects branch-shaped histories.
 - Every migration contains ordered up and down statements. Their trimmed, joined SQL is the stable executable snapshot used for comparison and rollback.
-- The default catalog contains six dependency-ordered modules: workspace core and application configuration, Agent/Skill catalog, workflows, Git lifecycle bookkeeping, Workspace Effect state, and durable plugin marketplace source configuration.
+- The default catalog contains seven dependency-ordered modules: workspace core and application configuration, Agent/Skill catalog, workflows, Git lifecycle bookkeeping, Workspace Effect state, durable plugin marketplace source configuration, and Agent Target Effect Expand persistence.
 - Skills, configurable agents, and workflows use `(namespace, name)` as their case-insensitive
   visible identity. Soft-deleted rows do not reserve that identity, and local resources use the
   `local` namespace.
@@ -18,6 +18,12 @@ This module owns Ora's linear, reversible SQLite schema history and reconciles a
   Artifacts; and append-only Audit events.
 - Migration `0006` stores plugin marketplace source configuration in SQLite: the duplicate-free
   URL, tracked branch, per-source `use_proxy` policy, and stable precedence position.
+- Migration `0007` expands Agent Target Effect persistence beside the surface-keyed Skill model:
+  `effect_agent_targets` uniquely keyed by Workspace plus Agent Plugin; target status with
+  desired/observed/applied/ready generations and phase; target-keyed reconcile requests; and
+  target-owned conditions with Blocking/NonBlocking impact. Existing surface request rows are
+  deterministically backfilled into one target request using the maximum requested generation and
+  earliest due time. Production workers continue to claim only surface-keyed requests.
 - A reconcile request carries its own scheduling state: `pending`, `claimed`, `blocked`, or
   `retry_scheduled`, plus the lease that proves who currently owns the surface and the
   `request_token` that fences that owner's writes. Only one worker can hold a surface, an expired

--- a/crates/db/src/migration/catalog.rs
+++ b/crates/db/src/migration/catalog.rs
@@ -84,6 +84,12 @@ impl MigrationCatalog {
         &self.target_versions
     }
 
+    /// Returns every migration definition owned by the catalog, including versions beyond the active target.
+    #[cfg(test)]
+    pub(crate) fn migrations(&self) -> &[Migration] {
+        &self.migrations
+    }
+
     /// Finds a migration definition by version so reconciliation can execute it.
     pub fn migration(&self, version: &str) -> Option<&Migration> {
         self.migrations_by_version

--- a/crates/db/src/migration/schema/mod.rs
+++ b/crates/db/src/migration/schema/mod.rs
@@ -6,6 +6,7 @@ mod schema_v0003;
 mod schema_v0004;
 mod schema_v0005;
 mod schema_v0006;
+mod schema_v0007;
 
 /// Returns the ordered schema migrations shipped with the database crate.
 pub(super) fn migrations() -> Vec<Migration> {
@@ -16,5 +17,6 @@ pub(super) fn migrations() -> Vec<Migration> {
         schema_v0004::migration(),
         schema_v0005::migration(),
         schema_v0006::migration(),
+        schema_v0007::migration(),
     ]
 }

--- a/crates/db/src/migration/schema/schema_v0007.rs
+++ b/crates/db/src/migration/schema/schema_v0007.rs
@@ -1,0 +1,276 @@
+use super::Migration;
+
+const UP_STATEMENTS: &[&str] = &[
+    r#"
+-- Agent Target rows are the Expand-phase owner for future Skill+MCP convergence. Surface-keyed
+-- Skill tables remain authoritative for the live worker until a later Contract ticket.
+CREATE TABLE effect_agent_targets (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspace_effects(workspace_id) ON DELETE CASCADE,
+    agent_plugin_id TEXT NOT NULL,
+    capability_revision TEXT NOT NULL,
+    lifecycle TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    UNIQUE (workspace_id, agent_plugin_id),
+    CHECK (lifecycle IN ('active', 'retired')),
+    CHECK (updated_at >= created_at)
+);
+CREATE INDEX effect_agent_targets_workspace
+    ON effect_agent_targets(workspace_id, agent_plugin_id);
+"#,
+    r#"
+CREATE TABLE effect_agent_target_status (
+    agent_target_id TEXT PRIMARY KEY REFERENCES effect_agent_targets(id) ON DELETE CASCADE,
+    desired_generation INTEGER NOT NULL DEFAULT 0,
+    observed_generation INTEGER NOT NULL DEFAULT 0,
+    applied_generation INTEGER NOT NULL DEFAULT 0,
+    ready_generation INTEGER NOT NULL DEFAULT 0,
+    phase TEXT NOT NULL,
+    status_version INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    CHECK (desired_generation >= 0),
+    CHECK (observed_generation >= 0),
+    CHECK (applied_generation >= 0),
+    CHECK (ready_generation >= 0),
+    CHECK (applied_generation <= observed_generation),
+    CHECK (observed_generation <= desired_generation),
+    CHECK (ready_generation <= applied_generation),
+    CHECK (status_version > 0),
+    CHECK (phase IN (
+        'pending', 'waiting_for_idle', 'quiescing', 'applying', 'resuming',
+        'current', 'ready_with_issues', 'degraded', 'retiring', 'recovery_required'
+    )),
+    CHECK (updated_at >= created_at)
+);
+"#,
+    r#"
+-- Parallel to surface-keyed effect_reconcile_requests. Nothing in production claims this table yet.
+CREATE TABLE effect_agent_target_reconcile_requests (
+    agent_target_id TEXT PRIMARY KEY REFERENCES effect_agent_targets(id) ON DELETE CASCADE,
+    requested_generation INTEGER NOT NULL,
+    request_token TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    wake_reason TEXT NOT NULL DEFAULT 'desired_changed',
+    blocked_reason TEXT,
+    lease_owner TEXT,
+    lease_expires_at INTEGER,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    requested_at INTEGER NOT NULL,
+    not_before_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    CHECK (requested_generation >= 0),
+    CHECK (attempt_count >= 0),
+    CHECK (not_before_at >= requested_at),
+    CHECK (updated_at >= requested_at),
+    CHECK (state IN ('pending', 'claimed', 'blocked', 'retry_scheduled')),
+    CHECK ((state = 'claimed') = (lease_owner IS NOT NULL)),
+    CHECK ((state = 'claimed') = (lease_expires_at IS NOT NULL)),
+    CHECK ((state = 'blocked') = (blocked_reason IS NOT NULL)),
+    CHECK (wake_reason IN (
+        'desired_changed', 'capability_changed', 'retry', 'recovery', 'startup_repair'
+    ))
+);
+CREATE INDEX effect_agent_target_reconcile_requests_due
+    ON effect_agent_target_reconcile_requests(state, not_before_at, requested_at, agent_target_id);
+CREATE INDEX effect_agent_target_reconcile_requests_leases
+    ON effect_agent_target_reconcile_requests(lease_expires_at) WHERE state = 'claimed';
+"#,
+    r#"
+CREATE TABLE effect_agent_target_conditions (
+    id TEXT PRIMARY KEY,
+    agent_target_id TEXT NOT NULL
+        REFERENCES effect_agent_target_status(agent_target_id) ON DELETE CASCADE,
+    surface_id TEXT REFERENCES effect_surfaces(id) ON DELETE SET NULL,
+    consumer_id TEXT,
+    subject_kind TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    impact TEXT NOT NULL,
+    failed_generation INTEGER,
+    message TEXT NOT NULL,
+    first_observed_at INTEGER NOT NULL,
+    last_observed_at INTEGER NOT NULL,
+    CHECK (impact IN ('blocking', 'non_blocking')),
+    CHECK (subject_kind IN (
+        'agent_target', 'surface', 'consumer', 'desired_item', 'managed_item', 'mcp'
+    )),
+    CHECK (reason IN (
+        'no_consumers', 'incompatible_surface_declarations', 'desired_collision',
+        'preserved_conflict', 'ownership_conflict', 'drift_conflict', 'source_unavailable',
+        'path_unsafe', 'scan_failed', 'waiting_for_idle', 'consumer_resume_failed',
+        'materialization_failed', 'transient_io', 'recovery_required',
+        'unsupported_by_agent', 'capability_invalid'
+    )),
+    CHECK (failed_generation IS NULL OR failed_generation >= 0),
+    CHECK (last_observed_at >= first_observed_at),
+    CHECK (consumer_id IS NULL OR surface_id IS NOT NULL),
+    FOREIGN KEY (surface_id, consumer_id)
+        REFERENCES effect_surface_consumers(surface_id, consumer_id) ON DELETE SET NULL
+);
+CREATE UNIQUE INDEX effect_agent_target_conditions_unique
+    ON effect_agent_target_conditions(
+        agent_target_id,
+        subject_kind,
+        subject_id,
+        reason,
+        IFNULL(surface_id, ''),
+        IFNULL(consumer_id, '')
+    );
+"#,
+    r#"
+-- One Agent Target per historical surface consumer declaration.
+INSERT INTO effect_agent_targets (
+    id, workspace_id, agent_plugin_id, capability_revision, lifecycle, created_at, updated_at
+)
+SELECT lower(hex(randomblob(16))),
+       surfaces.workspace_id,
+       consumers.consumer_id,
+       '',
+       'active',
+       MIN(consumers.created_at),
+       MAX(consumers.updated_at)
+FROM effect_surface_consumers consumers
+JOIN effect_surfaces surfaces ON surfaces.id = consumers.surface_id
+GROUP BY surfaces.workspace_id, consumers.consumer_id;
+"#,
+    r#"
+-- Clamp independently maximized generations so Expand rows always satisfy ordering CHECKs.
+INSERT INTO effect_agent_target_status (
+    agent_target_id, desired_generation, observed_generation, applied_generation,
+    ready_generation, phase, status_version, created_at, updated_at
+)
+SELECT
+    targets.id,
+    MAX(COALESCE(surface_status.desired_generation, 0)),
+    MIN(
+        MAX(COALESCE(surface_status.desired_generation, 0)),
+        MAX(COALESCE(surface_status.observed_generation, 0))
+    ),
+    MIN(
+        MIN(
+            MAX(COALESCE(surface_status.desired_generation, 0)),
+            MAX(COALESCE(surface_status.observed_generation, 0))
+        ),
+        MAX(COALESCE(surface_status.applied_generation, 0))
+    ),
+    MIN(
+        MIN(
+            MIN(
+                MAX(COALESCE(surface_status.desired_generation, 0)),
+                MAX(COALESCE(surface_status.observed_generation, 0))
+            ),
+            MAX(COALESCE(surface_status.applied_generation, 0))
+        ),
+        MAX(COALESCE(consumer_status.ready_generation, 0))
+    ),
+    'current',
+    1,
+    targets.created_at,
+    targets.updated_at
+FROM effect_agent_targets targets
+JOIN effect_surfaces surfaces
+    ON surfaces.workspace_id = targets.workspace_id
+JOIN effect_surface_consumers consumers
+    ON consumers.surface_id = surfaces.id
+   AND consumers.consumer_id = targets.agent_plugin_id
+LEFT JOIN effect_surface_status surface_status
+    ON surface_status.surface_id = surfaces.id
+LEFT JOIN effect_consumer_status consumer_status
+    ON consumer_status.surface_id = surfaces.id
+   AND consumer_status.consumer_id = consumers.consumer_id
+GROUP BY targets.id;
+"#,
+    r#"
+-- Merge every surface request that touches a target into one pending target request.
+INSERT INTO effect_agent_target_reconcile_requests (
+    agent_target_id, requested_generation, request_token, state, wake_reason,
+    blocked_reason, lease_owner, lease_expires_at, attempt_count,
+    requested_at, not_before_at, updated_at
+)
+SELECT
+    targets.id,
+    MAX(requests.requested_generation),
+    lower(hex(randomblob(16))),
+    'pending',
+    'desired_changed',
+    NULL,
+    NULL,
+    NULL,
+    0,
+    MIN(requests.requested_at),
+    MAX(MIN(requests.not_before_at), MIN(requests.requested_at)),
+    MAX(requests.updated_at)
+FROM effect_reconcile_requests requests
+JOIN effect_surfaces surfaces ON surfaces.id = requests.surface_id
+JOIN effect_surface_consumers consumers ON consumers.surface_id = surfaces.id
+JOIN effect_agent_targets targets
+    ON targets.workspace_id = surfaces.workspace_id
+   AND targets.agent_plugin_id = consumers.consumer_id
+GROUP BY targets.id;
+"#,
+    r#"
+-- Consumer-scoped surface conditions become Blocking target conditions on that plugin.
+INSERT INTO effect_agent_target_conditions (
+    id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
+    failed_generation, message, first_observed_at, last_observed_at
+)
+SELECT lower(hex(randomblob(16))),
+       targets.id,
+       conditions.surface_id,
+       conditions.consumer_id,
+       'consumer',
+       json_object('kind', 'consumer', 'consumer_id', conditions.consumer_id),
+       conditions.reason,
+       'blocking',
+       conditions.failed_generation,
+       conditions.message,
+       conditions.first_observed_at,
+       conditions.last_observed_at
+FROM effect_conditions conditions
+JOIN effect_surfaces surfaces ON surfaces.id = conditions.surface_id
+JOIN effect_agent_targets targets
+    ON targets.workspace_id = surfaces.workspace_id
+   AND targets.agent_plugin_id = conditions.consumer_id
+WHERE conditions.consumer_id IS NOT NULL;
+"#,
+    r#"
+-- Surface-scoped conditions fan out to every Agent Target that consumes the surface.
+INSERT INTO effect_agent_target_conditions (
+    id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
+    failed_generation, message, first_observed_at, last_observed_at
+)
+SELECT lower(hex(randomblob(16))),
+       targets.id,
+       conditions.surface_id,
+       consumers.consumer_id,
+       'surface',
+       json_object('kind', 'surface', 'surface_key', conditions.surface_id),
+       conditions.reason,
+       'blocking',
+       conditions.failed_generation,
+       conditions.message,
+       conditions.first_observed_at,
+       conditions.last_observed_at
+FROM effect_conditions conditions
+JOIN effect_surface_consumers consumers ON consumers.surface_id = conditions.surface_id
+JOIN effect_surfaces surfaces ON surfaces.id = conditions.surface_id
+JOIN effect_agent_targets targets
+    ON targets.workspace_id = surfaces.workspace_id
+   AND targets.agent_plugin_id = consumers.consumer_id
+WHERE conditions.consumer_id IS NULL;
+"#,
+];
+
+const DOWN_STATEMENTS: &[&str] = &[r#"
+DROP TABLE IF EXISTS effect_agent_target_conditions;
+DROP TABLE IF EXISTS effect_agent_target_reconcile_requests;
+DROP TABLE IF EXISTS effect_agent_target_status;
+DROP TABLE IF EXISTS effect_agent_targets;
+"#];
+
+/// Builds Agent Target Effect persistence beside the surface-keyed Skill model.
+pub fn migration() -> Migration {
+    Migration::new("0007", UP_STATEMENTS, DOWN_STATEMENTS)
+}

--- a/crates/db/src/repository/README.md
+++ b/crates/db/src/repository/README.md
@@ -9,7 +9,9 @@ This module implements `ora-application` persistence ports on SQLite and exposes
   between SQL rows and application values.
 - `SqliteEffectRepository` stores normalized Desired selections, source state, surface descriptors,
   ownership ledgers, status, and durable operations. Desired replacement uses generation CAS;
-  operation finalization changes its ledger and journal phase in one immediate transaction.
+  operation finalization changes its ledger and journal phase in one immediate transaction. It also
+  implements the Expand-phase `AgentTargetRepository` port for target-keyed status and requests
+  without activating target claim loops.
 - Normal reads exclude soft-deleted rows. Soft deletion records timestamps rather than removing individual domain records physically.
 - `RepositoryPool` serializes access to its connection and gives repository operations a consistent error boundary.
 

--- a/crates/db/src/repository/effect/README.md
+++ b/crates/db/src/repository/effect/README.md
@@ -3,7 +3,8 @@
 This module implements the `ora-effect` persistence and source ports. The public adapter owns
 transaction boundaries for Desired CAS, source publication and propagation, surface lifecycle,
 operation finalization, and retry wakeups. `mapping` contains row validation, normalized inserts,
-enum encodings, and request-upsert helpers shared by those transactions.
+enum encodings, and request-upsert helpers shared by those transactions. `agent_target` implements
+the Expand-phase Agent Target repository port without switching the surface-keyed Skill worker.
 
 Desired replacement, source reference protection, and operation finalization use immediate write
 transactions so checks cannot race their corresponding writes. Observed and Preserved scans never

--- a/crates/db/src/repository/effect/agent_target/README.md
+++ b/crates/db/src/repository/effect/agent_target/README.md
@@ -1,0 +1,19 @@
+# Agent Target SQLite persistence
+
+This module implements `ora_effect::AgentTargetRepository` on `SqliteEffectRepository`. It owns
+typed reads and writes for Agent Target rows, status, target-owned conditions, and target-keyed
+reconcile requests introduced by migration `0007`.
+
+## Responsibilities
+
+- Upsert and load Agent Targets uniquely keyed by Workspace identity plus Agent Plugin identity.
+- Persist status generations (`desired` / `observed` / `applied` / `ready`), phase, status version,
+  and Blocking/NonBlocking conditions as whole objects.
+- Upsert target reconcile requests with max-generation and earliest-due coalescing.
+- Keep these APIs independent of the surface-keyed Skill claim loop.
+
+## Non-responsibilities
+
+- Claiming or completing target reconcile requests in production workers.
+- Dual-writing surface and target requests, compatibility views, or MCP materialization.
+- Mutating or retiring the existing `effect_reconcile_requests` / `effect_conditions` tables.

--- a/crates/db/src/repository/effect/agent_target/encode.rs
+++ b/crates/db/src/repository/effect/agent_target/encode.rs
@@ -1,0 +1,235 @@
+//! Enum and numeric encodings shared by Agent Target SQLite persistence.
+
+use crate::DatabaseError;
+use ora_effect::{
+    AgentTargetConditionReason, AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileState,
+    AgentTargetRepositoryError, AgentTargetWakeReason, ConditionImpact, Generation,
+};
+pub(super) fn map_db_error(error: DatabaseError) -> AgentTargetRepositoryError {
+    match error {
+        DatabaseError::CorruptEffectState(message) => AgentTargetRepositoryError::corrupt(message),
+        other => AgentTargetRepositoryError::storage(other),
+    }
+}
+
+pub(super) fn generation_to_sql(generation: Generation) -> Result<i64, DatabaseError> {
+    i64::try_from(generation.value()).map_err(|_| {
+        DatabaseError::CorruptEffectState("generation exceeds SQLite integer range".to_string())
+    })
+}
+
+pub(super) fn generation_from_sql(value: i64) -> Result<Generation, DatabaseError> {
+    u64::try_from(value)
+        .map(Generation::new)
+        .map_err(|_| DatabaseError::CorruptEffectState("negative generation".to_string()))
+}
+
+pub(super) fn generation_from_row(
+    row: &rusqlite::Row<'_>,
+    index: usize,
+) -> Result<Generation, rusqlite::Error> {
+    let value: i64 = row.get(index)?;
+    generation_from_sql(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Integer,
+            Box::new(error),
+        )
+    })
+}
+
+pub(super) fn u64_to_sql(value: u64, field: &str) -> Result<i64, DatabaseError> {
+    i64::try_from(value).map_err(|_| {
+        DatabaseError::CorruptEffectState(format!("{field} exceeds SQLite integer range"))
+    })
+}
+
+pub(super) fn u64_from_row(row: &rusqlite::Row<'_>, index: usize) -> Result<u64, rusqlite::Error> {
+    let value: i64 = row.get(index)?;
+    u64::try_from(value).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Integer,
+            Box::new(DatabaseError::CorruptEffectState(
+                "negative status version".to_string(),
+            )),
+        )
+    })
+}
+
+pub(super) fn u32_from_row(row: &rusqlite::Row<'_>, index: usize) -> Result<u32, rusqlite::Error> {
+    let value: i64 = row.get(index)?;
+    u32::try_from(value).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Integer,
+            Box::new(DatabaseError::CorruptEffectState(
+                "invalid attempt count".to_string(),
+            )),
+        )
+    })
+}
+
+pub(super) fn lifecycle_value(lifecycle: AgentTargetLifecycle) -> &'static str {
+    match lifecycle {
+        AgentTargetLifecycle::Active => "active",
+        AgentTargetLifecycle::Retired => "retired",
+    }
+}
+
+pub(super) fn parse_lifecycle(value: &str) -> Result<AgentTargetLifecycle, DatabaseError> {
+    match value {
+        "active" => Ok(AgentTargetLifecycle::Active),
+        "retired" => Ok(AgentTargetLifecycle::Retired),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target lifecycle".to_string(),
+        )),
+    }
+}
+
+pub(super) fn phase_value(phase: AgentTargetPhase) -> &'static str {
+    match phase {
+        AgentTargetPhase::Pending => "pending",
+        AgentTargetPhase::WaitingForIdle => "waiting_for_idle",
+        AgentTargetPhase::Quiescing => "quiescing",
+        AgentTargetPhase::Applying => "applying",
+        AgentTargetPhase::Resuming => "resuming",
+        AgentTargetPhase::Current => "current",
+        AgentTargetPhase::ReadyWithIssues => "ready_with_issues",
+        AgentTargetPhase::Degraded => "degraded",
+        AgentTargetPhase::Retiring => "retiring",
+        AgentTargetPhase::RecoveryRequired => "recovery_required",
+    }
+}
+
+pub(super) fn parse_phase(value: &str) -> Result<AgentTargetPhase, DatabaseError> {
+    match value {
+        "pending" => Ok(AgentTargetPhase::Pending),
+        "waiting_for_idle" => Ok(AgentTargetPhase::WaitingForIdle),
+        "quiescing" => Ok(AgentTargetPhase::Quiescing),
+        "applying" => Ok(AgentTargetPhase::Applying),
+        "resuming" => Ok(AgentTargetPhase::Resuming),
+        "current" => Ok(AgentTargetPhase::Current),
+        "ready_with_issues" => Ok(AgentTargetPhase::ReadyWithIssues),
+        "degraded" => Ok(AgentTargetPhase::Degraded),
+        "retiring" => Ok(AgentTargetPhase::Retiring),
+        "recovery_required" => Ok(AgentTargetPhase::RecoveryRequired),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target phase".to_string(),
+        )),
+    }
+}
+
+pub(super) fn impact_value(impact: ConditionImpact) -> &'static str {
+    match impact {
+        ConditionImpact::Blocking => "blocking",
+        ConditionImpact::NonBlocking => "non_blocking",
+    }
+}
+
+pub(super) fn parse_impact(value: &str) -> Result<ConditionImpact, DatabaseError> {
+    match value {
+        "blocking" => Ok(ConditionImpact::Blocking),
+        "non_blocking" => Ok(ConditionImpact::NonBlocking),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown condition impact".to_string(),
+        )),
+    }
+}
+
+pub(super) fn reconcile_state_value(state: AgentTargetReconcileState) -> &'static str {
+    match state {
+        AgentTargetReconcileState::Pending => "pending",
+        AgentTargetReconcileState::Claimed => "claimed",
+        AgentTargetReconcileState::Blocked => "blocked",
+        AgentTargetReconcileState::RetryScheduled => "retry_scheduled",
+    }
+}
+
+pub(super) fn parse_reconcile_state(
+    value: &str,
+) -> Result<AgentTargetReconcileState, DatabaseError> {
+    match value {
+        "pending" => Ok(AgentTargetReconcileState::Pending),
+        "claimed" => Ok(AgentTargetReconcileState::Claimed),
+        "blocked" => Ok(AgentTargetReconcileState::Blocked),
+        "retry_scheduled" => Ok(AgentTargetReconcileState::RetryScheduled),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target reconcile state".to_string(),
+        )),
+    }
+}
+
+pub(super) fn wake_reason_value(reason: AgentTargetWakeReason) -> &'static str {
+    match reason {
+        AgentTargetWakeReason::DesiredChanged => "desired_changed",
+        AgentTargetWakeReason::CapabilityChanged => "capability_changed",
+        AgentTargetWakeReason::Retry => "retry",
+        AgentTargetWakeReason::Recovery => "recovery",
+        AgentTargetWakeReason::StartupRepair => "startup_repair",
+    }
+}
+
+pub(super) fn parse_wake_reason(value: &str) -> Result<AgentTargetWakeReason, DatabaseError> {
+    match value {
+        "desired_changed" => Ok(AgentTargetWakeReason::DesiredChanged),
+        "capability_changed" => Ok(AgentTargetWakeReason::CapabilityChanged),
+        "retry" => Ok(AgentTargetWakeReason::Retry),
+        "recovery" => Ok(AgentTargetWakeReason::Recovery),
+        "startup_repair" => Ok(AgentTargetWakeReason::StartupRepair),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target wake reason".to_string(),
+        )),
+    }
+}
+
+pub(super) fn condition_reason_value(reason: AgentTargetConditionReason) -> &'static str {
+    match reason {
+        AgentTargetConditionReason::NoConsumers => "no_consumers",
+        AgentTargetConditionReason::IncompatibleSurfaceDeclarations => {
+            "incompatible_surface_declarations"
+        }
+        AgentTargetConditionReason::DesiredCollision => "desired_collision",
+        AgentTargetConditionReason::PreservedConflict => "preserved_conflict",
+        AgentTargetConditionReason::OwnershipConflict => "ownership_conflict",
+        AgentTargetConditionReason::DriftConflict => "drift_conflict",
+        AgentTargetConditionReason::SourceUnavailable => "source_unavailable",
+        AgentTargetConditionReason::PathUnsafe => "path_unsafe",
+        AgentTargetConditionReason::ScanFailed => "scan_failed",
+        AgentTargetConditionReason::WaitingForIdle => "waiting_for_idle",
+        AgentTargetConditionReason::ConsumerResumeFailed => "consumer_resume_failed",
+        AgentTargetConditionReason::MaterializationFailed => "materialization_failed",
+        AgentTargetConditionReason::TransientIo => "transient_io",
+        AgentTargetConditionReason::RecoveryRequired => "recovery_required",
+        AgentTargetConditionReason::UnsupportedByAgent => "unsupported_by_agent",
+        AgentTargetConditionReason::CapabilityInvalid => "capability_invalid",
+    }
+}
+
+pub(super) fn parse_condition_reason(
+    value: &str,
+) -> Result<AgentTargetConditionReason, DatabaseError> {
+    match value {
+        "no_consumers" => Ok(AgentTargetConditionReason::NoConsumers),
+        "incompatible_surface_declarations" => {
+            Ok(AgentTargetConditionReason::IncompatibleSurfaceDeclarations)
+        }
+        "desired_collision" => Ok(AgentTargetConditionReason::DesiredCollision),
+        "preserved_conflict" => Ok(AgentTargetConditionReason::PreservedConflict),
+        "ownership_conflict" => Ok(AgentTargetConditionReason::OwnershipConflict),
+        "drift_conflict" => Ok(AgentTargetConditionReason::DriftConflict),
+        "source_unavailable" => Ok(AgentTargetConditionReason::SourceUnavailable),
+        "path_unsafe" => Ok(AgentTargetConditionReason::PathUnsafe),
+        "scan_failed" => Ok(AgentTargetConditionReason::ScanFailed),
+        "waiting_for_idle" => Ok(AgentTargetConditionReason::WaitingForIdle),
+        "consumer_resume_failed" => Ok(AgentTargetConditionReason::ConsumerResumeFailed),
+        "materialization_failed" => Ok(AgentTargetConditionReason::MaterializationFailed),
+        "transient_io" => Ok(AgentTargetConditionReason::TransientIo),
+        "recovery_required" => Ok(AgentTargetConditionReason::RecoveryRequired),
+        "unsupported_by_agent" => Ok(AgentTargetConditionReason::UnsupportedByAgent),
+        "capability_invalid" => Ok(AgentTargetConditionReason::CapabilityInvalid),
+        _ => Err(DatabaseError::CorruptEffectState(
+            "unknown agent target condition reason".to_string(),
+        )),
+    }
+}

--- a/crates/db/src/repository/effect/agent_target/mod.rs
+++ b/crates/db/src/repository/effect/agent_target/mod.rs
@@ -1,0 +1,713 @@
+//! Typed SQLite persistence for Agent Target Expand-phase Effect state.
+//!
+//! These APIs coexist with the surface-keyed Skill repository. Production workers must not claim
+//! target reconcile requests until a later Contract ticket switches ownership.
+
+mod encode;
+
+use super::SqliteEffectRepository;
+use crate::DatabaseError;
+use encode::*;
+use ora_domain::WorkspaceId;
+use ora_effect::{
+    AgentCapabilityRevision, AgentPluginId, AgentTarget, AgentTargetCondition,
+    AgentTargetConditionSubject, AgentTargetId, AgentTargetIdentity, AgentTargetLifecycle,
+    AgentTargetReconcileRequest, AgentTargetReconcileState, AgentTargetRecord,
+    AgentTargetRepository, AgentTargetRepositoryError, AgentTargetStatus, AgentTargetWakeReason,
+    ConsumerId, Generation, SurfaceKey,
+};
+use rusqlite::{OptionalExtension, TransactionBehavior, params};
+use uuid::Uuid;
+
+impl AgentTargetRepository for SqliteEffectRepository {
+    fn upsert_agent_target(
+        &self,
+        identity: &AgentTargetIdentity,
+        capability_revision: &AgentCapabilityRevision,
+        lifecycle: AgentTargetLifecycle,
+        updated_at: i64,
+    ) -> Result<AgentTarget, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection_mut(|connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                ensure_workspace_effect(&transaction, &identity.workspace_id, updated_at)?;
+                let existing = transaction
+                    .query_row(
+                        "SELECT id, created_at FROM effect_agent_targets
+                         WHERE workspace_id = ?1 AND agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+                    )
+                    .optional()?;
+                let (id, created_at) = if let Some((id, created_at)) = existing {
+                    transaction.execute(
+                        "UPDATE effect_agent_targets
+                         SET capability_revision = ?1, lifecycle = ?2, updated_at = ?3
+                         WHERE id = ?4",
+                        params![
+                            capability_revision.as_str(),
+                            lifecycle_value(lifecycle),
+                            updated_at,
+                            &id
+                        ],
+                    )?;
+                    (id, created_at)
+                } else {
+                    let id = Uuid::new_v4().to_string();
+                    transaction.execute(
+                        "INSERT INTO effect_agent_targets (
+                             id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                             created_at, updated_at
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+                        params![
+                            &id,
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str(),
+                            capability_revision.as_str(),
+                            lifecycle_value(lifecycle),
+                            updated_at,
+                        ],
+                    )?;
+                    transaction.execute(
+                        "INSERT INTO effect_agent_target_status (
+                             agent_target_id, desired_generation, observed_generation,
+                             applied_generation, ready_generation, phase, status_version,
+                             created_at, updated_at
+                         ) VALUES (?1, 0, 0, 0, 0, 'current', 1, ?2, ?2)",
+                        params![&id, updated_at],
+                    )?;
+                    (id, updated_at)
+                };
+                transaction.commit()?;
+                Ok(AgentTarget {
+                    id: AgentTargetId::new(id),
+                    identity: identity.clone(),
+                    capability_revision: capability_revision.clone(),
+                    lifecycle,
+                    created_at,
+                    updated_at,
+                })
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTarget>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                connection
+                    .query_row(
+                        "SELECT id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                                created_at, updated_at
+                         FROM effect_agent_targets
+                         WHERE workspace_id = ?1 AND agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        map_agent_target_row,
+                    )
+                    .optional()
+                    .map_err(Into::into)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target_by_id(
+        &self,
+        agent_target_id: &AgentTargetId,
+    ) -> Result<Option<AgentTarget>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                connection
+                    .query_row(
+                        "SELECT id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                                created_at, updated_at
+                         FROM effect_agent_targets
+                         WHERE id = ?1",
+                        params![agent_target_id.as_str()],
+                        map_agent_target_row,
+                    )
+                    .optional()
+                    .map_err(Into::into)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn save_agent_target_status(
+        &self,
+        status: &AgentTargetStatus,
+    ) -> Result<(), AgentTargetRepositoryError> {
+        validate_generation_order(status)?;
+        self.pool
+            .with_connection_mut(|connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let updated = transaction.execute(
+                    "UPDATE effect_agent_target_status
+                     SET desired_generation = ?1, observed_generation = ?2,
+                         applied_generation = ?3, ready_generation = ?4, phase = ?5,
+                         status_version = ?6, updated_at = ?7
+                     WHERE agent_target_id = ?8",
+                    params![
+                        generation_to_sql(status.desired_generation)?,
+                        generation_to_sql(status.observed_generation)?,
+                        generation_to_sql(status.applied_generation)?,
+                        generation_to_sql(status.ready_generation)?,
+                        phase_value(status.phase),
+                        u64_to_sql(status.status_version, "status_version")?,
+                        status.updated_at,
+                        status.agent_target_id.as_str(),
+                    ],
+                )?;
+                if updated == 0 {
+                    return Err(DatabaseError::CorruptEffectState(
+                        "agent target status row is missing".to_string(),
+                    ));
+                }
+                replace_target_conditions(
+                    &transaction,
+                    status.agent_target_id.as_str(),
+                    &status.conditions,
+                )?;
+                transaction.commit()?;
+                Ok(())
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target_status(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetStatus>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                let Some(target) = connection
+                    .query_row(
+                        "SELECT id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                                created_at, updated_at
+                         FROM effect_agent_targets
+                         WHERE workspace_id = ?1 AND agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        map_agent_target_row,
+                    )
+                    .optional()?
+                else {
+                    return Ok(None);
+                };
+                load_status_for_target(connection, &target).map(Some)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn upsert_agent_target_reconcile_request(
+        &self,
+        identity: &AgentTargetIdentity,
+        requested_generation: Generation,
+        wake_reason: AgentTargetWakeReason,
+        not_before_at: i64,
+        updated_at: i64,
+    ) -> Result<AgentTargetReconcileRequest, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection_mut(|connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let target_id: String = transaction
+                    .query_row(
+                        "SELECT id FROM effect_agent_targets
+                         WHERE workspace_id = ?1 AND agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        |row| row.get(0),
+                    )
+                    .map_err(|_| {
+                        DatabaseError::CorruptEffectState(format!(
+                            "agent target missing for workspace {} and plugin {}",
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ))
+                    })?;
+                let existing = transaction
+                    .query_row(
+                        "SELECT requested_generation, request_token, state, wake_reason,
+                                blocked_reason, lease_owner, lease_expires_at, attempt_count,
+                                requested_at, not_before_at, updated_at
+                         FROM effect_agent_target_reconcile_requests
+                         WHERE agent_target_id = ?1",
+                        params![&target_id],
+                        map_request_columns,
+                    )
+                    .optional()?;
+                let request = if let Some(existing) = existing {
+                    // Keep the highest requested generation and the earliest due time across wakes.
+                    let requested_generation =
+                        existing.requested_generation.max(requested_generation);
+                    let wake_requested_at = updated_at.min(not_before_at);
+                    let requested_at = existing.requested_at.min(wake_requested_at);
+                    let due_at = existing.not_before_at.min(not_before_at).max(requested_at);
+                    let (state, blocked_reason, lease_owner, lease_expires_at) =
+                        if existing.state == AgentTargetReconcileState::Claimed {
+                            (
+                                existing.state,
+                                existing.blocked_reason,
+                                existing.lease_owner,
+                                existing.lease_expires_at,
+                            )
+                        } else {
+                            (AgentTargetReconcileState::Pending, None, None, None)
+                        };
+                    let updated_at = updated_at.max(existing.updated_at);
+                    transaction.execute(
+                        "UPDATE effect_agent_target_reconcile_requests
+                         SET requested_generation = ?1, state = ?2, wake_reason = ?3,
+                             blocked_reason = ?4, lease_owner = ?5, lease_expires_at = ?6,
+                             requested_at = ?7, not_before_at = ?8, updated_at = ?9
+                         WHERE agent_target_id = ?10",
+                        params![
+                            generation_to_sql(requested_generation)?,
+                            reconcile_state_value(state),
+                            wake_reason_value(wake_reason),
+                            blocked_reason.as_deref(),
+                            lease_owner.as_deref(),
+                            lease_expires_at,
+                            requested_at,
+                            due_at,
+                            updated_at,
+                            &target_id,
+                        ],
+                    )?;
+                    AgentTargetReconcileRequest {
+                        agent_target_id: AgentTargetId::new(target_id),
+                        identity: identity.clone(),
+                        requested_generation,
+                        request_token: existing.request_token,
+                        state,
+                        wake_reason,
+                        blocked_reason,
+                        lease_owner,
+                        lease_expires_at,
+                        attempt_count: existing.attempt_count,
+                        requested_at,
+                        not_before_at: due_at,
+                        updated_at,
+                    }
+                } else {
+                    let token = Uuid::new_v4().to_string();
+                    let requested_at = updated_at.min(not_before_at);
+                    let due_at = not_before_at.max(requested_at);
+                    transaction.execute(
+                        "INSERT INTO effect_agent_target_reconcile_requests (
+                             agent_target_id, requested_generation, request_token, state,
+                             wake_reason, blocked_reason, lease_owner, lease_expires_at,
+                             attempt_count, requested_at, not_before_at, updated_at
+                         ) VALUES (?1, ?2, ?3, 'pending', ?4, NULL, NULL, NULL, 0, ?5, ?6, ?7)",
+                        params![
+                            &target_id,
+                            generation_to_sql(requested_generation)?,
+                            &token,
+                            wake_reason_value(wake_reason),
+                            requested_at,
+                            due_at,
+                            updated_at,
+                        ],
+                    )?;
+                    AgentTargetReconcileRequest {
+                        agent_target_id: AgentTargetId::new(target_id),
+                        identity: identity.clone(),
+                        requested_generation,
+                        request_token: token,
+                        state: AgentTargetReconcileState::Pending,
+                        wake_reason,
+                        blocked_reason: None,
+                        lease_owner: None,
+                        lease_expires_at: None,
+                        attempt_count: 0,
+                        requested_at,
+                        not_before_at: due_at,
+                        updated_at,
+                    }
+                };
+                transaction.commit()?;
+                Ok(request)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target_reconcile_request(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetReconcileRequest>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                connection
+                    .query_row(
+                        "SELECT targets.id, targets.workspace_id, targets.agent_plugin_id,
+                                requests.requested_generation, requests.request_token,
+                                requests.state, requests.wake_reason, requests.blocked_reason,
+                                requests.lease_owner, requests.lease_expires_at,
+                                requests.attempt_count, requests.requested_at,
+                                requests.not_before_at, requests.updated_at
+                         FROM effect_agent_target_reconcile_requests requests
+                         JOIN effect_agent_targets targets
+                           ON targets.id = requests.agent_target_id
+                         WHERE targets.workspace_id = ?1 AND targets.agent_plugin_id = ?2",
+                        params![
+                            identity.workspace_id.as_ref(),
+                            identity.agent_plugin_id.as_str()
+                        ],
+                        map_full_request_row,
+                    )
+                    .optional()
+                    .map_err(Into::into)
+            })
+            .map_err(map_db_error)
+    }
+
+    fn replace_agent_target_conditions(
+        &self,
+        agent_target_id: &AgentTargetId,
+        conditions: &[AgentTargetCondition],
+    ) -> Result<(), AgentTargetRepositoryError> {
+        self.pool
+            .with_connection_mut(|connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                replace_target_conditions(&transaction, agent_target_id.as_str(), conditions)?;
+                transaction.commit()?;
+                Ok(())
+            })
+            .map_err(map_db_error)
+    }
+
+    fn load_agent_target_record(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetRecord>, AgentTargetRepositoryError> {
+        let Some(target) = self.load_agent_target(identity)? else {
+            return Ok(None);
+        };
+        let status = self.load_agent_target_status(identity)?.ok_or_else(|| {
+            AgentTargetRepositoryError::corrupt("agent target status row is missing")
+        })?;
+        let reconcile_request = self.load_agent_target_reconcile_request(identity)?;
+        Ok(Some(AgentTargetRecord {
+            target,
+            status,
+            reconcile_request,
+        }))
+    }
+
+    fn list_agent_targets_for_workspace(
+        &self,
+        workspace_id: &WorkspaceId,
+    ) -> Result<Vec<AgentTarget>, AgentTargetRepositoryError> {
+        self.pool
+            .with_connection(|connection| {
+                let mut statement = connection.prepare(
+                    "SELECT id, workspace_id, agent_plugin_id, capability_revision, lifecycle,
+                            created_at, updated_at
+                     FROM effect_agent_targets
+                     WHERE workspace_id = ?1
+                     ORDER BY agent_plugin_id",
+                )?;
+                let rows =
+                    statement.query_map(params![workspace_id.as_ref()], map_agent_target_row)?;
+                rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+            })
+            .map_err(map_db_error)
+    }
+}
+
+/// Refuses to create an Agent Target without the Workspace Effect aggregate that owns generations.
+fn ensure_workspace_effect(
+    transaction: &rusqlite::Transaction<'_>,
+    workspace_id: &WorkspaceId,
+    _now: i64,
+) -> Result<(), DatabaseError> {
+    let exists: bool = transaction.query_row(
+        "SELECT EXISTS(SELECT 1 FROM workspace_effects WHERE workspace_id = ?1)",
+        params![workspace_id.as_ref()],
+        |row| row.get(0),
+    )?;
+    if exists {
+        return Ok(());
+    }
+    Err(DatabaseError::CorruptEffectState(format!(
+        "workspace effect missing for {}",
+        workspace_id.as_ref()
+    )))
+}
+
+fn load_status_for_target(
+    connection: &rusqlite::Connection,
+    target: &AgentTarget,
+) -> Result<AgentTargetStatus, DatabaseError> {
+    let mut status = connection.query_row(
+        "SELECT desired_generation, observed_generation, applied_generation, ready_generation,
+                phase, status_version, created_at, updated_at
+         FROM effect_agent_target_status
+         WHERE agent_target_id = ?1",
+        params![target.id.as_str()],
+        |row| {
+            Ok(AgentTargetStatus {
+                agent_target_id: target.id.clone(),
+                identity: target.identity.clone(),
+                desired_generation: generation_from_row(row, 0)?,
+                observed_generation: generation_from_row(row, 1)?,
+                applied_generation: generation_from_row(row, 2)?,
+                ready_generation: generation_from_row(row, 3)?,
+                phase: parse_phase(&row.get::<_, String>(4)?).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        4,
+                        rusqlite::types::Type::Text,
+                        Box::new(error),
+                    )
+                })?,
+                status_version: u64_from_row(row, 5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+                conditions: Vec::new(),
+            })
+        },
+    )?;
+    status.conditions = load_target_conditions(connection, target.id.as_str())?;
+    Ok(status)
+}
+
+fn load_target_conditions(
+    connection: &rusqlite::Connection,
+    agent_target_id: &str,
+) -> Result<Vec<AgentTargetCondition>, DatabaseError> {
+    let mut statement = connection.prepare(
+        "SELECT id, surface_id, consumer_id, subject_kind, subject_id, reason, impact,
+                failed_generation, message, first_observed_at, last_observed_at
+         FROM effect_agent_target_conditions
+         WHERE agent_target_id = ?1
+         ORDER BY subject_kind, subject_id, reason, IFNULL(surface_id, ''), IFNULL(consumer_id, '')",
+    )?;
+    let rows = statement.query_map(params![agent_target_id], |row| {
+        let subject_json: String = row.get(4)?;
+        let subject = serde_json::from_str::<AgentTargetConditionSubject>(&subject_json).map_err(
+            |error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    4,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+            },
+        )?;
+        let reason_raw: String = row.get(5)?;
+        let reason = parse_condition_reason(&reason_raw).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+        let impact = parse_impact(&row.get::<_, String>(6)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+        let failed_generation = match row.get::<_, Option<i64>>(7)? {
+            Some(value) => Some(generation_from_sql(value).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    7,
+                    rusqlite::types::Type::Integer,
+                    Box::new(error),
+                )
+            })?),
+            None => None,
+        };
+        let surface_id: Option<String> = row.get(1)?;
+        let consumer_id: Option<String> = row.get(2)?;
+        Ok(AgentTargetCondition {
+            id: row.get(0)?,
+            subject,
+            reason,
+            impact,
+            message: row.get(8)?,
+            first_observed_at: row.get(9)?,
+            last_observed_at: row.get(10)?,
+            failed_generation,
+            surface_key: surface_id.map(SurfaceKey::new),
+            consumer_id: consumer_id.map(ConsumerId::new),
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+fn replace_target_conditions(
+    transaction: &rusqlite::Transaction<'_>,
+    agent_target_id: &str,
+    conditions: &[AgentTargetCondition],
+) -> Result<(), DatabaseError> {
+    transaction.execute(
+        "DELETE FROM effect_agent_target_conditions WHERE agent_target_id = ?1",
+        params![agent_target_id],
+    )?;
+    for condition in conditions {
+        let subject_kind = match &condition.subject {
+            AgentTargetConditionSubject::AgentTarget => "agent_target",
+            AgentTargetConditionSubject::Surface { .. } => "surface",
+            AgentTargetConditionSubject::Consumer { .. } => "consumer",
+            AgentTargetConditionSubject::DesiredSkill { .. } => "desired_item",
+            AgentTargetConditionSubject::ManagedSkill { .. } => "managed_item",
+            AgentTargetConditionSubject::Mcp { .. } => "mcp",
+        };
+        let subject_id = serde_json::to_string(&condition.subject)
+            .map_err(|error| DatabaseError::CorruptEffectState(error.to_string()))?;
+        let id = if condition.id.is_empty() {
+            Uuid::new_v4().to_string()
+        } else {
+            condition.id.clone()
+        };
+        transaction.execute(
+            "INSERT INTO effect_agent_target_conditions (
+                 id, agent_target_id, surface_id, consumer_id, subject_kind, subject_id, reason,
+                 impact, failed_generation, message, first_observed_at, last_observed_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                id,
+                agent_target_id,
+                condition.surface_key.as_ref().map(SurfaceKey::as_str),
+                condition.consumer_id.as_ref().map(ConsumerId::as_str),
+                subject_kind,
+                subject_id,
+                condition_reason_value(condition.reason),
+                impact_value(condition.impact),
+                condition
+                    .failed_generation
+                    .map(generation_to_sql)
+                    .transpose()?,
+                &condition.message,
+                condition.first_observed_at,
+                condition.last_observed_at,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn map_agent_target_row(row: &rusqlite::Row<'_>) -> Result<AgentTarget, rusqlite::Error> {
+    Ok(AgentTarget {
+        id: AgentTargetId::new(row.get::<_, String>(0)?),
+        identity: AgentTargetIdentity::new(
+            WorkspaceId::new(row.get::<_, String>(1)?),
+            AgentPluginId::new(row.get::<_, String>(2)?),
+        ),
+        capability_revision: AgentCapabilityRevision::new(row.get::<_, String>(3)?),
+        lifecycle: parse_lifecycle(&row.get::<_, String>(4)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                4,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        created_at: row.get(5)?,
+        updated_at: row.get(6)?,
+    })
+}
+
+struct RequestColumns {
+    requested_generation: Generation,
+    request_token: String,
+    state: AgentTargetReconcileState,
+    blocked_reason: Option<String>,
+    lease_owner: Option<String>,
+    lease_expires_at: Option<i64>,
+    attempt_count: u32,
+    requested_at: i64,
+    not_before_at: i64,
+    updated_at: i64,
+}
+
+fn map_request_columns(row: &rusqlite::Row<'_>) -> Result<RequestColumns, rusqlite::Error> {
+    // Validate wake_reason even though coalescing replaces it with the newest wake.
+    let _: AgentTargetWakeReason =
+        parse_wake_reason(&row.get::<_, String>(3)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+    Ok(RequestColumns {
+        requested_generation: generation_from_row(row, 0)?,
+        request_token: row.get(1)?,
+        state: parse_reconcile_state(&row.get::<_, String>(2)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                2,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        blocked_reason: row.get(4)?,
+        lease_owner: row.get(5)?,
+        lease_expires_at: row.get(6)?,
+        attempt_count: u32_from_row(row, 7)?,
+        requested_at: row.get(8)?,
+        not_before_at: row.get(9)?,
+        updated_at: row.get(10)?,
+    })
+}
+
+fn map_full_request_row(
+    row: &rusqlite::Row<'_>,
+) -> Result<AgentTargetReconcileRequest, rusqlite::Error> {
+    Ok(AgentTargetReconcileRequest {
+        agent_target_id: AgentTargetId::new(row.get::<_, String>(0)?),
+        identity: AgentTargetIdentity::new(
+            WorkspaceId::new(row.get::<_, String>(1)?),
+            AgentPluginId::new(row.get::<_, String>(2)?),
+        ),
+        requested_generation: generation_from_row(row, 3)?,
+        request_token: row.get(4)?,
+        state: parse_reconcile_state(&row.get::<_, String>(5)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        wake_reason: parse_wake_reason(&row.get::<_, String>(6)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?,
+        blocked_reason: row.get(7)?,
+        lease_owner: row.get(8)?,
+        lease_expires_at: row.get(9)?,
+        attempt_count: u32_from_row(row, 10)?,
+        requested_at: row.get(11)?,
+        not_before_at: row.get(12)?,
+        updated_at: row.get(13)?,
+    })
+}
+
+fn validate_generation_order(status: &AgentTargetStatus) -> Result<(), AgentTargetRepositoryError> {
+    if status.applied_generation > status.observed_generation
+        || status.observed_generation > status.desired_generation
+        || status.ready_generation > status.applied_generation
+    {
+        return Err(AgentTargetRepositoryError::corrupt(
+            "agent target generation ordering is illegal",
+        ));
+    }
+    Ok(())
+}

--- a/crates/db/src/repository/effect/mod.rs
+++ b/crates/db/src/repository/effect/mod.rs
@@ -1,3 +1,4 @@
+mod agent_target;
 mod mapping;
 
 use crate::{DatabaseError, RepositoryPool};

--- a/crates/db/src/tests.rs
+++ b/crates/db/src/tests.rs
@@ -29,7 +29,7 @@ fn bootstraps_the_current_workspace_schema() {
     let catalog = default_migration_catalog().expect("build migration catalog");
     assert_eq!(
         catalog.target_versions(),
-        ["0001", "0002", "0003", "0004", "0005", "0006"]
+        ["0001", "0002", "0003", "0004", "0005", "0006", "0007"]
     );
 
     let database = with_trace_logging(|| {
@@ -44,6 +44,10 @@ fn bootstraps_the_current_workspace_schema() {
         load_table_names(database.connection()),
         vec![
             "agents",
+            "effect_agent_target_conditions",
+            "effect_agent_target_reconcile_requests",
+            "effect_agent_target_status",
+            "effect_agent_targets",
             "effect_audit_events",
             "effect_conditions",
             "effect_consumer_status",

--- a/crates/effect/README.md
+++ b/crates/effect/README.md
@@ -1,12 +1,15 @@
 # ora-effect
 
 `ora-effect` owns Ora's workspace-scoped declarative Skill State and the machinery that safely
-projects it onto consumer-declared filesystem surfaces.
+projects it onto consumer-declared filesystem surfaces. It also defines the Agent Target domain
+types and persistence port used by the Expand-phase target-keyed Effect schema.
 
 ## Responsibilities
 
 - Strong identities for selections, exact source states, managed ownership, surfaces, operations,
   and generations.
+- Agent Target identity (Workspace × Agent Plugin), target status generations, target-owned
+  conditions with Blocking/NonBlocking impact, and target reconcile-request shapes.
 - A pure planner that separates desired, managed, observed, and preserved state and never grants
   ownership from disk contents alone.
 - Consumer descriptor merging, structured conditions, retry policy, and per-consumer readiness.
@@ -24,4 +27,6 @@ all materialized content except the ownership marker.
 
 Reconciliation plans a complete surface before mutation, serializes one physical surface at a
 time through its repository request, and treats watcher payloads only as wakeups. Different
-surfaces may be driven concurrently by the host.
+surfaces may be driven concurrently by the host. Agent Target persistence types coexist with the
+surface-keyed Skill worker; runtime cutover to target-keyed claims is out of scope for this crate's
+domain layer alone.

--- a/crates/effect/README.md
+++ b/crates/effect/README.md
@@ -10,6 +10,8 @@ types and persistence port used by the Expand-phase target-keyed Effect schema.
   and generations.
 - Agent Target identity (Workspace × Agent Plugin), target status generations, target-owned
   conditions with Blocking/NonBlocking impact, and target reconcile-request shapes.
+- Agent Capability Revision binding of an exact plugin package version to the canonical digest of
+  the plugin's declared configuration capabilities.
 - A pure planner that separates desired, managed, observed, and preserved state and never grants
   ownership from disk contents alone.
 - Consumer descriptor merging, structured conditions, retry policy, and per-consumer readiness.

--- a/crates/effect/src/agent_target/README.md
+++ b/crates/effect/src/agent_target/README.md
@@ -9,7 +9,8 @@ by a physical Skill surface.
 
 - Strong identities for Agent Targets, capability revisions, and target-owned conditions.
 - Binding Agent Capability Revision to an exact plugin package version and the canonical digest of
-  the declared configuration capability.
+  the declared configuration capability. Process-local Skill-only Expand declarations leave revision
+  unset rather than encoding absence as an empty string.
 - Closed enums for target phase, condition impact, reconcile state, and wake reason.
 - The `AgentTargetRepository` port for typed persistence without activating target-keyed workers.
 - Complete record shapes suitable for whole-object repository round-trips.

--- a/crates/effect/src/agent_target/README.md
+++ b/crates/effect/src/agent_target/README.md
@@ -8,6 +8,8 @@ by a physical Skill surface.
 ## Responsibilities
 
 - Strong identities for Agent Targets, capability revisions, and target-owned conditions.
+- Binding Agent Capability Revision to an exact plugin package version and the canonical digest of
+  the declared configuration capability.
 - Closed enums for target phase, condition impact, reconcile state, and wake reason.
 - The `AgentTargetRepository` port for typed persistence without activating target-keyed workers.
 - Complete record shapes suitable for whole-object repository round-trips.

--- a/crates/effect/src/agent_target/README.md
+++ b/crates/effect/src/agent_target/README.md
@@ -1,0 +1,19 @@
+# Agent Target domain
+
+This module defines the Agent Target-shaped Effect persistence vocabulary used by the Expand
+migration and typed repository APIs. An Agent Target is uniquely identified by Workspace identity
+plus Agent Plugin identity. Status, reconcile requests, and conditions are owned by the target, not
+by a physical Skill surface.
+
+## Responsibilities
+
+- Strong identities for Agent Targets, capability revisions, and target-owned conditions.
+- Closed enums for target phase, condition impact, reconcile state, and wake reason.
+- The `AgentTargetRepository` port for typed persistence without activating target-keyed workers.
+- Complete record shapes suitable for whole-object repository round-trips.
+
+## Non-responsibilities
+
+- SQLite schema, backfill SQL, or repository transactions.
+- Target-keyed worker claim loops, admission gates, MCP resolution, or OpenCode materialization.
+- Compatibility views that hide the temporary coexistence of surface-keyed and target-keyed tables.

--- a/crates/effect/src/agent_target/mod.rs
+++ b/crates/effect/src/agent_target/mod.rs
@@ -70,26 +70,16 @@ impl From<ConsumerId> for AgentPluginId {
 }
 
 /// Digest of the Agent Plugin version and its declared configuration capabilities.
+///
+/// Process-local Skill-only Expand declarations leave revision unset (`Option::None` on the
+/// declaration) instead of encoding that absence as an empty string here.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct AgentCapabilityRevision(String);
 
 impl AgentCapabilityRevision {
-    /// Accepts an opaque revision token; empty means "not yet negotiated" during Expand.
+    /// Accepts an already-persisted revision token from the Agent Target ledger.
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
-    }
-
-    /// Skill-only Expand declarations that have not negotiated an MCP capability yet.
-    ///
-    /// Live attach always binds a version and digest. This sentinel exists so the Skill-only
-    /// replacement path can still remove a plugin when it has no surfaces left.
-    pub fn unspecified() -> Self {
-        Self(String::new())
-    }
-
-    /// Returns whether this revision is the Expand Skill-only sentinel rather than a bound digest.
-    pub fn is_unspecified(&self) -> bool {
-        self.0.is_empty()
     }
 
     /// Returns the persistence representation.

--- a/crates/effect/src/agent_target/mod.rs
+++ b/crates/effect/src/agent_target/mod.rs
@@ -79,9 +79,30 @@ impl AgentCapabilityRevision {
         Self(value.into())
     }
 
+    /// Skill-only Expand declarations that have not negotiated an MCP capability yet.
+    ///
+    /// Live attach always binds a version and digest. This sentinel exists so the Skill-only
+    /// replacement path can still remove a plugin when it has no surfaces left.
+    pub fn unspecified() -> Self {
+        Self(String::new())
+    }
+
+    /// Returns whether this revision is the Expand Skill-only sentinel rather than a bound digest.
+    pub fn is_unspecified(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Returns the persistence representation.
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Binds one exact plugin package version to the canonical capability declaration digest.
+    ///
+    /// Both inputs are required because a version-only upgrade and a capability-only change must
+    /// each produce a distinct revision so Agent Targets can be reconciled again.
+    pub fn bind(plugin_version: &str, capability_digest: &crate::Digest) -> Self {
+        Self(format!("{plugin_version}/{}", capability_digest.as_str()))
     }
 }
 
@@ -265,4 +286,25 @@ pub struct AgentTargetRecord {
     pub target: AgentTarget,
     pub status: AgentTargetStatus,
     pub reconcile_request: Option<AgentTargetReconcileRequest>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Digest;
+    use pretty_assertions::assert_eq;
+
+    /// Version-only and digest-only changes must each produce a distinct revision.
+    #[test]
+    fn capability_revision_bind_includes_version_and_digest() {
+        let digest_a = Digest::sha256(b"capability-a");
+        let digest_b = Digest::sha256(b"capability-b");
+        let first = AgentCapabilityRevision::bind("0.2.2", &digest_a);
+        assert_eq!(
+            first,
+            AgentCapabilityRevision::new(format!("0.2.2/{}", digest_a.as_str()))
+        );
+        assert_ne!(first, AgentCapabilityRevision::bind("0.3.0", &digest_a));
+        assert_ne!(first, AgentCapabilityRevision::bind("0.2.2", &digest_b));
+    }
 }

--- a/crates/effect/src/agent_target/mod.rs
+++ b/crates/effect/src/agent_target/mod.rs
@@ -1,0 +1,268 @@
+//! Agent Target identity, status, conditions, and reconcile-request domain types.
+//!
+//! These types define the target-keyed Effect persistence shape introduced beside the existing
+//! surface-keyed Skill worker. Runtime cutover is intentionally out of scope for this module.
+
+mod ports;
+
+pub use ports::{AgentTargetRepository, AgentTargetRepositoryError, initial_agent_target_status};
+
+use crate::{ConsumerId, Generation, ManagedIdentity, SkillSelectionKey, SurfaceKey};
+use ora_domain::WorkspaceId;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display, Formatter};
+use uuid::Uuid;
+
+/// Opaque primary key for one persisted Agent Target row.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AgentTargetId(String);
+
+impl AgentTargetId {
+    /// Wraps an already-persisted identity without inventing a new one.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Allocates a random identity so targets cannot be inferred from Workspace paths.
+    pub fn random() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+
+    /// Returns the persistence representation.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for AgentTargetId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Canonical Agent Plugin identity used as half of an Agent Target unique key.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AgentPluginId(String);
+
+impl AgentPluginId {
+    /// Accepts the stable plugin identity string already used by surface consumers.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Returns the persistence representation.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for AgentPluginId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl From<ConsumerId> for AgentPluginId {
+    /// Surface consumers already carry the Agent Plugin identity string.
+    fn from(value: ConsumerId) -> Self {
+        Self::new(value.as_str())
+    }
+}
+
+/// Digest of the Agent Plugin version and its declared configuration capabilities.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AgentCapabilityRevision(String);
+
+impl AgentCapabilityRevision {
+    /// Accepts an opaque revision token; empty means "not yet negotiated" during Expand.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Returns the persistence representation.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for AgentCapabilityRevision {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Whether an Agent Target still participates in Desired convergence.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetLifecycle {
+    Active,
+    Retired,
+}
+
+/// Unique natural key for one Agent Target: Workspace × Agent Plugin.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AgentTargetIdentity {
+    pub workspace_id: WorkspaceId,
+    pub agent_plugin_id: AgentPluginId,
+}
+
+impl AgentTargetIdentity {
+    /// Builds the only legal Agent Target identity shape.
+    pub fn new(workspace_id: WorkspaceId, agent_plugin_id: AgentPluginId) -> Self {
+        Self {
+            workspace_id,
+            agent_plugin_id,
+        }
+    }
+}
+
+/// Durable Agent Target row without runtime scheduling state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTarget {
+    pub id: AgentTargetId,
+    pub identity: AgentTargetIdentity,
+    pub capability_revision: AgentCapabilityRevision,
+    pub lifecycle: AgentTargetLifecycle,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// High-level progression of one Agent Target reconciliation state machine.
+///
+/// ReadyWithIssues is target-owned: Skill surfaces never express that phase.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetPhase {
+    Pending,
+    WaitingForIdle,
+    Quiescing,
+    Applying,
+    Resuming,
+    Current,
+    ReadyWithIssues,
+    Degraded,
+    Retiring,
+    RecoveryRequired,
+}
+
+/// Whether a condition blocks readiness or only remains visible after Ready.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConditionImpact {
+    Blocking,
+    NonBlocking,
+}
+
+/// Identifies the precise subject of an Agent Target-owned condition.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentTargetConditionSubject {
+    AgentTarget,
+    Surface { surface_key: SurfaceKey },
+    Consumer { consumer_id: ConsumerId },
+    DesiredSkill { selection_key: SkillSelectionKey },
+    ManagedSkill { managed_identity: ManagedIdentity },
+    Mcp { managed_identity: String },
+}
+
+/// Stable machine-readable reasons for an Agent Target not being fully ready.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetConditionReason {
+    NoConsumers,
+    IncompatibleSurfaceDeclarations,
+    DesiredCollision,
+    PreservedConflict,
+    OwnershipConflict,
+    DriftConflict,
+    SourceUnavailable,
+    PathUnsafe,
+    ScanFailed,
+    WaitingForIdle,
+    ConsumerResumeFailed,
+    MaterializationFailed,
+    TransientIo,
+    RecoveryRequired,
+    UnsupportedByAgent,
+    CapabilityInvalid,
+}
+
+/// A current, structured explanation owned by one Agent Target.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetCondition {
+    pub id: String,
+    pub subject: AgentTargetConditionSubject,
+    pub reason: AgentTargetConditionReason,
+    pub impact: ConditionImpact,
+    pub message: String,
+    pub first_observed_at: i64,
+    pub last_observed_at: i64,
+    pub failed_generation: Option<Generation>,
+    /// Optional physical surface association retained for Skill diagnostics.
+    pub surface_key: Option<SurfaceKey>,
+    /// Optional consumer association retained when the condition is consumer-scoped.
+    pub consumer_id: Option<ConsumerId>,
+}
+
+/// Current status of one Agent Target, including readiness generations and conditions.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetStatus {
+    pub agent_target_id: AgentTargetId,
+    pub identity: AgentTargetIdentity,
+    pub desired_generation: Generation,
+    pub observed_generation: Generation,
+    pub applied_generation: Generation,
+    pub ready_generation: Generation,
+    pub phase: AgentTargetPhase,
+    pub status_version: u64,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub conditions: Vec<AgentTargetCondition>,
+}
+
+/// Scheduling state for a durable Agent Target reconcile request.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetReconcileState {
+    Pending,
+    Claimed,
+    Blocked,
+    RetryScheduled,
+}
+
+/// Why a target was woken; kept as a closed set so workers cannot invent opaque strings.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTargetWakeReason {
+    DesiredChanged,
+    CapabilityChanged,
+    Retry,
+    Recovery,
+    StartupRepair,
+}
+
+/// Durable Agent Target reconcile request used by later target-keyed workers.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetReconcileRequest {
+    pub agent_target_id: AgentTargetId,
+    pub identity: AgentTargetIdentity,
+    pub requested_generation: Generation,
+    pub request_token: String,
+    pub state: AgentTargetReconcileState,
+    pub wake_reason: AgentTargetWakeReason,
+    pub blocked_reason: Option<String>,
+    pub lease_owner: Option<String>,
+    pub lease_expires_at: Option<i64>,
+    pub attempt_count: u32,
+    pub requested_at: i64,
+    pub not_before_at: i64,
+    pub updated_at: i64,
+}
+
+/// Complete persisted Agent Target snapshot returned by repository round-trips.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTargetRecord {
+    pub target: AgentTarget,
+    pub status: AgentTargetStatus,
+    pub reconcile_request: Option<AgentTargetReconcileRequest>,
+}

--- a/crates/effect/src/agent_target/ports.rs
+++ b/crates/effect/src/agent_target/ports.rs
@@ -1,0 +1,134 @@
+//! Persistence port for Agent Target-shaped Effect state.
+//!
+//! Implementations must keep this shape independent of the surface-keyed Skill worker so Expand
+//! can land without switching runtime claim loops.
+
+use super::{
+    AgentCapabilityRevision, AgentTarget, AgentTargetCondition, AgentTargetId, AgentTargetIdentity,
+    AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileRequest, AgentTargetRecord,
+    AgentTargetStatus, AgentTargetWakeReason,
+};
+use crate::Generation;
+use ora_domain::WorkspaceId;
+use thiserror::Error;
+
+/// Loads and mutates Agent Target persistence without activating target-keyed workers.
+///
+/// Callers during Expand may exercise these methods in tests and migration verification. Production
+/// Skill reconciliation must continue to use the surface-keyed Effect repository APIs.
+pub trait AgentTargetRepository {
+    /// Creates or refreshes the durable Agent Target row for one Workspace × Agent Plugin pair.
+    fn upsert_agent_target(
+        &self,
+        identity: &AgentTargetIdentity,
+        capability_revision: &AgentCapabilityRevision,
+        lifecycle: AgentTargetLifecycle,
+        updated_at: i64,
+    ) -> Result<AgentTarget, AgentTargetRepositoryError>;
+
+    /// Loads one Agent Target by its natural identity when present.
+    fn load_agent_target(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTarget>, AgentTargetRepositoryError>;
+
+    /// Loads one Agent Target by opaque primary key when present.
+    fn load_agent_target_by_id(
+        &self,
+        agent_target_id: &AgentTargetId,
+    ) -> Result<Option<AgentTarget>, AgentTargetRepositoryError>;
+
+    /// Replaces status generations, phase, version, and owned conditions atomically.
+    fn save_agent_target_status(
+        &self,
+        status: &AgentTargetStatus,
+    ) -> Result<(), AgentTargetRepositoryError>;
+
+    /// Loads status plus owned conditions for one Agent Target identity.
+    fn load_agent_target_status(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetStatus>, AgentTargetRepositoryError>;
+
+    /// Upserts a durable target reconcile request using max-generation / earliest-due semantics.
+    fn upsert_agent_target_reconcile_request(
+        &self,
+        identity: &AgentTargetIdentity,
+        requested_generation: Generation,
+        wake_reason: AgentTargetWakeReason,
+        not_before_at: i64,
+        updated_at: i64,
+    ) -> Result<AgentTargetReconcileRequest, AgentTargetRepositoryError>;
+
+    /// Loads the durable request for one Agent Target when present.
+    fn load_agent_target_reconcile_request(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetReconcileRequest>, AgentTargetRepositoryError>;
+
+    /// Replaces the complete condition set owned by one Agent Target.
+    fn replace_agent_target_conditions(
+        &self,
+        agent_target_id: &AgentTargetId,
+        conditions: &[AgentTargetCondition],
+    ) -> Result<(), AgentTargetRepositoryError>;
+
+    /// Loads the complete persisted record for repository round-trip assertions.
+    fn load_agent_target_record(
+        &self,
+        identity: &AgentTargetIdentity,
+    ) -> Result<Option<AgentTargetRecord>, AgentTargetRepositoryError>;
+
+    /// Lists every Agent Target belonging to one Workspace.
+    fn list_agent_targets_for_workspace(
+        &self,
+        workspace_id: &WorkspaceId,
+    ) -> Result<Vec<AgentTarget>, AgentTargetRepositoryError>;
+}
+
+/// Reports Agent Target persistence failures without leaking SQLite details to domain callers.
+#[derive(Debug, Error)]
+pub enum AgentTargetRepositoryError {
+    #[error("agent target repository error: {0}")]
+    Storage(String),
+    #[error("agent target not found for workspace `{workspace_id}` and plugin `{agent_plugin_id}`")]
+    NotFound {
+        workspace_id: String,
+        agent_plugin_id: String,
+    },
+    #[error("corrupt agent target state: {0}")]
+    Corrupt(String),
+}
+
+impl AgentTargetRepositoryError {
+    /// Wraps a storage failure while preserving the original display text.
+    pub fn storage(error: impl ToString) -> Self {
+        Self::Storage(error.to_string())
+    }
+
+    /// Wraps a corrupt-row failure discovered while decoding persisted state.
+    pub fn corrupt(error: impl ToString) -> Self {
+        Self::Corrupt(error.to_string())
+    }
+}
+
+/// Initial status used when an Agent Target is first materialized without prior surface history.
+pub fn initial_agent_target_status(
+    agent_target_id: AgentTargetId,
+    identity: AgentTargetIdentity,
+    now: i64,
+) -> AgentTargetStatus {
+    AgentTargetStatus {
+        agent_target_id,
+        identity,
+        desired_generation: Generation::default(),
+        observed_generation: Generation::default(),
+        applied_generation: Generation::default(),
+        ready_generation: Generation::default(),
+        phase: AgentTargetPhase::Current,
+        status_version: 1,
+        created_at: now,
+        updated_at: now,
+        conditions: Vec::new(),
+    }
+}

--- a/crates/effect/src/lib.rs
+++ b/crates/effect/src/lib.rs
@@ -1,5 +1,6 @@
 //! Workspace-scoped declarative Skill State and safe filesystem reconciliation.
 
+mod agent_target;
 mod filesystem;
 mod identity;
 mod planner;
@@ -11,6 +12,13 @@ mod surface;
 #[cfg(test)]
 mod tests;
 
+pub use agent_target::{
+    AgentCapabilityRevision, AgentPluginId, AgentTarget, AgentTargetCondition,
+    AgentTargetConditionReason, AgentTargetConditionSubject, AgentTargetId, AgentTargetIdentity,
+    AgentTargetLifecycle, AgentTargetPhase, AgentTargetReconcileRequest, AgentTargetReconcileState,
+    AgentTargetRecord, AgentTargetRepository, AgentTargetRepositoryError, AgentTargetStatus,
+    AgentTargetWakeReason, ConditionImpact, initial_agent_target_status,
+};
 pub use filesystem::{
     FilesystemEffectError, FilesystemSurfaceAdapter, MARKER_FILE_NAME, ManagedSkillMarker,
     OperationPaths, RecoveryDecision, ScanDiagnostic, SurfaceScan,

--- a/crates/logging/src/error_report.rs
+++ b/crates/logging/src/error_report.rs
@@ -14,6 +14,10 @@ static SECRET_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap_or_else(|error| panic!("invalid built-in error redaction pattern: {error}"))
 });
+static BEARER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\bBearer\s+[^\s,;]+")
+        .unwrap_or_else(|error| panic!("invalid built-in Bearer redaction pattern: {error}"))
+});
 static URL_CREDENTIAL_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)(https?://)[^/@\s:]+(?::[^/@\s]*)?@")
         .unwrap_or_else(|error| panic!("invalid built-in URL credential pattern: {error}"))
@@ -115,6 +119,14 @@ impl ErrorReport {
         }
     }
 
+    /// Redacts secret-shaped values from diagnostics that are not error chains.
+    ///
+    /// Plugin stderr, timeout text, and MCP protocol logs must never carry header values,
+    /// environment values, or document bytes, including in debug builds.
+    pub fn sanitize_text(value: &str) -> String {
+        sanitize_node(value)
+    }
+
     /// Returns the top-level semantic context rendered for the active build mode.
     pub fn message(&self) -> &str {
         &self.message
@@ -142,7 +154,8 @@ fn sanitize_node(value: &str) -> String {
             }
         })
         .collect::<String>();
-    let redacted_secrets = SECRET_PATTERN.replace_all(&single_line, "$1=[REDACTED]");
+    let redacted_bearer = BEARER_PATTERN.replace_all(&single_line, "Bearer [REDACTED]");
+    let redacted_secrets = SECRET_PATTERN.replace_all(&redacted_bearer, "$1=[REDACTED]");
     let redacted_credentials =
         URL_CREDENTIAL_PATTERN.replace_all(&redacted_secrets, "$1[REDACTED]@");
     let redacted_urls = URL_PATTERN.replace_all(&redacted_credentials, "[URL]");
@@ -217,6 +230,17 @@ mod tests {
         "git failed at C:\\Users\\alice\\repo; remote=https://alice:secret@example.com/org/repo; value='customer@example.com'"
     )]
     struct SensitiveExternalError;
+
+    #[test]
+    fn sanitize_text_redacts_authorization_headers_in_every_build() {
+        let sanitized = ErrorReport::sanitize_text(
+            r#"Authorization: Bearer tavily-secret-key api_key=also-secret"#,
+        );
+        assert_eq!(
+            sanitized,
+            "Authorization=[REDACTED] [REDACTED] api_key=[REDACTED]"
+        );
+    }
 
     #[test]
     fn redacts_paths_remotes_and_quoted_values() {

--- a/crates/plugin-lifecycle/src/data_plane_tests.rs
+++ b/crates/plugin-lifecycle/src/data_plane_tests.rs
@@ -497,6 +497,7 @@ async fn workbench_plugin_declaring_emits_fails_after_launch() {
         methods: HashSet::from(["counter/get".to_string()]),
         emits: HashSet::from(["counter/tick".to_string()]),
         effect_surfaces: Vec::new(),
+        mcp_configuration: ora_plugin_runtime::McpConfigurationRegistration::Absent,
     });
     let (lifecycle, _events) = open_lifecycle(temp_dir.path(), launcher, NoopNotificationSink);
     let plugin_id = PluginId::new("official", "ora.example").expect("plugin id");
@@ -532,6 +533,7 @@ async fn workbench_plugin_runs_and_lease_reports_registered_methods() {
         methods: HashSet::from(["counter/get".to_string(), "internal/reset".to_string()]),
         emits: HashSet::new(),
         effect_surfaces: Vec::new(),
+        mcp_configuration: ora_plugin_runtime::McpConfigurationRegistration::Absent,
     });
     let (lifecycle, mut events) = open_lifecycle(temp_dir.path(), launcher, NoopNotificationSink);
     start_example(&lifecycle, &mut events).await;

--- a/crates/plugin-lifecycle/src/registration.rs
+++ b/crates/plugin-lifecycle/src/registration.rs
@@ -90,16 +90,19 @@ mod tests {
             methods: HashSet::from(["counter/get".to_string()]),
             emits: HashSet::from(["counter/tick".to_string()]),
             effect_surfaces: Vec::new(),
+            mcp_configuration: ora_plugin_runtime::McpConfigurationRegistration::Absent,
         };
         let bad_name = PluginRegistration {
             methods: HashSet::from(["Counter.Get".to_string()]),
             emits: HashSet::new(),
             effect_surfaces: Vec::new(),
+            mcp_configuration: ora_plugin_runtime::McpConfigurationRegistration::Absent,
         };
         let superset = PluginRegistration {
             methods: HashSet::from(["counter/get".to_string(), "internal/reset".to_string()]),
             emits: HashSet::new(),
             effect_surfaces: Vec::new(),
+            mcp_configuration: ora_plugin_runtime::McpConfigurationRegistration::Absent,
         };
         assert_eq!(
             (

--- a/crates/plugin-runtime/README.md
+++ b/crates/plugin-runtime/README.md
@@ -26,7 +26,12 @@ A plugin declares both traffic directions once, in its `ora/register` notificati
   "jsonrpc": "2.0",
   "method": "ora/register",
   "params": {
-    "methods": ["agent/start", "effect/waitForIdle", "effect/restart"],
+    "methods": [
+      "agent/start",
+      "effect/waitForIdle",
+      "effect/restart",
+      "agent/configureWorkspace",
+    ],
     "emits": ["agent/acp"],
     "effectSurfaces": [
       {
@@ -35,6 +40,11 @@ A plugin declares both traffic directions once, in its `ora/register` notificati
         "coordination": "wait_for_idle_and_restart",
       },
     ],
+    "mcpConfiguration": {
+      "protocolVersion": 1,
+      "transports": ["http"],
+      "coordination": "wait_for_idle_and_restart",
+    },
   },
 }
 ```
@@ -48,6 +58,10 @@ A plugin declares both traffic directions once, in its `ora/register` notificati
   runtime. The runtime crate parses the locator, format, and coordination tokens strictly;
   capability-specific code validates their meaning and derives the trusted consumer identity from
   the launched plugin rather than from this payload.
+- `mcpConfiguration` is an optional additive Agent capability. The runtime records a structurally
+  valid declaration, or an invalid issue, without failing handshake: older plugins omit the field,
+  and a malformed capability only disables MCP materialization. Unknown top-level registration
+  fields other than this one remain ignored so older hosts can skip the capability entirely.
 - Plugin requests to the host (`ora/storage/*` and the like) need no declaration: the
   launch-time handler decides what it serves and answers method-not-found otherwise.
 
@@ -96,3 +110,7 @@ is a protocol failure. Launches without host methods pass `NoHostRequests`.
 
 The handler is bound to one process at launch; that binding, not anything in the request
 params, is how a handler knows which plugin is calling.
+
+Plugin stderr is drained continuously and logged only after secret-shaped values (including
+`Authorization` headers and Bearer tokens) are redacted, so a plugin that prints configuration
+payloads cannot put those values into Host traces.

--- a/crates/plugin-runtime/src/lib.rs
+++ b/crates/plugin-runtime/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod codec;
 mod host_requests;
+mod mcp_configuration;
 mod protocol;
 mod state;
 mod tasks;
@@ -11,6 +12,12 @@ mod tests;
 
 pub use host_requests::{
     HostRequestError, HostRequestHandler, METHOD_NOT_FOUND_CODE, NoHostRequests,
+};
+pub use mcp_configuration::{
+    CONFIGURE_WORKSPACE_METHOD, MCP_CONFIGURATION_PROTOCOL_V1, McpConfigurationCapability,
+    McpConfigurationCapabilityIssue, McpConfigurationProtocolVersion, McpConfigurationRegistration,
+    McpCoordinationMode, McpTransportKind, McpTransportSet, parse_mcp_configuration,
+    parse_mcp_configuration_value,
 };
 pub use protocol::{
     PluginEffectCoordination, PluginEffectSurface, PluginNotification, PluginRegistration,

--- a/crates/plugin-runtime/src/lib.rs
+++ b/crates/plugin-runtime/src/lib.rs
@@ -17,7 +17,6 @@ pub use mcp_configuration::{
     CONFIGURE_WORKSPACE_METHOD, MCP_CONFIGURATION_PROTOCOL_V1, McpConfigurationCapability,
     McpConfigurationCapabilityIssue, McpConfigurationProtocolVersion, McpConfigurationRegistration,
     McpCoordinationMode, McpTransportKind, McpTransportSet, parse_mcp_configuration,
-    parse_mcp_configuration_value,
 };
 pub use protocol::{
     PluginEffectCoordination, PluginEffectSurface, PluginNotification, PluginRegistration,

--- a/crates/plugin-runtime/src/mcp_configuration.rs
+++ b/crates/plugin-runtime/src/mcp_configuration.rs
@@ -323,7 +323,7 @@ pub fn parse_mcp_configuration(params: Option<&Value>) -> McpConfigurationRegist
 }
 
 /// Parses one capability JSON value using the same rules Host and compatibility fixtures share.
-pub fn parse_mcp_configuration_value(value: &Value) -> McpConfigurationRegistration {
+fn parse_mcp_configuration_value(value: &Value) -> McpConfigurationRegistration {
     let Some(object) = value.as_object() else {
         return McpConfigurationRegistration::Invalid(McpConfigurationCapabilityIssue::NotAnObject);
     };
@@ -511,6 +511,26 @@ mod tests {
             McpConfigurationRegistration::Invalid(
                 McpConfigurationCapabilityIssue::DuplicateTransport("http".to_string())
             )
+        );
+    }
+
+    /// Unknown transport tokens disable MCP without failing handshake.
+    #[test]
+    fn unknown_transport_invalidates_capability() {
+        assert_eq!(
+            parse_fixture("unknown-transport.json"),
+            McpConfigurationRegistration::Invalid(
+                McpConfigurationCapabilityIssue::UnknownTransport("sse".to_string())
+            )
+        );
+    }
+
+    /// An empty transport list is unrepresentable as a protocol v1 capability.
+    #[test]
+    fn empty_transports_invalidate_capability() {
+        assert_eq!(
+            parse_fixture("empty-transports.json"),
+            McpConfigurationRegistration::Invalid(McpConfigurationCapabilityIssue::TransportsEmpty)
         );
     }
 

--- a/crates/plugin-runtime/src/mcp_configuration.rs
+++ b/crates/plugin-runtime/src/mcp_configuration.rs
@@ -1,0 +1,566 @@
+//! Optional MCP Configuration Capability published during `ora/register`.
+//!
+//! Handshake must stay additive: older plugins omit the field, and a malformed declaration only
+//! disables MCP materialization. The runtime therefore never fails registration because this
+//! payload is missing, unknown at the top level, or internally invalid.
+
+use std::collections::BTreeSet;
+use std::fmt::{self, Display, Formatter};
+use std::num::NonZeroU32;
+
+use serde_json::{Map, Value, json};
+
+/// JSON-RPC method that must be registered together with a valid MCP configuration capability.
+pub const CONFIGURE_WORKSPACE_METHOD: &str = "agent/configureWorkspace";
+
+/// Protocol v1 is the only Host-supported MCP configuration snapshot version.
+pub const MCP_CONFIGURATION_PROTOCOL_V1: u32 = 1;
+
+/// Positive protocol version advertised by an Agent plugin.
+///
+/// Zero is unrepresentable because the wire contract requires a positive integer; unsupported
+/// positive versions are still constructible so Host negotiation can classify them without
+/// collapsing the value into a boolean flag.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct McpConfigurationProtocolVersion(NonZeroU32);
+
+impl McpConfigurationProtocolVersion {
+    /// Protocol v1, the only version this Host materializes.
+    pub const V1: Self = Self(NonZeroU32::MIN);
+
+    /// Accepts a positive integer from the registration wire.
+    pub fn new(value: u32) -> Result<Self, McpConfigurationCapabilityIssue> {
+        NonZeroU32::new(value)
+            .map(Self)
+            .ok_or(McpConfigurationCapabilityIssue::ProtocolVersionNotPositiveInteger)
+    }
+
+    /// Returns the integer advertised on the wire.
+    pub fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+/// Transport kinds an Agent plugin may materialize in protocol v1.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum McpTransportKind {
+    Http,
+    Stdio,
+}
+
+impl McpTransportKind {
+    /// Parses one wire token; unknown tokens invalidate the capability rather than the handshake.
+    pub fn parse(value: &str) -> Result<Self, McpConfigurationCapabilityIssue> {
+        match value {
+            "http" => Ok(Self::Http),
+            "stdio" => Ok(Self::Stdio),
+            other => Err(McpConfigurationCapabilityIssue::UnknownTransport(
+                other.to_string(),
+            )),
+        }
+    }
+
+    /// Returns the canonical wire token.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Http => "http",
+            Self::Stdio => "stdio",
+        }
+    }
+}
+
+/// Non-empty unique set of supported transports.
+///
+/// Construction is the only way to obtain a value, so empty and duplicate sets cannot leak into
+/// Host snapshot filtering.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct McpTransportSet {
+    kinds: BTreeSet<McpTransportKind>,
+}
+
+impl McpTransportSet {
+    /// Accepts a unique, non-empty transport list from registration or SDK input.
+    pub fn new(
+        kinds: impl IntoIterator<Item = McpTransportKind>,
+    ) -> Result<Self, McpConfigurationCapabilityIssue> {
+        let mut unique = BTreeSet::new();
+        for kind in kinds {
+            if !unique.insert(kind) {
+                return Err(McpConfigurationCapabilityIssue::DuplicateTransport(
+                    kind.as_str().to_string(),
+                ));
+            }
+        }
+        if unique.is_empty() {
+            return Err(McpConfigurationCapabilityIssue::TransportsEmpty);
+        }
+        Ok(Self { kinds: unique })
+    }
+
+    /// Returns whether this Agent can materialize `kind`.
+    pub fn supports(&self, kind: McpTransportKind) -> bool {
+        self.kinds.contains(&kind)
+    }
+
+    /// Iterates supported kinds in canonical order so digest bytes stay stable.
+    pub fn iter(&self) -> impl Iterator<Item = McpTransportKind> + '_ {
+        self.kinds.iter().copied()
+    }
+}
+
+/// Coordination mode an Agent uses around MCP materialization.
+///
+/// Protocol v1 only negotiates wait-for-idle-and-restart so Session turns cannot observe a
+/// half-written configuration document.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum McpCoordinationMode {
+    WaitForIdleAndRestart,
+}
+
+impl McpCoordinationMode {
+    /// Parses the only legal protocol v1 coordination token.
+    pub fn parse(value: &str) -> Result<Self, McpConfigurationCapabilityIssue> {
+        match value {
+            "wait_for_idle_and_restart" => Ok(Self::WaitForIdleAndRestart),
+            other => Err(McpConfigurationCapabilityIssue::UnknownCoordination(
+                other.to_string(),
+            )),
+        }
+    }
+
+    /// Returns the canonical wire token.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WaitForIdleAndRestart => "wait_for_idle_and_restart",
+        }
+    }
+}
+
+/// Structurally valid MCP configuration capability declared by an Agent plugin.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct McpConfigurationCapability {
+    protocol_version: McpConfigurationProtocolVersion,
+    transports: McpTransportSet,
+    coordination: McpCoordinationMode,
+}
+
+impl McpConfigurationCapability {
+    /// Builds a capability after the caller has already enforced uniqueness and presence.
+    pub fn new(
+        protocol_version: McpConfigurationProtocolVersion,
+        transports: McpTransportSet,
+        coordination: McpCoordinationMode,
+    ) -> Self {
+        Self {
+            protocol_version,
+            transports,
+            coordination,
+        }
+    }
+
+    /// Returns the advertised protocol version.
+    pub fn protocol_version(&self) -> McpConfigurationProtocolVersion {
+        self.protocol_version
+    }
+
+    /// Returns the supported transport set used to filter snapshot entries.
+    pub fn transports(&self) -> &McpTransportSet {
+        &self.transports
+    }
+
+    /// Returns the coordination mode the Host must honor before calling configure.
+    pub fn coordination(&self) -> McpCoordinationMode {
+        self.coordination
+    }
+
+    /// Canonical JSON bytes hashed into an Agent Capability Revision.
+    ///
+    /// Key and transport order are fixed so equivalent declarations produce the same digest even
+    /// when the plugin authored a different JSON key sequence.
+    pub fn canonical_declaration_bytes(&self) -> Vec<u8> {
+        let transports = self
+            .transports
+            .iter()
+            .map(McpTransportKind::as_str)
+            .collect::<Vec<_>>();
+        serde_json::to_vec(&json!({
+            "coordination": self.coordination.as_str(),
+            "protocolVersion": self.protocol_version.get(),
+            "transports": transports,
+        }))
+        .unwrap_or_else(|_| {
+            // serde_json serialization of these primitive values cannot fail; keep the Host
+            // digest path total rather than introducing a fallible capability type.
+            b"{}".to_vec()
+        })
+    }
+}
+
+/// Why a present `mcpConfiguration` object cannot be used for materialization.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum McpConfigurationCapabilityIssue {
+    NotAnObject,
+    UnknownField(String),
+    ProtocolVersionMissing,
+    ProtocolVersionNotPositiveInteger,
+    ProtocolVersionUnsupported { actual: u32 },
+    TransportsMissing,
+    TransportsEmpty,
+    TransportsNotAnArray,
+    DuplicateTransport(String),
+    UnknownTransport(String),
+    CoordinationMissing,
+    UnknownCoordination(String),
+}
+
+impl McpConfigurationCapabilityIssue {
+    /// Stable public error code the Host surfaces without copying capability payload bytes.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::ProtocolVersionUnsupported { .. } => "mcp_capability_version_unsupported",
+            Self::NotAnObject
+            | Self::UnknownField(_)
+            | Self::ProtocolVersionMissing
+            | Self::ProtocolVersionNotPositiveInteger
+            | Self::TransportsMissing
+            | Self::TransportsEmpty
+            | Self::TransportsNotAnArray
+            | Self::DuplicateTransport(_)
+            | Self::UnknownTransport(_)
+            | Self::CoordinationMissing
+            | Self::UnknownCoordination(_) => "mcp_capability_invalid",
+        }
+    }
+}
+
+impl Display for McpConfigurationCapabilityIssue {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotAnObject => formatter.write_str("mcpConfiguration must be an object"),
+            Self::UnknownField(field) => {
+                write!(formatter, "mcpConfiguration contains unknown field {field}")
+            }
+            Self::ProtocolVersionMissing => {
+                formatter.write_str("mcpConfiguration is missing protocolVersion")
+            }
+            Self::ProtocolVersionNotPositiveInteger => {
+                formatter.write_str("mcpConfiguration protocolVersion must be a positive integer")
+            }
+            Self::ProtocolVersionUnsupported { actual } => {
+                write!(
+                    formatter,
+                    "mcpConfiguration protocolVersion {actual} is unsupported"
+                )
+            }
+            Self::TransportsMissing => {
+                formatter.write_str("mcpConfiguration is missing transports")
+            }
+            Self::TransportsEmpty => {
+                formatter.write_str("mcpConfiguration transports must not be empty")
+            }
+            Self::TransportsNotAnArray => {
+                formatter.write_str("mcpConfiguration transports must be an array")
+            }
+            Self::DuplicateTransport(transport) => {
+                write!(
+                    formatter,
+                    "mcpConfiguration transports contains duplicate {transport}"
+                )
+            }
+            Self::UnknownTransport(transport) => {
+                write!(
+                    formatter,
+                    "mcpConfiguration transports contains unknown {transport}"
+                )
+            }
+            Self::CoordinationMissing => {
+                formatter.write_str("mcpConfiguration is missing coordination")
+            }
+            Self::UnknownCoordination(mode) => {
+                write!(formatter, "mcpConfiguration coordination {mode} is unknown")
+            }
+        }
+    }
+}
+
+/// Wire-level MCP configuration capability as published during `ora/register`.
+///
+/// `Absent` is the older-plugin case. `Invalid` keeps the process usable for conversation while
+/// disabling MCP materialization. `Declared` is structurally valid and still subject to Host
+/// pairing with `agent/configureWorkspace`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum McpConfigurationRegistration {
+    #[default]
+    Absent,
+    Invalid(McpConfigurationCapabilityIssue),
+    Declared(McpConfigurationCapability),
+}
+
+impl McpConfigurationRegistration {
+    /// Canonical bytes hashed into an Agent Capability Revision for any registration outcome.
+    ///
+    /// Invalid declarations still produce a stable digest so repairing a malformed capability is
+    /// observed as a real capability change rather than as a silent no-op.
+    pub fn canonical_declaration_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Absent => b"null".to_vec(),
+            Self::Invalid(issue) => {
+                // Hash the specific issue, not only the public error code, so repairing one
+                // malformed payload into a different malformed payload is still a real change.
+                format!("invalid:{issue}").into_bytes()
+            }
+            Self::Declared(capability) => capability.canonical_declaration_bytes(),
+        }
+    }
+}
+
+/// Reads the optional `mcpConfiguration` object without failing the plugin handshake.
+pub fn parse_mcp_configuration(params: Option<&Value>) -> McpConfigurationRegistration {
+    let Some(value) = params.and_then(|params| params.get("mcpConfiguration")) else {
+        return McpConfigurationRegistration::Absent;
+    };
+    parse_mcp_configuration_value(value)
+}
+
+/// Parses one capability JSON value using the same rules Host and compatibility fixtures share.
+pub fn parse_mcp_configuration_value(value: &Value) -> McpConfigurationRegistration {
+    let Some(object) = value.as_object() else {
+        return McpConfigurationRegistration::Invalid(McpConfigurationCapabilityIssue::NotAnObject);
+    };
+    match parse_capability_object(object) {
+        Ok(capability) => McpConfigurationRegistration::Declared(capability),
+        Err(issue) => McpConfigurationRegistration::Invalid(issue),
+    }
+}
+
+/// Enforces the closed protocol v1 object shape, including unknown-field rejection.
+///
+/// Unknown keys are rejected here rather than ignored so a plugin cannot silently advertise a
+/// native schema or extra coordination the Host would never honor.
+fn parse_capability_object(
+    object: &Map<String, Value>,
+) -> Result<McpConfigurationCapability, McpConfigurationCapabilityIssue> {
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "protocolVersion" | "transports" | "coordination"
+        ) {
+            return Err(McpConfigurationCapabilityIssue::UnknownField(key.clone()));
+        }
+    }
+    let protocol_version = parse_protocol_version(object.get("protocolVersion"))?;
+    if protocol_version.get() != MCP_CONFIGURATION_PROTOCOL_V1 {
+        return Err(
+            McpConfigurationCapabilityIssue::ProtocolVersionUnsupported {
+                actual: protocol_version.get(),
+            },
+        );
+    }
+    let transports = parse_transports(object.get("transports"))?;
+    let coordination = parse_coordination(object.get("coordination"))?;
+    Ok(McpConfigurationCapability::new(
+        protocol_version,
+        transports,
+        coordination,
+    ))
+}
+
+/// Requires a JSON number that can become a positive protocol version.
+///
+/// Zero and non-integers are the same invalid class because the wire contract has no meaning for
+/// a non-positive or fractional version.
+fn parse_protocol_version(
+    value: Option<&Value>,
+) -> Result<McpConfigurationProtocolVersion, McpConfigurationCapabilityIssue> {
+    let Some(value) = value else {
+        return Err(McpConfigurationCapabilityIssue::ProtocolVersionMissing);
+    };
+    let Some(number) = value.as_u64() else {
+        return Err(McpConfigurationCapabilityIssue::ProtocolVersionNotPositiveInteger);
+    };
+    let Ok(number) = u32::try_from(number) else {
+        return Err(McpConfigurationCapabilityIssue::ProtocolVersionNotPositiveInteger);
+    };
+    McpConfigurationProtocolVersion::new(number)
+}
+
+/// Parses the advertised transport list and rejects duplicates before set construction.
+///
+/// Duplicate detection happens on the raw token so `["http","http"]` fails even when both tokens
+/// would otherwise parse as the same `McpTransportKind`.
+fn parse_transports(
+    value: Option<&Value>,
+) -> Result<McpTransportSet, McpConfigurationCapabilityIssue> {
+    let Some(value) = value else {
+        return Err(McpConfigurationCapabilityIssue::TransportsMissing);
+    };
+    let Some(entries) = value.as_array() else {
+        return Err(McpConfigurationCapabilityIssue::TransportsNotAnArray);
+    };
+    let mut kinds = Vec::with_capacity(entries.len());
+    let mut seen = BTreeSet::new();
+    for entry in entries {
+        let Some(token) = entry.as_str() else {
+            return Err(McpConfigurationCapabilityIssue::UnknownTransport(
+                entry.to_string(),
+            ));
+        };
+        if !seen.insert(token.to_string()) {
+            return Err(McpConfigurationCapabilityIssue::DuplicateTransport(
+                token.to_string(),
+            ));
+        }
+        kinds.push(McpTransportKind::parse(token)?);
+    }
+    McpTransportSet::new(kinds)
+}
+
+/// Parses the single protocol v1 coordination token; unknown strings disable MCP only.
+fn parse_coordination(
+    value: Option<&Value>,
+) -> Result<McpCoordinationMode, McpConfigurationCapabilityIssue> {
+    let Some(value) = value else {
+        return Err(McpConfigurationCapabilityIssue::CoordinationMissing);
+    };
+    let Some(token) = value.as_str() else {
+        return Err(McpConfigurationCapabilityIssue::UnknownCoordination(
+            value.to_string(),
+        ));
+    };
+    McpCoordinationMode::parse(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        McpConfigurationCapability, McpConfigurationCapabilityIssue,
+        McpConfigurationProtocolVersion, McpConfigurationRegistration, McpCoordinationMode,
+        McpTransportKind, McpTransportSet, parse_mcp_configuration,
+    };
+    use pretty_assertions::assert_eq;
+    use serde_json::{Value, json};
+
+    /// Loads one shared registration fixture so Rust and TypeScript assert the same JSON.
+    fn fixture(name: &str) -> Value {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../packages/plugin-sdk/tests/fixtures/mcp-configuration/registration")
+            .join(name);
+        let bytes = std::fs::read(&path).unwrap_or_else(|error| {
+            panic!("read MCP registration fixture {}: {error}", path.display())
+        });
+        serde_json::from_slice(&bytes).expect("MCP registration fixture is JSON")
+    }
+
+    fn parse_fixture(name: &str) -> McpConfigurationRegistration {
+        parse_mcp_configuration(Some(&fixture(name)))
+    }
+
+    fn http_v1_capability() -> McpConfigurationCapability {
+        McpConfigurationCapability::new(
+            McpConfigurationProtocolVersion::V1,
+            McpTransportSet::new([McpTransportKind::Http]).expect("http set"),
+            McpCoordinationMode::WaitForIdleAndRestart,
+        )
+    }
+
+    /// Older Agent plugins omit the field and remain conversation-capable.
+    #[test]
+    fn omitted_capability_is_absent() {
+        assert_eq!(
+            parse_fixture("omitted.json"),
+            McpConfigurationRegistration::Absent
+        );
+    }
+
+    /// Unknown top-level registration fields must not poison a valid capability object.
+    #[test]
+    fn unknown_top_level_fields_are_ignored() {
+        assert_eq!(
+            parse_fixture("unknown-top-level-fields.json"),
+            McpConfigurationRegistration::Declared(http_v1_capability())
+        );
+    }
+
+    /// An unsupported protocol version disables MCP without failing the handshake parse.
+    #[test]
+    fn unknown_protocol_version_invalidates_capability() {
+        assert_eq!(
+            parse_fixture("unknown-protocol-version.json"),
+            McpConfigurationRegistration::Invalid(
+                McpConfigurationCapabilityIssue::ProtocolVersionUnsupported { actual: 2 }
+            )
+        );
+    }
+
+    /// Extra capability fields are treated as malformed rather than silently dropped.
+    #[test]
+    fn malformed_capability_with_unknown_field_is_invalid() {
+        assert_eq!(
+            parse_fixture("malformed.json"),
+            McpConfigurationRegistration::Invalid(McpConfigurationCapabilityIssue::UnknownField(
+                "nativeSchema".to_string()
+            ))
+        );
+    }
+
+    /// Duplicate transports are illegal in protocol v1 even when each token is known.
+    #[test]
+    fn duplicate_transports_invalidate_capability() {
+        assert_eq!(
+            parse_fixture("duplicate-transports.json"),
+            McpConfigurationRegistration::Invalid(
+                McpConfigurationCapabilityIssue::DuplicateTransport("http".to_string())
+            )
+        );
+    }
+
+    /// A well-formed HTTP-only v1 declaration is the OpenCode 0.3.0 shape.
+    #[test]
+    fn valid_http_v1_capability_is_declared() {
+        assert_eq!(
+            parse_fixture("valid-http-v1.json"),
+            McpConfigurationRegistration::Declared(http_v1_capability())
+        );
+    }
+
+    /// Canonical bytes stay stable so capability revision digests do not churn on key order.
+    #[test]
+    fn canonical_declaration_bytes_use_sorted_keys_and_transports() {
+        let capability = McpConfigurationCapability::new(
+            McpConfigurationProtocolVersion::V1,
+            McpTransportSet::new([McpTransportKind::Stdio, McpTransportKind::Http])
+                .expect("transport set"),
+            McpCoordinationMode::WaitForIdleAndRestart,
+        );
+        assert_eq!(
+            capability.canonical_declaration_bytes(),
+            br#"{"coordination":"wait_for_idle_and_restart","protocolVersion":1,"transports":["http","stdio"]}"#
+        );
+    }
+
+    /// Zero is unrepresentable as a protocol version.
+    #[test]
+    fn zero_protocol_version_is_rejected() {
+        assert_eq!(
+            parse_mcp_configuration(Some(&json!({
+                "mcpConfiguration": {
+                    "protocolVersion": 0,
+                    "transports": ["http"],
+                    "coordination": "wait_for_idle_and_restart"
+                }
+            }))),
+            McpConfigurationRegistration::Invalid(
+                McpConfigurationCapabilityIssue::ProtocolVersionNotPositiveInteger
+            )
+        );
+    }
+
+    /// Repairing one malformed declaration into a different malformed declaration must change the digest.
+    #[test]
+    fn invalid_canonical_bytes_distinguish_malformed_payloads() {
+        assert_ne!(
+            parse_fixture("malformed.json").canonical_declaration_bytes(),
+            parse_fixture("duplicate-transports.json").canonical_declaration_bytes()
+        );
+    }
+}

--- a/crates/plugin-runtime/src/protocol.rs
+++ b/crates/plugin-runtime/src/protocol.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 
 use crate::PluginRuntimeError;
 use crate::host_requests::{HostRequestHandler, serve_request};
+use crate::mcp_configuration::{McpConfigurationRegistration, parse_mcp_configuration};
 use crate::state::{ResponseRequest, RuntimeInner, RuntimeStatus};
 
 pub(crate) const JSON_RPC_VERSION: &str = "2.0";
@@ -23,6 +24,8 @@ pub struct PluginRegistration {
     pub emits: HashSet<String>,
     /// Workspace-relative Effect surfaces this runtime consumes.
     pub effect_surfaces: Vec<PluginEffectSurface>,
+    /// Optional MCP configuration capability; invalid values never fail handshake.
+    pub mcp_configuration: McpConfigurationRegistration,
 }
 
 /// Declares one filesystem Skill surface consumed by a plugin runtime.
@@ -153,6 +156,7 @@ async fn handle_plugin_originated<H: HostRequestHandler>(
                 .ok_or_else(|| "plugin registration is missing a methods array".to_string())?,
             emits: parse_method_list(params, "emits")?.unwrap_or_default(),
             effect_surfaces: parse_effect_surfaces(params)?,
+            mcp_configuration: parse_mcp_configuration(params),
         };
         *inner.registration.write().await = registration;
         inner.status_tx.send_replace(RuntimeStatus::Ready);

--- a/crates/plugin-runtime/src/tasks.rs
+++ b/crates/plugin-runtime/src/tasks.rs
@@ -93,7 +93,7 @@ where
                 ora_info!(
                     message = "plugin stderr",
                     plugin_id = %plugin_id,
-                    output = %message.trim_end(),
+                    output = %ora_logging::ErrorReport::sanitize_text(message.trim_end()),
                 );
             }
             Err(error) => {

--- a/crates/plugin-runtime/src/tests.rs
+++ b/crates/plugin-runtime/src/tests.rs
@@ -91,6 +91,7 @@ async fn accepts_initial_registration() {
             methods: HashSet::from(["example.echo".to_string()]),
             emits: HashSet::from(["example.tick".to_string()]),
             effect_surfaces: Vec::new(),
+            mcp_configuration: crate::McpConfigurationRegistration::Absent,
         }
     );
     assert_eq!(*inner.status_tx.borrow(), RuntimeStatus::Ready);
@@ -118,6 +119,7 @@ async fn defaults_missing_emits_to_an_empty_whitelist() {
             methods: HashSet::from(["example.echo".to_string()]),
             emits: HashSet::new(),
             effect_surfaces: Vec::new(),
+            mcp_configuration: crate::McpConfigurationRegistration::Absent,
         }
     );
 }
@@ -154,6 +156,39 @@ async fn parses_effect_surface_registration() {
             coordination: PluginEffectCoordination::WaitForIdleAndRestart,
         }]
     );
+}
+
+/// A malformed MCP capability is recorded without failing the plugin handshake.
+#[tokio::test]
+async fn malformed_mcp_configuration_keeps_registration_ready() {
+    use crate::{McpConfigurationCapabilityIssue, McpConfigurationRegistration};
+
+    let (inner, _inbound) = test_inner();
+    handle_message(
+        &inner,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "ora/register",
+            "params": {
+                "methods": ["example.echo"],
+                "mcpConfiguration": {
+                    "protocolVersion": 1,
+                    "transports": ["http", "http"],
+                    "coordination": "wait_for_idle_and_restart"
+                }
+            },
+        }),
+    )
+    .await
+    .expect("register despite malformed MCP capability");
+
+    assert_eq!(
+        inner.registration.read().await.mcp_configuration,
+        McpConfigurationRegistration::Invalid(McpConfigurationCapabilityIssue::DuplicateTransport(
+            "http".to_string()
+        ))
+    );
+    assert_eq!(*inner.status_tx.borrow(), RuntimeStatus::Ready);
 }
 
 /// Duplicate method names invalidate registration rather than selecting one handler.
@@ -402,6 +437,7 @@ async fn ignores_a_late_response_to_an_abandoned_request() {
             methods: HashSet::from(["example.echo".to_string()]),
             emits: HashSet::new(),
             effect_surfaces: Vec::new(),
+            mcp_configuration: crate::McpConfigurationRegistration::Absent,
         }),
         status_tx,
         exited_tx,

--- a/docs/adr/0001-agent-plugins-materialize-mcp-configuration.md
+++ b/docs/adr/0001-agent-plugins-materialize-mcp-configuration.md
@@ -1,0 +1,3 @@
+# Agent plugins materialize MCP configuration
+
+Ora resolves installed MCP packages into target-independent `ResolvedMcp` values, while each Agent plugin renders and reconciles those values into its target Agent's native configuration. MCP delivery reuses the Workspace-scoped, durable convergence and coordination semantics proven by Skill Effects, but it does not reuse the Skill filesystem adapter or move target-specific configuration schemas into the Ora host.

--- a/docs/adr/0002-installed-mcps-propagate-to-every-workspace.md
+++ b/docs/adr/0002-installed-mcps-propagate-to-every-workspace.md
@@ -1,0 +1,3 @@
+# Ready MCPs propagate to every Workspace
+
+Every installed MCP Package is Default-enabled, but it enters the MCP Desired Set of all existing and future Agent Workspaces only while it is Ready. An MCP that Needs Configuration remains installed without affecting Agent conversations; becoming Ready publishes it automatically, while losing readiness removes its effective Desired entries until it becomes Ready again. This preserves the automatic propagation semantics used for installed Skills without treating installation alone as successful materialization.

--- a/docs/adr/0003-unsupported-mcps-do-not-block-agent-targets.md
+++ b/docs/adr/0003-unsupported-mcps-do-not-block-agent-targets.md
@@ -1,0 +1,3 @@
+# Unsupported MCPs do not block Agent Targets
+
+When an Agent plugin cannot materialize one Ready MCP, reconciliation records a target-specific `UnsupportedByAgent` issue, applies the remaining supported MCPs, and advances the Agent Target to Ready with Issues. Because Ready MCPs propagate to every Workspace automatically and support varies by Agent plugin, failing the entire target would allow one globally installed MCP to disable otherwise usable Agents; capability or Desired State changes trigger reevaluation of the skipped item.

--- a/docs/adr/0004-mcp-lifecycle-preserves-referenced-package-versions.md
+++ b/docs/adr/0004-mcp-lifecycle-preserves-referenced-package-versions.md
@@ -1,0 +1,3 @@
+# MCP lifecycle preserves referenced package versions
+
+An MCP Source keeps a stable Plugin identity while each immutable revision binds an exact package version and configuration-store revision. Updates commit new and old package versions side by side, publish the new revision, and garbage-collect an old version only after no Desired state, applied receipt, runtime resource, or operation references it; uninstall first retires the source and converges Agent configuration removal before deleting packages. This avoids dangling stdio executable references and makes update or uninstall recovery durable instead of relying on the current installer's immediate deletion order.

--- a/docs/adr/0005-opencode-uses-a-workspace-managed-configuration-document.md
+++ b/docs/adr/0005-opencode-uses-a-workspace-managed-configuration-document.md
@@ -1,0 +1,3 @@
+# OpenCode uses a Workspace-managed configuration document
+
+The OpenCode Agent plugin materializes its complete MCP snapshot into `<workspace>/.opencode/opencode.json`, owned as one Managed Agent Configuration Document with a durable locator and fingerprint. OpenCode discovers that document from each Session Workspace, which preserves Workspace isolation while the current plugin shares one CLI process; user-authored configuration remains in the project-root `opencode.json`, and the generated path is repository-locally excluded from Git because the first release may contain plaintext credentials.

--- a/docs/adr/0006-skills-and-mcps-share-effect-convergence.md
+++ b/docs/adr/0006-skills-and-mcps-share-effect-convergence.md
@@ -1,0 +1,3 @@
+# Skills and MCPs share Effect convergence
+
+Skills and MCPs share one Workspace generation, durable request store, claim loop, operation recovery protocol, and safety scan, while keeping separate strongly typed planning and materialization adapters. Their operations may complete independently, but an Agent Target advances its Ready Generation only after every required Skill and MCP operation for that Workspace generation has been processed, preferably within one quiesce and resume window; this reuses the proven reliability mechanism without coupling filesystem Skill projection to Agent-specific MCP rendering.

--- a/docs/adr/0007-first-mcp-release-materializes-string-settings-in-workspace.md
+++ b/docs/adr/0007-first-mcp-release-materializes-string-settings-in-workspace.md
@@ -1,0 +1,3 @@
+# The first MCP release materializes string Settings in the Workspace
+
+The first MCP delivery slice may write resolved values declared as ordinary `string` Settings, including Tavily's current API key declaration, into the Agent plugin's generated Workspace configuration document. This deliberately precedes SecretRef support to close the marketplace-to-conversation loop, so the document must be repository-locally ignored, permission-restricted, excluded from logs and diagnostics, and clearly presented as containing plaintext; future Secret settings require a separate secure Agent handoff and must never silently reuse this path.

--- a/docs/adr/0008-mcp-configuration-is-an-optional-negotiated-agent-capability.md
+++ b/docs/adr/0008-mcp-configuration-is-an-optional-negotiated-agent-capability.md
@@ -1,0 +1,3 @@
+# MCP configuration is an optional negotiated Agent capability
+
+Agent plugins advertise a versioned `mcpConfiguration` capability with supported transports and coordination semantics, and expose one full-snapshot `agent/configureWorkspace` method when that capability is present. This additive registration contract lets new hosts treat older Agents as `UnsupportedByAgent` and lets older hosts ignore the new capability without inventing a global `pluginApi` version; published plugins that require the capability still declare and enforce a minimum Ora product version through marketplace dependency validation so installation cannot silently promise an unavailable MCP experience.

--- a/docs/agent-mcp-config-research.md
+++ b/docs/agent-mcp-config-research.md
@@ -1,0 +1,689 @@
+# Agent MCP-Config Wiring — Research
+
+> Investigate how an installed MCP plugin's configuration reaches an Agent plugin's
+> process so the agent can use the MCP during conversation, and define the minimum
+> closed loop: install `ora-space.opencode` (agent) + `ora-space.tavily-search` (mcp)
+> from the `ora-space/marketplace`, then get tavily's MCP config into the opencode
+> agent's working directory, mirroring how Ora already wires **skills**.
+>
+> Date: 2026-08-27. Primary sources only: Ora Rust crates, the `specs/` nested repo,
+> the `ora-space/marketplace` + `ora-space/opencode-agent` + `ora-space/tavily-search-mcp`
+> repos, and `opencode.ai/docs`. Every claim carries a citation.
+
+---
+
+## 0. Executive summary
+
+- **Supply side is fully built.** Download → sha256 → extract → kind-aware validate →
+  commit → discover is implemented in `ora-plugin-manager`. `assets/config.json` compiles
+  to a `CompiledMcpConfiguration` in `ora-plugin-config`; user setting values persist in
+  a revisioned `store.json`. Verified end-to-end for both target plugins.
+- **Demand side is entirely absent.** `ResolvedMcp` — the concrete transport with real
+  URLs, resolved setting values, and a resolved `workspace` cwd — **does not exist as a
+  type anywhere in the codebase** (grep for `ResolvedMcp|resolve_mcp` returns only three
+  doc comments, no definition). Nothing combines the compiled config with `store.json`
+  and pushes it to an agent.
+- **No delivery channel is wired.** Three candidate channels exist on paper; **none is
+  implemented**: (A) an Effect filesystem surface with an `mcp_config.v1` format — only
+  `skill_directory_v1` exists and the validator rejects the rest
+  (`agent_runtime/plugin_agent/effect.rs:67`); (B) the ACP `session/new` `mcp_servers`
+  field — present in the schema but Ora always sends it empty
+  (`agent_runtime/warm.rs:526`); (C) the spec's `ora/agent/configure_agent` method —
+  **zero references** in `crates/`.
+- **The opencode agent plugin v0.2.2 declares only a skills surface**
+  (`.opencode/skills`, `skill_directory.v1`). It has no MCP-config surface and no code
+  that renders an MCP descriptor into `opencode.json`. The tavily README states this step
+  is the agent plugin's job ("an Agent plugin later turns the installed descriptor into
+  target-agent configuration") — but the opencode plugin hasn't implemented it.
+- **Spec vs code divergence.** The active spec assigns MCP rendering to the agent plugin
+  via `configure_agent` (`specs/active/plugin/5-mcp.md#agent-配置时序`). The implemented
+  skills path uses a different mechanism — the Effect filesystem surface worker — which
+  the spec only proposes extending to MCP in `changes/effect/v2.md` (`mcp_config.v1`).
+- **Recommendation:** build `ResolvedMcp`, then deliver via the **Effect filesystem
+  surface (Channel A)** — it is the literal "mirror skills" path, reuses the proven
+  `EffectWorker` + `FilesystemSurfaceAdapter`, and is the channel the
+  `AGENTS.md` convergence rule already anticipates. See §7–§8.
+
+---
+
+## 1. The minimum closed loop — what works today vs. what is missing
+
+Goal: install both plugins, save a tavily API key, then in an opencode conversation use
+tavily web-search MCP.
+
+| Step                                                                  | Status                                | Owner                                  |
+| --------------------------------------------------------------------- | ------------------------------------- | -------------------------------------- |
+| Browse marketplace, pick opencode + tavily                            | ✅                                    | marketplace registry                   |
+| Download `.orax`, verify sha256, extract, validate, commit            | ✅                                    | `plugin-manager/install.rs`            |
+| Compile tavily `assets/config.json` → `CompiledMcpConfiguration`      | ✅                                    | `plugin-config/src/mcp/mod.rs`         |
+| Persist tavily `apiKey` in `store.json` (settings UI)                 | ✅                                    | `plugin-config/src/service.rs`         |
+| Discover opencode agent plugin, spawn Deno process, `agent/start`     | ✅                                    | `plugin-lifecycle`, `backend`          |
+| opencode plugin spawns `opencode acp --cwd <cwd>`                     | ✅                                    | opencode plugin `lifecycle.ts`         |
+| **Resolve tavily descriptor + `store.json` → concrete HTTP endpoint** | ❌                                    | **gap: `ResolvedMcp`**                 |
+| **Select which MCPs are enabled for the agent's Workspace**           | ❌                                    | **gap: per-Workspace MCP desired set** |
+| **Deliver resolved MCP config to the opencode agent**                 | ❌                                    | **gap: no channel wired**              |
+| opencode CLI loads tavily from `opencode.json` `mcp` block            | ⚠️ target format known, writer absent | opencode plugin / Ora                  |
+
+The three ❌ rows are the work. Everything above them ships today.
+
+---
+
+## 2. Supply side (installed) — install → compile → store
+
+### 2.1 Install flow
+
+`Installer::install` (`crates/plugin-manager/src/install.rs:144`) orchestrates download →
+extract → validate → commit. Download + sha256 in `download_package` (`install.rs:344-373`);
+the manifest's `sha256` becomes a `Checksum::sha256` on the `DownloadRequest`, verified by
+the `HttpDownload` impl (`crates/utils/src/http/reqwest.rs:190`,
+`crates/utils/src/http/local.rs:111`). Local-import path `Installer::install_local`
+(`install.rs:254-341`) re-verifies the digest against the archive (`install.rs:296-305`).
+Extraction is `ora_utils::archive::extract_archive` with `ArchiveFormat::Zip`
+(`install.rs:174-179`). Validated staging tree is atomically renamed to
+`<data-dir>/plugins/installed/<namespace>/<name>/<version>/` (`install.rs:186-189`).
+
+### 2.2 Kind-aware validation (where `kind=mcp` policy lives)
+
+`validate` (`crates/plugin-manager/src/validation.rs:116-215`) enforces two MCP rules:
+
+- Cross-kind exclusion (`validation.rs:145-158`): a non-MCP package shipping a
+  transport-bearing config file is rejected — "only `mcp` packages may declare an MCP
+  transport".
+- MCP-specific (`validation.rs:180-182`) delegates to `validate_mcp`
+  (`crates/plugin-manager/src/mcp.rs:29-69`): must not ship `main.js` (`mcp.rs:35-39`,
+  config-only); config must compile to the MCP shape, not Settings-only
+  (`mcp.rs:56-60`); stdio command must be a real executable contained inside the package
+  (`mcp.rs:64-66`, `validate_command_containment` `mcp.rs:73-128`). Produces
+  `InstalledMcpDescriptor { configuration: CompiledMcpConfiguration }` (`mcp.rs:20-22`).
+
+### 2.3 The value model (install-time, immutable)
+
+`crates/plugin-config/src/mcp/mod.rs`:
+
+```rust
+// mod.rs:42-50
+pub struct CompiledMcpConfiguration {
+    pub schema_version: u32,                     // always 1
+    pub settings: Option<CompiledDeclaration>,   // user-facing Settings subset
+    pub transport: McpTransport,                 // exactly one transport
+}
+// mod.rs:55-58
+pub enum McpTransport { Stdio(McpStdioTransport), Http(McpHttpTransport) }
+// mod.rs:62-68
+pub struct McpStdioTransport { command: PortableRelativePath, args: Vec<McpArgument>, env: BTreeMap<String, McpValueExpression> }
+// mod.rs:72-75
+pub struct McpHttpTransport { url: Url, headers: BTreeMap<String, McpValueExpression> }
+// mod.rs:79-83
+pub enum McpArgument { Value(McpValueExpression), WorkspaceContext }   // { "context":"workspace" } → agent cwd
+// mod.rs:90-97
+pub enum McpValueExpression { Literal(String), Setting { id: String, prefix: String, suffix: String } }
+```
+
+`compile_configuration_file` (`mod.rs:130-149`) dispatches by the `transport` member.
+`McpValueExpression::Setting` is validated at compile time — the referenced `setting` id
+must exist in declared settings (`transport.rs:241-262`) — but is **never substituted at
+runtime** (see §4).
+
+### 2.4 Persistence
+
+`store.json` at `<data-dir>/plugins/data/<namespace>/<name>/store.json`
+(`crates/plugin-config/src/service.rs:487-499`), so tavily maps to
+`plugins/data/official/ora-space.tavily-search/store.json` (dotted name segments preserved,
+`service.rs:696-749`). Shape:
+
+```rust
+// crates/plugin-config/src/values.rs:9-15
+struct StoredConfiguration { schema_version: u32, revision: u64, values: BTreeMap<String, SettingValue> }
+```
+
+Optimistic revision (`service.rs:263-272`), declaration fingerprint guard
+(`declaration.rs:21,126-127`; checked `service.rs:251-253`), atomic write with
+platform permission tightening (`filesystem.rs:59-73`), corrupt-file backup
+(`service.rs:300-371`). The editor-side `ConfigurationService::get` + `details_from`
+merges declaration + store for the settings UI (`service.rs:196-215`, `values.rs:28-82`)
+— but produces nothing an agent process can consume.
+
+---
+
+## 3. Agent runtime — two `cwd` values
+
+Ora distinguishes two working directories:
+
+- **Process `cwd` at `agent/start` = `home_directory` (neutral, NOT the workspace).**
+  `AgentStartParams { cwd, host_version }` (`crates/backend/src/agent_runtime/plugin_agent/control.rs:58-63`)
+  sent by `start_agent` (`control.rs:155-161`). `home_directory` from `BackendPaths`
+  (`bootstrap.rs:42`) flows through `ConnectionSupervisors` → `SupervisorContext`
+  (`connection.rs:122,155`) into `spawn_initialized_process` (`connection.rs:573`).
+- **Session `cwd` at `session/new` = the Workspace directory (project or worktree path).**
+  `warm.rs:513-527` calls `session/new` with `NewSessionRequest::new(cwd)`; the `cwd` is
+  resolved via `resolve_warm_cwd` → `workspace_cwd` → `resolve_workspace_cwd`
+  (`agent_runtime/mod.rs:312,853,874-878`). Confirmed by `agent_runtime/README.md:18`.
+
+The agent process itself is spawned and owned by the **plugin**, not Ora
+(`plugin_agent/README.md:32`: "A plugin spawns and owns its agent CLI itself"). Ora passes
+the workspace path via `session/new`.
+
+---
+
+## 4. Skills materialization — the mechanism to mirror
+
+This is the reference pattern. Skills reach the agent's workspace as **files at a path the
+agent plugin declares**, written by Ora's Effect worker.
+
+### 4.1 The pipeline
+
+1. **Trigger** — `SqliteEffectRepository::publish_source`
+   (`crates/db/src/repository/effect/mod.rs:45-177`) at startup
+   (`skill_reconciliation.rs:30-119` line 82), on plugin discovery
+   (`PluginApi::sync_installed_skills` `crates/backend/src/plugin.rs:243-251`), and on user
+   create/update.
+2. **Desired set** — `install_source_in_all_workspaces`
+   (`db/src/repository/effect/mapping.rs:207-227`) inserts the source into every
+   Workspace's `workspace_effect_desired_items` (`effect/mod.rs:161-168`); updates call
+   `upsert_propagation_request` (`effect/mod.rs:172`).
+3. **Surface declaration (by the agent plugin)** — the opencode plugin declares
+   `effectSurfaces` during registration; `registered_skill_surfaces`
+   (`crates/backend/src/agent_runtime/plugin_agent/effect.rs:54-89`) converts them to
+   `FilesystemSkillSurface` (rejecting any format ≠ `skill_directory_v1`, `effect.rs:67-69`).
+   Persisted by `PluginApi::replace_agent_effect_surfaces` (`plugin.rs:465-507`) which
+   wakes the worker (`plugin.rs:503-505`).
+4. **Convergence** — `EffectWorker::converge_surface_registrations`
+   (`effect_worker.rs:278-307`) reads `agent_effect_surface_declarations()`
+   (`plugin.rs:514-522`) and, for Workspaces missing the surface, calls
+   `converge_workspace_surfaces` (`effect_surface_registration.rs:22-58`) which writes
+   surfaces for every Workspace in the same pass — the "new Workspace → existing consumer"
+   direction the `AGENTS.md` rule demands.
+5. **Claim + reconcile** — `run_pass` (`effect_worker.rs:220-243`) claims due
+   `effect_reconcile_requests` and calls `reconcile_one` (`effect_worker.rs:461`),
+   constructing a `FilesystemSurfaceAdapter` (`effect_worker.rs:467-472`).
+6. **Filesystem write** — `FilesystemSurfaceAdapter::stage`
+   (`crates/effect/src/filesystem.rs:268-301`) copies the skill package, writes a
+   `.ora-managed.json` ownership marker; `apply_create` (`filesystem.rs:314-327`) atomically
+   renames staged → `<workspace_root>/<surface_path>/<skill_name>/`. The surface root is
+   `workspace_root.join(surface_path)` (`filesystem.rs:120-121`).
+7. **Consumer coordination** — before write, `quiesce` calls `effect/waitForIdle`
+   (`effect_worker.rs:621-646`); after, `resume` calls `effect/restart`
+   (`effect_worker.rs:656-680`) with `{surfaceKey, workspaceRoot, relativePath}`
+   (`agent_runtime/plugin_agent/effect.rs:119-134`).
+
+### 4.2 The on-disk result
+
+Skills materialize at `<workspace_root>/.opencode/skills/<skill_name>/SKILL.md` +
+`.ora-managed.json`, confirmed by `effect_worker.rs:986-994`. The `.opencode/skills` path is
+**plugin-declared** by the opencode plugin (`effect_worker.rs:869`,
+`effect_surface_registration.rs:113-115`):
+
+```rust
+FilesystemSkillSurface {
+    workspace_relative_path: SurfacePath::parse(".opencode/skills").unwrap(),
+    materialization_format: MaterializationFormat::skill_directory_v1(),
+    consumer: ConsumerId::new("official/ora-space.opencode"),
+    coordination: ConsumerCoordination::WaitForIdleAndRestart,
+}
+```
+
+### 4.3 Key invariant
+
+The write is **asynchronous convergence**, driven by durable SQLite reconcile requests +
+a 30s safety scan (`SCAN_INTERVAL` `effect_worker.rs:32`), level-triggered
+(`desired_generation > ready_generation`). It is NOT at `agent/start` or `session/new`.
+
+---
+
+## 5. MCP demand side — the gap
+
+### 5.1 `ResolvedMcp` does not exist
+
+Grep for `ResolvedMcp|resolve_mcp|McpResolved` across all `.rs` returns **zero type
+definitions**. Three doc comments name it as future work:
+
+- `crates/plugin-config/src/mcp/mod.rs:6-7` — "Resolution against `store.json`
+  (`ResolvedMcp`) is a later, separate step and is deliberately not modeled here."
+- `crates/plugin-config/src/mcp/README.md:25` — "`ResolvedMcp`, Agent materialization,
+  and workspace MCP selection are later slices."
+- `crates/plugin-manager/src/mcp.rs:17-18` — "It is not a `ResolvedMcp`."
+
+No code combines `CompiledMcpConfiguration` + `StoredConfiguration` into a concrete
+transport. The `ora-plugin-config` README (`plugin-config/README.md:28-29`) is explicit:
+"The crate does not … pass configuration to Agent processes."
+
+### 5.2 No MCP surface, no convergence, no writer
+
+- **No MCP surface type.** `FilesystemSkillSurface` (`crates/effect/src/surface.rs:94-100`)
+  is the only surface type; `MaterializationFormat` has only `skill_directory_v1()`
+  (`surface.rs:62,64-66`); the registration validator rejects everything else
+  (`agent_runtime/plugin_agent/effect.rs:67`).
+- **No MCP Desired type.** `DesiredSkillState`/`SkillState` are skill-specific
+  (`crates/effect/src/reconcile.rs` reads `SKILL.md`, computes skill digests). No
+  `DesiredMcpState`.
+- **No MCP convergence.** `converge_workspace_surfaces`
+  (`effect_surface_registration.rs:22-58`) handles only `FilesystemSkillSurface`;
+  `agent_effect_surface_declarations()` returns `Vec<FilesystemSkillSurface>`.
+- **MCP config is plugin-global, not per-Workspace.** tavily's `apiKey` lives in
+  `<data_dir>/plugins/data/official/ora-space.tavily-search/store.json`
+  (`bootstrap.rs:2069-2070` test), not in the workspace.
+- **MCP plugins never launch.** `permissions.rs:95` returns `Vec::new()` for
+  `PluginContribution::Mcp`; `registration.rs:54-56` rejects MCP registration with "mcp
+  plugins have no process and cannot register." The wire contract
+  `InstalledPluginContribution::Mcp` (`crates/contracts/src/plugin.rs:34-35`) is a bare
+  unit — no transport, no URL.
+- **Surface crate is aware of MCP config but produces no surface.**
+  `SurfaceDefinition::from_installed` (`crates/surface/src/definition.rs:83-110`) returns
+  `None` for MCP plugins (`definition.rs:87`) yet still calls `compile_configuration_file`
+  (`definition.rs:195-207`) — the natural seam for an MCP surface.
+
+### 5.3 `McpArgument::WorkspaceContext` and `McpValueExpression::Setting` are unresolved
+
+Both are compiled and stored but never consumed (`mcp/mod.rs:79-83`, `transport.rs:178-199`,
+`transport.rs:241-262`). The intended resolution (per `mcp/mod.rs:81` doc): some consumer
+loads `store.json`, substitutes `prefix + effective_value(id) + suffix` for each
+`Setting`, resolves `WorkspaceContext` to the agent instance cwd, and produces a
+`ResolvedMcp`. That consumer does not exist.
+
+---
+
+## 6. What the spec says
+
+### 6.1 Active spec (implemented for skills; spec'd-but-unbuilt for MCP)
+
+- **MCP is config-only; the agent plugin renders.** `specs/active/plugin/5-mcp.md#定位`
+  (L5-9): "Ora 负责安装与解析 MCP 包；Agent 插件负责把 Ora 的规范化描述转换成 Claude
+  Code、Codex、OpenCode 等目标 Agent 的配置格式."
+- **`configure_agent` (spec'd active, NOT in code — grep: 0 matches).**
+  `specs/active/plugin/5-mcp.md#agent-配置时序` (L261-291): before `start_agent`, Ora calls
+  `ora/agent/configure_agent { agent_instance_id, cwd, revision, mcps: [ResolvedMcp] }`;
+  the plugin idempotently reconciles Ora-managed entries, preserves user entries, plans
+  then atomically replaces, returns applied revision + managed identity + fingerprint.
+- **Use-time resolution.** `5-mcp.md#使用期解析` (L210-220, L238-245): "使用 MCP 前，Ora
+  根据精确安装版本、当前插件 `store.json` 和 Agent Workspace 生成 `ResolvedMcp`";
+  `context: workspace` resolves to the Agent instance's authoritative cwd.
+- **Agent contract.** `4-agent.md#oraagentstart_agent` (L35-50, params `agent_instance_id`
+  - `cwd`), `#oraagentstop_agent` (L52-62), `#oraagentlist_models` (L64-74); ACP
+    adaptation is the plugin's job (`#acp-下的模型列表` L76-93). Same `cwd` for all sessions
+    of an instance (`#agent-实例与-session` L25).
+- **Workspace-scoped Effect state.** `specs/active/effect/1-category.md#定位` (L5-7);
+  `WorkspaceEffectSpec { skills, mcps }` (`2-declaration.md#workspace-声明` L12-23);
+  `AgentTarget = { workspace_id, agent_plugin_id }` (`#agenttarget` L69-89);
+  `McpDefinition` is agent-agnostic, "Agent adapter 负责将它安全物化为目标格式"
+  (`#mcpdefinition` L48-66). Watcher: durable reconcile requests, level-triggered, startup
+  safety scan (`4-watcher.md#定位` L1-7, `#durable-reconcile-request` L49-82,
+  `#desired-state-提交` L88-107, `#启动与安全扫描` L141-151). Reconcile timing:
+  `2-declaration.md#reconcile-时序` L148-168.
+- **`agent_effect_surface_declarations` is NOT in specs** — it appears only in `AGENTS.md`:
+  "Register every consumer kind into the single declaration snapshot the convergence pass
+  reads (`PluginApi::agent_effect_surface_declarations`)."
+
+### 6.2 Planned (Effect v2 — `changes/`)
+
+`specs/changes/effect/v2.md` introduces filesystem Surface adapters: `adapter_kind =
+filesystem_directory | filesystem_document`, `format_kind = skill_directory.v1 |
+mcp_config.v1` (`#05-effect_surfaces` L141-191); Surface↔Consumer with
+`coordination_kind = uninterrupted | wait_for_idle_and_restart` (`#06` L193-229);
+generation/phase status (`#09` L337-424, `#10` L426-524); ownership-recorded managed items
+with `ManagedIdentity` markers (`#08` L278-332); cross-target Operations journal
+(`#14` L887-1063). This is the spec's planned version of "Ora writes MCP config directly
+to a filesystem target" — **planned, not active**.
+
+### 6.3 Spec vs code (the divergence)
+
+The active spec routes MCP through `configure_agent` (agent plugin renders + writes). The
+**implemented** skills path routes through the Effect filesystem surface (Ora writes files
+at a plugin-declared path, with plugin coordination via `effect/restart`). These are
+different mechanisms. For MCP, **neither** is implemented:
+
+| Mechanism                                              | Spec status       | Code status                            |
+| ------------------------------------------------------ | ----------------- | -------------------------------------- |
+| `configure_agent` (plugin renders → target config)     | active spec       | **absent** (0 refs)                    |
+| Effect filesystem surface `mcp_config.v1` (Ora writes) | planned (v2)      | **absent** (only `skill_directory_v1`) |
+| ACP `session/new` `mcp_servers`                        | — (schema exists) | **always empty**                       |
+
+---
+
+## 7. Marketplace & plugin truth
+
+### 7.1 `ora-space.opencode` (agent) — `opencode-agent` repo
+
+- **Manifest** (`opencode-agent:package.json` `ora.*`): `id=ora-space.opencode`,
+  `kind=agent`, `main=./src/main.ts`, `engines {ora>=0.8.0, pluginApi=1, bun>=1.0.0}`,
+  `contributes.agent.contractVersion=1`. (Note: `package.json.version=0.1.0` lags the
+  marketplace `orax.toml.version=0.2.2` — the `orax.toml` version is install/verify
+  authority.)
+- **.orax v0.2.2 contents** (downloaded + unpacked, 13662 bytes): `orax.toml`, `main.js`
+  (33054 bytes — `deno bundle` output, SDK vendored), `logo.svg`, `README.md`. No
+  `assets/`, no `config.json`.
+- **Launch** (`opencode-agent:src/services/opencode-client.ts`): spawns
+  `<opencode-bin> acp --cwd <cwd>` (argv `[...extraArgs, "acp", "--cwd", cwd]`,
+  `extraArgs` always `[]`). Binary resolved in `command.ts`: `ORA_OPENCODE_BIN` env, else
+  `opencode.cmd` (Windows) / `opencode`. The plugin owns the CLI stdio: stdout NDJSON →
+  re-parsed → forwarded as ACP frames; host frames → CLI stdin. Payload never parsed
+  (`handlers/acp.ts`).
+- **Effect surface (CRITICAL)** (`opencode-agent:src/handlers/effects.ts`):
+
+  ```ts
+  export const SKILLS_SURFACE: EffectSurfaceDeclaration = {
+    workspaceRelativePath: ".opencode/skills",
+    materializationFormat: "skill_directory.v1",
+    coordination: "wait_for_idle_and_restart",
+  };
+  ```
+
+  The opencode plugin declares **only** this surface. `SkillEffectCoordinator` tracks
+  in-flight `session/prompt` turns from ACP frames (reads `method`+`id` only), idles,
+  restarts the CLI (so it re-scans `.opencode/skills`), then replays. **No MCP-config
+  surface; no code reads an MCP descriptor or writes `opencode.json`.**
+
+### 7.2 `ora-space.tavily-search` (mcp) — `tavily-search-mcp` repo
+
+- **Repo is descriptor-only**: `README.md`, `assets/config.json`, `logo.svg`, `orax.toml`.
+  No `src/`, no `main.js`, no `package.json`, no release workflow.
+- **`assets/config.json` verbatim** (`tavily-search-mcp:assets/config.json`):
+
+  ```json
+  {
+    "schemaVersion": 1,
+    "settings": {
+      "apiKey": {
+        "type": "string",
+        "title": "API key",
+        "description": "Tavily API key used to authenticate with the MCP server",
+        "required": true
+      }
+    },
+    "transport": {
+      "type": "http",
+      "url": "https://mcp.tavily.com/mcp",
+      "headers": {
+        "Authorization": { "setting": "apiKey", "prefix": "Bearer " }
+      }
+    }
+  }
+  ```
+
+- **.orax v0.1.0 contents** (downloaded + unpacked, 1541 bytes): `assets/config.json`
+  (395B), `logo.svg`, `orax.toml`, `README.md`. (Archive built on Windows — backslash
+  entry separators; `unzip` warns but extracts correctly.)
+- **What Ora must collect/resolve**: one stored setting `apiKey` (string, required) →
+  `store.json`. Resolve to: HTTP endpoint `https://mcp.tavily.com/mcp` with header
+  `Authorization: Bearer <stored-apiKey>` (literal `Bearer ` prefix + stored value).
+
+### 7.3 opencode CLI's own MCP config (the target format)
+
+Source: `https://opencode.ai/docs/mcp-servers` + `/docs/config`. opencode reads MCP from
+the top-level `"mcp"` key of `opencode.json`/`.jsonc`. Config locations (merged, not
+replaced; project config searches up from cwd to the nearest git dir):
+
+| Scope       | Path                               |
+| ----------- | ---------------------------------- |
+| Global      | `~/.config/opencode/opencode.json` |
+| Custom file | `$OPENCODE_CONFIG`                 |
+| Project     | `<project-root>/opencode.json`     |
+| Custom dir  | `$OPENCODE_CONFIG_DIR`             |
+| Inline      | `$OPENCODE_CONFIG_CONTENT`         |
+
+MCP entry schema — note opencode uses `"remote"`/`"local"`, **not** `"http"`/`"stdio"`:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "my-remote-mcp": {
+      "type": "remote",
+      "url": "https://my-mcp-server.com",
+      "enabled": true,
+      "headers": { "Authorization": "Bearer MY_API_KEY" },
+    },
+  },
+}
+```
+
+### 7.4 The target opencode.json for tavily
+
+The resolved tavily descriptor, rendered into the agent's project-root `opencode.json`,
+should be:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "ora-space.tavily-search": {
+      "type": "remote",
+      "url": "https://mcp.tavily.com/mcp",
+      "enabled": true,
+      "headers": { "Authorization": "Bearer <stored-apiKey>" },
+    },
+  },
+}
+```
+
+Because opencode merges config and the opencode plugin passes the **workspace** as
+session `cwd` (§3), writing to `<workspace_root>/opencode.json` is the right target —
+opencode searches up from cwd and finds it.
+
+### 7.5 .orax layout summary
+
+| kind                | .orax contents                                       | build                                   |
+| ------------------- | ---------------------------------------------------- | --------------------------------------- |
+| `agent`             | `orax.toml, main.js, logo.svg, README.md`            | `release.yml` `zip -j … dist/main.js …` |
+| `mcp` (config-only) | `orax.toml, assets/config.json, logo.svg, README.md` | external/manual                         |
+
+Marketplace conventions: `registry/<first-char>/<identifier>/` = `orax.toml + README.md +
+logo.svg`; marketplace `orax.toml` adds `url` (release asset) + `sha256`; `resolver=1` is
+the orax.toml schema version (distinct from `schemaVersion=1` for config.json and
+`manifestVersion/contractVersion=1` in `package.json`); install target written
+`namespace/identifier` (e.g. `official/ora-space.tavily-search`).
+
+---
+
+## 7.6 The bridge is the gap
+
+The tavily README states the design intent explicitly: "an Agent plugin later turns the
+installed descriptor into target-agent configuration." The opencode plugin v0.2.2 has not
+implemented that step — its only Effect surface is `.opencode/skills`. Ora can install +
+validate + store tavily, and spawn opencode, but nothing compiles the tavily descriptor
+into `opencode.json`. **This is the seam to close.**
+
+---
+
+## 8. Three delivery channels (all currently unimplemented)
+
+### Channel A — Effect filesystem surface (mirrors skills) — RECOMMENDED
+
+Add an MCP consumer kind to the existing skills-style Effect surface machinery.
+
+- **Ora side**: new surface type (e.g. `FilesystemMcpSurface`) + new
+  `MaterializationFormat::mcp_config_v1()` in `crates/effect`; extend the validator
+  (`agent_runtime/plugin_agent/effect.rs:67`) to accept it; teach `FilesystemSurfaceAdapter`
+  (or a sibling `McpConfigSurfaceAdapter`) to render `ResolvedMcp` → the target config
+  fragment (opencode `mcp` block) and write it (with `.ora-managed.json` ownership marker,
+  atomic replace, quiesce/restart coordination).
+- **Plugin side**: the opencode plugin declares a second surface, e.g.
+  `{ workspaceRelativePath: "opencode.json", materializationFormat: "mcp_config.v1",
+coordination: "wait_for_idle_and_restart" }`.
+- **Pros**: exact "mirror skills" match; reuses proven `EffectWorker` +
+  `FilesystemSurfaceAdapter` + convergence + ownership markers; satisfies the `AGENTS.md`
+  "both directions, convergence in a worker" rule; the plugin only declares the path/format
+  (no render logic).
+- **Cons**: new surface type + format + reconciler is a real build; Ora owns the
+  opencode-format rendering (acceptable — Ora already writes skill files at plugin-declared
+  paths; the surface path keeps the plugin authoritative about _where_ and _how to
+  coordinate_). This is the `changes/effect/v2.md` `mcp_config.v1` direction — building it
+  makes the v2 proposal real for MCP.
+
+### Channel B — ACP `session/new` `mcp_servers` (in-memory, thinnest)
+
+Populate the existing ACP `NewSessionRequest.mcp_servers` field (schema:
+`contracts/.../agent.rs:1011-1049`; `McpServer` enum `Stdio/Http/Sse/Acp` at
+`agent.rs:2815`) with resolved MCP configs at `session/new` (`warm.rs:513-527`),
+replacing `NewSessionRequest::new(cwd)`.
+
+- **Pros**: smallest Ora change; no file writes; no plugin change if opencode's ACP mode
+  honors `mcp_servers`; per-session scoping.
+- **Cons**: does NOT match the user's "写入配置文件" requirement; **unverified that the
+  opencode CLI's ACP mode actually launches MCPs passed via `session/new`** (the ACP schema
+  defines the field, but opencode's behavior is an open question — see §10); diverges from
+  the skills pattern and the spec's `configure_agent`.
+
+### Channel C — spec's `configure_agent` (plugin renders → target config)
+
+Implement the active spec: Ora calls `ora/agent/configure_agent { mcps: [ResolvedMcp] }`
+before `start_agent`; the opencode plugin implements the handler to render `ResolvedMcp[]`
+into `opencode.json` (scoped to `cwd`) with managed-identity markers + atomic replace.
+
+- **Pros**: matches the active spec exactly; keeps target-format knowledge in the plugin
+  (consistent with the opencode README's "nothing in Ora is hardcoded for this plugin"
+  posture); reuses the plugin's existing restart coordination.
+- **Cons**: Ora must add a new host→plugin method + the plugin must add a handler (bigger
+  plugin change than Channel A's "declare a surface"); diverges from the implemented skills
+  path (so the two consumer kinds — skills, MCP — would materialize through different
+  mechanisms, complicating the convergence pass).
+
+### Recommendation
+
+**Channel A.** It is the literal "参考 skills 的配置方式" path, reuses the most existing
+machinery, and aligns with the `AGENTS.md` convergence rule (a new Workspace-scoped consumer
+kind registered into `agent_effect_surface_declarations`, converged in a worker for both
+directions). The render logic (opencode `mcp` block) is small and the surface path stays
+plugin-declared. Channel B is the fallback if opencode's ACP mode is confirmed to honor
+`mcp_servers` and a file-less path is acceptable. Channel C is the spec-purist path if the
+team wants one canonical mechanism and is willing to migrate skills to `configure_agent`
+too.
+
+**Regardless of channel, the universal prerequisite is `ResolvedMcp`.** Build that first.
+
+---
+
+## 9. Minimum closed loop — phased plan (Channel A)
+
+**Phase 0 — `ResolvedMcp` (prerequisite, all channels).**
+New type in `crates/plugin-config/src/mcp/` (or a new `resolve` module) that combines
+`CompiledMcpConfiguration` + `StoredConfiguration` (via `ConfigurationService`) into a
+concrete transport: resolve `McpValueExpression::Setting { id, prefix, suffix }` →
+`prefix + effective_value(id) + suffix`; resolve `McpArgument::WorkspaceContext` → the
+agent instance cwd; produce `ResolvedMcp { transport: ResolvedMcpTransport::Http{url, headers} | Stdio{command, args, env} }`.
+Add a per-Workspace MCP selection (desired set) mirroring `WorkspaceEffectSpec.mcps`.
+
+**Phase 1 — MCP surface + format (Ora side).**
+In `crates/effect`: add `FilesystemMcpSurface` (or generalize the surface trait) +
+`MaterializationFormat::mcp_config_v1()`; lift the `effect.rs:67` validator reject; add an
+`McpConfigSurfaceAdapter` that renders `ResolvedMcp[]` → opencode `mcp` JSON fragment,
+writes `<workspace_root>/opencode.json` with a `.ora-managed.json` marker, atomic replace.
+Wire it into `converge_workspace_surfaces` + `reconcile_one` so MCP enters the same
+durable-request + convergence loop as skills.
+
+**Phase 2 — opencode plugin declares the MCP surface.**
+In `opencode-agent:src/handlers/effects.ts`, add a second `EffectSurfaceDeclaration`:
+`{ workspaceRelativePath: "opencode.json", materializationFormat: "mcp_config.v1",
+coordination: "wait_for_idle_and_restart" }`. Extend `SkillEffectCoordinator` (or add a
+sibling) to quiesce + restart on MCP-surface changes. Bump the plugin version + publish a
+new `.orax` to the marketplace.
+
+**Phase 3 — end-to-end.** Install opencode (new version) + tavily; save the tavily API key
+in Ora settings; the Effect worker writes `opencode.json`; start a conversation; opencode
+loads tavily and exposes web-search. Verify with a real tavily key.
+
+> Scope guardrails: the AGENTS.md rule requires implementing **both directions** of the
+> Workspace↔consumer pairing — new MCP consumer → all existing Workspaces, and new
+> Workspace → all existing MCP consumers, both by convergence. Phase 1 must register the
+> MCP surface into the single declaration snapshot the convergence pass reads, not into a
+> second source.
+
+---
+
+## 10. Open questions & risks
+
+1. **Does opencode's ACP mode honor `session/new` `mcp_servers`?** Decides whether Channel
+   B is viable at all. Action: test against the opencode CLI, or read its ACP handler
+   source. (External — not in the Ora repo.)
+2. **opencode config merge vs. managed replace.** opencode merges config files by key. The
+   spec's `configure_agent` requires preserving user entries and using a stable
+   `managed_identity` to distinguish Ora-managed entries. opencode's `mcp` block is keyed
+   by server name — using `ora-space.<name>` as the key gives a stable managed identity,
+   but a user editing that exact key would collide. Define the ownership/merge policy for
+   `mcp_config.v1`.
+3. **`opencode.json` location.** Project-root `opencode.json` (in the workspace) is the
+   natural target, but opencode also reads global `~/.config/opencode/opencode.json`. If
+   the user wants MCP available across projects, global may be preferred — but that escapes
+   the Workspace scope Ora materializes per-Workspace. Decide scope per product intent.
+4. **Secret handling.** tavily's `apiKey` is Phase-1 `string` (stored in `store.json`); the
+   spec reserves `secret` type for later (`2-settings.md#setting-声明` L75; reserved types
+   rejected in MCP config, `mcp/mod.rs:108-113` + `mod.rs:190-203`). The resolved
+   `Authorization: Bearer <apiKey>` lands in a workspace file — confirm this is acceptable
+   for Phase 1 (it mirrors how opencode itself stores MCP keys in `opencode.json`).
+5. **stdio MCP + `WorkspaceContext`.** tavily is HTTP (no cwd concern), but a stdio MCP
+   (e.g. a future package) uses `McpArgument::WorkspaceContext` → the agent instance cwd.
+   Confirm the cwd passed to opencode (session `cwd` = workspace) is the right "authoritative
+   cwd" for stdio MCP launch by the opencode CLI.
+6. **Surface crate seam.** `SurfaceDefinition::from_installed` (`surface/src/definition.rs:83-110`)
+   already compiles MCP config but returns `None` for MCP. Decide whether MCP surface
+   declaration is plugin-supplied (Channel A, mirrors skills) or host-derived (the surface
+   crate knows MCP intrinsically). The skills precedent is plugin-supplied.
+
+---
+
+## 11. Source index
+
+**Ora crates**
+
+- Install: `crates/plugin-manager/src/install.rs:144,254,271,280,282-305,344-373,186-189`;
+  `crates/plugin-manager/src/validation.rs:116-215,145-158,180-182`;
+  `crates/plugin-manager/src/mcp.rs:20-22,29-69,73-128,35-39,56-60`;
+  `crates/plugin-manager/src/lib.rs:42-59`
+- Compile/store: `crates/plugin-config/src/mcp/mod.rs:6-7,37,42-50,55-58,62-68,72-75,79-83,87-97,108-113,130-149,153,161-184,189-203`;
+  `crates/plugin-config/src/mcp/transport.rs:55,65,75,107,148,157,178-199,206,228,241-262,274,292,309,323`;
+  `crates/plugin-config/src/mcp/README.md:25`; `crates/plugin-config/src/declaration.rs:11,13,21,126-127`;
+  `crates/plugin-config/src/service.rs:196-215,251-272,300-371,390-449,452-499,517,696-749`;
+  `crates/plugin-config/src/values.rs:9-15,17-25,28-82,146`; `crates/plugin-config/src/lib.rs:17-18`;
+  `crates/plugin-config/README.md:4-6,28-29`
+- Lifecycle/contracts: `crates/plugin-lifecycle/src/permissions.rs:95`;
+  `crates/plugin-lifecycle/src/registration.rs:54-56`; `crates/plugin-lifecycle/src/state.rs:122-129,160`;
+  `crates/contracts/src/plugin.rs:34-35,144`
+- Agent runtime: `crates/backend/src/agent_runtime/plugin_agent/control.rs:58-63,155-161`;
+  `crates/backend/src/agent_runtime/warm.rs:20,513-527`; `crates/backend/src/agent_runtime/mod.rs:312,853,874-878`;
+  `crates/backend/src/agent_runtime/README.md:18`; `crates/backend/src/bootstrap.rs:42,183,2069-2070`;
+  `crates/backend/src/agent_runtime/plugin_agent/README.md:32`;
+  `crates/backend/src/agent_runtime/plugin_agent/effect.rs:5,54-89,67-69,119-134,240`
+- Effect/skills: `crates/effect/src/filesystem.rs:120-121,268-301,314-327`;
+  `crates/effect/src/surface.rs:62,64-66,94-100,115,129,175,179-180`; `crates/effect/src/reconcile.rs`;
+  `crates/effect/src/tests.rs:354-382`; `crates/effect/src/lib.rs:38`;
+  `crates/surface/src/definition.rs:83-110,87,195-207`;
+  `crates/backend/src/effect_worker.rs:32,220-243,278-307,461-472,621-646,656-680,704,869-894,986-994`;
+  `crates/backend/src/effect_surface_registration.rs:22-58,39-56,71,113-115`;
+  `crates/backend/src/plugin.rs:243-251,465-507,503-505,514-522`;
+  `crates/backend/src/skill_reconciliation.rs:30-119`;
+  `crates/db/src/repository/effect/mod.rs:9,45-177,161-168,172,896`;
+  `crates/db/src/repository/effect/mapping.rs:207-227`
+
+**Specs** (`specs/`, nested repo, branch `main`)
+
+- `specs/active/plugin/5-mcp.md` §定位 L5-9, §职责 L13-20, §包结构 L40, §配置格式 L52-59,
+  §stdio L62-96, §http L133-169, §排他领域模型 L172-195, §工作目录 L129-130, §使用期解析
+  L210-220 & L238-245, §agent-配置时序 L261-291, §agent-沙盒 L294-306
+- `specs/active/plugin/4-agent.md` §oraagentstart_agent L35-50, §oraagentstop_agent L52-62,
+  §oraagentlist_models L64-74, §acp-下的模型列表 L76-93, §agent-实例与-session L25,
+  §实现边界 L98-104
+- `specs/active/plugin/1-capability.md` §permissionsprocesssandbox L201-214, §解析与执行规则 L222
+- `specs/active/plugin/2-settings.md` §setting-声明 L28-75, §运行上下文 L160-167
+- `specs/active/effect/1-category.md#定位` L5-7; `2-declaration.md#定位` L5-8,
+  §workspace-声明 L12-23, §mcpdefinition L48-66, §agenttarget L69-89, §reconcile-时序
+  L148-168, §managed-state L176-203; `4-watcher.md#定位` L1-7, §durable-reconcile-request
+  L49-82, §desired-state-提交 L88-107, §启动与安全扫描 L141-151
+- `specs/changes/effect/v2.md` §05-effect_surfaces L141-191, §06-effect_surface_consumers
+  L193-229, §08-effect_managed_items L278-332, §09-effect_surface_status L337-424,
+  §10-effect_consumer_status L426-524, §14-effect_operations L887-1063
+- `AGENTS.md` — `agent_effect_surface_declarations` + "both directions" convergence rule
+
+**Marketplace & plugins**
+
+- `ora-space/marketplace`: `registry/o/ora-space.opencode/{orax.toml,README.md}`,
+  `registry/o/ora-space.tavily-search/{orax.toml,README.md}`
+- `ora-space/opencode-agent`: `package.json`, `orax.toml`, `deno.json`,
+  `src/main.ts`, `src/handlers/{lifecycle.ts,acp.ts,models.ts,effects.ts}`,
+  `src/services/{opencode-client.ts,command.ts,ndjson.ts}`, `.github/workflows/release.yml`
+- `ora-space/tavily-search-mcp`: `assets/config.json`, `orax.toml`, `README.md`
+- opencode CLI docs: `https://opencode.ai/docs/mcp-servers`, `https://opencode.ai/docs/config`
+- Verified .orax downloads: tavily v0.1.0 (1541B, sha256 matches), opencode v0.2.2 (13662B, sha256 matches)
+
+**Verified in-session (grep)**: `configure_agent` → 0 matches in `crates/`;
+`mcp_servers`/`mcpServers` → 0 Ora producers (only `NewSessionRequest::new(cwd)` at
+`warm.rs:526`); `MaterializationFormat` → only `skill_directory_v1()` constructor; no
+`mcp_config`/`McpConfig` materialization format.

--- a/docs/agent-mcp-configuration-spec.md
+++ b/docs/agent-mcp-configuration-spec.md
@@ -1,0 +1,385 @@
+# Agent MCP 配置交付
+
+## 问题陈述
+
+Ora 已能从官方插件市场发现 Agent 和 MCP 插件，下载 `.orax` 发布包，校验 SHA-256，安全解压，验证插件类型并原子安装；也能持久化用户填写的 MCP 配置。但这些供给侧能力尚未让 MCP 真正进入 Agent 对话。
+
+当前，已安装 MCP 的声明和配置无法传递到 Agent Workspace：Ora 没有运行时 `Resolved MCP` 模型、MCP Effect Source、Workspace MCP Desired Set、Agent 原生配置物化能力，也没有覆盖 MCP 配置的目标就绪门禁。OpenCode Agent 插件只消费现有 Skill Surface，不写入 OpenCode MCP 配置。因此，即使用户成功安装 OpenCode 和 Tavily 并填写 API Key，仍无法在 Ora 对话中使用 Tavily。
+
+现有生命周期也无法安全支撑精确版本引用：插件升级会立即删除旧版本；Agent 生命周期检测忽略“只有版本发生变化”的情况；卸载会在 Effect 引用退出前删除插件文件。对于可执行文件位于插件包内的 stdio MCP，这可能令 Desired State 或已应用状态指向已不存在的版本。
+
+本功能必须打通“插件市场安装—配置—Workspace 收敛—对话可用”的最小闭环，同时满足以下约束：Agent 原生格式不进入 Ora Core；未完成配置的 MCP 不影响普通对话；新请求不能进入只完成部分配置的 Workspace generation；Workspace 与消费者的配对不能依赖启动时的一次性事件。
+
+## 解决方案
+
+所有已安装 MCP 默认具有启用意图（Default-enabled）。缺少必填配置时，MCP 保持“已安装、待配置”（Needs Configuration），但不进入任何 Workspace MCP Desired Set。配置完整并可生成 Ready 的不可变 MCP Source Revision 后，Ora 自动将该 revision 传播到全部现有 Agent Workspace；未来创建的 Workspace 也自动包含它。
+
+深化现有 MCP 配置模块：将安装期声明与有效配置解析为目标无关的 MCP 定义，并结合具体 Workspace 生成 `Resolved MCP`。Skill 与 MCP 共享 Effect 的 generation、持久化请求、租约、操作日志、恢复和安全扫描机制，但保留各自强类型的规划器与物化适配器。
+
+Agent 插件通过可选、带版本的 MCP Configuration Capability 声明能力。支持该能力的插件通过单一且幂等的 `agent/configureWorkspace` 方法接收 Agent Target 的完整 MCP Configuration Snapshot。目标原生配置由 Agent 插件渲染，Ora Host 不理解其格式。Agent 不支持的 transport 按 MCP、按 Agent Target 记录为非阻塞问题；支持项仍正常应用，目标进入 Ready with Issues，并允许对话。
+
+首个适配器由 OpenCode Agent 插件实现，只物化 Streamable HTTP MCP。它在 Workspace 下生成 Ora 全量托管的 `.opencode/opencode.json`，与用户维护的项目根目录 `opencode.json`/`opencode.jsonc` 分离。Ora 将精确生成路径加入仓库本地 Git exclude，收紧文件权限，从诊断中清除配置值，并用持久化操作记录和指纹实现崩溃恢复与外部改动检测。
+
+Agent Target 只有在当前 Workspace generation 所需的 Skill 与 MCP 操作全部处理完成后才接收新请求。普通配置变化不打断正在执行的 turn。收敛器等待相关 Session 空闲，关闭新请求入口，执行一次 idle barrier，应用 Skill 与 MCP，重启或恢复 Agent，最后推进 Agent Target Ready Generation 并重新开放入口。
+
+端到端流程如下：
+
+1. 用户从官方插件市场安装 OpenCode Agent 插件与 Tavily MCP。
+2. Tavily 显示为“已安装、待配置”；它不进入 Desired Set，现有对话不受影响。
+3. 用户在 Ora 配置界面填写并保存 Tavily API Key。
+4. Ora 发布 Ready 的 Tavily MCP Source Revision，并传播到所有现有 Agent Workspace。
+5. Effect 收敛器等待各 OpenCode Agent Target 空闲，发送完整快照，并记录文档和条目回执。
+6. OpenCode 插件原子写入 Workspace 托管文档，并通过协商的协调协议刷新运行时。
+7. Ora 推进 Ready Generation，允许新 turn 进入。
+8. OpenCode 从 Workspace 配置发现 Tavily，并在对话中暴露其 MCP 工具。
+9. 此后创建的 Workspace 无需用户再次选择或点击“应用”，即可自动获得 Tavily。
+
+## 用户故事
+
+1. 作为 Ora 用户，我希望从官方插件市场安装 Agent 插件，以便在 Ora 中使用该 Agent。
+2. 作为 Ora 用户，我希望从官方插件市场安装 MCP，以便由 Ora 校验和管理 MCP 定义。
+3. 作为 Ora 用户，我希望缺少必填项的 MCP 明确显示 Needs Configuration，以免把安装成功误认为运行时可用。
+4. 作为 Ora 用户，我希望未配置完成的 MCP 不影响现有对话，以免安装行为使全部 Workspace 不可用。
+5. 作为 Ora 用户，我希望安装未配置完成的 MCP 后立即进入明确的配置入口。
+6. 作为 Ora 用户，我希望保存完整配置后 MCP 自动生效，无需再次点击“应用”。
+7. 作为 Ora 用户，我希望 Ready 的 Default-enabled MCP 自动传播到全部现有 Workspace。
+8. 作为 Ora 用户，我希望未来创建的 Workspace 自动获得全部 Ready MCP，使创建顺序不影响能力。
+9. 作为 Ora 用户，我希望重置或丢失必填配置后，MCP 自动退出 Workspace Desired State。
+10. 作为 Ora 用户，我希望重新补齐配置后，MCP 自动重新加入全部 Workspace。
+11. 作为 Ora 用户，我希望配置变化等待正在执行的 turn 结束，避免普通配置修改中断工作。
+12. 作为 Ora 用户，我希望 Agent Target 应用新 generation 时阻止新 turn 进入，避免能力状态新旧混杂。
+13. 作为 Ora 用户，我希望等待门禁期间看到明确的等待或应用状态。
+14. 作为 Ora 用户，我希望能够取消尚未通过门禁的请求。
+15. 作为 Ora 用户，我希望阻塞性收敛失败提供稳定且可执行的错误信息。
+16. 作为 Ora 用户，我希望 Agent 不支持某个 MCP transport 时仍能正常使用其他能力。
+17. 作为 Ora 用户，我希望“不受支持”按 Agent Target 独立记录，使同一 MCP 可在不同 Agent 上产生不同结果。
+18. 作为 Ora 用户，我希望 Agent 插件升级后自动重新评估 transport 支持。
+19. 作为 Ora 用户，我希望同一 generation 的 Skill 和 MCP 一起就绪后才开始新 turn。
+20. 作为 Ora 用户，我希望 Ora 保留我维护的项目根目录 OpenCode 配置。
+21. 作为 Ora 用户，我希望 Ora 生成的 MCP 配置位于独立托管文档中，使所有权和清理行为可预测。
+22. 作为 Ora 用户，我希望 Ora 拒绝接管托管路径上既有的非托管文件。
+23. 作为 Ora 用户，我希望 Ora 检测托管文档被外部修改的情况，避免无法证明所有权时覆盖内容。
+24. 作为 Ora 用户，我希望冲突恢复先备份再重建，不允许无备份强制覆盖。
+25. 作为 Ora 用户，我希望生成文件只加入仓库本地 Git exclude，不修改项目 `.gitignore`。
+26. 作为 Ora 用户，我希望托管路径已被 Git 跟踪时阻止物化。
+27. 作为 Ora 用户，我希望生成文件采用仅当前 OS 用户可访问的限制性权限。
+28. 作为 Ora 用户，我希望配置值不进入日志、审计、公开错误或遥测。
+29. 作为 Ora 用户，我希望卸载先清理 Agent 配置，再删除 MCP 插件包。
+30. 作为 Ora 用户，我希望“保留数据”卸载后重装可以复用兼容配置。
+31. 作为 Ora 用户，我希望“删除数据”仅在目标配置清理完成后删除配置数据。
+32. 作为 Ora 用户，我希望 Ora 重启后能继续中断的卸载操作。
+33. 作为 Ora 用户，我希望升级先完整验证新包，失败时旧 revision 继续可用。
+34. 作为 Ora 用户，我希望精确版本仍被引用时保留旧插件包。
+35. 作为 Ora 用户，我希望新版本变为 Needs Configuration 时退出旧有效版本，而不是暗中继续运行旧版本。
+36. 作为 Ora 用户，我希望升级和卸载在等待收敛期间显示为进行中，不提前报告完成。
+37. 作为 Agent 插件作者，我希望 MCP 支持是可选且带版本的能力，不影响基础对话契约。
+38. 作为 Agent 插件作者，我希望明确声明支持的 transport，使 Ora 可在渲染前完成分类。
+39. 作为 Agent 插件作者，我希望收到完整快照而非增删改事件，以便丢失通知或重启后仍可幂等收敛。
+40. 作为 Agent 插件作者，我希望 Ora 提供稳定托管标识、精确包版本和规范化 transport，无需读取其他插件内部状态。
+41. 作为 Agent 插件作者，我希望目标格式渲染留在插件内部，避免 Ora Core 依赖具体 Agent schema。
+42. 作为 Agent 插件作者，我希望配置调用携带 Workspace root、generation 和 operation identity，以实现幂等写入与可审计回执。
+43. 作为 Agent 插件作者，我希望畸形 Host 请求和不支持的协议版本在进入适配器前被拒绝。
+44. 作为 Agent 插件作者，我希望 Host 严格校验回执，避免不完整结果被误标为 Ready。
+45. 作为 MCP 插件作者，我希望安装有效性、配置完整度、Source 身份和精确版本相互独立且可复现。
+46. 作为插件市场维护者，我希望 Host 依赖和发布元数据受到强制校验。
+47. 作为开发者，我希望 Skill 与 MCP 复用一套可恢复 Effect 机制，同时保留强类型规划器和高层测试接缝。
+48. 作为支持或安全审查人员，我希望错误安全稳定、明文范围明确，并拒绝未来 Secret Setting 误走普通字符串链路。
+
+## 实现决策
+
+### 1. 权威术语与不变量
+
+- 以项目上下文定义的 Agent Workspace、MCP Package、Default-enabled MCP、Workspace MCP Desired Set、MCP Source、MCP Source Revision、Agent Target、Agent Target Ready Generation、MCP Configuration Capability、MCP Configuration Snapshot、MCP Materialization、Managed Agent Configuration Document、Ready with Issues 和 Needs Configuration 为权威术语。
+- 安装有效、配置完整、Source Ready、Workspace Desired、目标已应用和运行时工具可用是六个独立事实，禁止依据其中一个推断另一个。
+- 所有已安装 MCP 均具有 Default-enabled 意图；只有 Ready MCP 存在活跃 Source Revision 并进入 Desired Set。
+- 本期 MCP 选择范围为 Workspace，且自动完成；不提供 Workspace 级关闭、Agent 级手工选择或 Session 级选择。
+- Agent 原生字段只能出现在 MCP Materialization 接缝之后；Host 领域类型禁止包含 OpenCode 字段或渲染规则。
+- Agent Target 仅在所需 generation 达到 Current 或 Ready with Issues 时允许新 turn；Waiting、Applying、Degraded 和 Recovery Required 均不可放行。
+- Unsupported by Agent 是目标级非阻塞状态；Needs Configuration 是插件级状态并阻止 Desired membership，二者不得混用。
+- 必须通过持续收敛同时实现“新消费者→既有 Workspace”和“新 Workspace→既有消费者”。所有消费者声明进入收敛器读取的唯一 Agent Effect declaration snapshot；禁止新增 MCP 专用声明注册表。
+
+### 2. MCP 配置与解析模块
+
+- 深化现有 MCP 配置模块，不在 Backend 调用方拼装解析，也不增加只做转发的薄层。
+- 模块输入包括已校验 MCP descriptor、canonical Plugin identity、精确 package version 与 package root、配置存储快照；需要 Workspace 解析时再传入 Agent Workspace root。
+- 模块负责声明编译、完整度判断、普通 Setting 有效值、前后缀展开、HTTP header 校验、stdio 参数渲染、包内可执行文件 containment、Workspace 上下文解析、规范化摘要，以及目标无关 MCP 定义与 `Resolved MCP` 构造。
+- 返回值必须是穷尽枚举：Ready（携带不可变 Source candidate）、Needs Configuration（缺失或无效 Setting ID）、Unavailable（稳定安全原因）或精确版本/路径 containment 错误；调用方不得检查可选字段来猜测状态。
+- Source Revision 身份绑定 canonical Plugin identity、精确 package version、descriptor digest、configuration-store revision、normalized resolved-state digest 和 payload schema version，不能只使用 SemVer。
+- revision payload 包含规范化 transport 与当前声明为普通 string/number/boolean 的有效值，不包含 Workspace path；Workspace 上下文在构造目标快照时解析。
+- Tavily 当前把 API Key 声明为普通 string，本期明确按非 Secret 的本地明文数据处理。该值可存在于插件配置存储、不可变 revision payload、内存/JSON-RPC 快照、恢复所需的持久化 operation payload 和托管文档中，但全部仅限当前 OS 用户本地环境。
+- 普通 Setting 值禁止进入日志、trace、审计、公开错误、UI analytics、崩溃摘要、用户可见 digest 或 Issue。规范 digest 使用规范字节的单向 SHA-256，不能替代明文泄漏控制。
+- 未来声明为 Secret 的 Setting 必须以 `mcp_secret_unsupported` 拒绝发布和 protocol v1 传输；SecretRef 需要独立协议，禁止静默降级为普通字符串。
+- stdio 可执行文件必须位于被保留的精确插件版本内，并在使用前再次校验；工作目录始终是 Agent Workspace，不是共享 Agent 进程的中性目录。
+
+### 3. Source 发布与自动传播
+
+- 复用通用 Effect source 存储，使用 `effect_kind = mcp`、`source_kind = plugin`。稳定 source key 为 canonical Plugin identity；包或配置变化只产生同一 Source 下的新 revision。
+- Workspace Desired State 增加强类型 MCP map；Skill map 与 MCP map 保持独立字段，不合并为通用可选字段 payload。
+- 安装成功始终更新已安装插件目录和配置摘要；仅当配置 Complete 且解析为 Ready 时发布活跃 Source。
+- 保存、重置、恢复或重新校验配置后，在配置存储写入成功后执行一次 readiness synchronization。
+- Ready 转换必须原子完成：发布不可变 revision、推进 source head、更新全部既有 Workspace desired item、推进 generation，并 upsert 对应 Agent Target 的持久化 reconcile request。
+- Ready→Ready 更新保持 Source identity，只推进 revision。Ready→Needs Configuration/Unavailable 退休活跃 Source、移除全部 Desired item 并触发清理，但保留 Default-enabled 意图。重新 Ready 后自动加入全部 Workspace。
+- 新 Workspace 初始化在同一数据库事务中选取全部活跃 Skill head 与 Ready MCP head，不选 retired、unavailable 或配置不完整的 MCP。
+- Desired 变化与 durable request 同事务提交；内存通知只是优化。配置存储与 SQLite 无法共享事务，因此启动修复和周期安全扫描必须比较安装包、配置 revision 与活跃 Source，修复缺失发布、ghost Source 和缺失请求；相同输入不得重复推进 generation。
+
+### 4. 共享 Effect 收敛与 Agent Target 调度
+
+#### 持久化模型
+
+- 扩展通用 Source 约束以接受 `mcp`；增加 `mcp_source_revision_metadata`，以 source revision 为键，保存 canonical Plugin identity、精确包版本、descriptor digest、configuration-store revision、resolved-state digest 与 payload schema version。垃圾回收只查询这些索引列，不解析不透明 JSON。
+- 增加 `effect_agent_targets`（Workspace identity + Agent Plugin identity 唯一），保存 capability revision 与生命周期；增加 `effect_agent_target_status`，保存 desired/observed/applied/ready generation、phase、status version 和时间戳。
+- 将 `effect_reconcile_requests` 改为 Agent Target 维度，保留 requested generation、wake reason、lease、attempt 和调度字段。迁移时，同一目标的既有 surface request 合并为最大 generation 与最早到期时间。
+- 保留物理 Skill Surface；新增逻辑 MCP Surface，adapter kind 为 `agent_configuration`、format kind 为 `mcp_configuration.v1`，consumer 指向 Agent Plugin，不保存 Host 渲染的文件路径。
+- `effect_conditions` 改由 Agent Target 拥有，可选关联 surface/consumer，并强制 `impact` 为 `blocking` 或 `non_blocking`；既有条件迁移为 Blocking。
+- 增加 `effect_managed_documents`（Agent Target + materialization kind 唯一），保存 locator、applied fingerprint、applied generation 与 status revision；增加 `effect_managed_document_entries`，分别约束“document + managed identity”和“document + native key”唯一，每项引用精确 MCP source revision。
+- 增加 `effect_operation_source_revisions`，使恢复与垃圾回收无需解析 operation payload 即可查询精确版本引用。
+- 增加 `plugin_package_operations`，记录 Plugin identity、`update`/`uninstall`、previous/candidate version、phase、data-retention policy、last safe error 和时间戳；每个 Plugin identity 最多一个非终态操作。
+- 外键与 check constraint 必须强制 generation 顺序、枚举合法性、文档条目所有权和终态 operation 不可变。使用单向迁移与确定性回填，不保留兼容 view 或双写期。
+
+#### 调度与状态机
+
+- Skill 与 MCP 共用一个 Workspace generation、request store、claim/lease 协议、operation journal、重试模型、启动恢复和周期安全扫描，但保留各自强类型 planner/adapter。
+- request 以 Agent Target 为键，一次请求覆盖该目标消费的全部 Skill Surface 和当前 generation 的完整 MCP 文档投影。共享物理 Skill Surface 继续用独立 lease 和 active-operation 唯一约束串行化。
+- worker claim 后、获取 admission barrier 前各读取一次最新 generation；为某 generation 创建的 Prepared operation 不得改变其 generation。
+- 任一相关 Session 为 Working 或 Stopping Turn 时，目标进入 Waiting for Idle，订阅 Session 状态变化并释放 claim，不修改目标，也不定时热轮询。
+- 全部 Session 空闲后，收敛器以同一 Agent Target gate 原子关闭新 turn，调用一次 idle barrier，应用所需 Skill/MCP，调用一次 restart/resume，重新开放入口并推进 Ready Generation。
+- 请求 admission 与 reconcile 使用同一 keyed gate：请求先获得 gate 时收敛等待；收敛先获得 gate 时请求等待 readiness，且不得长期持有数据库事务或全局锁。
+- 等待请求可取消；只在目标达到所需 generation 的 Current/Ready with Issues 后继续。进入 blocking Degraded/Recovery Required 时，以稳定结构化错误失败。
+- 收敛期间出现更高 generation 时，当前不可变 operation 先完成或恢复，随后处理新 generation；旧完成结果不得清除更高请求。
+- Applied Generation 表示全部目标修改完成；Ready Generation 还要求 Agent 成功恢复且 admission 已开放。Skill 与 MCP 可分别执行，但只有二者全部处理完才能推进 Ready Generation。
+- condition impact 使用 Blocking/NonBlocking 枚举。Unsupported by Agent 为 NonBlocking；所有权或漂移冲突、无效插件回执、不安全路径、权限错误、Git 已跟踪冲突和 Recovery Required 均为 Blocking。
+- Ready with Issues 要求全部受支持操作已 current，且只剩至少一个 NonBlocking condition。共享 Effect worker 保持有界、level-triggered；禁止创建 MCP 专用 worker 或 request 表。
+
+| 起始状态                    | 触发条件                                  | 目标状态          | 必须执行的效果                               |
+| --------------------------- | ----------------------------------------- | ----------------- | -------------------------------------------- |
+| Current / Ready with Issues | Desired 或 capability revision 推进       | Pending           | upsert target request，暂不关闭 Session      |
+| Pending                     | 相关 Session 为 Working/Stopping Turn     | Waiting for Idle  | 等待 Session 变化，不修改目标、不轮询        |
+| Pending / Waiting for Idle  | Session 全部 Idle 且 admission 关闭       | Quiescing         | 在同一 gate 排队或拒绝新 turn                |
+| Quiescing                   | idle barrier 成功                         | Applying          | 先持久化不可变 operation plan，再执行副作用  |
+| Applying                    | 所需 Skill/MCP 均成功或只剩非阻塞不支持项 | Resuming          | 持久化回执、问题与 applied generation        |
+| Applying / Resuming         | 可重试失败                                | Degraded          | 保留 Ready Generation，按持久化 backoff 重试 |
+| Applying / Recovery         | 无法证明所有权或检测到漂移                | Recovery Required | 停止自动修改，等待备份并重建                 |
+| Resuming                    | Agent 恢复且无问题                        | Current           | 推进 Ready Generation 并开放 admission       |
+| Resuming                    | Agent 恢复且只剩非阻塞问题                | Ready with Issues | 推进 Ready Generation 并暴露问题             |
+
+### 5. Agent MCP Configuration Capability 与协议
+
+- Agent registration 增加可选顶层 `mcpConfiguration`。protocol v1 声明正整数版本、非空且不重复的 transport 集合与 coordination mode；支持 `http`、`stdio` 和 `wait_for_idle_and_restart`。OpenCode 0.3.0 只声明 `http`。
+- 声明 capability 时必须同时注册 `agent/configureWorkspace`。能力或方法缺一、未知字段、重复/未知 transport、协议版本不支持均使 MCP capability 无效，但不使基础 Agent contract 无效；没有既有托管冲突时普通对话仍可用。
+- 该能力是加法式扩展：旧插件省略后视为不支持全部 MCP；旧 Host 忽略未知顶层 registration 字段和额外方法，因此不提升全局 `pluginApi` major version。
+- SDK 用一个可选 MCP configuration definition 同时注册 capability 与方法，避免作者通过高层 API 只声明一侧。
+- `agent/configureWorkspace` 只接收完整快照。请求包含 protocol version、稳定 operation identity、稳定 Agent Target identity、绝对 Workspace root、非负 Workspace generation，以及该目标支持的完整 `Resolved MCP` 列表。
+- 每个 `Resolved MCP` 包含 canonical MCP identity、stable managed identity、精确 package version 和且仅一个规范化 transport。HTTP 包含绝对 URL 与已校验 headers；stdio 包含精确 package executable、渲染后参数、已校验环境绑定和 Workspace working directory。
+- 请求禁止携带原始 package manifest、原始 `assets/config.json`、完整 Settings store、Ora 数据库路径或其他插件路径。
+- capability 不支持的 transport 不进入插件请求，由 Host 记录 NonBlocking Unsupported by Agent；完整快照中不再出现的既有托管项必须被插件移除。
+- 插件规划整份目标文档、检查所有权与冲突、原子写入或删除，并在字节达到正常进程崩溃耐久要求后返回。
+- 成功回执包含 exact applied generation、document locator、document SHA-256 fingerprint 和完整 entry receipts；每项包含 managed identity、native key、entry fingerprint 和 exact source revision identity。
+- Host 必须拒绝 generation 不匹配、locator 越界、managed identity 缺失/重复、额外条目、fingerprint 非法，或未恰好覆盖全部受支持 Desired MCP 的回执。
+- Waiting for Idle 只能通过修改前的既有协调接口返回，不能作为 configure 的部分成功。渲染阶段发现的 target-specific unsupported issue 必须指向请求中的 managed identity 并使用允许的稳定 code；其他失败均为 Blocking，且不得破坏上一版已提交文档。
+- JSON-RPC、插件 stderr、Host trace 与 timeout error 禁止包含 header value、Setting 派生参数、environment value 或文档内容。
+
+### 6. Agent Effect 声明收敛
+
+- 唯一 Agent Effect declaration snapshot 同时包含 Skill Surface declarations、可选 MCP capability 与 Agent Capability Revision。
+- Agent 插件注册或声明变化时，对全部现有 Workspace 收敛并唤醒目标；新 Workspace 通过 worker 常规 pass 收敛全部既有声明，禁止只在进程启动时完成反向配对。
+- 生命周期变化检测必须包含精确已安装版本与 Effect declarations 的 canonical digest；只有版本或 capability digest 变化也属于真实变化。
+- 插件临时停止或断连只把目标标为 unavailable 并保留 Desired；卸载通过 durable lifecycle operation 退休声明。能力恢复或新增 transport 时唤醒全部目标，并在下次完整快照后清除过期 unsupported issue。
+
+### 7. 托管状态、操作与崩溃恢复
+
+- Agent 原生文档由 managed-document ledger 整体拥有；多个 MCP entry 可共享同一 locator，不能复用“每个 Skill item 对应唯一文件系统目标”的不变量。
+- 调用插件前持久化 Prepared operation，包含 generation、source revision identities、managed identities、计划删除项、adapter kind、payload version，以及足以在崩溃后精确重放的规范化快照。
+- protocol v1 的 operation payload 可包含普通 Setting 明文，但必须遵守与配置存储和托管文档相同的本地权限与脱敏要求。
+- 插件返回后，先持久化 observed document/entry fingerprints 并标记 Applied，再原子更新 document ledger、entries、conditions 和 applied generation，最后终结 operation。
+- 调用前崩溃时重试同一 Prepared operation。调用中或调用后崩溃时，以同一 operation identity 与 snapshot 重放；插件读取现有文档，若 desired bytes 已存在则返回同一回执。
+- 插件已写入但 ledger 未提交时，根据 durable operation 与现场指纹恢复，绝不只凭路径推断所有权。现场字节既不匹配上一版 applied fingerprint，也不匹配可恢复 Prepared 结果时进入 Recovery Required，禁止覆盖或删除。
+- Recovery Required 只能手工恢复：先把冲突文档备份到带本地时间戳的文件，审计只记录 locator/fingerprint，再重跑完整 Desired snapshot；禁止跳过备份的强制覆盖。
+- 受支持 MCP 集合为空时，只在 fingerprint 与 ledger 一致时删除托管文档并返回空回执；没有文档则 no-op。路径存在但没有 ledger 或 active recoverable operation 时报告 ownership conflict，禁止按名称、位置或内容相似度接管。
+- 可重试 I/O 与插件传输失败使用持久化指数 backoff + jitter；Unsupported by Agent 等待 Desired/capability revision 变化；Recovery Required 等待显式恢复动作。
+
+### 8. OpenCode 适配器
+
+- protocol v1 只支持 Streamable HTTP；Ready stdio MCP 对 OpenCode 产生 NonBlocking Unsupported by Agent。
+- 托管文档固定为 Workspace 下 `.opencode/opencode.json`，必须使用路径 API 解析。输出为 UTF-8 严格 JSON、两空格缩进、LF、确定性 key 顺序和一个末尾换行；整文件 SHA-256 为 document fingerprint。
+- 文档只包含 OpenCode schema 标识和顶层 MCP map，不包含其他 OpenCode 设置。HTTP entry 使用 remote transport、解析后的 HTTPS URL、`enabled = true`、`oauth = false` 和完整 headers。
+- native MCP key 在包版本和配置 revision 间稳定：对 lowercase canonical Plugin identity，将 `[a-z0-9_-]` 之外的连续字符替换为一个下划线，去除首尾下划线，将可读部分截断到 48 字符，前置 `ora_`，再追加下划线与原始 canonical identity 的 SHA-256 前 12 位小写十六进制。无字符替换时也必须追加 digest。
+- key 生成必须为纯函数并覆盖碰撞测试；若仍碰撞，返回 `mcp_native_key_collision`，禁止覆盖。回执保存 canonical identity 到 native key 的映射；包版本变化不得改变 key。
+- 项目根目录 `opencode.json`/`opencode.jsonc` 始终归用户所有。写入前检查 Workspace 可达的 OpenCode 配置层；用户配置已占用计划 native key 时，以 Preserved State conflict 阻止物化，不依赖配置优先级覆盖。
+- 禁止使用进程级 `OPENCODE_CONFIG` 选择 Workspace，因为多个 Workspace Session 可能共享一个 OpenCode CLI 进程。
+- 通过 Git 解析出的仓库本地 exclude 文件加入精确托管路径；不修改 `.gitignore`，不忽略整个 `.opencode` 或 Skill Surface。路径已被跟踪、无法检查 Git 状态或无法写 exclude 均为 Blocking。非 Git Workspace 跳过 exclude，但仍强制权限与脱敏。
+- 创建和替换文件采用与插件配置数据一致的 OS 用户限制权限；权限设置失败时不得留下新明文文件。使用同目录 staging + atomic replace，并通过项目既有耐久抽象完成 fsync 等操作后再返回成功。
+- 删除时只在指纹验证通过后删除托管文档，不删除 `.opencode`、Skill、用户配置或其他文件。
+
+### 9. 配置变化、请求门禁与 UI
+
+- MCP 安装在包安装和目录刷新成功后即返回成功，即使状态为 Needs Configuration。此时自动打开该插件配置编辑器并聚焦第一个缺失必填项。
+- 保存完整配置后立即返回新 configuration revision，通过 Effect status 展示传播与目标收敛；不提供独立 Apply 按钮。
+- UI 必须区分 Installed、Needs Configuration、Ready but reconciling、Current、Ready with Issues、Waiting for Idle、Degraded 和 Recovery Required。
+- Ready with Issues 只显示 Agent-specific MCP identity 与安全稳定 issue code。新 turn 等待 readiness 时显示能力配置进度并允许取消，禁止把请求发送到旧 generation。
+- Working turn 期间重置或使配置无效，只将新 generation 标记 pending，临时保留当前托管文档；UI 明示清理将在 turn 结束后执行。普通重置禁止取消 turn。
+- Recovery Required 显示冲突 locator、previous/observed fingerprint 和备份重建动作，不显示文档内容。升级与卸载等待目标收敛时持续显示进行中。
+
+### 10. MCP 升级与垃圾回收
+
+- 新版本完成校验后与旧版本并存提交；安装请求不得立即删除旧版本。durable update operation 记录 Plugin identity、previous/candidate version 与 phase，启动时恢复未完成操作。
+- candidate Source 发布前必须确定性完成下载、checksum、解压、kind 校验、descriptor 编译与配置 readiness。发布前失败时，旧 source head、Desired revision 与旧包继续可用。
+- candidate 为 Ready 时发布新不可变 revision 并传播；为 Needs Configuration 时退休 active source、移除旧有效 MCP，但保留 Default-enabled 意图。
+- Source 发布后物化失败属于普通 reconcile failure，不静默回滚 Desired；插件原子写保证新文档成功前保留上一版已提交文档。
+- candidate package commit 成功后，已安装目录显示 candidate version；Effect status 单独展示 Ready、传播与应用状态，目录版本不能代表目标已就绪。
+- 只有 source head、Workspace desired item、managed receipt、未终结 Effect operation、active Agent resource grant 与 durable package lifecycle operation 均不引用某版本时，才可垃圾回收。
+- 垃圾回收可重试且幂等；删除无引用旧版本失败不回滚 active revision。启动扫描恢复并存版本回收；MCP 资源引用以 active source 与 lifecycle operation 为准，禁止简单选择磁盘最高版本。
+
+### 11. MCP 卸载生命周期
+
+- 卸载为 durable saga。首个数据库事务记录 intent、退休 active source、从全部 Desired Set 移除、推进 generation 并 upsert reconcile request。
+- 清理 Agent 配置期间保留插件包与可选数据，以保证 stdio executable 与精确 source 可恢复。只有全部受影响目标处理完 removal generation 且无 managed receipt 引用后，才可删除包。
+- Ready with Issues 只在被卸载 MCP 已无回执时算完成；Degraded/Recovery Required 阻止物理删除。存在文档冲突时必须先备份并重建。
+- 目标清理后，以原子 staging 删除 package root 并更新内存目录。Retain Data 保留版本无关配置；重装时只有配置 Complete 且兼容才自动发布。Delete Data 在目标清理后才 staging 并删除配置根，且不得存在 Ready Source 或 recoverable operation 引用。
+- 启动时恢复全部非终态 uninstall phase，对照磁盘与 Source 修复 ghost source 与缺失发布，并报告无法恢复的 staging conflict。物理删除失败只计划重试，不重新创建 Desired 或 managed entry。
+
+### 12. Host 版本与发布
+
+- 保持 marketplace resolver schema version 1，不向 release manifest 添加当前不支持的 `pluginApi`、`contractVersion` 或 `engines`。
+- 在 marketplace install、local import、update preparation 与 startup discovery 强制执行既有 Ora dependency 版本约束，不能只校验语法。
+- 版本匹配通过单一注入式 host-version provider 读取真实 Desktop 产品版本，禁止使用 workspace crate 的 `0.0.0`。
+- 不兼容包在安装或激活前以 `plugin_host_version_incompatible` 拒绝，并只携带有界的 actual/required 参数。
+- MCP capability 独立协商 protocol v1，不提升全局 plugin protocol major。
+- 统一 SDK 各 manifest 的版本元数据，发布不低于 `0.5.0` 的 SDK；先发布 Ora Host，再发布 OpenCode Agent `0.3.0`。OpenCode release archive 可下载且校验通过后才更新 marketplace；市场 manifest 与包内 manifest 的 identity/kind/version 必须一致，checksum 必须匹配下载字节。
+- Tavily `0.1.0` 作为验收 MCP 保持不变，除非发现与本功能无关的独立打包缺陷。
+
+### 13. 稳定错误与安全诊断
+
+- 公开和持久化失败使用稳定 code，message 只用于解释，禁止参与控制流。
+- 必须覆盖：`mcp_needs_configuration`、`mcp_configuration_unavailable`、`mcp_source_unavailable`、`mcp_unsupported_by_agent`、`mcp_secret_unsupported`、`mcp_capability_invalid`、`mcp_capability_version_unsupported`、`mcp_configuration_failed`、`mcp_configuration_response_invalid`、`mcp_materialization_conflict`、`mcp_native_key_collision`、`mcp_config_file_tracked`、`mcp_config_git_exclude_failed`、`mcp_config_permissions_failed`、`mcp_package_version_referenced`、`mcp_uninstall_waiting_for_targets` 和 `plugin_host_version_incompatible`。
+- error parameter 只允许 canonical Plugin identity、Agent Plugin identity、Workspace identity、generation、transport kind、Workspace 相对 locator、required/actual host version 与 fingerprint。
+- 禁止包含带凭据 URL、header/environment value、Setting 派生参数、原始配置 JSON、文档字节或向前端暴露绝对 package data path。
+- 结构化日志使用 Ora logging wrapper 与本地时间；即使 trace 级别也不记录配置 payload 或 JSON-RPC body。审计只记录 identity、operation phase、generation、locator、fingerprint、outcome code 与时间戳。
+
+### 14. 文档更新
+
+- 更新现行 MCP 插件规范，以 Workspace Effect 驱动的 `agent/configureWorkspace` 替代启动前 `configure_agent`。
+- 更新 Agent 规范，说明可选 capability、共享进程约束、Agent Capability Revision 与 admission gate。
+- 更新 Effect declaration/watcher 规范，说明 MCP readiness、target-keyed request、Skill/MCP 联合 readiness、condition impact、Ready with Issues 与双向收敛。
+- 模块职责、接口、生命周期或失败语义变化时，同步更新对应英文 README；MCP 配置、Effect、Backend Agent Runtime、插件 Runtime/生命周期/管理器、数据库 repository 与 SDK 文档必须与实现一致。
+- 项目 glossary 与已接受 ADR 为权威；研究文档只提供证据，不是规范来源。
+
+### 15. 交付顺序
+
+1. 落地域类型、数据库迁移、MCP 解析、Source 发布、启动修复及模块测试。
+2. 将 Effect 调度重构为 Agent Target request 与联合 readiness，同时保持现有 Skill 行为。
+3. 落地可选 registration capability、Host 协议适配器、SDK 接口与兼容性测试。
+4. 落地 OpenCode 托管文档、Git/权限保护、UI 状态与 Backend 集成测试。
+5. 落地引用感知的升级、卸载、恢复与 Host 版本约束。
+6. 更新规范与 README，运行完整仓库检查，依次发布 SDK、OpenCode、marketplace，并完成 Tavily 手工验收。
+
+## 测试决策
+
+### 测试原则与接缝
+
+- 最高价值测试接缝是通过 Backend/Application 接口执行一次完整 Workspace Effect reconcile：使用真实临时 SQLite、临时 Workspace、伪 Agent Plugin Runtime adapter 与真实文件系统 adapter，贯穿 Desired 传播、持久化调度、Agent 协调、配置调用、回执、readiness 与恢复。
+- 断言外部可观察状态：Workspace generation、Agent Target phase/Ready Generation、完整文档字节与 fingerprint、协议接缝上的插件调用、包版本保留、公开状态与稳定错误码；不绑定私有 helper 调用顺序。
+- MCP resolver 另做聚焦模块测试，覆盖表达式渲染、完整度、URL/header、package containment、canonical digest 与 Workspace context。插件 wire protocol 做兼容性测试；OpenCode adapter 在临时 Git/非 Git Workspace 中做契约测试，并优先比较完整对象。
+- 扩展既有 Effect worker/recovery、配置服务、安装升级、Backend bootstrap、SDK 与 UI 测试接缝，不为测试增加产品公共接口。
+
+### 必须实现的自动化场景
+
+1. 缺少必填 Setting 的静态有效 MCP 安装成功并显示 Needs Configuration。
+2. Needs Configuration 不创建 active source、Desired item、generation bump 或 configure call。
+3. 保存完整配置后发布一个 Ready revision 并传播到全部既有 Workspace。
+4. 新 Workspace 在事务初始化时获得全部 active Ready MCP。
+5. 相同有效配置 no-op 不产生 revision、generation 或 request。
+6. 有效值变化在稳定 Source 下发布新 revision 并推进全部 Desired。
+7. 重置必填项退休 Source、移除 Desired，并最终清理 Agent entry。
+8. 补齐配置后自动恢复同一 Source identity 并重新传播。
+9. 配置存储写入后、Source 发布前崩溃可由启动修复。
+10. Source 发布后、内存通知前崩溃可由 durable scan 修复。
+11. 新 capability 收敛到全部既有 Workspace。
+12. 新 Workspace 经 worker 收敛全部声明，无需插件再次启动。
+13. 只有插件版本或 capability digest 变化也会唤醒目标。
+14. capability 缺失产生 NonBlocking Unsupported，基础对话仍可用。
+15. OpenCode 应用 HTTP、跳过 stdio，并进入 Ready with Issues。
+16. 同一 MCP 在 transport 支持不同的 Agent 上产生独立结果。
+17. 插件新增 transport 后清除旧 unsupported issue 并自动物化。
+18. 重复、畸形 capability 不使基础 Agent contract 失效。
+19. 完整请求/回执 round-trip 保留允许字段并拒绝未知版本。
+20. 回执缺失、重复、额外或不匹配时不推进 Ready Generation。
+21. 快速连续 generation 合并到最新请求，但不修改已 Prepared operation。
+22. Working Session 进入 Waiting for Idle，不修改目标、不热轮询。
+23. 最后一个 Session 变 Idle 后唤醒目标，并在修改前取得 admission。
+24. idle check 与 quiescing 之间不能有新 turn 穿过 gate。
+25. 等待请求在 Current/Ready with Issues 后继续，等待期间可取消。
+26. blocking Degraded/Recovery Required 以稳定安全错误终止等待请求。
+27. 同一 generation 的 Skill 与 MCP 均完成后才推进 Ready Generation。
+28. Skill no-op + MCP 变化不重复写 Skill。
+29. MCP no-op + Skill 变化不重复调用 target configure。
+30. reconcile 期间到达的第二个 generation 保持 pending。
+31. OpenCode 将 Tavily 渲染为启用、非 OAuth 的 remote MCP，并使用已解析 Authorization header。
+32. native key 确定、稳定、限长、字符安全并检测碰撞。
+33. OpenCode 输出满足 schema、排序、缩进、换行与 fingerprint 约定。
+34. 托管路径不覆盖项目根 `opencode.json`/`opencode.jsonc`。
+35. 用户配置占用 native key 时产生 Preserved State conflict。
+36. 既有非托管 `.opencode/opencode.json` 不被修改。
+37. 外部修改托管文档时进入 Recovery Required，不覆盖。
+38. 备份重建先保留冲突字节，再生成 Desired 文档。
+39. Git Workspace 只增加精确 repository-local exclude。
+40. 托管路径已跟踪时，即使存在 exclude 也阻止物化。
+41. 非 Git Workspace 跳过 exclude，仍应用限制权限。
+42. Git exclude 或权限失败时不留下新明文文档。
+43. 删除最后一个 MCP 时只删除 fingerprint 匹配的托管文档。
+44. 插件调用前崩溃重试同一 Prepared operation。
+45. 插件写入后 ledger 提交前崩溃可安全恢复，且不按路径推断所有权。
+46. ledger 提交后 operation finalize 前崩溃可幂等完成。
+47. 两个 worker 不能同时 claim 同一 Agent Target。
+48. 多目标共享物理 Skill Surface 时仍串行修改。
+49. 可重试插件/文件错误持久化 backoff，日志不含配置值。
+50. MCP 升级保留旧版本直至全部引用消失。
+51. candidate 校验失败时旧 Source/Desired 保持 current。
+52. Ready candidate 发布精确 revision；物化失败后不暗中回滚。
+53. Needs Configuration candidate 移除旧有效 MCP 并保留启用意图。
+54. Desired、receipt、operation、runtime grant 或 lifecycle 引用阻止垃圾回收。
+55. 卸载先退休 Desired 并清理 Agent 配置，再 staging 删除包。
+56. Retain Data 卸载重装后复用兼容配置。
+57. Delete Data 只在目标清理后删除配置。
+58. Recovery Required 阻止物理卸载，直至备份重建完成。
+59. 启动恢复中断的 update、uninstall 与 garbage collection。
+60. 启动退休 absent package 的 ghost source，并为已安装 Ready package 补发 Source。
+61. Host 版本约束在 install、update、local import 均生效。
+62. 版本匹配使用注入的 Desktop 产品版本。
+63. marketplace 与 OpenCode release 的 identity、kind、version、URL、checksum 完全匹配。
+64. UI 区分安装成功与 Needs Configuration，并提供编辑器。
+65. 保存完整配置后无需 Apply，自动刷新 Source 与 target status。
+66. 请求门禁期间 UI 显示 waiting/applying 并允许取消。
+67. Ready with Issues 显示安全 target-specific issue，仍允许请求。
+68. 日志、错误、审计与前端事件均不含 Tavily key 或 Authorization header。
+69. 渲染翻译 UI 的前端测试显式初始化项目 i18n，且 stderr 无警告。
+70. 最小相关 Rust、SDK、Frontend 与集成测试通过后，完整仓库 lint/test 通过。
+
+### 手工端到端验收
+
+- 使用本地开发构建和交互式提供的真实 Tavily API Key；不得提交、写入 fixture、出现在截图中，或作为本功能 CI secret。
+- 同步官方 marketplace，通过 UI 安装已发布的 OpenCode Agent 与 Tavily MCP，确认 Tavily 初始为 Needs Configuration，且不影响既有对话。
+- 保存 API Key，观察自动传播与就绪；确认托管文档只在仓库本地被忽略、权限受限，并包含预期 OpenCode HTTP entry。
+- 只在 Ready 后开始新对话，让 OpenCode 执行 Tavily 支持的网页搜索，验证工具已暴露并返回真实结果。
+- 新建 Workspace，验证首次允许 turn 前已自动获得 Tavily。
+- Working turn 期间重置 API Key，验证空闲后才清理；随后卸载 Tavily，确认先移除托管配置再删除包。
+
+## 不在范围内
+
+- Secret Setting、SecretRef、OS credential vault 或安全环境变量间接引用；protocol v1 必须拒绝 Secret。
+- 对 Tavily 当前 API Key 提供加密保护；当前包将其声明为普通 string，本期明确按明文处理。
+- Workspace 级 MCP 开关、Agent 级用户选择或 Session 级选择。
+- OpenCode stdio 物化；Core 与协议建模 stdio，但 OpenCode v1 只声明 HTTP。
+- deprecated HTTP+SSE、MCP OAuth discovery、多 endpoint、fallback transport 或 Ora 启动 bundled HTTP server。
+- 不经过 Agent 协调与 restart/resume 的热插拔。
+- 普通配置重置或卸载时自动取消 Working turn；紧急凭据吊销属于独立功能。
+- 将共享 OpenCode CLI 重构为每 Workspace 一个进程。
+- 通过 ACP `session/new.mcp_servers` 传递配置。
+- Host 渲染 OpenCode 或其他 Agent 原生 schema。
+- 合并写入用户维护的 `.opencode/opencode.json`；该路径要么全量归 Ora 管理，要么视为冲突。
+- 建立全局 plugin protocol major-version 框架。
+- 为旧实验性 MCP 交付方式提供兼容层。
+- 发布或修改 Tavily MCP，除非验证发现独立打包缺陷。
+
+## 补充说明
+
+- 以本 Workspace Effect 模型替换旧的启动前 MCP 配置规范。只有按顺序完成 Host、SDK、OpenCode、marketplace、自动化测试与 Tavily E2E，才能宣告端到端功能完成；分阶段发布时必须保留可追踪的发布门禁。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,52 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Repo selection
+
+This repo is a fork: `origin` → `wanglongan587/desktop`, `upstream` → `ora-space/desktop` (push disabled). `gh` infers `origin` (the fork) by default when run inside the clone. File Ora-project issues against the upstream tracker:
+
+- **Upstream (default for Ora work)**: pass `--repo ora-space/desktop` (or run `gh repo set-default ora-space/desktop` once).
+- **Fork-specific work**: omit `--repo` to target `wanglongan587/desktop`.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -12,13 +12,15 @@ Ora keeps SQLite migration definitions in Rust code inside `ora-db` rather than 
 
 ## Shipped catalog
 
-| Version | Adds                                                                                                                                                                               |
-| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0001`  | User configuration, projects, workspace locations and provisioning, workspaces, worktrees, task labels, and workspace-owned sessions.                                              |
-| `0002`  | Namespaced skills and configurable agents.                                                                                                                                         |
-| `0003`  | Workflow definitions, snapshots, workspace-owned runs, and node runs.                                                                                                              |
-| `0004`  | Durable Git cleanup jobs and worktree provisioning leases.                                                                                                                         |
-| `0005`  | Workspace Effect source state, normalized Desired selections, surface descriptors, ownership ledgers, status, file-operation journals, and durable reconcile/propagation requests. |
+| Version | Adds                                                                                                                                                                                 |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `0001`  | User configuration, projects, workspace locations and provisioning, workspaces, worktrees, task labels, and workspace-owned sessions.                                                |
+| `0002`  | Namespaced skills and configurable agents.                                                                                                                                           |
+| `0003`  | Workflow definitions, snapshots, workspace-owned runs, and node runs.                                                                                                                |
+| `0004`  | Durable Git cleanup jobs and worktree provisioning leases.                                                                                                                           |
+| `0005`  | Workspace Effect source state, normalized Desired selections, surface descriptors, ownership ledgers, status, file-operation journals, and durable reconcile/propagation requests.   |
+| `0006`  | Durable plugin marketplace source configuration (URL, branch, proxy policy, precedence).                                                                                             |
+| `0007`  | Agent Target Effect Expand: target rows, status with ready generation, target-keyed reconcile requests, target-owned conditions with impact; deterministic surface-request backfill. |
 
 `default_migration_catalog()` returns all migrations with every version as the active target.
 

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -107,7 +107,11 @@ current process. `ui.plugin` exposes the underlying `Plugin`.
 `agent/stop`, `agent/listModels`, and the `agent/acp` notification in both
 directions. Ora validates that whole contract when the handshake completes and
 refuses a plugin whose declaration is incomplete, so the helper registers all of
-it up front.
+it up front. Optional MCP support is a separate, versioned capability: pass
+`mcpConfiguration` to register both the `mcpConfiguration` field and the
+`agent/configureWorkspace` full-snapshot handler together. There is no
+high-level way to declare only one side. A missing or malformed MCP capability
+does not invalidate the baseline conversation contract.
 
 ```ts
 import {
@@ -137,6 +141,21 @@ const plugin = defineAgent({
     },
     restart: async ({ surfaceKey, generation }) => {
       // Restart every affected instance, then release the idempotent barrier for this generation.
+    },
+  },
+  mcpConfiguration: {
+    protocolVersion: 1,
+    transports: ["http"],
+    coordination: "wait_for_idle_and_restart",
+    configureWorkspace: async (snapshot) => {
+      // Materialize snapshot.resolvedMcps into the target Agent's native document and return
+      // generation, locator, fingerprints, and one entry receipt per supported MCP.
+      return {
+        appliedGeneration: snapshot.generation,
+        documentLocator: ".opencode/opencode.json",
+        documentFingerprint: "sha256:…",
+        entries: [],
+      };
     },
   },
 });

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -107,11 +107,11 @@ current process. `ui.plugin` exposes the underlying `Plugin`.
 `agent/stop`, `agent/listModels`, and the `agent/acp` notification in both
 directions. Ora validates that whole contract when the handshake completes and
 refuses a plugin whose declaration is incomplete, so the helper registers all of
-it up front. Optional MCP support is a separate, versioned capability: pass
-`mcpConfiguration` to register both the `mcpConfiguration` field and the
-`agent/configureWorkspace` full-snapshot handler together. There is no
-high-level way to declare only one side. A missing or malformed MCP capability
-does not invalidate the baseline conversation contract.
+it up front. Optional MCP Configuration Capability is a separate, versioned
+capability: pass `mcpConfiguration` to register both the `mcpConfiguration`
+field and the `agent/configureWorkspace` full-snapshot handler together. There
+is no high-level way to declare only one side. A missing or malformed MCP
+capability does not invalidate the baseline conversation contract.
 
 ```ts
 import {

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "format": "deno fmt src tests deno.json package.json README.md",
     "format:check": "deno fmt --check src tests deno.json package.json README.md",
-    "lint": "deno lint src tests && deno check src/mod.ts tests/plugin.test.ts tests/agent.test.ts tests/storage.test.ts tests/workbench.test.ts",
-    "test": "deno test tests"
+    "lint": "deno lint src tests && deno check src/mod.ts tests/plugin.test.ts tests/agent.test.ts tests/storage.test.ts tests/workbench.test.ts tests/mcp-configuration.test.ts",
+    "test": "deno test --allow-read tests"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-sdk/src/agent.ts
+++ b/packages/plugin-sdk/src/agent.ts
@@ -1,4 +1,11 @@
 import {
+  AGENT_CONFIGURE_WORKSPACE,
+  type AgentMcpConfigurationDefinition,
+  parseMcpConfigurationSnapshotRequest,
+  serializeMcpConfigurationReceipt,
+  validateMcpConfigurationCapability,
+} from "./mcp.ts";
+import {
   createPlugin,
   type EffectSurfaceDeclaration,
   type Plugin,
@@ -79,6 +86,13 @@ export interface AgentDefinition {
   onAcp(frame: JsonValue): void | Promise<void>;
   /** Declares Skill surfaces this Agent consumes and coordinates their safe replacement. */
   effects?: AgentEffectDefinition;
+  /**
+   * Optional MCP configuration capability.
+   *
+   * Supplying this definition always registers both the `mcpConfiguration` field and the
+   * `agent/configureWorkspace` handler. There is no high-level way to declare only one side.
+   */
+  mcpConfiguration?: AgentMcpConfigurationDefinition;
 }
 
 /**
@@ -122,6 +136,21 @@ export function defineAgent(definition: AgentDefinition): Plugin {
     plugin.registerMethod(EFFECT_RESTART, async (input) => {
       await effects.restart(parseRestartContext(input));
       return {};
+    });
+  }
+  const mcpConfiguration = definition.mcpConfiguration;
+  if (mcpConfiguration !== undefined) {
+    validateMcpConfigurationCapability(mcpConfiguration);
+    plugin.declareMcpConfiguration({
+      protocolVersion: mcpConfiguration.protocolVersion,
+      transports: mcpConfiguration.transports,
+      coordination: mcpConfiguration.coordination,
+    });
+    plugin.registerMethod(AGENT_CONFIGURE_WORKSPACE, async (input) => {
+      const receipt = await mcpConfiguration.configureWorkspace(
+        parseMcpConfigurationSnapshotRequest(input),
+      );
+      return serializeMcpConfigurationReceipt(receipt);
     });
   }
 

--- a/packages/plugin-sdk/src/mcp.ts
+++ b/packages/plugin-sdk/src/mcp.ts
@@ -169,11 +169,13 @@ export function serializeMcpConfigurationReceipt(
   return {
     appliedGeneration: receipt.appliedGeneration,
     documentLocator: receipt.documentLocator,
-    documentFingerprint: receipt.documentFingerprint,
+    documentFingerprint: normalizeFingerprint(receipt.documentFingerprint) ??
+      receipt.documentFingerprint,
     entries: receipt.entries.map((entry) => ({
       managedIdentity: entry.managedIdentity,
       nativeKey: entry.nativeKey,
-      entryFingerprint: entry.entryFingerprint,
+      entryFingerprint: normalizeFingerprint(entry.entryFingerprint) ??
+        entry.entryFingerprint,
       sourceRevisionId: entry.sourceRevisionId,
     })),
   };
@@ -214,7 +216,7 @@ const ENTRY_RECEIPT_FIELDS = new Set([
   "entryFingerprint",
   "sourceRevisionId",
 ]);
-const FINGERPRINT = /^sha256:[a-f0-9]{64}$/;
+const FINGERPRINT = /^sha256:([a-fA-F0-9]{64})$/;
 
 /** Parses registration JSON the same way Host handshake classifies the optional capability. */
 export function parseMcpConfigurationRegistration(
@@ -261,6 +263,7 @@ export type ReceiptValidationCode =
   | "locator_out_of_bounds"
   | "missing_managed_identity"
   | "duplicate_managed_identity"
+  | "duplicate_native_key"
   | "extra_managed_identity"
   | "source_revision_mismatch"
   | "illegal_fingerprint";
@@ -300,7 +303,8 @@ export function parseMcpConfigurationReceipt(
   if (!isWorkspaceRelativeLocator(input.documentLocator)) {
     return { ok: false, code: "locator_out_of_bounds" };
   }
-  if (!FINGERPRINT.test(input.documentFingerprint)) {
+  const documentFingerprint = normalizeFingerprint(input.documentFingerprint);
+  if (documentFingerprint === undefined) {
     return { ok: false, code: "illegal_fingerprint" };
   }
   const entries: McpEntryReceipt[] = [];
@@ -323,13 +327,14 @@ export function parseMcpConfigurationReceipt(
     ) {
       return { ok: false, code: "invalid_structure" };
     }
-    if (!FINGERPRINT.test(entry.entryFingerprint)) {
+    const entryFingerprint = normalizeFingerprint(entry.entryFingerprint);
+    if (entryFingerprint === undefined) {
       return { ok: false, code: "illegal_fingerprint" };
     }
     entries.push({
       managedIdentity: entry.managedIdentity,
       nativeKey: entry.nativeKey,
-      entryFingerprint: entry.entryFingerprint,
+      entryFingerprint,
       sourceRevisionId: entry.sourceRevisionId,
     });
   }
@@ -338,7 +343,7 @@ export function parseMcpConfigurationReceipt(
     receipt: {
       appliedGeneration: input.appliedGeneration,
       documentLocator: input.documentLocator,
-      documentFingerprint: input.documentFingerprint,
+      documentFingerprint,
       entries,
     },
   };
@@ -357,12 +362,17 @@ export function validateMcpConfigurationReceiptCoverage(
       entry,
     ) => [entry.managedIdentity, entry.sourceRevisionId]),
   );
-  const seen = new Set<string>();
+  const seenIdentities = new Set<string>();
+  const seenNativeKeys = new Set<string>();
   for (const entry of receipt.entries) {
-    if (seen.has(entry.managedIdentity)) {
+    if (seenIdentities.has(entry.managedIdentity)) {
       return "duplicate_managed_identity";
     }
-    seen.add(entry.managedIdentity);
+    seenIdentities.add(entry.managedIdentity);
+    if (seenNativeKeys.has(entry.nativeKey)) {
+      return "duplicate_native_key";
+    }
+    seenNativeKeys.add(entry.nativeKey);
     const expectedRevision = expectedById.get(entry.managedIdentity);
     if (expectedRevision === undefined) {
       return "extra_managed_identity";
@@ -371,7 +381,7 @@ export function validateMcpConfigurationReceiptCoverage(
       return "source_revision_mismatch";
     }
   }
-  if (seen.size !== expected.desired.length) {
+  if (seenIdentities.size !== expected.desired.length) {
     return "missing_managed_identity";
   }
   return undefined;
@@ -467,7 +477,7 @@ function parseTransport(value: unknown): ResolvedMcpTransport {
     rejectUnknownFields(value, HTTP_FIELDS);
     if (
       typeof value.url !== "string" ||
-      value.url.length === 0 ||
+      !isAbsoluteHttpUrl(value.url) ||
       !isRecord(value.headers) ||
       !stringMap(value.headers)
     ) {
@@ -518,7 +528,29 @@ function rejectUnknownFields(
 function stringMap(
   value: Record<string, unknown>,
 ): value is Record<string, string> {
-  return Object.values(value).every((entry) => typeof entry === "string");
+  return Object.entries(value).every(([key, entry]) =>
+    key.length > 0 && typeof entry === "string"
+  );
+}
+
+/** Host snapshots carry absolute HTTP(S) URLs; relative and non-HTTP schemes are rejected. */
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (url.protocol === "http:" || url.protocol === "https:") &&
+      url.hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Accepts SHA-256 hex in either case and stores the Host-canonical lowercase form. */
+function normalizeFingerprint(value: string): string | undefined {
+  const match = FINGERPRINT.exec(value);
+  if (match === null) {
+    return undefined;
+  }
+  return `sha256:${match[1].toLowerCase()}`;
 }
 
 function isAbsoluteWorkspaceRoot(value: string): boolean {

--- a/packages/plugin-sdk/src/mcp.ts
+++ b/packages/plugin-sdk/src/mcp.ts
@@ -1,0 +1,538 @@
+import { PluginMethodError } from "./plugin.ts";
+import type { JsonValue } from "./protocol.ts";
+
+/** JSON-RPC method that must be registered together with `mcpConfiguration`. */
+export const AGENT_CONFIGURE_WORKSPACE = "agent/configureWorkspace";
+
+/** Transport kinds protocol v1 may materialize. */
+export type McpTransportKind = "http" | "stdio";
+
+/** Coordination mode protocol v1 may negotiate. */
+export type McpCoordinationMode = "wait_for_idle_and_restart";
+
+/** Wire capability published on `ora/register` when MCP materialization is supported. */
+export interface McpConfigurationCapabilityDeclaration {
+  protocolVersion: 1;
+  transports: readonly McpTransportKind[];
+  coordination: McpCoordinationMode;
+}
+
+/** One Streamable HTTP MCP in a full snapshot. Header values stay on the wire, never in errors. */
+export interface ResolvedHttpMcpTransport {
+  kind: "http";
+  url: string;
+  headers: Readonly<Record<string, string>>;
+}
+
+/** One stdio MCP in a full snapshot. Environment values stay on the wire, never in errors. */
+export interface ResolvedStdioMcpTransport {
+  kind: "stdio";
+  executable: string;
+  args: readonly string[];
+  env: Readonly<Record<string, string>>;
+  workingDirectory: string;
+}
+
+export type ResolvedMcpTransport =
+  | ResolvedHttpMcpTransport
+  | ResolvedStdioMcpTransport;
+
+/** One target-independent Resolved MCP included in a complete snapshot. */
+export interface SnapshotResolvedMcp {
+  canonicalIdentity: string;
+  managedIdentity: string;
+  packageVersion: string;
+  sourceRevisionId: string;
+  transport: ResolvedMcpTransport;
+}
+
+/** Complete MCP Configuration Snapshot the Host sends to `agent/configureWorkspace`. */
+export interface McpConfigurationSnapshotRequest {
+  protocolVersion: 1;
+  operationId: string;
+  agentTargetId: string;
+  workspaceRoot: string;
+  generation: number;
+  resolvedMcps: readonly SnapshotResolvedMcp[];
+}
+
+/** One managed entry the plugin applied for the current snapshot. */
+export interface McpEntryReceipt {
+  managedIdentity: string;
+  nativeKey: string;
+  entryFingerprint: string;
+  sourceRevisionId: string;
+}
+
+/** Success receipt returned after the plugin durably applied a snapshot. */
+export interface McpConfigurationReceipt {
+  appliedGeneration: number;
+  documentLocator: string;
+  documentFingerprint: string;
+  entries: readonly McpEntryReceipt[];
+}
+
+/** Registers capability and handler together so authors cannot declare only one side. */
+export interface AgentMcpConfigurationDefinition
+  extends McpConfigurationCapabilityDeclaration {
+  configureWorkspace(
+    request: McpConfigurationSnapshotRequest,
+  ): McpConfigurationReceipt | Promise<McpConfigurationReceipt>;
+}
+
+const REQUEST_FIELDS = new Set([
+  "protocolVersion",
+  "operationId",
+  "agentTargetId",
+  "workspaceRoot",
+  "generation",
+  "resolvedMcps",
+]);
+const RESOLVED_FIELDS = new Set([
+  "canonicalIdentity",
+  "managedIdentity",
+  "packageVersion",
+  "sourceRevisionId",
+  "transport",
+]);
+const HTTP_FIELDS = new Set(["kind", "url", "headers"]);
+const STDIO_FIELDS = new Set([
+  "kind",
+  "executable",
+  "args",
+  "env",
+  "workingDirectory",
+]);
+
+/** Rejects a capability that would serialize into an invalid Host declaration. */
+export function validateMcpConfigurationCapability(
+  capability: McpConfigurationCapabilityDeclaration,
+): void {
+  if (capability.protocolVersion !== 1) {
+    throw new Error("mcpConfiguration protocolVersion must be 1");
+  }
+  if (capability.coordination !== "wait_for_idle_and_restart") {
+    throw new Error("mcpConfiguration coordination is not supported");
+  }
+  if (capability.transports.length === 0) {
+    throw new Error("mcpConfiguration transports must not be empty");
+  }
+  const seen = new Set<string>();
+  for (const transport of capability.transports) {
+    if (transport !== "http" && transport !== "stdio") {
+      throw new Error("mcpConfiguration transports contains an unknown kind");
+    }
+    if (seen.has(transport)) {
+      throw new Error("mcpConfiguration transports must be unique");
+    }
+    seen.add(transport);
+  }
+}
+
+/** Parses a Host snapshot before plugin-owned rendering so malformed requests never reach it. */
+export function parseMcpConfigurationSnapshotRequest(
+  input: JsonValue,
+): McpConfigurationSnapshotRequest {
+  if (!isRecord(input)) {
+    throw invalidSnapshot();
+  }
+  rejectUnknownFields(input, REQUEST_FIELDS);
+  if (
+    input.protocolVersion !== 1 ||
+    typeof input.operationId !== "string" ||
+    input.operationId.length === 0 ||
+    typeof input.agentTargetId !== "string" ||
+    input.agentTargetId.length === 0 ||
+    typeof input.workspaceRoot !== "string" ||
+    !isAbsoluteWorkspaceRoot(input.workspaceRoot) ||
+    typeof input.generation !== "number" ||
+    !Number.isSafeInteger(input.generation) ||
+    input.generation < 0 ||
+    !Array.isArray(input.resolvedMcps)
+  ) {
+    throw invalidSnapshot();
+  }
+  return {
+    protocolVersion: 1,
+    operationId: input.operationId,
+    agentTargetId: input.agentTargetId,
+    workspaceRoot: input.workspaceRoot,
+    generation: input.generation,
+    resolvedMcps: input.resolvedMcps.map(parseResolvedMcp),
+  };
+}
+
+/** Serializes a receipt with the closed field set Host validation expects. */
+export function serializeMcpConfigurationReceipt(
+  receipt: McpConfigurationReceipt,
+): JsonValue {
+  return {
+    appliedGeneration: receipt.appliedGeneration,
+    documentLocator: receipt.documentLocator,
+    documentFingerprint: receipt.documentFingerprint,
+    entries: receipt.entries.map((entry) => ({
+      managedIdentity: entry.managedIdentity,
+      nativeKey: entry.nativeKey,
+      entryFingerprint: entry.entryFingerprint,
+      sourceRevisionId: entry.sourceRevisionId,
+    })),
+  };
+}
+
+/** Wire parse of optional `mcpConfiguration` without failing the baseline agent contract. */
+export type ParsedMcpConfigurationRegistration =
+  | { status: "absent" }
+  | {
+    status: "invalid";
+    code: "mcp_capability_invalid" | "mcp_capability_version_unsupported";
+  }
+  | { status: "declared"; capability: McpConfigurationCapabilityDeclaration };
+
+/** Host pairing of capability and `agent/configureWorkspace` on a registration payload. */
+export type NegotiatedMcpConfiguration =
+  | { status: "unsupported" }
+  | {
+    status: "disabled";
+    code: "mcp_capability_invalid" | "mcp_capability_version_unsupported";
+  }
+  | { status: "enabled"; capability: McpConfigurationCapabilityDeclaration };
+
+const CAPABILITY_FIELDS = new Set([
+  "protocolVersion",
+  "transports",
+  "coordination",
+]);
+const RECEIPT_FIELDS = new Set([
+  "appliedGeneration",
+  "documentLocator",
+  "documentFingerprint",
+  "entries",
+]);
+const ENTRY_RECEIPT_FIELDS = new Set([
+  "managedIdentity",
+  "nativeKey",
+  "entryFingerprint",
+  "sourceRevisionId",
+]);
+const FINGERPRINT = /^sha256:[a-f0-9]{64}$/;
+
+/** Parses registration JSON the same way Host handshake classifies the optional capability. */
+export function parseMcpConfigurationRegistration(
+  params: JsonValue,
+): ParsedMcpConfigurationRegistration {
+  if (!isRecord(params) || !("mcpConfiguration" in params)) {
+    return { status: "absent" };
+  }
+  return parseMcpConfigurationValue(params.mcpConfiguration);
+}
+
+/**
+ * Pairs capability with handler so shared fixtures can assert Host negotiation without Deno.
+ *
+ * defineAgent already refuses a one-sided high-level API; this classifies raw registration JSON.
+ */
+export function negotiateMcpConfiguration(
+  params: JsonValue,
+): NegotiatedMcpConfiguration {
+  const methods = isRecord(params) && Array.isArray(params.methods)
+    ? params.methods.filter((entry): entry is string =>
+      typeof entry === "string"
+    )
+    : [];
+  const hasHandler = methods.includes(AGENT_CONFIGURE_WORKSPACE);
+  const registration = parseMcpConfigurationRegistration(params);
+  if (registration.status === "absent") {
+    return hasHandler
+      ? { status: "disabled", code: "mcp_capability_invalid" }
+      : { status: "unsupported" };
+  }
+  if (registration.status === "invalid") {
+    return { status: "disabled", code: registration.code };
+  }
+  return hasHandler
+    ? { status: "enabled", capability: registration.capability }
+    : { status: "disabled", code: "mcp_capability_invalid" };
+}
+
+/** Stable Host receipt rejection codes shared with Rust compatibility fixtures. */
+export type ReceiptValidationCode =
+  | "invalid_structure"
+  | "generation_mismatch"
+  | "locator_out_of_bounds"
+  | "missing_managed_identity"
+  | "duplicate_managed_identity"
+  | "extra_managed_identity"
+  | "source_revision_mismatch"
+  | "illegal_fingerprint";
+
+export type ParsedMcpConfigurationReceipt =
+  | { ok: true; receipt: McpConfigurationReceipt }
+  | { ok: false; code: ReceiptValidationCode };
+
+/** Desired identities a success receipt must cover exactly. */
+export interface ExpectedReceiptCoverage {
+  generation: number;
+  desired: readonly { managedIdentity: string; sourceRevisionId: string }[];
+}
+
+/** Parses a plugin receipt using the closed field set Host validation requires. */
+export function parseMcpConfigurationReceipt(
+  input: JsonValue,
+): ParsedMcpConfigurationReceipt {
+  if (!isRecord(input)) {
+    return { ok: false, code: "invalid_structure" };
+  }
+  try {
+    rejectUnknownFields(input, RECEIPT_FIELDS);
+  } catch {
+    return { ok: false, code: "invalid_structure" };
+  }
+  if (
+    typeof input.appliedGeneration !== "number" ||
+    !Number.isSafeInteger(input.appliedGeneration) ||
+    input.appliedGeneration < 0 ||
+    typeof input.documentLocator !== "string" ||
+    typeof input.documentFingerprint !== "string" ||
+    !Array.isArray(input.entries)
+  ) {
+    return { ok: false, code: "invalid_structure" };
+  }
+  if (!isWorkspaceRelativeLocator(input.documentLocator)) {
+    return { ok: false, code: "locator_out_of_bounds" };
+  }
+  if (!FINGERPRINT.test(input.documentFingerprint)) {
+    return { ok: false, code: "illegal_fingerprint" };
+  }
+  const entries: McpEntryReceipt[] = [];
+  for (const entry of input.entries) {
+    if (!isRecord(entry)) {
+      return { ok: false, code: "invalid_structure" };
+    }
+    try {
+      rejectUnknownFields(entry, ENTRY_RECEIPT_FIELDS);
+    } catch {
+      return { ok: false, code: "invalid_structure" };
+    }
+    if (
+      typeof entry.managedIdentity !== "string" ||
+      entry.managedIdentity.length === 0 ||
+      typeof entry.nativeKey !== "string" ||
+      entry.nativeKey.length === 0 ||
+      typeof entry.entryFingerprint !== "string" ||
+      typeof entry.sourceRevisionId !== "string"
+    ) {
+      return { ok: false, code: "invalid_structure" };
+    }
+    if (!FINGERPRINT.test(entry.entryFingerprint)) {
+      return { ok: false, code: "illegal_fingerprint" };
+    }
+    entries.push({
+      managedIdentity: entry.managedIdentity,
+      nativeKey: entry.nativeKey,
+      entryFingerprint: entry.entryFingerprint,
+      sourceRevisionId: entry.sourceRevisionId,
+    });
+  }
+  return {
+    ok: true,
+    receipt: {
+      appliedGeneration: input.appliedGeneration,
+      documentLocator: input.documentLocator,
+      documentFingerprint: input.documentFingerprint,
+      entries,
+    },
+  };
+}
+
+/** Rejects receipts that would let an incomplete plugin result be marked Ready. */
+export function validateMcpConfigurationReceiptCoverage(
+  receipt: McpConfigurationReceipt,
+  expected: ExpectedReceiptCoverage,
+): ReceiptValidationCode | undefined {
+  if (receipt.appliedGeneration !== expected.generation) {
+    return "generation_mismatch";
+  }
+  const expectedById = new Map(
+    expected.desired.map((
+      entry,
+    ) => [entry.managedIdentity, entry.sourceRevisionId]),
+  );
+  const seen = new Set<string>();
+  for (const entry of receipt.entries) {
+    if (seen.has(entry.managedIdentity)) {
+      return "duplicate_managed_identity";
+    }
+    seen.add(entry.managedIdentity);
+    const expectedRevision = expectedById.get(entry.managedIdentity);
+    if (expectedRevision === undefined) {
+      return "extra_managed_identity";
+    }
+    if (entry.sourceRevisionId !== expectedRevision) {
+      return "source_revision_mismatch";
+    }
+  }
+  if (seen.size !== expected.desired.length) {
+    return "missing_managed_identity";
+  }
+  return undefined;
+}
+
+function parseMcpConfigurationValue(
+  value: unknown,
+): ParsedMcpConfigurationRegistration {
+  if (!isRecord(value)) {
+    return { status: "invalid", code: "mcp_capability_invalid" };
+  }
+  for (const key of Object.keys(value)) {
+    if (!CAPABILITY_FIELDS.has(key)) {
+      return { status: "invalid", code: "mcp_capability_invalid" };
+    }
+  }
+  if (
+    value.protocolVersion === 0 || !Number.isSafeInteger(value.protocolVersion)
+  ) {
+    return { status: "invalid", code: "mcp_capability_invalid" };
+  }
+  if (
+    typeof value.protocolVersion === "number" && value.protocolVersion !== 1
+  ) {
+    return { status: "invalid", code: "mcp_capability_version_unsupported" };
+  }
+  if (
+    value.protocolVersion !== 1 ||
+    value.coordination !== "wait_for_idle_and_restart" ||
+    !Array.isArray(value.transports)
+  ) {
+    return { status: "invalid", code: "mcp_capability_invalid" };
+  }
+  try {
+    const capability: McpConfigurationCapabilityDeclaration = {
+      protocolVersion: 1,
+      transports: [...value.transports] as McpTransportKind[],
+      coordination: "wait_for_idle_and_restart",
+    };
+    validateMcpConfigurationCapability(capability);
+    return { status: "declared", capability };
+  } catch {
+    return { status: "invalid", code: "mcp_capability_invalid" };
+  }
+}
+
+function isWorkspaceRelativeLocator(value: string): boolean {
+  if (
+    value.length === 0 || value === "." || value.startsWith("/") ||
+    value.startsWith("\\")
+  ) {
+    return false;
+  }
+  if (/^[A-Za-z]:/.test(value)) {
+    return false;
+  }
+  return value.split(/[/\\]/).every((part) =>
+    part.length > 0 && part !== ".." && part !== "."
+  );
+}
+
+function parseResolvedMcp(value: unknown): SnapshotResolvedMcp {
+  if (!isRecord(value)) {
+    throw invalidSnapshot();
+  }
+  rejectUnknownFields(value, RESOLVED_FIELDS);
+  if (
+    typeof value.canonicalIdentity !== "string" ||
+    value.canonicalIdentity.length === 0 ||
+    typeof value.managedIdentity !== "string" ||
+    value.managedIdentity.length === 0 ||
+    typeof value.packageVersion !== "string" ||
+    value.packageVersion.length === 0 ||
+    typeof value.sourceRevisionId !== "string" ||
+    value.sourceRevisionId.length === 0
+  ) {
+    throw invalidSnapshot();
+  }
+  return {
+    canonicalIdentity: value.canonicalIdentity,
+    managedIdentity: value.managedIdentity,
+    packageVersion: value.packageVersion,
+    sourceRevisionId: value.sourceRevisionId,
+    transport: parseTransport(value.transport),
+  };
+}
+
+function parseTransport(value: unknown): ResolvedMcpTransport {
+  if (!isRecord(value) || typeof value.kind !== "string") {
+    throw invalidSnapshot();
+  }
+  if (value.kind === "http") {
+    rejectUnknownFields(value, HTTP_FIELDS);
+    if (
+      typeof value.url !== "string" ||
+      value.url.length === 0 ||
+      !isRecord(value.headers) ||
+      !stringMap(value.headers)
+    ) {
+      throw invalidSnapshot();
+    }
+    return {
+      kind: "http",
+      url: value.url,
+      headers: { ...value.headers },
+    };
+  }
+  if (value.kind === "stdio") {
+    rejectUnknownFields(value, STDIO_FIELDS);
+    if (
+      typeof value.executable !== "string" ||
+      value.executable.length === 0 ||
+      !Array.isArray(value.args) ||
+      !value.args.every((entry) => typeof entry === "string") ||
+      !isRecord(value.env) ||
+      !stringMap(value.env) ||
+      typeof value.workingDirectory !== "string" ||
+      value.workingDirectory.length === 0
+    ) {
+      throw invalidSnapshot();
+    }
+    return {
+      kind: "stdio",
+      executable: value.executable,
+      args: [...value.args],
+      env: { ...value.env },
+      workingDirectory: value.workingDirectory,
+    };
+  }
+  throw invalidSnapshot();
+}
+
+function rejectUnknownFields(
+  value: Record<string, unknown>,
+  allowed: Set<string>,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      throw invalidSnapshot();
+    }
+  }
+}
+
+function stringMap(
+  value: Record<string, unknown>,
+): value is Record<string, string> {
+  return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isAbsoluteWorkspaceRoot(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Messages stay generic so header, environment, and document values cannot leak into JSON-RPC. */
+function invalidSnapshot(): PluginMethodError {
+  return new PluginMethodError(
+    -32602,
+    "agent/configureWorkspace requires a protocol v1 snapshot",
+  );
+}

--- a/packages/plugin-sdk/src/mod.ts
+++ b/packages/plugin-sdk/src/mod.ts
@@ -13,28 +13,19 @@ export {
 export {
   AGENT_CONFIGURE_WORKSPACE,
   type AgentMcpConfigurationDefinition,
-  type ExpectedReceiptCoverage,
   type McpConfigurationCapabilityDeclaration,
   type McpConfigurationReceipt,
   type McpConfigurationSnapshotRequest,
   type McpCoordinationMode,
   type McpEntryReceipt,
   type McpTransportKind,
-  type NegotiatedMcpConfiguration,
-  negotiateMcpConfiguration,
-  type ParsedMcpConfigurationReceipt,
-  type ParsedMcpConfigurationRegistration,
-  parseMcpConfigurationReceipt,
-  parseMcpConfigurationRegistration,
   parseMcpConfigurationSnapshotRequest,
-  type ReceiptValidationCode,
   type ResolvedHttpMcpTransport,
   type ResolvedMcpTransport,
   type ResolvedStdioMcpTransport,
   serializeMcpConfigurationReceipt,
   type SnapshotResolvedMcp,
   validateMcpConfigurationCapability,
-  validateMcpConfigurationReceiptCoverage,
 } from "./mcp.ts";
 export type { EffectSurfaceDeclaration } from "./plugin.ts";
 export {

--- a/packages/plugin-sdk/src/mod.ts
+++ b/packages/plugin-sdk/src/mod.ts
@@ -10,6 +10,32 @@ export {
   type AgentStartContext,
   defineAgent,
 } from "./agent.ts";
+export {
+  AGENT_CONFIGURE_WORKSPACE,
+  type AgentMcpConfigurationDefinition,
+  type ExpectedReceiptCoverage,
+  type McpConfigurationCapabilityDeclaration,
+  type McpConfigurationReceipt,
+  type McpConfigurationSnapshotRequest,
+  type McpCoordinationMode,
+  type McpEntryReceipt,
+  type McpTransportKind,
+  type NegotiatedMcpConfiguration,
+  negotiateMcpConfiguration,
+  type ParsedMcpConfigurationReceipt,
+  type ParsedMcpConfigurationRegistration,
+  parseMcpConfigurationReceipt,
+  parseMcpConfigurationRegistration,
+  parseMcpConfigurationSnapshotRequest,
+  type ReceiptValidationCode,
+  type ResolvedHttpMcpTransport,
+  type ResolvedMcpTransport,
+  type ResolvedStdioMcpTransport,
+  serializeMcpConfigurationReceipt,
+  type SnapshotResolvedMcp,
+  validateMcpConfigurationCapability,
+  validateMcpConfigurationReceiptCoverage,
+} from "./mcp.ts";
 export type { EffectSurfaceDeclaration } from "./plugin.ts";
 export {
   createPlugin,

--- a/packages/plugin-sdk/src/plugin.ts
+++ b/packages/plugin-sdk/src/plugin.ts
@@ -8,6 +8,7 @@ import {
   type PluginTransport,
   type RequestId,
 } from "./protocol.ts";
+import type { McpConfigurationCapabilityDeclaration } from "./mcp.ts";
 
 export type MethodHandler = (
   input: JsonValue,
@@ -73,13 +74,7 @@ export class Plugin {
   readonly #methods = new Map<string, MethodHandler>();
   readonly #emits = new Set<string>();
   readonly #effectSurfaces: EffectSurfaceDeclaration[] = [];
-  #mcpConfiguration:
-    | {
-      protocolVersion: number;
-      transports: string[];
-      coordination: string;
-    }
-    | undefined;
+  #mcpConfiguration: McpConfigurationCapabilityDeclaration | undefined;
   readonly #notificationHandlers = new Map<string, NotificationHandler>();
   readonly #pendingHostRequests = new Map<number, PendingHostRequest>();
   #nextHostRequestId = 1;
@@ -119,11 +114,9 @@ export class Plugin {
    * `agent/configureWorkspace`. Calling this without that method is a low-level defect the Host
    * disables rather than a second high-level API.
    */
-  declareMcpConfiguration(capability: {
-    protocolVersion: number;
-    transports: readonly string[];
-    coordination: string;
-  }): void {
+  declareMcpConfiguration(
+    capability: McpConfigurationCapabilityDeclaration,
+  ): void {
     this.#assertRegistering();
     this.#mcpConfiguration = {
       protocolVersion: capability.protocolVersion,

--- a/packages/plugin-sdk/src/plugin.ts
+++ b/packages/plugin-sdk/src/plugin.ts
@@ -73,6 +73,13 @@ export class Plugin {
   readonly #methods = new Map<string, MethodHandler>();
   readonly #emits = new Set<string>();
   readonly #effectSurfaces: EffectSurfaceDeclaration[] = [];
+  #mcpConfiguration:
+    | {
+      protocolVersion: number;
+      transports: string[];
+      coordination: string;
+    }
+    | undefined;
   readonly #notificationHandlers = new Map<string, NotificationHandler>();
   readonly #pendingHostRequests = new Map<number, PendingHostRequest>();
   #nextHostRequestId = 1;
@@ -103,6 +110,26 @@ export class Plugin {
       throw new Error("Emitted method names cannot be empty");
     }
     this.#emits.add(name);
+  }
+
+  /**
+   * Declares the optional MCP configuration capability on the immutable registration.
+   *
+   * `defineAgent` is the supported pairing: it registers this field together with
+   * `agent/configureWorkspace`. Calling this without that method is a low-level defect the Host
+   * disables rather than a second high-level API.
+   */
+  declareMcpConfiguration(capability: {
+    protocolVersion: number;
+    transports: readonly string[];
+    coordination: string;
+  }): void {
+    this.#assertRegistering();
+    this.#mcpConfiguration = {
+      protocolVersion: capability.protocolVersion,
+      transports: [...capability.transports],
+      coordination: capability.coordination,
+    };
   }
 
   /** Declares one runtime-consumed Effect surface before registration is sent. */
@@ -220,6 +247,13 @@ export class Plugin {
         materializationFormat: surface.materializationFormat,
         coordination: surface.coordination,
       }));
+    }
+    if (this.#mcpConfiguration !== undefined) {
+      registration.mcpConfiguration = {
+        protocolVersion: this.#mcpConfiguration.protocolVersion,
+        transports: [...this.#mcpConfiguration.transports],
+        coordination: this.#mcpConfiguration.coordination,
+      };
     }
     await writer.write({
       jsonrpc: "2.0",

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/duplicate-native-key.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/duplicate-native-key.json
@@ -1,0 +1,19 @@
+{
+  "appliedGeneration": 4,
+  "documentLocator": ".opencode/opencode.json",
+  "documentFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "entries": [
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_shared_key",
+      "entryFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceRevisionId": "rev-tavily-1"
+    },
+    {
+      "managedIdentity": "mcp-other",
+      "nativeKey": "ora_shared_key",
+      "entryFingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "sourceRevisionId": "rev-other-1"
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/duplicate.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/duplicate.json
@@ -1,0 +1,19 @@
+{
+  "appliedGeneration": 4,
+  "documentLocator": ".opencode/opencode.json",
+  "documentFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "entries": [
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_tavily_search_abcdef123456",
+      "entryFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceRevisionId": "rev-tavily-1"
+    },
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_tavily_search_dup",
+      "entryFingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "sourceRevisionId": "rev-tavily-1"
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/extra.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/extra.json
@@ -1,0 +1,19 @@
+{
+  "appliedGeneration": 4,
+  "documentLocator": ".opencode/opencode.json",
+  "documentFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "entries": [
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_tavily_search_abcdef123456",
+      "entryFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceRevisionId": "rev-tavily-1"
+    },
+    {
+      "managedIdentity": "mcp-other",
+      "nativeKey": "ora_other_abcdef123456",
+      "entryFingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "sourceRevisionId": "rev-other-1"
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/generation-mismatch.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/generation-mismatch.json
@@ -1,0 +1,13 @@
+{
+  "appliedGeneration": 3,
+  "documentLocator": ".opencode/opencode.json",
+  "documentFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "entries": [
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_tavily_search_abcdef123456",
+      "entryFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceRevisionId": "rev-tavily-1"
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/illegal-fingerprint.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/illegal-fingerprint.json
@@ -1,0 +1,13 @@
+{
+  "appliedGeneration": 4,
+  "documentLocator": ".opencode/opencode.json",
+  "documentFingerprint": "not-a-digest",
+  "entries": [
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_tavily_search_abcdef123456",
+      "entryFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceRevisionId": "rev-tavily-1"
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/locator-escape.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/locator-escape.json
@@ -1,0 +1,13 @@
+{
+  "appliedGeneration": 4,
+  "documentLocator": "../secrets/opencode.json",
+  "documentFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "entries": [
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_tavily_search_abcdef123456",
+      "entryFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceRevisionId": "rev-tavily-1"
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/missing.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/missing.json
@@ -1,0 +1,6 @@
+{
+  "appliedGeneration": 4,
+  "documentLocator": ".opencode/opencode.json",
+  "documentFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "entries": []
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/source-revision-mismatch.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/source-revision-mismatch.json
@@ -1,0 +1,13 @@
+{
+  "appliedGeneration": 4,
+  "documentLocator": ".opencode/opencode.json",
+  "documentFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "entries": [
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_tavily_search_abcdef123456",
+      "entryFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceRevisionId": "rev-stale"
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/valid.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/receipts/valid.json
@@ -1,0 +1,13 @@
+{
+  "appliedGeneration": 4,
+  "documentLocator": ".opencode/opencode.json",
+  "documentFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "entries": [
+    {
+      "managedIdentity": "mcp-tavily",
+      "nativeKey": "ora_tavily_search_abcdef123456",
+      "entryFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceRevisionId": "rev-tavily-1"
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/capability-without-handler.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/capability-without-handler.json
@@ -1,0 +1,9 @@
+{
+  "methods": ["agent/start", "agent/stop", "agent/listModels"],
+  "emits": ["agent/acp"],
+  "mcpConfiguration": {
+    "protocolVersion": 1,
+    "transports": ["http"],
+    "coordination": "wait_for_idle_and_restart"
+  }
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/duplicate-transports.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/duplicate-transports.json
@@ -1,0 +1,14 @@
+{
+  "methods": [
+    "agent/start",
+    "agent/stop",
+    "agent/listModels",
+    "agent/configureWorkspace"
+  ],
+  "emits": ["agent/acp"],
+  "mcpConfiguration": {
+    "protocolVersion": 1,
+    "transports": ["http", "http"],
+    "coordination": "wait_for_idle_and_restart"
+  }
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/empty-transports.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/empty-transports.json
@@ -1,0 +1,14 @@
+{
+  "methods": [
+    "agent/start",
+    "agent/stop",
+    "agent/listModels",
+    "agent/configureWorkspace"
+  ],
+  "emits": ["agent/acp"],
+  "mcpConfiguration": {
+    "protocolVersion": 1,
+    "transports": [],
+    "coordination": "wait_for_idle_and_restart"
+  }
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/handler-without-capability.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/handler-without-capability.json
@@ -1,0 +1,9 @@
+{
+  "methods": [
+    "agent/start",
+    "agent/stop",
+    "agent/listModels",
+    "agent/configureWorkspace"
+  ],
+  "emits": ["agent/acp"]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/malformed.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/malformed.json
@@ -1,0 +1,15 @@
+{
+  "methods": [
+    "agent/start",
+    "agent/stop",
+    "agent/listModels",
+    "agent/configureWorkspace"
+  ],
+  "emits": ["agent/acp"],
+  "mcpConfiguration": {
+    "protocolVersion": 1,
+    "transports": ["http"],
+    "coordination": "wait_for_idle_and_restart",
+    "nativeSchema": "opencode"
+  }
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/omitted.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/omitted.json
@@ -1,0 +1,4 @@
+{
+  "methods": ["agent/start", "agent/stop", "agent/listModels"],
+  "emits": ["agent/acp"]
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/unknown-protocol-version.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/unknown-protocol-version.json
@@ -1,0 +1,14 @@
+{
+  "methods": [
+    "agent/start",
+    "agent/stop",
+    "agent/listModels",
+    "agent/configureWorkspace"
+  ],
+  "emits": ["agent/acp"],
+  "mcpConfiguration": {
+    "protocolVersion": 2,
+    "transports": ["http"],
+    "coordination": "wait_for_idle_and_restart"
+  }
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/unknown-top-level-fields.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/unknown-top-level-fields.json
@@ -1,0 +1,15 @@
+{
+  "methods": [
+    "agent/start",
+    "agent/stop",
+    "agent/listModels",
+    "agent/configureWorkspace"
+  ],
+  "emits": ["agent/acp"],
+  "futureHostHint": { "ignored": true },
+  "mcpConfiguration": {
+    "protocolVersion": 1,
+    "transports": ["http"],
+    "coordination": "wait_for_idle_and_restart"
+  }
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/unknown-transport.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/unknown-transport.json
@@ -1,0 +1,14 @@
+{
+  "methods": [
+    "agent/start",
+    "agent/stop",
+    "agent/listModels",
+    "agent/configureWorkspace"
+  ],
+  "emits": ["agent/acp"],
+  "mcpConfiguration": {
+    "protocolVersion": 1,
+    "transports": ["sse"],
+    "coordination": "wait_for_idle_and_restart"
+  }
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/valid-http-v1.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/registration/valid-http-v1.json
@@ -1,0 +1,14 @@
+{
+  "methods": [
+    "agent/start",
+    "agent/stop",
+    "agent/listModels",
+    "agent/configureWorkspace"
+  ],
+  "emits": ["agent/acp"],
+  "mcpConfiguration": {
+    "protocolVersion": 1,
+    "transports": ["http"],
+    "coordination": "wait_for_idle_and_restart"
+  }
+}

--- a/packages/plugin-sdk/tests/fixtures/mcp-configuration/requests/full-snapshot.json
+++ b/packages/plugin-sdk/tests/fixtures/mcp-configuration/requests/full-snapshot.json
@@ -1,0 +1,22 @@
+{
+  "protocolVersion": 1,
+  "operationId": "op-7",
+  "agentTargetId": "target-1",
+  "workspaceRoot": "/workspace",
+  "generation": 4,
+  "resolvedMcps": [
+    {
+      "canonicalIdentity": "official/ora-space.tavily-search",
+      "managedIdentity": "mcp-tavily",
+      "packageVersion": "0.1.0",
+      "sourceRevisionId": "rev-tavily-1",
+      "transport": {
+        "kind": "http",
+        "url": "https://mcp.tavily.com/mcp",
+        "headers": {
+          "Authorization": "Bearer tavily-secret-key"
+        }
+      }
+    }
+  ]
+}

--- a/packages/plugin-sdk/tests/mcp-configuration.test.ts
+++ b/packages/plugin-sdk/tests/mcp-configuration.test.ts
@@ -2,12 +2,14 @@ import {
   AGENT_CONFIGURE_WORKSPACE,
   defineAgent,
   type McpConfigurationSnapshotRequest,
+  parseMcpConfigurationSnapshotRequest,
+} from "../src/mod.ts";
+import {
   negotiateMcpConfiguration,
   parseMcpConfigurationReceipt,
   parseMcpConfigurationRegistration,
-  parseMcpConfigurationSnapshotRequest,
   validateMcpConfigurationReceiptCoverage,
-} from "../src/mod.ts";
+} from "../src/mcp.ts";
 import {
   decodeFrames,
   encodeFrame,
@@ -201,6 +203,57 @@ Deno.test("snapshot parse rejects unknown fields without echoing header values",
   }
 });
 
+Deno.test("snapshot parse rejects relative HTTP URLs and empty header names", () => {
+  const snapshot = {
+    protocolVersion: 1,
+    operationId: "op-7",
+    agentTargetId: "target-1",
+    workspaceRoot: "/workspace",
+    generation: 4,
+    resolvedMcps: [{
+      canonicalIdentity: "official/ora-space.tavily-search",
+      managedIdentity: "mcp-tavily",
+      packageVersion: "0.1.0",
+      sourceRevisionId: "rev-tavily-1",
+      transport: {
+        kind: "http" as const,
+        url: "/relative",
+        headers: { Authorization: "Bearer tavily-secret-key" } as Record<
+          string,
+          string
+        >,
+      },
+    }],
+  };
+  try {
+    parseMcpConfigurationSnapshotRequest(snapshot);
+    throw new Error("expected relative URL to fail");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    assertEquals(
+      message,
+      "agent/configureWorkspace requires a protocol v1 snapshot",
+    );
+    assertStringDoesNotContain(message, "tavily-secret-key");
+  }
+
+  snapshot.resolvedMcps[0].transport.url = "https://mcp.tavily.com/mcp";
+  snapshot.resolvedMcps[0].transport.headers = {
+    "": "Bearer tavily-secret-key",
+  };
+  try {
+    parseMcpConfigurationSnapshotRequest(snapshot);
+    throw new Error("expected empty header name to fail");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    assertEquals(
+      message,
+      "agent/configureWorkspace requires a protocol v1 snapshot",
+    );
+    assertStringDoesNotContain(message, "tavily-secret-key");
+  }
+});
+
 const HTTP_V1 = {
   protocolVersion: 1,
   transports: ["http"],
@@ -235,6 +288,18 @@ Deno.test("shared registration fixtures classify omitted, unknown, malformed, an
   assertEquals(
     parseMcpConfigurationRegistration(
       await loadFixture("registration/duplicate-transports.json"),
+    ),
+    { status: "invalid", code: "mcp_capability_invalid" },
+  );
+  assertEquals(
+    parseMcpConfigurationRegistration(
+      await loadFixture("registration/unknown-transport.json"),
+    ),
+    { status: "invalid", code: "mcp_capability_invalid" },
+  );
+  assertEquals(
+    parseMcpConfigurationRegistration(
+      await loadFixture("registration/empty-transports.json"),
     ),
     { status: "invalid", code: "mcp_capability_invalid" },
   );
@@ -304,6 +369,38 @@ Deno.test("shared receipt fixtures reject missing, duplicate, extra, and mismatc
       code,
     );
   }
+
+  const duplicateNativeKey = parseMcpConfigurationReceipt(
+    await loadFixture("receipts/duplicate-native-key.json"),
+  );
+  if (!duplicateNativeKey.ok) {
+    throw new Error("duplicate-native-key.json must parse as a receipt object");
+  }
+  assertEquals(
+    validateMcpConfigurationReceiptCoverage(duplicateNativeKey.receipt, {
+      generation: 4,
+      desired: [
+        { managedIdentity: "mcp-tavily", sourceRevisionId: "rev-tavily-1" },
+        { managedIdentity: "mcp-other", sourceRevisionId: "rev-other-1" },
+      ],
+    }),
+    "duplicate_native_key",
+  );
+
+  const uppercase = structuredClone(
+    await loadFixture("receipts/valid.json"),
+  ) as {
+    documentFingerprint: string;
+    entries: { entryFingerprint: string }[];
+  };
+  uppercase.documentFingerprint =
+    "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  uppercase.entries[0].entryFingerprint =
+    "sha256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  assertEquals(parseMcpConfigurationReceipt(uppercase), {
+    ok: true,
+    receipt: await loadFixture("receipts/valid.json"),
+  });
 
   assertEquals(
     parseMcpConfigurationReceipt(

--- a/packages/plugin-sdk/tests/mcp-configuration.test.ts
+++ b/packages/plugin-sdk/tests/mcp-configuration.test.ts
@@ -1,0 +1,320 @@
+import {
+  AGENT_CONFIGURE_WORKSPACE,
+  defineAgent,
+  type McpConfigurationSnapshotRequest,
+  negotiateMcpConfiguration,
+  parseMcpConfigurationReceipt,
+  parseMcpConfigurationRegistration,
+  parseMcpConfigurationSnapshotRequest,
+  validateMcpConfigurationReceiptCoverage,
+} from "../src/mod.ts";
+import {
+  decodeFrames,
+  encodeFrame,
+  type JsonValue,
+  type PluginTransport,
+} from "../src/protocol.ts";
+
+/** Compares JSON-compatible values without a Node compatibility dependency. */
+function assertEquals(actual: unknown, expected: unknown): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`Expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+function assertStringDoesNotContain(value: string, forbidden: string): void {
+  if (value.includes(forbidden)) {
+    throw new Error(`Expected diagnostics not to contain ${forbidden}`);
+  }
+}
+
+/** Creates paired in-memory streams for exercising the SDK without global stdio. */
+function createTransportHarness(): {
+  transport: PluginTransport;
+  send: (message: JsonValue) => Promise<void>;
+  responses: AsyncGenerator<unknown>;
+} {
+  const hostInput = new TransformStream<Uint8Array>();
+  const pluginOutput = new TransformStream<Uint8Array>(
+    undefined,
+    undefined,
+    new CountQueuingStrategy({ highWaterMark: Infinity }),
+  );
+  const inputWriter = hostInput.writable.getWriter();
+  return {
+    transport: {
+      readable: hostInput.readable,
+      writable: pluginOutput.writable,
+      redirectConsole: false,
+    },
+    send: (message) => inputWriter.write(encodeFrame(message)),
+    responses: decodeFrames(pluginOutput.readable),
+  };
+}
+
+async function loadFixture(relativePath: string): Promise<JsonValue> {
+  const url = new URL(
+    `./fixtures/mcp-configuration/${relativePath}`,
+    import.meta.url,
+  );
+  return JSON.parse(await Deno.readTextFile(url));
+}
+
+function minimalAgent() {
+  return {
+    start: () => {},
+    stop: () => {},
+    listModels: () => [],
+    onAcp: () => {},
+  };
+}
+
+Deno.test("older agents omit mcpConfiguration and configureWorkspace", async () => {
+  const plugin = defineAgent(minimalAgent());
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+  const registration = (await harness.responses.next()).value as {
+    params: JsonValue;
+  };
+  assertEquals(
+    registration.params,
+    await loadFixture("registration/omitted.json"),
+  );
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("defineAgent registers mcpConfiguration together with the snapshot handler", async () => {
+  const snapshots: McpConfigurationSnapshotRequest[] = [];
+  const plugin = defineAgent({
+    ...minimalAgent(),
+    mcpConfiguration: {
+      protocolVersion: 1,
+      transports: ["http"],
+      coordination: "wait_for_idle_and_restart",
+      configureWorkspace: (request) => {
+        snapshots.push(request);
+        return {
+          appliedGeneration: request.generation,
+          documentLocator: ".opencode/opencode.json",
+          documentFingerprint:
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          entries: request.resolvedMcps.map((mcp) => ({
+            managedIdentity: mcp.managedIdentity,
+            nativeKey: "ora_tavily_search_abcdef123456",
+            entryFingerprint:
+              "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            sourceRevisionId: mcp.sourceRevisionId,
+          })),
+        };
+      },
+    },
+  });
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+  const registration = (await harness.responses.next()).value as {
+    params: JsonValue;
+  };
+  assertEquals(
+    registration.params,
+    await loadFixture("registration/valid-http-v1.json"),
+  );
+
+  const snapshot = await loadFixture("requests/full-snapshot.json");
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 8,
+    method: AGENT_CONFIGURE_WORKSPACE,
+    params: snapshot,
+  });
+  assertEquals((await harness.responses.next()).value, {
+    jsonrpc: "2.0",
+    id: 8,
+    result: await loadFixture("receipts/valid.json"),
+  });
+  assertEquals(snapshots, [snapshot]);
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("unknown snapshot protocol versions are rejected without leaking secrets", async () => {
+  const plugin = defineAgent({
+    ...minimalAgent(),
+    mcpConfiguration: {
+      protocolVersion: 1,
+      transports: ["http"],
+      coordination: "wait_for_idle_and_restart",
+      configureWorkspace: () => {
+        throw new Error("handler must not run");
+      },
+    },
+  });
+  const harness = createTransportHarness();
+  const run = plugin.run(harness.transport);
+  await harness.responses.next();
+  const snapshot = await loadFixture("requests/full-snapshot.json") as Record<
+    string,
+    JsonValue
+  >;
+  await harness.send({
+    jsonrpc: "2.0",
+    id: 9,
+    method: AGENT_CONFIGURE_WORKSPACE,
+    params: { ...snapshot, protocolVersion: 2 },
+  });
+  const response = (await harness.responses.next()).value as {
+    error: { message: string };
+  };
+  assertEquals(
+    response.error.message,
+    "agent/configureWorkspace requires a protocol v1 snapshot",
+  );
+  assertStringDoesNotContain(JSON.stringify(response), "tavily-secret-key");
+  assertStringDoesNotContain(JSON.stringify(response), "Bearer");
+  await harness.send({ jsonrpc: "2.0", method: "ora/shutdown" });
+  await run;
+});
+
+Deno.test("snapshot parse rejects unknown fields without echoing header values", () => {
+  const snapshot = {
+    protocolVersion: 1,
+    operationId: "op-7",
+    agentTargetId: "target-1",
+    workspaceRoot: "/workspace",
+    generation: 4,
+    resolvedMcps: [],
+    configurationStore: { apiKey: "tavily-secret-key" },
+  };
+  try {
+    parseMcpConfigurationSnapshotRequest(snapshot);
+    throw new Error("expected parse to fail");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    assertEquals(
+      message,
+      "agent/configureWorkspace requires a protocol v1 snapshot",
+    );
+    assertStringDoesNotContain(message, "tavily-secret-key");
+    assertStringDoesNotContain(message, "configurationStore");
+  }
+});
+
+const HTTP_V1 = {
+  protocolVersion: 1,
+  transports: ["http"],
+  coordination: "wait_for_idle_and_restart",
+} as const;
+
+Deno.test("shared registration fixtures classify omitted, unknown, malformed, and unpaired declarations", async () => {
+  assertEquals(
+    parseMcpConfigurationRegistration(
+      await loadFixture("registration/omitted.json"),
+    ),
+    { status: "absent" },
+  );
+  assertEquals(
+    parseMcpConfigurationRegistration(
+      await loadFixture("registration/unknown-top-level-fields.json"),
+    ),
+    { status: "declared", capability: HTTP_V1 },
+  );
+  assertEquals(
+    parseMcpConfigurationRegistration(
+      await loadFixture("registration/unknown-protocol-version.json"),
+    ),
+    { status: "invalid", code: "mcp_capability_version_unsupported" },
+  );
+  assertEquals(
+    parseMcpConfigurationRegistration(
+      await loadFixture("registration/malformed.json"),
+    ),
+    { status: "invalid", code: "mcp_capability_invalid" },
+  );
+  assertEquals(
+    parseMcpConfigurationRegistration(
+      await loadFixture("registration/duplicate-transports.json"),
+    ),
+    { status: "invalid", code: "mcp_capability_invalid" },
+  );
+  assertEquals(
+    negotiateMcpConfiguration(await loadFixture("registration/omitted.json")),
+    { status: "unsupported" },
+  );
+  assertEquals(
+    negotiateMcpConfiguration(
+      await loadFixture("registration/capability-without-handler.json"),
+    ),
+    { status: "disabled", code: "mcp_capability_invalid" },
+  );
+  assertEquals(
+    negotiateMcpConfiguration(
+      await loadFixture("registration/handler-without-capability.json"),
+    ),
+    { status: "disabled", code: "mcp_capability_invalid" },
+  );
+  assertEquals(
+    negotiateMcpConfiguration(
+      await loadFixture("registration/valid-http-v1.json"),
+    ),
+    { status: "enabled", capability: HTTP_V1 },
+  );
+});
+
+Deno.test("shared receipt fixtures reject missing, duplicate, extra, and mismatched coverage", async () => {
+  const tavilyCoverage = {
+    generation: 4,
+    desired: [{
+      managedIdentity: "mcp-tavily",
+      sourceRevisionId: "rev-tavily-1",
+    }],
+  };
+  const valid = parseMcpConfigurationReceipt(
+    await loadFixture("receipts/valid.json"),
+  );
+  assertEquals(valid, {
+    ok: true,
+    receipt: await loadFixture("receipts/valid.json"),
+  });
+  if (!valid.ok) {
+    throw new Error("valid receipt must parse");
+  }
+  assertEquals(
+    validateMcpConfigurationReceiptCoverage(valid.receipt, tavilyCoverage),
+    undefined,
+  );
+
+  const coverageCases = [
+    ["missing.json", "missing_managed_identity"],
+    ["duplicate.json", "duplicate_managed_identity"],
+    ["extra.json", "extra_managed_identity"],
+    ["generation-mismatch.json", "generation_mismatch"],
+    ["source-revision-mismatch.json", "source_revision_mismatch"],
+  ] as const;
+  for (const [name, code] of coverageCases) {
+    const parsed = parseMcpConfigurationReceipt(
+      await loadFixture(`receipts/${name}`),
+    );
+    if (!parsed.ok) {
+      throw new Error(`${name} must parse as a receipt object`);
+    }
+    assertEquals(
+      validateMcpConfigurationReceiptCoverage(parsed.receipt, tavilyCoverage),
+      code,
+    );
+  }
+
+  assertEquals(
+    parseMcpConfigurationReceipt(
+      await loadFixture("receipts/illegal-fingerprint.json"),
+    ),
+    { ok: false, code: "illegal_fingerprint" },
+  );
+  assertEquals(
+    parseMcpConfigurationReceipt(
+      await loadFixture("receipts/locator-escape.json"),
+    ),
+    { ok: false, code: "locator_out_of_bounds" },
+  );
+});

--- a/plugin-agent-runtime.md
+++ b/plugin-agent-runtime.md
@@ -145,6 +145,38 @@ Vec<_>` 变成 `agent: Option<InstalledPluginAgent>`——`kind == "agent"` 时�
 缺任何一个就直接判定插件不可用（不重启、标记 `Failing`）。这是 fail-fast 的关键：在没有会话、
 没有用户等待的时刻暴露契约不符，而不是等用户点了发送才报错。
 
+可选顶层 `mcpConfiguration` 是加法式 MCP Configuration Capability，**不参与**上述基础契约校验，
+也不提升全局 `pluginApi` major。protocol v1 要求正整数版本、非空且不重复的 transport 集合
+（`http` / `stdio`）以及合法 coordination mode（目前仅 `wait_for_idle_and_restart`）。声明该
+capability 时必须同时注册 `agent/configureWorkspace`；SDK 高层 API 将二者成对注册，调用方不能
+只声明一侧。缺失、畸形、重复 transport、未知协议版本或缺一配对只禁用 MCP materialization，
+基础对话契约仍然成立。未知顶层 registration 字段被忽略，因此旧 Host 可以跳过该能力。
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "ora/register",
+  "params": {
+    "methods": [
+      "agent/start",
+      "agent/stop",
+      "agent/listModels",
+      "agent/configureWorkspace",
+    ],
+    "emits": ["agent/acp"],
+    "mcpConfiguration": {
+      "protocolVersion": 1,
+      "transports": ["http"],
+      "coordination": "wait_for_idle_and_restart",
+    },
+  },
+}
+```
+
+旧插件省略 `mcpConfiguration` 时，宿主将每个 Ready MCP 视为该 Agent Target 的 NonBlocking
+`UnsupportedByAgent`。Agent Capability Revision 绑定精确插件版本与 capability 声明的 canonical
+digest；二者任一变化都是新 revision。
+
 ## 4. 控制方法
 
 三个方法都是 request/response，走 `PluginRuntime::invoke`，受 `call_timeout` 约束。
@@ -201,6 +233,22 @@ capabilities 才把连接置为 `Ready`。
 为什么不复用 ACP 的 session config options：设置页要在**没有任何会话**的情况下展示可选模型，
 而 config options 是 `session/new` 之后才有的会话级能力。两者共存——`listModels` 服务
 "选 agent / 选模型"的前置 UI，config options 服务会话内切换。
+
+### `agent/configureWorkspace`
+
+可选 MCP Configuration Capability 的唯一 Host→插件配置方法。只接收完整快照，不接收增量事件。
+该方法与 `mcpConfiguration` 成对出现；Host 在调用前排除 Agent 不支持的 transport，并将它们
+表示为 Agent Target 级 NonBlocking `UnsupportedByAgent`。
+
+请求包含 protocol version、稳定 operation identity、稳定 Agent Target identity、绝对 Workspace
+root、非负 Workspace generation，以及该目标支持的完整 `Resolved MCP` 列表。禁止携带原始插件
+manifest、完整配置存储、Ora 数据库路径或无关插件路径。JSON-RPC、stderr、timeout error、日志和
+trace 不得包含 header value、environment value、文档内容或 Authorization 材料。
+
+成功回执必须包含 exact applied generation、Workspace-relative document locator、document SHA-256
+fingerprint，以及恰好覆盖全部受支持 Desired MCP 的 entry receipts。Host 拒绝 generation 不匹配、
+locator 越界、managed identity 缺失/重复/额外、Desired 覆盖不完整、source revision 不匹配或
+fingerprint 非法的回执。
 
 ## 5. ACP 透传
 


### PR DESCRIPTION
## Summary

落地 **Agent MCP Configuration Capability**（Agent 插件可选声明的「MCP 配置能力」）：Host、插件运行时、生命周期校验、线协议和 TypeScript 插件 SDK 一起谈妥「能不能、按什么版本把 MCP 配进 Workspace」，而不是在 Ora 核心里写某个具体 Agent 的配置文件。

Closes ora-space/desktop#487

> **合并顺序：** 本分支基于 `90b2f6f6`（Agent Target 持久化，对应 #484）。上游 `main` 尚无该提交；与已开的 #498 历史分叉。应先合入 #484，再将本分支 rebase 到最新 `main` 后合并。


## 解决了什么问题

父议题 #479 要打通「安装 MCP → 填配置 → Workspace 里真正能用」。本票是其中的协议层：

- 插件作者用 **一个** SDK 定义，同时登记 `mcpConfiguration` 能力和 `agent/configureWorkspace` 处理方法。高层 API 无法只声明一半。
- 旧 Agent 插件可以完全不写这项能力，基础对话契约仍然有效；缺能力只表示「这个 Agent 不负责把 MCP 写进自己的配置」，不是安装失败。
- Host 只发一份完整、可重复执行的 **MCP Configuration Snapshot**（某一代 Workspace 上、该 Agent 支持的全部 Resolved MCP），并严格校验完整回执。不发「加一条 / 删一条」的增量事件，避免丢通知或进程重启后状态对不齐。

## 为什么这么做

MCP 配置能力必须是 **加法式协商**（additive negotiation：新字段可有可无，旧 Host / 旧插件互不破坏），不能为此把全局插件协议升 major。因此：

- 注册顶层的 `mcpConfiguration` 可选。畸形、重复、未知 transport、不支持的协议版本只让 MCP 物化失效，并给出稳定错误码 `mcp_capability_invalid` / `mcp_capability_version_unsupported`。
- 不支持的 transport 在进入插件请求前被滤掉，记成目标级、非阻塞的 `Unsupported by Agent`，不会把整个 Agent Target 打成不可对话。
- 请求只带协议允许的领域信息（协议版本、操作身份、Agent Target、绝对 Workspace 根、非负 generation、完整受支持 Resolved MCP）。不带原始包清单、配置库、数据库路径或 Host 渲染的 OpenCode 字段。
- JSON-RPC 诊断、stderr、超时错误和 Host trace 不打印 header / 环境变量 / 文档内容。失败用稳定 **code** 做控制流，message 只给人看。

## 考虑与取舍

- **一份声明快照，而不是两套注册表。** Skill 表面和 MCP 能力放进同一个 per-plugin map。现有 Skill 收敛 worker 仍只投影文件系统 Skill 表面（#489 才切 Agent Target worker），但读取的是同一份 `agent_effect_surface_declarations`，避免以后忘了第二份来源。
- **非法状态不可表示。** 能力修订不再用空字符串当「未协商」哨兵，而是 `Option`：未绑定就是没有。回执用穷尽枚举拒绝 generation 不匹配、locator 越界、身份缺失/重复、**重复 native key**、指纹非法、覆盖不完整。
- **Rust / TypeScript 双份解析，而不是抽一层转发。** 线协议夹具两边共用 JSON；各自解析是为了在插件进程和 Host 两边独立拒绝畸形输入。SDK 公开面给插件作者；Host 用的协商/回执分类器不从包入口再导出。
- **本票边界。** 不做 Effect worker 切流（#489）、MCP Source 发布（#486）、admission 门禁（#490）、OpenCode 文档渲染（#488）、崩溃恢复（#492）、升级/卸载/发布。

审查后续补强：回执拒绝重复 native key；SDK 强制绝对 HTTP URL 与非空 header 名；configure / 回执失败映射 `mcp_configuration_failed` / `mcp_configuration_response_invalid`；指纹十六进制大小写与 Host 对齐；共享夹具覆盖未知/空 transport。

## Test plan

- [x] `cargo test -p ora-backend --lib mcp_configuration`
- [x] `cargo test -p ora-plugin-runtime --lib mcp_configuration`
- [x] `cargo test -p ora-effect --lib agent_target`
- [x] `pnpm --filter @ora-space/plugin-sdk test`
- [x] Effect worker 仍能为晚创建的 Workspace 注册 Skill 表面
- [ ] CI 全量 `task test`（本票相关套件已本地通过）
