### PR TITLE
feat(workspace): add double-click shortcut to create tasks and clarify archive tooltip

### DIFF
--- a/packages/app-shell/src/features/workspace/workspace-project-tree-node.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-project-tree-node.tsx
@@ -134,6 +134,10 @@ export const ProjectTreeNode = memo(function ProjectTreeNode({
     ),
   ];
 
+  // One create path shared by the hover plus and the double-click shortcut.
+  const startNewTask = () =>
+    startSessionDraft({ projectId: project.id, taskId: null });
+
   return (
     <div>
       <TreeRow
@@ -156,14 +160,13 @@ export const ProjectTreeNode = memo(function ProjectTreeNode({
             .setCreateFocus({ projectId: project.id, taskId: null });
           useUiStore.getState().toggleProjectExpand(project.id);
         }}
+        onDoubleClick={startNewTask}
         action={
           <SidebarCreateMenu
             projectId={project.id}
             workspaceId={mainWorkspaceId}
             scope="project"
-            onNewTask={() => {
-              startSessionDraft({ projectId: project.id, taskId: null });
-            }}
+            onNewTask={startNewTask}
           />
         }
         onRename={(name) => updateProject.mutateAsync({ project, name })}
@@ -285,6 +288,10 @@ const WorktreeTaskNode = memo(function WorktreeTaskNode({
     );
   });
 
+  // One create path shared by the hover plus and the double-click shortcut.
+  const startNewTask = () =>
+    startSessionDraft({ projectId: task.projectId, taskId: task.id });
+
   return (
     <div>
       <TreeRow
@@ -306,18 +313,14 @@ const WorktreeTaskNode = memo(function WorktreeTaskNode({
             .setCreateFocus({ projectId, taskId: task.id });
           useUiStore.getState().toggleTaskExpand(task.id);
         }}
+        onDoubleClick={startNewTask}
         action={
           <SidebarCreateMenu
             projectId={projectId}
             workspaceId={task.workspaceId}
             taskId={task.id}
             scope="task"
-            onNewTask={() =>
-              startSessionDraft({
-                projectId: task.projectId,
-                taskId: task.id,
-              })
-            }
+            onNewTask={startNewTask}
           />
         }
         onRename={(name) => updateTask.mutateAsync({ task, title: name })}

--- a/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-sidebar.test.tsx
@@ -740,6 +740,44 @@ describe("WorkspaceSidebar", () => {
     );
   });
 
+  it("starts a new task under a worktree on double-click", async () => {
+    const user = userEvent.setup();
+    renderSidebar(workspaceWithOneSession());
+
+    await waitFor(() => expect(treeRow(TASK.title)).not.toBeNull());
+    await user.dblClick(screen.getByText(TASK.title));
+
+    expect(useWorkspaceSelectionStore.getState().selection).toMatchObject({
+      projectId: PROJECT.id,
+      taskId: TASK.id,
+      sessionId: null,
+      workflowRunId: null,
+    });
+    expect(useWorkspaceSelectionStore.getState().selection.draftId).toEqual(
+      expect.any(String),
+    );
+    await waitFor(() => expect(treeRow(NEW_SESSION_LABEL)).not.toBeNull());
+  });
+
+  it("starts a new task under a project on double-click", async () => {
+    const user = userEvent.setup();
+    renderSidebar(workspaceWithOneSession());
+
+    await waitFor(() => expect(treeRow(PROJECT.name)).not.toBeNull());
+    await user.dblClick(screen.getByText(PROJECT.name));
+
+    expect(useWorkspaceSelectionStore.getState().selection).toMatchObject({
+      projectId: PROJECT.id,
+      taskId: null,
+      sessionId: null,
+      workflowRunId: null,
+    });
+    expect(useWorkspaceSelectionStore.getState().selection.draftId).toEqual(
+      expect.any(String),
+    );
+    await waitFor(() => expect(treeRow(NEW_SESSION_LABEL)).not.toBeNull());
+  });
+
   it("shows an archive control on session rows instead of the overflow menu", async () => {
     renderSidebar(workspaceWithOneSession());
 

--- a/packages/app-shell/src/features/workspace/workspace-tree-row.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-tree-row.tsx
@@ -112,6 +112,8 @@ interface TreeRowProps {
   meta?: string;
   expanded?: boolean;
   onClick: () => void;
+  /** Double-click shortcut; branch rows create a new task in place. */
+  onDoubleClick?: () => void;
   /** Hover-only plus (create under a project or a new session under a worktree). */
   action?: ReactNode;
   /** Persists the inline rename; same editor as session rows. */
@@ -137,6 +139,7 @@ export function TreeRow({
   meta,
   expanded,
   onClick,
+  onDoubleClick,
   action,
   onRename,
   commands,
@@ -203,6 +206,7 @@ export function TreeRow({
               role="button"
               tabIndex={0}
               onClick={onClick}
+              onDoubleClick={onDoubleClick}
               onKeyDown={(event) => {
                 if (event.key !== "Enter" && event.key !== " ") return;
                 event.preventDefault();

--- a/packages/app-shell/src/i18n/i18n-instance.ts
+++ b/packages/app-shell/src/i18n/i18n-instance.ts
@@ -164,7 +164,7 @@ export const translationResources = {
     "sidebar.rename": "重命名",
     "sidebar.renameTooLong": "标题最多 255 个字符。",
     "sidebar.archive": "归档",
-    "sidebar.archiveSoon": "归档即将推出",
+    "sidebar.archiveSoon": "归档功能即将推出，可右键该行并选择「删除」",
     "sidebar.console": "控制台",
     "sidebar.openActions": "打开操作菜单",
     "sidebar.navigation": "主导航",
@@ -1662,7 +1662,8 @@ export const translationResources = {
     "sidebar.rename": "Rename",
     "sidebar.renameTooLong": "Title can be at most 255 characters.",
     "sidebar.archive": "Archive",
-    "sidebar.archiveSoon": "Archive is coming soon",
+    "sidebar.archiveSoon":
+      "Archive is coming soon. Right-click the row and choose Delete.",
     "sidebar.console": "Console",
     "sidebar.openActions": "Open actions",
     "sidebar.navigation": "Main navigation",


### PR DESCRIPTION
Add double-click on project/task tree rows to create a new task in place, sharing a single `startNewTask` path between the hover plus and the new shortcut. Also update the archive tooltip in both English and Chinese to mention that users can right-click and choose Delete for now.