### PR TITLE
fix(chat): 模型下拉框限制高度并新增搜索框

### DIFF
--- a/packages/app-shell/src/features/chat/model-selector.test.tsx
+++ b/packages/app-shell/src/features/chat/model-selector.test.tsx
@@ -309,3 +309,85 @@ describe("ModelSelector agent availability", () => {
     );
   });
 });
+
+describe("ModelSelector model search", () => {
+  it("filters the model list by typed text without the menu swallowing keystrokes", async () => {
+    const user = userEvent.setup();
+    renderModelSelector();
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    const menu = await openAgentList(user);
+    await waitFor(() =>
+      expect(within(menu).queryByText("Big Pickle")).not.toBeNull(),
+    );
+
+    const search = within(menu).getByRole("textbox", {
+      name: /搜索模型|Search models/,
+    });
+    await user.type(search, "Small");
+    expect(search).toHaveValue("Small");
+    expect(within(menu).queryByText("Big Pickle")).toBeNull();
+    expect(within(menu).queryByText("Small Pickle")).not.toBeNull();
+
+    await user.clear(search);
+    expect(within(menu).queryByText("Big Pickle")).not.toBeNull();
+    expect(within(menu).queryByText("Small Pickle")).not.toBeNull();
+  });
+
+  it("reports no matches for a query nothing in the model list satisfies", async () => {
+    const user = userEvent.setup();
+    renderModelSelector();
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    const menu = await openAgentList(user);
+    await waitFor(() =>
+      expect(within(menu).queryByText("Big Pickle")).not.toBeNull(),
+    );
+
+    const search = within(menu).getByRole("textbox", {
+      name: /搜索模型|Search models/,
+    });
+    await user.type(search, "nonexistent-model");
+
+    expect(within(menu).queryByText("Big Pickle")).toBeNull();
+    expect(within(menu).queryByText("Small Pickle")).toBeNull();
+    await waitFor(() =>
+      expect(
+        within(menu).queryByText(/未找到匹配的模型|No matching models/),
+      ).not.toBeNull(),
+    );
+  });
+
+  it("does not move focus into the search box just from opening the menu", async () => {
+    const user = userEvent.setup();
+    renderModelSelector();
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    const menu = await openAgentList(user);
+    await waitFor(() =>
+      expect(within(menu).queryByText("Big Pickle")).not.toBeNull(),
+    );
+
+    const search = within(menu).getByRole("textbox", {
+      name: /搜索模型|Search models/,
+    });
+    expect(document.activeElement).not.toBe(search);
+  });
+
+  it("does not offer a search box in the agent group", async () => {
+    const user = userEvent.setup();
+    renderModelSelector();
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    const menu = await openAgentList(user);
+    await waitFor(() =>
+      expect(within(menu).queryByText("Big Pickle")).not.toBeNull(),
+    );
+
+    expect(
+      within(menu).getAllByRole("textbox", {
+        name: /搜索模型|Search models/,
+      }),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/app-shell/src/features/chat/model-selector.tsx
+++ b/packages/app-shell/src/features/chat/model-selector.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import {
@@ -8,12 +9,14 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
+  Input,
 } from "@ora/ui";
 import {
   IconCheck,
   IconChevronDown,
   IconLoader2,
   IconRobot,
+  IconSearch,
 } from "@tabler/icons-react";
 import { useChatStore } from "../../chat-store-context";
 import { useSettingsStore } from "../../state/stores/settings-store";
@@ -62,6 +65,10 @@ export function ModelSelector({
   sessionId?: string;
 }) {
   const { t } = useTranslation();
+  // Local to the picker rather than persisted: it is a scratch filter on
+  // whatever the current model list is, not a preference worth remembering
+  // once the menu closes.
+  const [modelQuery, setModelQuery] = useState("");
   const updateSettings = useSettingsStore((state) => state.updateSettings);
   const selection = useWorkspaceSelectionStore((state) => state.selection);
   const chatStore = useChatStore();
@@ -235,8 +242,14 @@ export function ModelSelector({
     });
   };
 
+  const modelValues = modelOption ? selectableValues(modelOption) : [];
+  const needle = modelQuery.trim().toLowerCase();
+  const visibleModelValues = needle
+    ? modelValues.filter((value) => value.name.toLowerCase().includes(needle))
+    : modelValues;
+
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={(open) => !open && setModelQuery("")}>
       <DropdownMenuTrigger
         render={
           <Button
@@ -245,7 +258,7 @@ export function ModelSelector({
             size="sm"
             disabled={disabled}
             aria-label={t("chat.modelSelector.label")}
-            className="group/model h-7 gap-1.5 rounded-md px-2 text-xs font-normal text-muted-foreground hover:text-foreground"
+            className="group/model h-7 gap-1.5 rounded-md px-2 text-xs font-normal text-muted-foreground hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring/50"
           />
         }
       >
@@ -276,7 +289,11 @@ export function ModelSelector({
           />
         )}
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" side="top" className="w-56">
+      <DropdownMenuContent
+        align="end"
+        side="top"
+        className="w-56 max-h-[min(24rem,var(--available-height))]"
+      >
         <DropdownMenuGroup className="p-1">
           <DropdownMenuLabel className="px-2 py-1.5 text-xs font-normal text-muted-foreground">
             {t("chat.modelSelector.agent")}
@@ -315,6 +332,31 @@ export function ModelSelector({
               </span>
             )}
           </DropdownMenuLabel>
+          {/* Kept out of the agent group above: the agent list is short and
+              unsearched, and a query here should never be mistaken for
+              filtering which CLI is offered. */}
+          {modelValues.length > 0 && (
+            <div className="relative px-0.5 pb-1">
+              <IconSearch className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={modelQuery}
+                onChange={(event) => setModelQuery(event.target.value)}
+                placeholder={t("chat.modelSelector.search")}
+                aria-label={t("chat.modelSelector.search")}
+                className="h-7 border-transparent bg-muted/50 pl-8 text-xs shadow-none focus-visible:ring-1 focus-visible:ring-ring/50"
+                // Excluded from the tab order so the menu's own focus manager,
+                // which moves focus to the popup's first tabbable descendant
+                // on open, does not land here — opening the menu should not
+                // steal focus into the search box. A click still focuses it.
+                tabIndex={-1}
+                // The dropdown's own typeahead and arrow-key navigation listen
+                // on the popup element, so unfiltered keystrokes here would be
+                // swallowed as menu navigation instead of reaching the input.
+                onKeyDown={(event) => event.stopPropagation()}
+                onClick={(event) => event.stopPropagation()}
+              />
+            </div>
+          )}
           {modelOption === null ? (
             <p className="px-2 py-4 text-center text-xs text-muted-foreground">
               {t(
@@ -323,8 +365,12 @@ export function ModelSelector({
                   : "chat.modelSelector.empty",
               )}
             </p>
+          ) : visibleModelValues.length === 0 ? (
+            <p className="px-2 py-4 text-center text-xs text-muted-foreground">
+              {t("chat.modelSelector.noResults")}
+            </p>
           ) : (
-            selectableValues(modelOption).map((value) => (
+            visibleModelValues.map((value) => (
               <DropdownMenuItem
                 key={value.value}
                 className="gap-1.5 rounded-sm px-2 py-1.5 text-xs"

--- a/packages/app-shell/src/i18n/i18n-instance.ts
+++ b/packages/app-shell/src/i18n/i18n-instance.ts
@@ -1273,6 +1273,8 @@ export const translationResources = {
     "chat.modelSelector.model": "模型",
     "chat.modelSelector.updating": "更新中…",
     "chat.modelSelector.empty": "该 Agent 未提供可选模型",
+    "chat.modelSelector.search": "搜索模型",
+    "chat.modelSelector.noResults": "未找到匹配的模型",
     "chat.agentUnavailable.title": "当前 Agent 不可用",
     "chat.agentUnavailable.uninstalled":
       "提供该 Agent 的插件已被卸载，重新安装后才能继续这段对话。",
@@ -2895,6 +2897,8 @@ export const translationResources = {
     "chat.modelSelector.model": "Model",
     "chat.modelSelector.updating": "Updating…",
     "chat.modelSelector.empty": "This agent offers no model choice",
+    "chat.modelSelector.search": "Search models",
+    "chat.modelSelector.noResults": "No matching models",
     "chat.agentUnavailable.title": "This session's agent is unavailable",
     "chat.agentUnavailable.uninstalled":
       "The plugin that provided this agent was uninstalled. Reinstall it to continue this conversation.",


### PR DESCRIPTION
## 概述

- 模型下拉框弹出层高度限制为 24rem（超出后内部滚动），不再撑到窗口边缘。
- 在模型列表上方新增搜索框，用于按名称过滤模型，Agent 列表不受影响、不加搜索框。
- 打开下拉框不再自动把焦点抢到搜索框（排除在弹层默认聚焦扫描之外）。
- 搜索框内输入不会被菜单自身的 typeahead/方向键导航吞掉。
- 搜索框与触发按钮的聚焦光环缩小到 `ring-1`，避免在紧凑控件上显得过粗。
- 新增/更新中英文案：`chat.modelSelector.search`、`chat.modelSelector.noResults`。

## 测试计划

- [x] `model-selector.test.tsx` 新增用例：搜索过滤、无匹配结果提示、Agent 分组无搜索框、打开菜单不抢焦点
- [x] 全部 12 个用例通过（含既有用例）
- [x] `eslint` 通过
- [x] 通过 `run-with-clean-stderr.mjs` 校验，无 stderr 警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)