### PR TITLE
style(http): rustfmt s3 path-style tests

### DIFF
--- a/crates/utils/src/http/s3.rs
+++ b/crates/utils/src/http/s3.rs
@@ -226,12 +226,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            path_style_object_key(
-                &url,
-                "s3-hc-dgg.hics.huawei.com",
-                "ora-marketplace-1.0"
-            )
-            .as_deref(),
+            path_style_object_key(&url, "s3-hc-dgg.hics.huawei.com", "ora-marketplace-1.0")
+                .as_deref(),
             Some("agent/ora-space.codeagent-v0.5.1.orax")
         );
     }
@@ -239,15 +235,14 @@ mod tests {
     /// Foreign hosts, wrong buckets, bare bucket URLs, and parent segments do not extract.
     #[test]
     fn rejects_non_matching_path_style_urls() {
-        let foreign = Url::parse("https://github.com/org/repo/releases/download/v1/pkg.orax")
-            .unwrap();
+        let foreign =
+            Url::parse("https://github.com/org/repo/releases/download/v1/pkg.orax").unwrap();
         assert_eq!(
             path_style_object_key(&foreign, "s3.example.com", "bucket"),
             None
         );
 
-        let wrong_bucket =
-            Url::parse("https://s3.example.com/other-bucket/pkg.orax").unwrap();
+        let wrong_bucket = Url::parse("https://s3.example.com/other-bucket/pkg.orax").unwrap();
         assert_eq!(
             path_style_object_key(&wrong_bucket, "s3.example.com", "bucket"),
             None


### PR DESCRIPTION
## 背景

#524 合并后 CI 的 \`crates\` 任务失败，\`ci-ok\` 聚合任务连带失败。

## 原因

\`task test:crates\` 会先跑 \`lint:crates\`，其中执行 \`cargo fmt --all -- --check\`。\`crates/utils/src/http/s3.rs\` 的测试代码不符合 rustfmt 规则，产生 diff 导致检查以 exit 1 退出（非逻辑问题）。

CI 日志关键片段：

\`\`\`
Diff in crates/utils/src/http/s3.rs:226
-            path_style_object_key(
-                &url,
-                "s3-hc-dgg.hics.huawei.com",
-                "ora-marketplace-1.0"
-            )
-            .as_deref(),
+            path_style_object_key(&url, "s3-hc-dgg.hics.huawei.com", "ora-marketplace-1.0")
+                .as_deref(),
task: Failed to run task "lint:crates": exit status 1
\`\`\`

## 修复

运行 \`cargo fmt --all\`（等价于 \`task format:crates\`）重新格式化，仅改动 \`crates/utils/src/http/s3.rs\` 一个文件（+5 / -10）。

## 验证

| 检查 | 命令 | 结果 |
|---|---|---|
| 格式检查（CI 同款） | \`cargo fmt --all -- --check\` | ✅ exit 0 |
| clippy | \`cargo clippy -p ora-utils --features http,http-reqwest -- -D warnings\` | ✅ exit 0 |
| 单测 | \`cargo test -p ora-utils --features http,http-reqwest s3\` | ✅ 12 passed |