### PR TITLE
fix: 使用系统证书链校验修复企业网络插件下载失败

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ast_node"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "better_scoped_tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,7 +233,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -196,6 +241,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -735,6 +789,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +913,20 @@ checksum = "f3ba8041ae7319b3ca6a64c399df4112badcbbe0868b4517637647614bede4be"
 dependencies = [
  "once_cell",
  "termcolor",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2959,6 +3033,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3458,13 +3541,17 @@ dependencies = [
  "futures",
  "pretty_assertions",
  "quick-xml",
+ "rcgen",
  "reqwest 0.12.28",
+ "rustls",
+ "rustls-platform-verifier",
  "serde",
  "sha2",
  "tar",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-rustls",
  "unicode-normalization",
  "url",
  "windows-sys 0.61.2",
@@ -3541,6 +3628,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -4007,6 +4104,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rcgen"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4332,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -7060,6 +7180,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7104,6 +7242,16 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,11 @@ petgraph = "0.7"
 portable-pty = "0.9"
 pretty_assertions = "1"
 r2d2 = "0.8"
+rcgen = "0.14"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "stream"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-platform-verifier = "0.7"
 semver = "1"
 quick-xml = "0.41"
 sha2 = "0.10"
@@ -141,6 +144,7 @@ thiserror = "2"
 time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 tokio = "1"
 tokio-util = "0.7"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 toml = "1"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -10,13 +10,21 @@ workspace = true
 default = ["validation"]
 archive = ["dep:zip", "dep:tar", "dep:flate2"]
 http = ["dep:url", "dep:sha2"]
-http-reqwest = ["http", "dep:reqwest", "dep:tokio"]
+http-reqwest = [
+    "http",
+    "dep:reqwest",
+    "dep:rustls",
+    "dep:rustls-platform-verifier",
+    "dep:tokio",
+]
 validation = ["dep:sha2", "dep:quick-xml"]
 
 [dependencies]
 flate2 = { workspace = true, optional = true }
 quick-xml = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+rustls-platform-verifier = { workspace = true, optional = true }
 serde = { workspace = true }
 sha2 = { workspace = true, optional = true }
 tar = { workspace = true, optional = true }
@@ -34,8 +42,10 @@ windows-sys = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 pretty_assertions = { workspace = true }
+rcgen = { workspace = true }
 sha2 = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util"] }
+tokio-rustls = { workspace = true }
 zip = { workspace = true }

--- a/crates/utils/README.md
+++ b/crates/utils/README.md
@@ -25,9 +25,10 @@ that any other crate can consume without introducing dependency cycles.
 - `http-reqwest` (Cargo feature `http-reqwest`, implies `http`): the `reqwest`-backed
   `ReqwestDownloader` that streams remote HTTP(S) responses with timeouts, retries, progress,
   cancellation, and proxy resolution driven by explicit config and `*_PROXY`/`NO_PROXY` variables.
-  It trusts the operating system native certificate store (alongside the bundled webpki roots) so
-  downloads succeed behind corporate MITM proxies whose root CA is installed in the OS trust
-  store, and it preserves the full reqwest cause chain in network errors for diagnosability.
+  It uses Rustls with a platform-aware certificate verifier. On Windows, chain verification runs
+  through CryptoAPI, so enterprise roots and platform chain policy match Schannel-backed system
+  Git on the same machine. It also preserves the full reqwest cause chain in network errors for
+  diagnosability.
 - `html` (Cargo feature `validation`): conservative validation rejecting README text that embeds
   scriptable HTML (forbidden tags, `on*` event handlers, `javascript:`/`data:` URIs).
 - `svg` (Cargo feature `validation`): security validation for SVG icons — accepts well-formed

--- a/crates/utils/src/http/README.md
+++ b/crates/utils/src/http/README.md
@@ -23,7 +23,10 @@ Generic, domain-free download capability used by crates that fetch release artif
 ## Non-responsibilities
 
 - Choosing a concrete transport: only `http` is shipped by default; the network backend is opt-in.
-- TLS handling, redirect-target validation, resume, and digital-signature verification. The reqwest backend does, however, trust the operating system native certificate store (in addition to the bundled webpki roots) so it works behind corporate MITM proxies whose root CA is installed in the OS trust store, matching the behavior of a browser or `git` on the same machine.
+- Redirect-target validation, resume, and digital-signature verification. The reqwest backend uses
+  Rustls with a platform-aware verifier. On Windows, certificate-chain verification delegates to
+  CryptoAPI, so enterprise roots, intermediate-chain discovery, revocation decisions, and platform
+  distrust policy match Schannel-backed system Git on the same machine.
 - Concurrency budgeting across parallel installs; that is the orchestrator`s job.
 
 ## Key invariants

--- a/crates/utils/src/http/reqwest.rs
+++ b/crates/utils/src/http/reqwest.rs
@@ -10,6 +10,7 @@ use std::error::Error as StdError;
 use std::fs::File;
 use std::future::Future;
 use std::io::Write;
+use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
@@ -35,6 +36,7 @@ const FNV_OFFSET: u64 = 0xcbf29ce484222325;
 pub struct ReqwestDownloader {
     proxy_config: ProxyConfig,
     user_agent: String,
+    tls_extra_roots: Vec<rustls::pki_types::CertificateDer<'static>>,
 }
 
 impl ReqwestDownloader {
@@ -43,7 +45,18 @@ impl ReqwestDownloader {
         Self {
             proxy_config,
             user_agent: DEFAULT_USER_AGENT.to_owned(),
+            tls_extra_roots: Vec::new(),
         }
+    }
+
+    /// Adds a private CA root to explicit test trust for deterministic HTTPS regression tests.
+    #[cfg(test)]
+    pub(crate) fn with_extra_tls_root(
+        mut self,
+        root: rustls::pki_types::CertificateDer<'static>,
+    ) -> Self {
+        self.tls_extra_roots.push(root);
+        self
     }
 
     /// Builds a downloader with an explicit User-Agent, useful for gateway/CDN identification.
@@ -206,7 +219,16 @@ impl ReqwestDownloader {
         options: &DownloadOptions,
         url: &Url,
     ) -> Result<reqwest::Client, DownloadError> {
-        let mut builder = reqwest::Client::builder().user_agent(&self.user_agent);
+        let tls_config =
+            platform_tls_config(&self.tls_extra_roots).map_err(|error| DownloadError::Network {
+                url: url.clone(),
+                source: std::io::Error::other(format!(
+                    "failed to initialize platform TLS verification: {error}"
+                )),
+            })?;
+        let mut builder = reqwest::Client::builder()
+            .use_preconfigured_tls(tls_config)
+            .user_agent(&self.user_agent);
         if let Some(connect) = options.connect_timeout {
             builder = builder.connect_timeout(connect);
         }
@@ -218,6 +240,40 @@ impl ReqwestDownloader {
         }
         builder.build().map_err(|error| network_error(url, error))
     }
+}
+
+/// Builds a Rustls client with certificate verification adapted to the host platform.
+///
+/// Copying native roots into a WebPKI store is insufficient on Windows because it bypasses the
+/// CryptoAPI chain engine, including enterprise policy and intermediate discovery. The explicit
+/// roots branch is test-only so HTTPS behavior can be exercised without modifying machine trust.
+fn platform_tls_config(
+    extra_roots: &[rustls::pki_types::CertificateDer<'static>],
+) -> Result<rustls::ClientConfig, String> {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let verifier: Arc<dyn rustls::client::danger::ServerCertVerifier> = if extra_roots.is_empty() {
+        Arc::new(
+            rustls_platform_verifier::Verifier::new(Arc::clone(&provider))
+                .map_err(|error| error.to_string())?,
+        )
+    } else {
+        let mut roots = rustls::RootCertStore::empty();
+        for root in extra_roots.iter().cloned() {
+            roots.add(root).map_err(|error| error.to_string())?;
+        }
+        rustls::client::WebPkiServerVerifier::builder_with_provider(
+            Arc::new(roots),
+            Arc::clone(&provider),
+        )
+        .build()
+        .map_err(|error| error.to_string())?
+    };
+    Ok(rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|error| error.to_string())?
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_no_client_auth())
 }
 
 impl HttpDownload for ReqwestDownloader {

--- a/crates/utils/src/http/tests.rs
+++ b/crates/utils/src/http/tests.rs
@@ -259,8 +259,10 @@ mod reqwest_integration {
     };
     use pretty_assertions::assert_eq;
     use sha2::{Digest, Sha256};
+    use std::sync::Arc;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use tokio_rustls::TlsAcceptor;
     use url::Url;
 
     fn sha256_bytes(data: &[u8]) -> [u8; 32] {
@@ -287,6 +289,114 @@ mod reqwest_integration {
             let _ = socket.flush().await;
         });
         Url::parse(&format!("http://127.0.0.1:{port}/pkg.orax")).unwrap()
+    }
+
+    /// Serves one HTTPS response from a certificate signed by a private test CA.
+    async fn serve_https_once(
+        body: &'static [u8],
+    ) -> (Url, rustls::pki_types::CertificateDer<'static>) {
+        let ca_key = rcgen::KeyPair::generate().unwrap();
+        let mut ca_params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![
+            rcgen::KeyUsagePurpose::KeyCertSign,
+            rcgen::KeyUsagePurpose::CrlSign,
+        ];
+        let ca = rcgen::CertifiedIssuer::self_signed(ca_params, ca_key).unwrap();
+        let server_key = rcgen::KeyPair::generate().unwrap();
+        let mut server_params =
+            rcgen::CertificateParams::new(vec!["localhost".to_owned()]).unwrap();
+        server_params.key_usages = vec![rcgen::KeyUsagePurpose::DigitalSignature];
+        server_params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ServerAuth];
+        let server_cert = server_params.signed_by(&server_key, &ca).unwrap();
+        let private_key = rustls::pki_types::PrivatePkcs8KeyDer::from(server_key.serialize_der());
+        let server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![server_cert.der().clone()], private_key.into())
+            .unwrap();
+        let acceptor = TlsAcceptor::from(Arc::new(server_config));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let Ok(mut socket) = acceptor.accept(socket).await else {
+                return;
+            };
+            let mut buffer = [0_u8; 4096];
+            let _bytes_read = socket.read(&mut buffer).await.unwrap();
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/octet-stream\r\n\r\n",
+                body.len()
+            );
+            socket.write_all(header.as_bytes()).await.unwrap();
+            socket.write_all(body).await.unwrap();
+            let _flush_result = socket.flush().await;
+        });
+        (
+            Url::parse(&format!("https://localhost:{port}/pkg.orax")).unwrap(),
+            ca.der().clone(),
+        )
+    }
+
+    /// Downloads through a private CA when that CA is explicitly trusted by the test client.
+    #[tokio::test]
+    async fn downloads_from_explicitly_trusted_private_ca() {
+        let payload: &'static [u8] = b"enterprise release package";
+        let (url, ca_root) = serve_https_once(payload).await;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let destination = temp_dir.path().join("pkg.orax");
+        let downloader = ReqwestDownloader::new(Default::default()).with_extra_tls_root(ca_root);
+
+        let outcome = downloader
+            .download(DownloadRequest {
+                source: DownloadSource::Url(url),
+                destination: destination.clone(),
+                checksum: Some(Checksum::sha256(sha256_bytes(payload))),
+                options: DownloadOptions {
+                    max_retries: 0,
+                    ..DownloadOptions::default()
+                },
+                progress: None,
+                cancel: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.bytes, payload.len() as u64);
+        assert_eq!(std::fs::read(&destination).unwrap(), payload);
+    }
+
+    /// Rejects the same private CA when it has not been added to platform trust for the client.
+    #[tokio::test]
+    async fn rejects_untrusted_private_ca() {
+        let (url, _ca_root) = serve_https_once(b"untrusted release package").await;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let destination = temp_dir.path().join("pkg.orax");
+        let downloader = ReqwestDownloader::new(Default::default());
+
+        let error = downloader
+            .download(DownloadRequest {
+                source: DownloadSource::Url(url),
+                destination,
+                checksum: None,
+                options: DownloadOptions {
+                    max_retries: 0,
+                    ..DownloadOptions::default()
+                },
+                progress: None,
+                cancel: None,
+            })
+            .await
+            .unwrap_err();
+
+        let message = match error {
+            DownloadError::Network { source, .. } => source.to_string(),
+            other => panic!("expected network error, got {other:?}"),
+        };
+        assert!(
+            message.contains("invalid peer certificate"),
+            "expected certificate rejection, got: {message}"
+        );
     }
 
     /// Streams a payload from a loopback server into a destination and verifies bytes + checksum.


### PR DESCRIPTION
## 背景与问题

本 PR 修复 [Issue #512](https://github.com/ora-space/desktop/issues/512) 中“华为黄区点击下载插件失败”的问题。

Ora 从插件市场安装插件时，会由 `ReqwestDownloader` 通过 HTTPS 下载 `.orax` 发布包。HTTPS 是在普通 HTTP 之上增加加密和服务器身份校验的网络协议。现场日志显示连接在 HTTP 请求发出前就因 `invalid peer certificate: UnknownIssuer` 失败；`UnknownIssuer` 表示下载器无法建立从服务器证书到受信任根证书的完整“证书链”。

Issue 中的现场验证进一步明确了链路：

1. 直连 `codehub-y.huawei.com` 时，服务器只下发叶子证书，即直接代表该服务器身份的证书。
2. 签发它的 `HWIT Enterprise CA 1` 中间证书只存在于 Windows 的 Intermediate/CA 存储；其上级根证书存在于 Root 存储。
3. 原下载器使用 `reqwest + rustls-tls-native-roots`。该组合会把 Root 存储中的证书导入 Rustls/WebPKI，但不会让 Windows 证书链引擎从 Intermediate/CA 存储补齐缺失的中间证书。
4. 因为服务器没有下发中间证书，Rustls 无法把叶子证书连接到可信根证书，最终报告 `UnknownIssuer`。
5. Windows curl 使用 Schannel，可以通过 Windows 系统证书存储补齐链，因此访问同一地址能够返回 HTTP 200。

Rustls 是 Ora 使用的 TLS（网络加密与身份认证）实现；WebPKI 是它默认使用的证书规则验证器；Schannel 是 Windows 的 TLS 实现。

## 本次改动

- 为通用 HTTP 下载器接入 `rustls-platform-verifier`，继续使用 Rustls 传输数据，但根据运行平台选择证书验证方式。
- 在 Windows 上把服务器证书链交给 CryptoAPI 验证。CryptoAPI 是 Windows 提供的系统级密码与证书接口，其证书链引擎能够使用 Root 和 Intermediate/CA 等系统证书存储，补齐服务器未下发的中间证书。
- 显式配置 Ring 密码学实现，避免依赖图中同时出现多个 Rustls 密码学实现时产生不明确选择。
- 保留现有代理、超时、重试、下载大小限制、SHA-256 校验和原子替换逻辑。
- 增加本地 HTTPS 回归测试：使用测试专用私有 CA（证书颁发机构）签发服务器证书，验证显式受信任时能够下载，未受信任时仍然拒绝连接。
- 更新 `ora-utils` HTTP 模块文档，准确说明不同平台上的证书校验边界。

## 为什么这样解决

插件市场同步使用系统 Git，而插件包下载使用 Ora 内部的 reqwest/Rustls 下载器。系统 Git 在 Windows 上使用 Schannel 时能够完成证书链构建，但原下载器没有经过同一套 Windows 证书链决策，所以两条路径在企业网络中表现不一致。

本次修改保留 Rustls 作为传输实现，仅替换证书验证组件。在 Windows 上，`rustls-platform-verifier` 最终调用 CryptoAPI 的证书链能力，因此可以从系统 Intermediate/CA 存储找到 `HWIT Enterprise CA 1`，解决 Issue #512 中缺失中间证书导致的断链问题。

Issue 中记录的“为该 marketplace 源开启代理”能够作为现场临时绕过方案：代理会重新签发一条原 Rustls 能直接锚定的证书链。但它依赖华为黄区的特定代理、代理凭据和数据库配置，也会改变该源原本的直连路由语义，无法解决其他企业内网中同类的证书链问题。因此本 PR 选择修复证书验证边界，而不是强制修改 marketplace 源的代理选项。

## 安全性、权衡与取舍

- **没有关闭证书校验。** 未使用“接受无效证书”等绕过选项；主机名、证书有效期、证书用途和信任链仍会严格验证。
- **没有把整个 HTTP 客户端切换到平台原生 TLS。** 全量切换到 Schannel 会扩大跨平台行为差异和测试范围。本方案只替换证书验证边界，改动更集中。
- **不强制改变代理配置。** 代理是网络路由策略，不应成为修复本机证书链读取不完整的必要条件；直连和代理仍由现有配置决定。
- **保留跨平台 Rustls 传输。** Windows 使用 CryptoAPI 处理证书链；其他平台仍由 `rustls-platform-verifier` 选择对应的平台策略。
- **增加少量依赖成本。** 生产构建增加 Rustls 平台验证器；测试增加 `rcgen` 和 `tokio-rustls`，用于生成证书和启动本地 HTTPS 服务。相较依赖增长，确定性覆盖企业 CA 场景更有价值。
- **测试信任根不进入生产接口。** 私有 CA 注入方法仅在测试构建中可用，生产环境只读取操作系统信任配置。

## 验证

- `task format`
- `task lint:crates`
- `cargo test -p ora-utils --features http-reqwest`
- `task test:crates`
- `task test`

以上检查均通过。最终分支基于最新 `upstream/main`。

Closes #512