### PR TITLE
feat(app-shell): 插件管理去掉启停按钮，并锁定对话区不再出现 Spec 模式

### DIFF
--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -20,6 +20,7 @@ import type {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@ora/ui";
 import { AppI18nProvider } from "../../i18n/i18n";
+import { appI18n } from "../../i18n/i18n-instance";
 import { ContractsClientContext } from "../../contracts-client-context";
 import { ChatStoreContext } from "../../chat-store-context";
 import { createChatStore } from "@ora/chat";
@@ -46,6 +47,8 @@ import {
   resetComposerSendAdoptionsForTests,
 } from "../../state/session-drafts";
 import { FILE_MENTION_DEBOUNCE_MS } from "./use-composer-file-mentions";
+
+void appI18n;
 
 function composerText(element: HTMLElement): string {
   return element.dataset.composerText ?? "";
@@ -259,6 +262,16 @@ describe("Tool calls", () => {
 });
 
 describe("Composer", () => {
+  it("does not offer the retired Spec mode toggle in the footer", () => {
+    renderWithI18n(<Composer onSend={vi.fn()} isResponding={false} />);
+
+    expect(
+      screen.queryByRole("button", { name: /Spec 模式|Spec mode/ }),
+    ).toBeNull();
+    expect(screen.queryByText("Spec 模式")).toBeNull();
+    expect(screen.queryByText("Spec mode")).toBeNull();
+  });
+
   it("sends trimmed text with Enter and clears the textarea", async () => {
     const user = userEvent.setup();
     const onSend = vi.fn();

--- a/packages/app-shell/src/features/settings/plugin-manager.tsx
+++ b/packages/app-shell/src/features/settings/plugin-manager.tsx
@@ -28,8 +28,6 @@ import {
   IconArrowBigUpLines,
   IconDots,
   IconLoader2,
-  IconPlayerPlay,
-  IconPlayerStop,
   IconProgressDown,
   IconRefresh,
   IconSearch,
@@ -44,7 +42,7 @@ import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
 import { usePluginScan } from "../../state/hooks/use-plugin-scan";
 import { useUpdatePlugin } from "../../state/hooks/use-update-plugin";
 
-/** The installed-plugin manager exposes runtime and package lifecycle commands. */
+/** The installed-plugin manager exposes package lifecycle commands without process start/stop. */
 export function PluginManager({
   plugins,
   onBack,
@@ -187,23 +185,11 @@ function InstalledPluginRow({
     plugin.kind === "agent" ? plugin.name : undefined,
   );
   const uninstalling = mutations.uninstall.isPending;
-  const lifecycleBusy =
-    mutations.activate.isPending || mutations.stop.isPending;
-  const busy = uninstalling || update.isPending || lifecycleBusy;
+  const busy = uninstalling || update.isPending;
   const hasUpdate =
     available !== undefined && available.version !== plugin.version;
   const [uninstallOpen, setUninstallOpen] = useState(false);
   const [deleteData, setDeleteData] = useState(true);
-  const failStart = (cause: unknown) => {
-    toast.error(t("settings.plugins.startFailed"), {
-      description: localizeContractError(cause, t),
-    });
-  };
-  const failStop = (cause: unknown) => {
-    toast.error(t("settings.plugins.stopFailed"), {
-      description: localizeContractError(cause, t),
-    });
-  };
   const failUpdate = (cause: unknown) => {
     toast.error(t("settings.plugins.updateFailed"), {
       description: localizeContractError(cause, t),
@@ -251,49 +237,6 @@ function InstalledPluginRow({
             </Badge>
           )}
         </span>
-
-        {(plugin.runtime === "stopped" || plugin.runtime === "failed") && (
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy}
-            onClick={() =>
-              mutations.activate.mutate(undefined, { onError: failStart })
-            }
-          >
-            {mutations.activate.isPending ? (
-              <IconLoader2 className="animate-spin" />
-            ) : (
-              <IconPlayerPlay />
-            )}
-            {t("settings.plugins.start")}
-          </Button>
-        )}
-
-        {plugin.runtime === "starting" && (
-          <Button variant="outline" size="sm" disabled>
-            <IconLoader2 className="animate-spin" />
-            {t("settings.plugins.starting")}
-          </Button>
-        )}
-
-        {plugin.runtime === "running" && (
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy}
-            onClick={() =>
-              mutations.stop.mutate(undefined, { onError: failStop })
-            }
-          >
-            {mutations.stop.isPending ? (
-              <IconLoader2 className="animate-spin" />
-            ) : (
-              <IconPlayerStop />
-            )}
-            {t("settings.plugins.stop")}
-          </Button>
-        )}
 
         {hasUpdate && (
           <Button

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -367,34 +367,43 @@ it("renders the brand mark of an installed plugin in the manager", async () => {
     "src",
     `data:image/svg+xml;charset=utf-8,${encodeURIComponent(WEATHER_LOGO)}`,
   );
+  expect(
+    screen.queryByRole("button", { name: /启动|Start/ }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: /停止|Stop/ }),
+  ).not.toBeInTheDocument();
 });
 
-/** The manager exposes lifecycle controls that start and stop an installed plugin. */
-it("starts and stops an installed plugin from the manager", async () => {
+/** Installed plugins no longer expose start or stop, regardless of runtime. */
+it("hides start and stop for stopped, starting, failed, and running plugins", async () => {
   const user = userEvent.setup();
   const state = createMockClientState();
-  state.installedPlugins = [weatherInstalled()];
-  const client = createMockClient(state);
-  renderSettings(client);
+  state.installedPlugins = [
+    weatherInstalled(),
+    { ...weatherInstalled(), id: "official/starting", runtime: "starting" },
+    {
+      ...weatherInstalled(),
+      id: "official/failed",
+      runtime: "failed",
+      failureReason: "launch failed",
+    },
+    { ...weatherInstalled(), id: "official/running", runtime: "running" },
+  ];
+  renderSettings(createMockClient(state));
 
   await openManagePlugins(user);
   await screen.findByText("official/weather");
 
-  await user.click(await screen.findByRole("button", { name: /启动|Start/ }));
-  await waitFor(() => {
-    expect(
-      screen.getByRole("button", { name: /停止|Stop/ }),
-    ).toBeInTheDocument();
-  });
-  expect(state.installedPlugins[0].runtime).toBe("running");
-
-  await user.click(screen.getByRole("button", { name: /停止|Stop/ }));
-  await waitFor(() => {
-    expect(
-      screen.getByRole("button", { name: /启动|Start/ }),
-    ).toBeInTheDocument();
-  });
-  expect(state.installedPlugins[0].runtime).toBe("stopped");
+  expect(
+    screen.queryByRole("button", { name: /启动|Start/ }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: /启动中|Starting/ }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: /停止|Stop/ }),
+  ).not.toBeInTheDocument();
 });
 
 /** Host-rendered fields preserve defaults and explicit boolean false through Save. */

--- a/packages/app-shell/src/features/workspace/workspace-view.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-view.test.tsx
@@ -399,6 +399,10 @@ describe("WorkspaceView", () => {
       screen.queryByRole("button", { name: /选择分支|Select branch/ }),
     ).toBeNull();
     expect(screen.queryByText(/直聊|Direct chat/)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Spec 模式|Spec mode/ }),
+    ).toBeNull();
+    expect(screen.queryByText("Spec 模式")).toBeNull();
   });
 
   it("shows only worktrees in the worktree context menu", async () => {


### PR DESCRIPTION
## 概述

这次改动只动前端界面，做了两件事：

1. **设置 → 管理插件**里，每条已安装插件上的「启动」「启动中」「停止」按钮全部去掉。
2. 给对话输入框（composer，即聊天底部用来打字、发消息的区域）补上测试，保证已经下线的 **Spec 模式**开关不会再出现。

对应分支名为 `ticket/830`。在 GitHub 仓库 `ora-space/desktop` 中未检索到编号 830 的 Issue，因此本 PR **未使用** `Closes #830`，合并后也不会自动关闭某个 Issue。若后续补建了对应 Issue，请再把本 PR 关联上去。

## 解决了什么问题

### 1. 插件管理里的启停按钮容易误导

插件管理页原本会按插件进程状态显示：

- 已停止 / 启动失败 →「启动」
- 正在启动 →「启动中」（不可点）
- 正在运行 →「停止」

用户实际需要的是：**安装、更新、配置、卸载**这类「这个包在不在电脑上」的操作，而不是手动开关插件进程。进程该不该跑，由 Ora 在真正用到这个插件时自动处理（例如用户在对话里选了某个 Agent）。把启停放在设置页，会让人以为必须先点「启动」插件才能用，也容易和「卸载」搞混。

### 2. Spec 模式已经从产品里拿掉，但测试没有锁死

更早的改动已经从对话输入框去掉了「Spec 模式」开关（那是一种围绕规格文档推进任务的交互，不是文件面板里的 Specs 文档列表）。如果以后有人误把开关加回去，原有测试不一定能拦住。这次补上「页脚里不能出现 Spec 模式」的断言，避免回潮。

## 为什么这么改

只改界面、不改后端接口。

- 后端的「激活插件 / 停止插件」接口仍然保留。宿主（host，即 Ora 桌面端里负责拉起插件进程的那一层）在用户选用某个 Agent 时仍可按需启动进程；这次只是设置页不再提供手动按钮。
- 翻译文案里的「启动 / 停止」字符串也先留着，避免一次改动同时删文案、删接口、改设置页，范围过大、难回滚。

Spec 模式这边：**没有再改输入框的产品代码**（开关本来就不在了），只加了回归测试。文件面板里的 Specs 标签页是另一套「看规格文档」的功能，与对话区的 Spec 模式不是一回事，本次刻意没有动它。

## 考虑过的点与取舍

| 方案 | 结论 |
| --- | --- |
| 连后端启停接口一起删 | **不做**。设置页不再操作进程，不代表运行时不再需要启停；删接口会波及按需启动、测试替身（mock）和其它调用方。 |
| 只藏按钮、代码里还留点击逻辑 | **不做**。死代码容易让人以为功能还在。按钮和点击处理一并删除。 |
| 已安装行上保留「停止」、只去掉「启动」 | **不做**。用户明确要求启动和停止都从管理界面拿掉，保持「设置页不管进程」这一条规则完整。 |
| 同时清理未再使用的 i18n 键（界面文案键名） | **不做**。键还可能被其它入口或后续恢复使用；这次以「界面不再露出」为边界。 |
| 把文件面板的 Specs 一起藏掉 | **不做**。用户要去掉的是对话区「Spec 模式」开关，不是规格文档浏览。 |

代价：用户不能再从设置页手动停掉一个卡住的插件进程，需要依赖自动生命周期或重启应用。这是有意把「进程是否在跑」从设置里拿掉，换来更简单、更不容易点错的管理页。

## 主要改动

- `packages/app-shell/src/features/settings/plugin-manager.tsx`：已安装插件行只保留更新、配置、卸载。
- `packages/app-shell/src/features/settings/plugins-settings.test.tsx`：覆盖 stopped / starting / failed / running 四种运行时状态，均不应出现启动或停止按钮。
- `packages/app-shell/src/features/chat/chat-view.test.tsx`、`workspace-view.test.tsx`：断言对话区页脚没有「Spec 模式 / Spec mode」。聊天测试文件自行初始化 i18n（国际化，界面中英文案），避免 CI 上不同测试分片漏初始化而误报。

## 测试计划

- [ ] 设置 → 管理插件：已安装列表不再出现启动 / 停止；更新、配置、卸载仍可用
- [ ] 对话输入框页脚：没有「Spec 模式」开关；发送、模型选择、权限模式不受影响
- [ ] 文件面板若仍有 Specs，应保持可打开（确认不是这次要改的对象）
- [x] `plugins-settings` 相关前端测试已通过
- [x] `chat-view` / `workspace-view` 中 Spec 模式相关断言已加上
