### PR TITLE
fix(agent): key the agent catalog by the whole plugin id

### DIFF
--- a/packages/app-shell/src/features/chat/agent-catalog.ts
+++ b/packages/app-shell/src/features/chat/agent-catalog.ts
@@ -10,8 +10,8 @@ import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
  */
 export interface AgentEntry {
   /**
-   * The agent's persisted, namespaced identity — the package name, which is exactly what a
-   * session stores as its `agentRef` and what the backend keys its runtime by.
+   * The agent's persisted, namespaced identity — the package's whole `namespace/name` id, which
+   * is exactly what a session stores as its `agentRef` and what the backend keys its runtime by.
    */
   agentRef: string;
   /** Name shown in the pickers, declared by the package's agent contribution. */
@@ -34,9 +34,9 @@ export function useAgentCatalog(): AgentEntry[] {
       (plugins ?? [])
         .filter((plugin) => plugin.kind === "agent")
         .map((plugin) => ({
-          // Supervisors are keyed by the package name rather than its `namespace/name` address,
-          // because the name alone is what every session persisted as its binding.
-          agentRef: plugin.name,
+          // Supervisors are keyed by the package's whole `namespace/name` address: two sources
+          // may publish the same name, and the name alone would collapse them into one agent.
+          agentRef: plugin.id,
           label: plugin.agentDisplayName,
           logo: plugin.logo,
         })),

--- a/packages/app-shell/src/features/chat/model-selector.test.tsx
+++ b/packages/app-shell/src/features/chat/model-selector.test.tsx
@@ -25,11 +25,12 @@ import { usePendingAgentStore } from "../../state/stores/pending-agent-store";
 import type { AgentStatus } from "@ora/contracts";
 import { ModelSelector } from "./model-selector";
 import { queryKeys } from "../../state/hooks/query-keys";
+import { AGENT_REF } from "../../test/agent-identity";
 
 beforeEach(() => {
   useWorkspaceSelectionStore.getState().clearSelection();
   useSettingsStore.setState({
-    settings: { ...DEFAULT_SETTINGS, agentCli: "ora-space.opencode" },
+    settings: { ...DEFAULT_SETTINGS, agentCli: AGENT_REF.opencode },
   });
   usePendingAgentStore.setState({ selections: {} });
 });
@@ -38,7 +39,7 @@ beforeEach(() => {
 function reportOpenCode(status: AgentStatus) {
   return (state: MockClientState) => {
     state.agentRuntimeStatuses = state.agentRuntimeStatuses.map((candidate) =>
-      candidate.agentRef === "ora-space.opencode"
+      candidate.agentRef === AGENT_REF.opencode
         ? { ...candidate, status }
         : candidate,
     );
@@ -177,7 +178,7 @@ describe("ModelSelector agent availability", () => {
     const user = userEvent.setup();
     renderModelSelector((state) => {
       state.agentRuntimeStatuses = state.agentRuntimeStatuses.filter(
-        (status) => status.agentRef !== "ora-space.opencode",
+        (status) => status.agentRef !== AGENT_REF.opencode,
       );
     });
 
@@ -190,7 +191,7 @@ describe("ModelSelector agent availability", () => {
     expect(within(picker()).queryByText("OpenCode")).toBeNull();
     expect(picker().querySelectorAll("svg")).toHaveLength(1);
     expect(useSettingsStore.getState().settings.agentCli).toBe(
-      "ora-space.opencode",
+      AGENT_REF.opencode,
     );
   });
 
@@ -203,7 +204,7 @@ describe("ModelSelector agent availability", () => {
       expect(within(picker()).queryByText("OpenCode")).toBeNull(),
     );
     expect(useSettingsStore.getState().settings.agentCli).toBe(
-      "ora-space.opencode",
+      AGENT_REF.opencode,
     );
     expect(picker().querySelectorAll("svg")).toHaveLength(1);
   });

--- a/packages/app-shell/src/features/chat/session-agent-banner.test.tsx
+++ b/packages/app-shell/src/features/chat/session-agent-banner.test.tsx
@@ -15,6 +15,7 @@ import { useAgentRuntimeStatus } from "../../state/hooks/use-agent-runtime-statu
 import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
 import { useUiStore } from "../../state/stores/ui-store";
 import { SessionAgentBanner } from "./session-agent-banner";
+import { AGENT_REF, officialAgentRef } from "../../test/agent-identity";
 
 /**
  * The runtime half of an installed package.
@@ -33,7 +34,7 @@ function agentPlugin(
   runtime: PluginRuntime = { runtime: "running" },
 ): InstalledPlugin {
   return {
-    id: "official/ora-space.reviewer",
+    id: officialAgentRef("ora-space.reviewer"),
     namespace: "official",
     name: "ora-space.reviewer",
     description: "ora-space.reviewer plugin",
@@ -113,7 +114,7 @@ describe("SessionAgentBanner", () => {
   });
 
   it("reports an agent whose package is gone as uninstalled", async () => {
-    renderBanner([], session("ora-space.reviewer"));
+    renderBanner([], session(officialAgentRef("ora-space.reviewer")));
 
     expect(await screen.findByRole("alert")).toHaveAttribute(
       "data-agent-availability",
@@ -122,7 +123,7 @@ describe("SessionAgentBanner", () => {
   });
 
   it("offers a marketplace button when the agent's package is gone", async () => {
-    renderBanner([], session("ora-space.reviewer"));
+    renderBanner([], session(officialAgentRef("ora-space.reviewer")));
     const user = userEvent.setup();
 
     const button = await screen.findByRole("button", {
@@ -135,14 +136,17 @@ describe("SessionAgentBanner", () => {
   });
 
   it("stays silent for a built-in CLI, which has no plugin package", async () => {
-    renderBanner([], session("ora-space.nga"));
+    renderBanner([], session(AGENT_REF.nga));
 
     await screen.findByTestId("availability-settled");
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("stays silent while an installed plugin is serving the session", async () => {
-    renderBanner([agentPlugin()], session("ora-space.reviewer"));
+    renderBanner(
+      [agentPlugin()],
+      session(officialAgentRef("ora-space.reviewer")),
+    );
 
     await screen.findByTestId("availability-settled");
     expect(screen.queryByRole("alert")).toBeNull();
@@ -156,7 +160,7 @@ describe("SessionAgentBanner", () => {
           failureReason: "deno exited with 1",
         }),
       ],
-      session("ora-space.reviewer"),
+      session(officialAgentRef("ora-space.reviewer")),
     );
 
     const alert = await screen.findByRole("alert");

--- a/packages/app-shell/src/features/chat/session-agent-banner.tsx
+++ b/packages/app-shell/src/features/chat/session-agent-banner.tsx
@@ -96,8 +96,8 @@ function AgentUnavailableBanner({
 /**
  * Decides whether a session's agent is currently servable, and why it is not.
  *
- * An agent package supplies exactly one agent under its plugin name (the
- * `name` segment of its id), which is the same value a session persists as its
+ * An agent package supplies exactly one agent under its whole plugin id
+ * (`namespace/name`), which is the same value a session persists as its
  * binding, so the two are matched directly; ui packages contribute no agent.
  * An identity no plugin claims is only reported as uninstalled when the runtime
  * does not supervise it either — a built-in CLI has no plugin row and must not
@@ -116,7 +116,7 @@ function resolveAvailability(
   }
   const plugin = plugins.find(
     (installed) =>
-      installed.kind === "agent" && installed.name === session.agentRef,
+      installed.kind === "agent" && installed.id === session.agentRef,
   );
   if (plugin === undefined) {
     if (

--- a/packages/app-shell/src/features/settings/plugin-manager.tsx
+++ b/packages/app-shell/src/features/settings/plugin-manager.tsx
@@ -182,7 +182,7 @@ function InstalledPluginRow({
   const update = useUpdatePlugin(plugin.id);
   const mutations = usePluginMutations(
     plugin.id,
-    plugin.kind === "agent" ? plugin.name : undefined,
+    plugin.kind === "agent" ? plugin.id : undefined,
   );
   const uninstalling = mutations.uninstall.isPending;
   const busy = uninstalling || update.isPending;

--- a/packages/app-shell/src/features/surface/surface-definitions.test.ts
+++ b/packages/app-shell/src/features/surface/surface-definitions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { InstalledPlugin } from "@ora/contracts";
 import { listSurfaceDefinitions } from "./surface-definitions";
+import { officialAgentRef } from "../../test/agent-identity";
 
 /** Builds one installed webview plugin (external site). */
 function webviewPlugin(
@@ -101,7 +102,7 @@ describe("listSurfaceDefinitions", () => {
         logo: null,
       },
       {
-        pluginId: "official/ora-space.tools",
+        pluginId: officialAgentRef("ora-space.tools"),
         kind: "webview",
         title: "X",
         pluginDisplayName: "Tools",

--- a/packages/app-shell/src/features/workflow-editor/workflow-editor.test.tsx
+++ b/packages/app-shell/src/features/workflow-editor/workflow-editor.test.tsx
@@ -40,6 +40,7 @@ import { useCreateWorkflow, useDeleteWorkflow } from "./workflow-definitions";
 import { WorkflowEditor } from "./workflow-editor";
 import { WorkflowEditorList } from "./workflow-editor-list";
 import { useWorkflowEditorStore } from "./workflow-editor-store";
+import { AGENT_REF } from "../../test/agent-identity";
 
 /** Seeds the mock client with the demo workflows and their published versions. */
 function seedDemoWorkflows(state: MockClientState): void {
@@ -928,7 +929,7 @@ describe("WorkflowEditor", () => {
     const configuredParameters = within(reviewNode).getByLabelText("配置参数");
     expect(configuredParameters).toHaveTextContent("角色Reviewer");
     expect(configuredParameters).toHaveTextContent(
-      "ora-space.codeagentcli · opencode/big-pickle",
+      `${AGENT_REF.codeagentcli} · opencode/big-pickle`,
     );
     expect(configuredParameters).toHaveTextContent("Skillscode-defect-scan");
     expect(configuredParameters).not.toHaveTextContent(
@@ -1041,7 +1042,7 @@ describe("WorkflowEditor", () => {
     // NGA exists as a CLI but reports no model catalog, so
     // picking it must keep the node on NGA instead of snapping back to the
     // first CLI with discovered models.
-    state.agentModelsByCli = { "ora-space.nga": null };
+    state.agentModelsByCli = { [AGENT_REF.nga]: null };
     renderEditor(<WorkflowEditor />, state);
 
     const reviewNode = await screen.findByLabelText("Agent节点: 审查 Agent");
@@ -1075,7 +1076,7 @@ describe("WorkflowEditor", () => {
       await screen.findByLabelText("Agent节点: Agent 1"),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByText("ora-space.opencode · opencode/big-pickle").length,
+      screen.getAllByText(`${AGENT_REF.opencode} · opencode/big-pickle`).length,
     ).toBeGreaterThan(0);
   });
 

--- a/packages/app-shell/src/features/workflow-editor/workflow-inspector.test.tsx
+++ b/packages/app-shell/src/features/workflow-editor/workflow-inspector.test.tsx
@@ -10,6 +10,7 @@ import {
 import { appI18n } from "../../i18n/i18n-instance";
 import { AppI18nProvider } from "../../i18n/i18n";
 import { WorkflowInspector } from "./workflow-inspector";
+import { AGENT_REF } from "../../test/agent-identity";
 
 const LONG_MODEL_LABEL =
   "OpenCode · deepseek/deepseek-v4-pro-with-an-extremely-long-model-identifier";
@@ -27,7 +28,7 @@ function createAgentNode(): Node<WorkflowNodeData, "workflow"> {
       agentConfig: {
         schemaVersion: 3,
         executor: {
-          agentCli: "ora-space.opencode",
+          agentCli: AGENT_REF.opencode,
           modelId:
             "deepseek/deepseek-v4-pro-with-an-extremely-long-model-identifier",
         },
@@ -133,7 +134,7 @@ function createStartNode(): Node<WorkflowNodeData, "workflow"> {
 function renderNarrowInspector(): HTMLElement {
   const capabilities = createMockWorkflowCapabilities("zh-CN", [
     {
-      agentCli: "ora-space.opencode",
+      agentCli: AGENT_REF.opencode,
       modelId:
         "deepseek/deepseek-v4-pro-with-an-extremely-long-model-identifier",
       label: LONG_MODEL_LABEL,

--- a/packages/app-shell/src/features/workflow-run/agent-config-display.test.ts
+++ b/packages/app-shell/src/features/workflow-run/agent-config-display.test.ts
@@ -6,10 +6,11 @@ import {
 } from "./agent-config-display";
 import type { WorkflowNodeData } from "@ora/workflow-runtime";
 import type { AgentEntry } from "../chat/agent-catalog";
+import { AGENT_REF } from "../../test/agent-identity";
 
 /** The installed agent packages these summaries are rendered against. */
 const AGENTS: AgentEntry[] = [
-  { agentRef: "ora-space.opencode", label: "OpenCode", logo: null },
+  { agentRef: AGENT_REF.opencode, label: "OpenCode", logo: null },
 ];
 
 describe("agent-config-display", () => {
@@ -17,7 +18,7 @@ describe("agent-config-display", () => {
     expect(
       formatAgentExecutorLabel(
         {
-          agentCli: "ora-space.opencode",
+          agentCli: AGENT_REF.opencode,
           modelId: "deepseek/deepseek-v4-pro",
         },
         AGENTS,
@@ -33,7 +34,7 @@ describe("agent-config-display", () => {
       agentConfig: {
         schemaVersion: 3,
         executor: {
-          agentCli: "ora-space.opencode",
+          agentCli: AGENT_REF.opencode,
           modelId: "deepseek/deepseek-v4-flash",
         },
         roleId: "researcher",
@@ -67,7 +68,7 @@ describe("agent-config-display", () => {
       condition: "contains source changes",
       agentConfig: {
         schemaVersion: 3,
-        executor: { agentCli: "ora-space.opencode", modelId: "ignored" },
+        executor: { agentCli: AGENT_REF.opencode, modelId: "ignored" },
         roleId: "reviewer",
         skills: [],
         mcps: [],

--- a/packages/app-shell/src/features/workflow-run/run-act-inspector.test.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-act-inspector.test.tsx
@@ -13,6 +13,7 @@ import {
 import { appI18n } from "../../i18n/i18n-instance";
 import { RunActInspector } from "./run-act-inspector";
 import type { WorkflowNodeData } from "@ora/workflow-runtime";
+import { AGENT_REF } from "../../test/agent-identity";
 
 const AGENT_DATA: WorkflowNodeData = {
   kind: "agent",
@@ -21,7 +22,7 @@ const AGENT_DATA: WorkflowNodeData = {
   agentConfig: {
     schemaVersion: 3,
     executor: {
-      agentCli: "ora-space.opencode",
+      agentCli: AGENT_REF.opencode,
       modelId: "deepseek/deepseek-v4-pro",
     },
     roleId: "研究员",

--- a/packages/app-shell/src/features/workflow-run/run-theater-act-card.test.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-theater-act-card.test.tsx
@@ -19,6 +19,7 @@ import {
   createMockClientState,
 } from "../../test/mock-client";
 import { RunTheaterActCard } from "./run-theater-act-card";
+import { AGENT_REF } from "../../test/agent-identity";
 
 const NODE_DATA: WorkflowNodeData = {
   kind: "agent",
@@ -176,7 +177,7 @@ describe("RunTheaterActCard conversation", () => {
           agentConfig: {
             schemaVersion: 3,
             executor: {
-              agentCli: "ora-space.opencode",
+              agentCli: AGENT_REF.opencode,
               modelId: "deepseek/deepseek-v4-flash",
             },
             roleId: "researcher",

--- a/packages/app-shell/src/features/workspace/agent-picker-isolation.test.tsx
+++ b/packages/app-shell/src/features/workspace/agent-picker-isolation.test.tsx
@@ -24,6 +24,7 @@ import {
 import { usePendingAgentStore } from "../../state/stores/pending-agent-store";
 import { WorkspaceSidebar } from "./workspace-sidebar";
 import { WorkspaceView } from "./workspace-view";
+import { AGENT_REF } from "../../test/agent-identity";
 
 const USER = { name: "Eric", email: "eric@example.com" };
 const PROJECT: Project = { id: "p1", name: "Ora Desktop" };
@@ -44,7 +45,7 @@ beforeEach(() => {
   useWorkspaceSelectionStore.getState().clearSelection();
   useDraftSessionsStore.getState().clear();
   useSettingsStore.setState({
-    settings: { ...DEFAULT_SETTINGS, agentCli: "ora-space.opencode" },
+    settings: { ...DEFAULT_SETTINGS, agentCli: AGENT_REF.opencode },
   });
   usePendingAgentStore.setState({ selections: {} });
 });

--- a/packages/app-shell/src/features/workspace/chat-interaction.test.tsx
+++ b/packages/app-shell/src/features/workspace/chat-interaction.test.tsx
@@ -21,6 +21,7 @@ import { useDraftSessionsStore } from "../../state/stores/draft-sessions-store";
 import { usePendingAgentStore } from "../../state/stores/pending-agent-store";
 import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
 import { WorkspaceView } from "./workspace-view";
+import { AGENT_REF } from "../../test/agent-identity";
 
 /** Builds one assistant text frame in the same shape as the generated ACP client. */
 function assistantText(
@@ -70,7 +71,7 @@ describe("chat interaction MVP", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },

--- a/packages/app-shell/src/features/workspace/workspace-dialogs.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-dialogs.test.tsx
@@ -23,6 +23,7 @@ import { useUiStore } from "../../state/stores/ui-store";
 import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
 import { useDraftSessionsStore } from "../../state/stores/draft-sessions-store";
 import { WorkspaceDialogs } from "./workspace-dialogs";
+import { AGENT_REF } from "../../test/agent-identity";
 
 beforeEach(() => {
   useUiStore.getState().setDialog(null);
@@ -361,7 +362,7 @@ describe("WorkspaceDialogs project deletion", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -369,7 +370,7 @@ describe("WorkspaceDialogs project deletion", () => {
       {
         id: "s2",
         workspaceId: "workspace-t2",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -446,7 +447,7 @@ describe("WorkspaceDialogs task deletion", () => {
     state.sessions = sessionIds.map((id): Session => ({
       id,
       workspaceId: "workspace-t1",
-      agentRef: "ora-space.opencode",
+      agentRef: AGENT_REF.opencode,
       status: "running",
       title: null,
       historyState: { type: "writable" },

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
@@ -42,6 +42,7 @@ import { useUnreadSessionsStore } from "../../state/stores/unread-sessions-store
 import { dismissSessionDraft } from "../../state/session-drafts";
 import { WorkspaceSidebar } from "./workspace-sidebar";
 import { useWorkflowEditorStore } from "../workflow-editor/workflow-editor-store";
+import { AGENT_REF } from "../../test/agent-identity";
 
 const USER = { name: "Eric", email: "eric@example.com" };
 // Deliberately not "Ora": the sidebar header renders that as the product mark,
@@ -56,7 +57,7 @@ const TASK: Task = {
 const SESSION: Session = {
   id: "s1",
   workspaceId: "workspace-t1",
-  agentRef: "ora-space.opencode",
+  agentRef: AGENT_REF.opencode,
   status: "running",
   title: null,
   historyState: { type: "writable" },
@@ -64,7 +65,7 @@ const SESSION: Session = {
 const DIRECT_SESSION: Session = {
   id: "s-direct",
   workspaceId: "workspace-p1",
-  agentRef: "ora-space.opencode",
+  agentRef: AGENT_REF.opencode,
   status: "running",
   title: null,
   historyState: { type: "writable" },
@@ -678,7 +679,7 @@ describe("WorkspaceSidebar", () => {
     state.sessions.push({
       id: "s2",
       workspaceId: "workspace-p1",
-      agentRef: "ora-space.opencode",
+      agentRef: AGENT_REF.opencode,
       status: "running",
       title: null,
       historyState: { type: "writable" },
@@ -1410,7 +1411,7 @@ describe("WorkspaceSidebar", () => {
       {
         id: "s2",
         workspaceId: "workspace-p1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: "Direct chat",
         historyState: { type: "writable" },

--- a/packages/app-shell/src/features/workspace/workspace-view.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-view.test.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../state/stores/settings-store";
 import { WorkspaceView } from "./workspace-view";
 import { directChatTitle } from "./workspace-view-utils";
+import { AGENT_REF } from "../../test/agent-identity";
 
 function composerText(element: HTMLElement): string {
   return element.dataset.composerText ?? "";
@@ -58,7 +59,7 @@ beforeEach(() => {
   // the next one a surface already pointing somewhere it never chose.
   usePendingAgentStore.setState({ selections: {}, switches: {} });
   useSettingsStore.setState({
-    settings: { ...DEFAULT_SETTINGS, agentCli: "ora-space.opencode" },
+    settings: { ...DEFAULT_SETTINGS, agentCli: AGENT_REF.opencode },
   });
 });
 
@@ -78,7 +79,7 @@ describe("WorkspaceView", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -202,7 +203,7 @@ describe("WorkspaceView", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -259,7 +260,7 @@ describe("WorkspaceView", () => {
       {
         id: "s1",
         workspaceId: "workspace-p1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -360,7 +361,7 @@ describe("WorkspaceView", () => {
 
     await waitFor(() => expect(textbox).toBeEnabled());
     expect(useSettingsStore.getState().settings.agentCli).toBe(
-      "ora-space.opencode",
+      AGENT_REF.opencode,
     );
   });
 
@@ -369,7 +370,7 @@ describe("WorkspaceView", () => {
     const state = createMockClientState();
     state.projects = [{ id: "p1", name: "Ora" }];
     const entry = state.agentRuntimeStatuses.find(
-      (candidate) => candidate.agentRef === "ora-space.opencode",
+      (candidate) => candidate.agentRef === AGENT_REF.opencode,
     );
     entry!.status = "unavailable";
     const client = createMockClient(state);
@@ -571,7 +572,7 @@ describe("WorkspaceView", () => {
         {
           id: "s1",
           workspaceId: "workspace-p1",
-          agentRef: "ora-space.opencode",
+          agentRef: AGENT_REF.opencode,
           status: "running",
           title: null,
           historyState: { type: "writable" },
@@ -840,7 +841,7 @@ describe("WorkspaceView", () => {
       {
         id: "s-other",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: "Other",
         historyState: { type: "writable" },
@@ -1016,7 +1017,7 @@ describe("WorkspaceView", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -1261,7 +1262,7 @@ describe("WorkspaceView", () => {
       expect(started).toEqual([
         {
           workspaceId: "workspace-p1",
-          agentRef: "ora-space.opencode",
+          agentRef: AGENT_REF.opencode,
           model: "opencode/small-pickle",
         },
       ]),
@@ -1285,7 +1286,7 @@ describe("WorkspaceView", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -1416,7 +1417,7 @@ describe("WorkspaceView", () => {
             request,
             options,
           );
-          if (request.agentRef !== "ora-space.claude") return response;
+          if (request.agentRef !== AGENT_REF.claude) return response;
           return {
             ...response,
             models: [
@@ -1447,7 +1448,7 @@ describe("WorkspaceView", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -1499,7 +1500,7 @@ describe("WorkspaceView", () => {
     // Rebinding here would tear down an agent that may be mid-reply, so nothing
     // is asked of the backend until the next message carries the move.
     expect(switched).toEqual([]);
-    expect(state.sessions[0]?.agentRef).toBe("ora-space.opencode");
+    expect(state.sessions[0]?.agentRef).toBe(AGENT_REF.opencode);
   });
 
   it("commits a recorded agent move with the next message", async () => {
@@ -1537,10 +1538,10 @@ describe("WorkspaceView", () => {
     await user.keyboard("{Enter}");
 
     await waitFor(() =>
-      expect(state.sessions[0]?.agentRef).toBe("ora-space.claude"),
+      expect(state.sessions[0]?.agentRef).toBe(AGENT_REF.claude),
     );
     expect(switched).toEqual([
-      { sessionId: "s1", agentRef: "ora-space.claude", model: null },
+      { sessionId: "s1", agentRef: AGENT_REF.claude, model: null },
     ]);
   });
 
@@ -1585,7 +1586,7 @@ describe("WorkspaceView", () => {
     // Asking the backend to move a session onto its own agent is refused with
     // `session_agent_unchanged`, which would have failed the message with it.
     expect(switched).toEqual([]);
-    expect(state.sessions[0]?.agentRef).toBe("ora-space.opencode");
+    expect(state.sessions[0]?.agentRef).toBe(AGENT_REF.opencode);
   });
 
   it("resumes a session whose history stopped recording", async () => {
@@ -1604,7 +1605,7 @@ describe("WorkspaceView", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "degraded", reason: "no space left on device" },

--- a/packages/app-shell/src/state/hooks/use-available-agents.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-available-agents.test.tsx
@@ -9,26 +9,33 @@ import {
 import { renderHookWithClient } from "../../test/hook-harness";
 import { useAgentRuntimeStatus } from "./use-agent-runtime-status";
 import { useAvailableAgents } from "./use-available-agents";
+import { AGENT_REF } from "../../test/agent-identity";
 
-/** Every agent the seeded installation supplies, in the order its packages are listed. */
+/**
+ * Every agent the seeded installation supplies, in the order its packages are listed.
+ *
+ * These are whole `namespace/name` ids, because that is what the runtime keys a supervised agent
+ * by and what a session persists as its binding. A catalog spelling the bare name instead would
+ * offer agents no session could ever be bound to.
+ */
 const INSTALLED = [
-  "ora-space.opencode",
-  "ora-space.nga",
-  "ora-space.codeagentcli",
-  "ora-space.claude",
-  "ora-space.codex",
+  AGENT_REF.opencode,
+  AGENT_REF.nga,
+  AGENT_REF.codeagentcli,
+  AGENT_REF.claude,
+  AGENT_REF.codex,
 ];
 
 /** The installed set without OpenCode, which every "one agent is missing" case here drops. */
 const WITHOUT_OPENCODE = INSTALLED.filter(
-  (agentRef) => agentRef !== "ora-space.opencode",
+  (agentRef) => agentRef !== AGENT_REF.opencode,
 );
 
 /** Replaces what the runtime reports about one agent, leaving the rest detected. */
 function reportOpenCode(status: AgentStatus) {
   return (state: MockClientState) => {
     const entry = state.agentRuntimeStatuses.find(
-      (candidate) => candidate.agentRef === "ora-space.opencode",
+      (candidate) => candidate.agentRef === AGENT_REF.opencode,
     );
     entry!.status = status;
   };
@@ -76,10 +83,36 @@ describe("useAvailableAgents", () => {
     );
 
     expect(result.current.offered[0]).toEqual({
-      agentRef: "ora-space.opencode",
+      agentRef: AGENT_REF.opencode,
       label: "OpenCode",
       logo: null,
     });
+  });
+
+  it("identifies each offered agent the way the runtime keys it, not by the package name", async () => {
+    const state = createMockClientState();
+    const { result } = renderHookWithClient(
+      () => ({
+        offered: useAvailableAgents(),
+        statuses: useAgentRuntimeStatus(),
+      }),
+      createMockClient(state),
+    );
+    await waitFor(() => expect(result.current.statuses.isSuccess).toBe(true));
+    await waitFor(() =>
+      expect(result.current.offered.length).toBeGreaterThan(0),
+    );
+
+    // The catalog and the runtime are two independently written halves of one identity, and a
+    // session binds to whichever the picker hands it. Asserting the offered set against the
+    // installed ids and the supervised refs at once is what makes a drift between the halves
+    // fail here rather than at `session/load`, where it surfaces as "agent is not installed".
+    expect(result.current.offered.map((agent) => agent.agentRef)).toEqual(
+      state.installedPlugins.map((plugin) => plugin.id),
+    );
+    expect(result.current.offered.map((agent) => agent.agentRef)).toEqual(
+      state.agentRuntimeStatuses.map((status) => status.agentRef),
+    );
   });
 
   it("offers an agent still completing its handshake", async () => {
@@ -102,7 +135,7 @@ describe("useAvailableAgents", () => {
     expect(
       await offeredAgents((state) => {
         state.agentRuntimeStatuses = state.agentRuntimeStatuses.filter(
-          (status) => status.agentRef !== "ora-space.opencode",
+          (status) => status.agentRef !== AGENT_REF.opencode,
         );
       }),
     ).toEqual(WITHOUT_OPENCODE);
@@ -115,7 +148,7 @@ describe("useAvailableAgents", () => {
           (plugin) => plugin.name !== "ora-space.claude",
         );
       }),
-    ).toEqual(INSTALLED.filter((agentRef) => agentRef !== "ora-space.claude"));
+    ).toEqual(INSTALLED.filter((agentRef) => agentRef !== AGENT_REF.claude));
   });
 
   it("offers the whole installed catalog while the detection status is still loading", async () => {

--- a/packages/app-shell/src/state/hooks/use-plugin-mutations.ts
+++ b/packages/app-shell/src/state/hooks/use-plugin-mutations.ts
@@ -34,7 +34,7 @@ export function usePluginMutations(pluginId: string, agentRef?: string) {
     scope: "availability" | "models",
   ) =>
     plugin.kind === "agent"
-      ? refreshAgent(plugin.name, scope)
+      ? refreshAgent(plugin.id, scope)
       : Promise.resolve([]);
 
   const activate = useMutation({

--- a/packages/app-shell/src/state/hooks/use-target-agent-readiness.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-target-agent-readiness.test.tsx
@@ -13,6 +13,7 @@ import { renderHookWithClient } from "../../test/hook-harness";
 import { DEFAULT_SETTINGS, useSettingsStore } from "../stores/settings-store";
 import { usePendingAgentStore } from "../stores/pending-agent-store";
 import { useTargetAgentReadiness } from "./use-target-agent-readiness";
+import { AGENT_REF } from "../../test/agent-identity";
 
 /** The project-only surface every case here resolves: no session, no task. */
 const PROJECT_SELECTION = { projectId: "p1", taskId: null, sessionId: null };
@@ -23,7 +24,7 @@ const PROJECT_SELECTION = { projectId: "p1", taskId: null, sessionId: null };
  */
 beforeEach(() => {
   useSettingsStore.setState({
-    settings: { ...DEFAULT_SETTINGS, agentCli: "ora-space.opencode" },
+    settings: { ...DEFAULT_SETTINGS, agentCli: AGENT_REF.opencode },
   });
   usePendingAgentStore.setState({ selections: {}, switches: {} });
 });
@@ -32,7 +33,7 @@ beforeEach(() => {
 function reportOpenCode(status: AgentStatus) {
   return (state: MockClientState) => {
     const entry = state.agentRuntimeStatuses.find(
-      (candidate) => candidate.agentRef === "ora-space.opencode",
+      (candidate) => candidate.agentRef === AGENT_REF.opencode,
     );
     entry!.status = status;
   };
@@ -79,7 +80,7 @@ describe("useTargetAgentReadiness", () => {
     expect(
       await readiness((state) => {
         state.agentRuntimeStatuses = state.agentRuntimeStatuses.filter(
-          (status) => status.agentRef !== "ora-space.opencode",
+          (status) => status.agentRef !== AGENT_REF.opencode,
         );
       }),
     ).toBe("blocked");

--- a/packages/app-shell/src/state/hooks/use-workspace-diff-live-sync.test.ts
+++ b/packages/app-shell/src/state/hooks/use-workspace-diff-live-sync.test.ts
@@ -14,11 +14,12 @@ import {
 } from "../../test/mock-client";
 import { queryKeys } from "./query-keys";
 import { useWorkspaceDiffLiveSync } from "./use-workspace-diff-live-sync";
+import { AGENT_REF } from "../../test/agent-identity";
 
 const SESSION: Session = {
   id: "session-1",
   workspaceId: "workspace-1",
-  agentRef: "ora-space.codeagentcli",
+  agentRef: AGENT_REF.codeagentcli,
   status: "running",
   title: null,
   historyState: { type: "writable" },

--- a/packages/app-shell/src/state/hooks/use-workspace-mutations.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-workspace-mutations.test.tsx
@@ -19,6 +19,7 @@ import {
   useDeleteTask,
   useRenameSession,
 } from "./use-workspace-mutations";
+import { AGENT_REF } from "../../test/agent-identity";
 
 beforeEach(() => {
   useDraftSessionsStore.getState().clear();
@@ -33,7 +34,7 @@ describe("useRenameSession", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: "Old",
         historyState: { type: "writable" },
@@ -68,7 +69,7 @@ describe("delete mutations clear parked composer state", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -76,7 +77,7 @@ describe("delete mutations clear parked composer state", () => {
       {
         id: "s2",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -105,7 +106,7 @@ describe("delete mutations clear parked composer state", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -143,7 +144,7 @@ describe("delete mutations clear parked composer state", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -191,7 +192,7 @@ describe("delete mutations clear parked composer state", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -243,7 +244,7 @@ describe("delete mutations clear parked composer state", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },

--- a/packages/app-shell/src/state/hooks/workspace-queries.test.ts
+++ b/packages/app-shell/src/state/hooks/workspace-queries.test.ts
@@ -8,6 +8,7 @@ import {
   createMockClientState,
 } from "../../test/mock-client";
 import { renderHookWithClient } from "../../test/hook-harness";
+import { AGENT_REF } from "../../test/agent-identity";
 
 describe("useProjects", () => {
   it("returns the project list from the client", async () => {
@@ -72,7 +73,7 @@ describe("useSessions", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },
@@ -85,7 +86,7 @@ describe("useSessions", () => {
       {
         id: "s1",
         workspaceId: "workspace-t1",
-        agentRef: "ora-space.opencode",
+        agentRef: AGENT_REF.opencode,
         status: "running",
         title: null,
         historyState: { type: "writable" },

--- a/packages/app-shell/src/state/stores/settings-store.test.ts
+++ b/packages/app-shell/src/state/stores/settings-store.test.ts
@@ -7,6 +7,7 @@ import {
   type SettingsPreferences,
   type ThemeApplier,
 } from "./settings-store";
+import { AGENT_REF } from "../../test/agent-identity";
 
 const STORAGE_KEY = "ora.settings.v1";
 
@@ -45,13 +46,13 @@ describe("useSettingsStore", () => {
   });
 
   it("persists settings to localStorage under the v1 key", () => {
-    useSettingsStore.getState().updateSettings({ agentCli: "ora-space.nga" });
+    useSettingsStore.getState().updateSettings({ agentCli: AGENT_REF.nga });
     const raw = window.localStorage.getItem(STORAGE_KEY);
     expect(raw).not.toBeNull();
     const parsed = JSON.parse(raw!) as {
       state: { settings: SettingsPreferences };
     };
-    expect(parsed.state.settings.agentCli).toBe("ora-space.nga");
+    expect(parsed.state.settings.agentCli).toBe(AGENT_REF.nga);
   });
 
   it("merges persisted partial settings over defaults via the merge strategy", () => {
@@ -72,6 +73,8 @@ describe("useSettingsStore", () => {
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
+        // Version 1 persisted the bare package name, which is the spelling the
+        // migration has to recognize as the former implicit default.
         state: { settings: { theme: "light", agentCli: "ora-space.opencode" } },
         version: 1,
       }),

--- a/packages/app-shell/src/state/stores/ui-store.test.ts
+++ b/packages/app-shell/src/state/stores/ui-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { useUiStore, UI_STORAGE_KEY } from "./ui-store";
 import { flushDebouncedPersistStorage } from "./debounced-json-storage";
 import type { Session } from "@ora/contracts";
+import { AGENT_REF } from "../../test/agent-identity";
 
 beforeEach(() => {
   flushDebouncedPersistStorage();
@@ -236,7 +237,7 @@ describe("useUiStore", () => {
     const session: Session = {
       id: "s1",
       workspaceId: "workspace-t1",
-      agentRef: "ora-space.opencode",
+      agentRef: AGENT_REF.opencode,
       status: "running",
       title: null,
       historyState: { type: "writable" },

--- a/packages/app-shell/src/test/agent-identity.ts
+++ b/packages/app-shell/src/test/agent-identity.ts
@@ -1,0 +1,51 @@
+/**
+ * Names the agents the test fixtures seed, in the spelling the backend actually reports.
+ *
+ * This module exists so exactly one place decides what an agent identity looks like. An agent is
+ * identified by its package's whole `namespace/name` id, because two marketplace sources may
+ * publish the same name and the name alone would collapse them into a single agent. The frontend
+ * once keyed its catalog by the bare name while the runtime keyed its supervisors by the id, and
+ * every fixture that spelled the bare name agreed with the bug rather than catching it — so tests
+ * take the identity from here instead of joining the halves themselves.
+ */
+
+/** Namespace the reserved first-party marketplace installs its packages under. */
+const OFFICIAL_NAMESPACE = "official";
+
+/** Builds the agent identity one first-party package supplies. */
+export function officialAgentRef(name: string): string {
+  return `${OFFICIAL_NAMESPACE}/${name}`;
+}
+
+/**
+ * Every agent this mock installation offers, supplied by an installed package and detected.
+ *
+ * Agents exist only because a package supplies them, so a test needs both halves to see one in a
+ * picker: the installed package that names it, and a runtime status that reaches it. A test that
+ * needs one unreachable overrides `agentRuntimeStatuses`; one that needs it gone entirely
+ * overrides `installedPlugins` as well.
+ */
+export const AGENT_PACKAGES = [
+  { key: "opencode", name: "ora-space.opencode", displayName: "OpenCode" },
+  { key: "nga", name: "ora-space.nga", displayName: "NGA" },
+  {
+    key: "codeagentcli",
+    name: "ora-space.codeagentcli",
+    displayName: "CodeAgentCLI",
+  },
+  { key: "claude", name: "ora-space.claude", displayName: "Claude Code" },
+  { key: "codex", name: "ora-space.codex", displayName: "Codex" },
+] as const;
+
+/** The namespace every seeded package is installed under. */
+export const SEEDED_NAMESPACE = OFFICIAL_NAMESPACE;
+
+/** The agent identity each seeded package supplies, by short key. */
+export const AGENT_REF = Object.fromEntries(
+  AGENT_PACKAGES.map((agent) => [agent.key, officialAgentRef(agent.name)]),
+) as Record<(typeof AGENT_PACKAGES)[number]["key"], string>;
+
+/** Every seeded agent identity, in the order the packages are listed. */
+export const SEEDED_AGENT_REFS = AGENT_PACKAGES.map((agent) =>
+  officialAgentRef(agent.name),
+);

--- a/packages/app-shell/src/test/mock-client.ts
+++ b/packages/app-shell/src/test/mock-client.ts
@@ -1,5 +1,10 @@
 import type * as acp from "@agentclientprotocol/sdk";
 import {
+  AGENT_PACKAGES,
+  SEEDED_NAMESPACE,
+  officialAgentRef,
+} from "./agent-identity";
+import {
   RemoteContractError,
   type Agent,
   type AgentRuntimeStatus,
@@ -112,28 +117,12 @@ export interface MockClientState {
   agentModelsByCli?: Partial<Record<string, acp.SessionConfigOption[] | null>>;
 }
 
-/**
- * Every agent this mock installation offers, supplied by an installed package and detected.
- *
- * Agents exist only because a package supplies them, so a test needs both halves to see one in a
- * picker: the installed package that names it, and a runtime status that reaches it. A test that
- * needs one unreachable overrides `agentRuntimeStatuses`; one that needs it gone entirely
- * overrides `installedPlugins` as well.
- */
-const AGENT_PACKAGES: { agentRef: string; displayName: string }[] = [
-  { agentRef: "ora-space.opencode", displayName: "OpenCode" },
-  { agentRef: "ora-space.nga", displayName: "NGA" },
-  { agentRef: "ora-space.codeagentcli", displayName: "CodeAgentCLI" },
-  { agentRef: "ora-space.claude", displayName: "Claude Code" },
-  { agentRef: "ora-space.codex", displayName: "Codex" },
-];
-
 /** Builds the installed-package record one seeded agent is supplied by. */
-function agentPackage(agentRef: string, displayName: string): InstalledPlugin {
+function agentPackage(name: string, displayName: string): InstalledPlugin {
   return {
-    id: `official/${agentRef}`,
-    namespace: "official",
-    name: agentRef,
+    id: officialAgentRef(name),
+    namespace: SEEDED_NAMESPACE,
+    name,
     displayName,
     version: "1.0.0",
     description: `${displayName} agent`,
@@ -150,6 +139,9 @@ function agentPackage(agentRef: string, displayName: string): InstalledPlugin {
 
 /** Creates a fresh in-memory mock state with no records. */
 export function createMockClientState(): MockClientState {
+  const installedPlugins = AGENT_PACKAGES.map((agent) =>
+    agentPackage(agent.name, agent.displayName),
+  );
   return {
     projects: [],
     workspaces: [],
@@ -157,12 +149,15 @@ export function createMockClientState(): MockClientState {
     sessions: [],
     agents: [],
     skills: [],
-    installedPlugins: AGENT_PACKAGES.map((agent) =>
-      agentPackage(agent.agentRef, agent.displayName),
-    ),
+    installedPlugins,
     pluginConfigurations: new Map(),
-    agentRuntimeStatuses: AGENT_PACKAGES.map((agent) => ({
-      agentRef: agent.agentRef,
+    // The runtime keys a supervised agent by the whole plugin id, so the seeded status has to be
+    // derived from the package rather than spelled again: a fixture that spells the two halves
+    // separately can agree with itself while disagreeing with the backend, which is exactly how a
+    // catalog keyed by the bare name once passed every test while offering an agent no session
+    // could bind to.
+    agentRuntimeStatuses: installedPlugins.map((plugin) => ({
+      agentRef: plugin.id,
       status: "ready",
     })),
     availablePlugins: [],

--- a/packages/workflow-mock/src/agent-identity.ts
+++ b/packages/workflow-mock/src/agent-identity.ts
@@ -1,0 +1,23 @@
+/**
+ * Names the agents this mock workflow layer offers, in the spelling the backend reports.
+ *
+ * An agent is identified by its supplying package's whole `namespace/name` id, never by the bare
+ * name: two marketplace sources may publish the same name, and the name alone would collapse them
+ * into a single agent. The demo data goes through this helper so the shape lives in one place
+ * rather than being joined by hand at every fixture that names an agent.
+ */
+
+/** Namespace the reserved first-party marketplace installs its packages under. */
+const OFFICIAL_NAMESPACE = "official";
+
+/** Builds the agent identity one first-party package supplies. */
+export function officialAgentRef(name: string): string {
+  return `${OFFICIAL_NAMESPACE}/${name}`;
+}
+
+/** The agent identities the mock workflow capabilities offer. */
+export const DEMO_AGENT_REF = {
+  codeagentcli: officialAgentRef("ora-space.codeagentcli"),
+  opencode: officialAgentRef("ora-space.opencode"),
+  nga: officialAgentRef("ora-space.nga"),
+} as const;

--- a/packages/workflow-mock/src/capabilities.ts
+++ b/packages/workflow-mock/src/capabilities.ts
@@ -1,3 +1,4 @@
+import { DEMO_AGENT_REF } from "./agent-identity";
 import type { WorkflowAgentConfig, WorkflowNodeKind } from "./node-data";
 
 export interface WorkflowChoice {
@@ -60,7 +61,7 @@ export interface WorkflowNodeType {
 }
 
 const DEFAULT_AGENT_MODEL: WorkflowAgentModel = {
-  agentCli: "ora-space.codeagentcli",
+  agentCli: DEMO_AGENT_REF.codeagentcli,
   modelId: "gpt-5",
   label: "CodeAgentCLI · GPT-5",
 };
@@ -68,21 +69,25 @@ const DEFAULT_AGENT_MODEL: WorkflowAgentModel = {
 const MOCK_AGENT_MODELS: WorkflowAgentModel[] = [
   DEFAULT_AGENT_MODEL,
   {
-    agentCli: "ora-space.opencode",
+    agentCli: DEMO_AGENT_REF.opencode,
     modelId: "opencode/sonnet",
     label: "OpenCode · Sonnet",
   },
   {
-    agentCli: "ora-space.opencode",
+    agentCli: DEMO_AGENT_REF.opencode,
     modelId: "deepseek/deepseek-v4-flash",
     label: "OpenCode · deepseek/deepseek-v4-flash",
   },
   {
-    agentCli: "ora-space.opencode",
+    agentCli: DEMO_AGENT_REF.opencode,
     modelId: "deepseek/deepseek-v4-pro",
     label: "OpenCode · deepseek/deepseek-v4-pro",
   },
-  { agentCli: "ora-space.nga", modelId: "nga/default", label: "NGA · Default" },
+  {
+    agentCli: DEMO_AGENT_REF.nga,
+    modelId: "nga/default",
+    label: "NGA · Default",
+  },
 ];
 
 const MOCK_AGENT_ROLES: WorkflowChoice[] = [

--- a/packages/workflow-mock/src/fixtures.ts
+++ b/packages/workflow-mock/src/fixtures.ts
@@ -1,3 +1,4 @@
+import { DEMO_AGENT_REF } from "./agent-identity";
 import type { Edge, Node, ReactFlowJsonObject } from "@xyflow/react";
 import type { WorkflowAgentConfig, WorkflowNodeData } from "./node-data";
 import type { WorkflowAnnotationNode } from "./annotation-data";
@@ -31,7 +32,7 @@ function createAgentConfig(
   return {
     schemaVersion: 3,
     executor: options.executor ?? {
-      agentCli: "ora-space.codeagentcli",
+      agentCli: DEMO_AGENT_REF.codeagentcli,
       modelId: "gpt-5",
     },
     roleId,

--- a/packages/workflow-mock/src/index.ts
+++ b/packages/workflow-mock/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./agent-identity";
 export * from "./capabilities";
 export * from "./annotation-data";
 export * from "./demo";

--- a/packages/workflow-mock/tests/node-factory.test.ts
+++ b/packages/workflow-mock/tests/node-factory.test.ts
@@ -1,3 +1,4 @@
+import { DEMO_AGENT_REF } from "../src/agent-identity";
 import { describe, expect, it } from "vitest";
 import { createMockWorkflowCapabilities, createMockWorkflowNode } from "../src";
 
@@ -27,7 +28,10 @@ describe("createMockWorkflowNode", () => {
           description: "交给模型自主执行",
           agentConfig: {
             schemaVersion: 3,
-            executor: { agentCli: "ora-space.codeagentcli", modelId: "gpt-5" },
+            executor: {
+              agentCli: DEMO_AGENT_REF.codeagentcli,
+              modelId: "gpt-5",
+            },
             roleId: "Architect",
             skills: [],
             mcps: [],
@@ -117,27 +121,27 @@ describe("createMockWorkflowNode", () => {
       ],
       agentModels: [
         {
-          agentCli: "ora-space.codeagentcli",
+          agentCli: DEMO_AGENT_REF.codeagentcli,
           modelId: "gpt-5",
           label: "CodeAgentCLI · GPT-5",
         },
         {
-          agentCli: "ora-space.opencode",
+          agentCli: DEMO_AGENT_REF.opencode,
           modelId: "opencode/sonnet",
           label: "OpenCode · Sonnet",
         },
         {
-          agentCli: "ora-space.opencode",
+          agentCli: DEMO_AGENT_REF.opencode,
           modelId: "deepseek/deepseek-v4-flash",
           label: "OpenCode · deepseek/deepseek-v4-flash",
         },
         {
-          agentCli: "ora-space.opencode",
+          agentCli: DEMO_AGENT_REF.opencode,
           modelId: "deepseek/deepseek-v4-pro",
           label: "OpenCode · deepseek/deepseek-v4-pro",
         },
         {
-          agentCli: "ora-space.nga",
+          agentCli: DEMO_AGENT_REF.nga,
           modelId: "nga/default",
           label: "NGA · Default",
         },
@@ -198,7 +202,7 @@ describe("createMockWorkflowNode", () => {
       defaultModel: "GPT-5",
       defaultAgentConfig: {
         schemaVersion: 3,
-        executor: { agentCli: "ora-space.codeagentcli", modelId: "gpt-5" },
+        executor: { agentCli: DEMO_AGENT_REF.codeagentcli, modelId: "gpt-5" },
         roleId: "Architect",
         skills: [],
         mcps: [],

--- a/packages/workflow-mock/tests/normalize-agent-config.test.ts
+++ b/packages/workflow-mock/tests/normalize-agent-config.test.ts
@@ -1,3 +1,4 @@
+import { DEMO_AGENT_REF } from "../src/agent-identity";
 import { describe, expect, it } from "vitest";
 import type { Node } from "@xyflow/react";
 import {
@@ -10,14 +11,14 @@ describe("normalizeWorkflowAgentConfig", () => {
   it("fills omitted mcps and skills with empty arrays", () => {
     const legacy = {
       schemaVersion: 3 as const,
-      executor: { agentCli: "ora-space.opencode", modelId: "m1" },
+      executor: { agentCli: DEMO_AGENT_REF.opencode, modelId: "m1" },
       roleId: "Researcher",
       prompt: "hello",
     } as unknown as WorkflowAgentConfig;
 
     expect(normalizeWorkflowAgentConfig(legacy)).toEqual({
       schemaVersion: 3,
-      executor: { agentCli: "ora-space.opencode", modelId: "m1" },
+      executor: { agentCli: DEMO_AGENT_REF.opencode, modelId: "m1" },
       roleId: "Researcher",
       skills: [],
       mcps: [],
@@ -39,7 +40,7 @@ describe("normalizeWorkflowAgentConfig", () => {
           description: "desc",
           agentConfig: {
             schemaVersion: 3 as const,
-            executor: { agentCli: "ora-space.opencode", modelId: "m1" },
+            executor: { agentCli: DEMO_AGENT_REF.opencode, modelId: "m1" },
             roleId: "Researcher",
             skills: [{ skillId: "s1", enabled: true }],
             prompt: "p",


### PR DESCRIPTION
## Problem

`feat(plugin)!: derive plugin namespace from the marketplace source` (5da4edde) changed the agent identity the runtime keys a supervisor by from the bare package name to the package's whole `namespace/name` id:

```rust
// crates/backend/src/agent_runtime/connection.rs
fn agent_identity(plugin_id: &PluginId) -> AgentRef {
    AgentRef::parse(plugin_id.canonical())  // official/ora-space.opencode
```

The frontend catalog was not updated with it and still built its `agentRef` from `plugin.name`:

```ts
// packages/app-shell/src/features/chat/agent-catalog.ts
agentRef: plugin.name,   // ora-space.opencode
```

The two halves therefore disagree on what an agent is called, with two user-visible consequences:

1. **An installed agent never reaches the picker.** `useAvailableAgents` intersects the catalog with the runtime status report; the bare name matches no supervised ref, so the agent is filtered out even though its package is installed and running.
2. **A session bound in the loading window can never be loaded again.** While the status query is unresolved the full catalog is offered, so a session created there persists the bare name. `ConnectionSupervisors::for_agent` cannot resolve it and the session fails on load:

```json
{"level":"ERROR","message":"request completed","method":"complete_failure",
 "context":{"operation":"stream_contract:loadSession","outcome":"failure"},
 "error":{"code":"agent_runtime_unavailable","message":"ora-space.opencode is not installed"}}
```

## Fix

Key the agent catalog, the session availability banner, and the plugin lifecycle cache invalidation by `plugin.id` instead of `plugin.name`.

## Why no test caught this

The mock backend spelled the runtime status ref separately from the installed package id:

```ts
installedPlugins: AGENT_PACKAGES.map((agent) => agentPackage(...)),  // id: official/<name>
agentRuntimeStatuses: AGENT_PACKAGES.map((agent) => ({
  agentRef: agent.agentRef,                                          // bare <name>
```

so the fixture agreed with itself while disagreeing with the backend, and every test that named the bare agent confirmed the bug rather than catching it. The seeded status is now derived from the package's `id` the way `agent_runtime_status` does, which makes the drift unrepresentable in the fixture, and `useAvailableAgents` gains an explicit assertion that the offered identities equal both the installed ids and the supervised refs. Reverting the one-line fix turns that file red (9/9).

Agent identities now come from one fixture module per package (`test/agent-identity.ts`, `workflow-mock/src/agent-identity.ts`) rather than being joined by hand at each call site, so the next change to the identity shape is not another shotgun edit.

## Not covered here

Two related gaps this PR deliberately leaves alone, both worth their own change:

- **Sessions persisted before v0.0.5 still hold the bare name.** v0.0.4 wrote `sessions.agent_cli` as the bare package name and no migration rewrites it, so upgrading users keep hitting the error above on their existing sessions. In v0.0.4 the manifest namespace was a closed set containing only `official`, so `UPDATE sessions SET agent_cli = 'official/' || agent_cli WHERE agent_cli NOT LIKE '%/%'` is unambiguous.
- **`for_agent` reports a definitively-uninstalled agent as `agent_runtime_unavailable`** ("Agent 运行时当前不可用", which reads as transient) rather than the `agent_not_installed` / "未安装提供该 Agent 的插件" pair that already exists.

## Testing

`task test:frontend` — 1188 passed.