### PR TITLE
fix(db): rollback newer migrations during startup

### DIFF
--- a/crates/db/README.md
+++ b/crates/db/README.md
@@ -11,7 +11,7 @@ and `ora-effect`.
 
 ## Bootstrap and boundaries
 
-`DatabaseBootstrapper` opens either a path-backed database or a shared in-memory database, configures connection behavior, applies missing migration versions, and returns a `RepositoryPool`. It never rolls back an applied migration because application startup must not make destructive schema decisions. File-backed parent directories must already be prepared by the composition root.
+`DatabaseBootstrapper` opens either a path-backed database or a shared in-memory database, configures connection behavior, aligns the applied migration versions with the application catalog, and returns a `RepositoryPool`. Missing versions are applied in order. A database created by a newer application is rolled back to the current catalog in reverse order using its persisted `down_sql`. Bootstrap does not compare the SQL content of versions shared by the database and catalog. File-backed parent directories must already be prepared by the composition root.
 
 `reconcile_migration_history` is the explicit tooling interface for SQL snapshot drift and target
 shortening. Development startup invokes it through `cargo xtask reconcile-migrations`; production

--- a/crates/db/src/bootstrap.rs
+++ b/crates/db/src/bootstrap.rs
@@ -16,7 +16,7 @@ pub fn reconcile_migration_history(
     })
 }
 
-/// Coordinates opening SQLite connections and applying missing migration versions.
+/// Coordinates opening SQLite connections and aligning migration versions for application startup.
 #[derive(Debug)]
 pub struct DatabaseBootstrapper<T> {
     timestamp_source: T,
@@ -38,7 +38,7 @@ where
         Self { timestamp_source }
     }
 
-    /// Opens a repository pool and applies target migration versions that are not yet recorded.
+    /// Opens a repository pool and aligns the database with the target migration version sequence.
     pub fn bootstrap_repository_pool(
         &self,
         location: &DatabaseLocation,
@@ -62,7 +62,7 @@ where
         ora_info!(message = "opened database", operation = "database_open");
 
         if let Err(error) = pool.with_connection_mut(|connection| {
-            migration::apply_pending_migrations(connection, catalog, &self.timestamp_source)
+            migration::reconcile_database_versions(connection, catalog, &self.timestamp_source)
         }) {
             ora_error!(
                 message = "database bootstrap failed",

--- a/crates/db/src/migration.rs
+++ b/crates/db/src/migration.rs
@@ -5,4 +5,4 @@ mod schema;
 
 pub use catalog::{Migration, MigrationCatalog, default_migration_catalog};
 pub use record::AppliedMigration;
-pub use runner::{apply_pending_migrations, reconcile_database};
+pub use runner::{reconcile_database, reconcile_database_versions};

--- a/crates/db/src/migration/README.md
+++ b/crates/db/src/migration/README.md
@@ -1,6 +1,6 @@
 # Database Migration Module
 
-This module owns Ora's linear, reversible SQLite schema history. Application bootstrap applies only missing migration versions. Explicit development tooling may reconcile a database to an exact target prefix, including SQL snapshot comparison and suffix rebuilding. Concrete schema definitions live in the private [`schema`](schema/) module, which is the single migration registry consumed by the catalog.
+This module owns Ora's linear, reversible SQLite schema history. Application bootstrap aligns migration versions without comparing SQL snapshots. Explicit development tooling may additionally reconcile a database to an exact target prefix based on SQL snapshot comparison and suffix rebuilding. Concrete schema definitions live in the private [`schema`](schema/) module, which is the single migration registry consumed by the catalog.
 
 ## Catalog invariants
 
@@ -42,20 +42,22 @@ This module owns Ora's linear, reversible SQLite schema history. Application boo
 
 ## Application bootstrap
 
-Application bootstrap validates the applied version sequence and applies only the missing target
-tail. It intentionally does not compare persisted SQL snapshots and never executes `down` SQL.
-This keeps a packaged application from destructively rebuilding user data when a previously
-published migration definition differs.
+Application bootstrap validates the version sequence shared by the database and current target.
+It applies a missing target tail in ascending order. If the database contains a trailing suffix
+introduced by a newer application, bootstrap executes that suffix's persisted `down_sql` in
+reverse order and removes its bookkeeping rows. It does not compare persisted SQL snapshots for
+shared versions, so changing a previously published migration definition cannot trigger a schema
+rebuild during packaged application startup.
 
 ## Explicit development reconciliation
 
-`reconcile_database` first verifies that every applied version belongs to the catalog and occupies the expected position. Unknown, skipped, or reordered versions are hard errors.
+`reconcile_database` first verifies that the applied and target histories have an identical shared version prefix. Unknown, skipped, or reordered versions inside that prefix are hard errors; an applied suffix beyond the target is rollback input and does not need to exist in the current catalog.
 
 It then compares the persisted SQL snapshots with current migration definitions over the shared target prefix. At the first changed `up_sql` or `down_sql`, it rolls back the complete applied suffix in reverse order using each row's persisted `down_sql`, then applies the current target suffix in forward order and stores fresh snapshots. Timestamps do not participate in this comparison.
 
 Ordinary target shortening uses the same persisted rollback snapshots. Ordinary target growth applies only the missing tail. Each migration step and its bookkeeping update run in one SQLite transaction, so a failing statement cannot leave that step's schema and row out of sync. Earlier successful rollback steps remain committed if a later rewritten `up` fails.
 
-An applied version absent from the catalog is an error. Reconciliation is otherwise idempotent when the database already matches the target.
+An applied version absent from the catalog inside the shared target prefix is an error. Reconciliation is otherwise idempotent when the database already matches the target.
 
 The public `reconcile_migration_history` interface opens and reconciles a database for explicit
 tooling. `cargo xtask reconcile-migrations DATA_DIRECTORY` calls it before `task run:desktop`

--- a/crates/db/src/migration/catalog.rs
+++ b/crates/db/src/migration/catalog.rs
@@ -90,11 +90,6 @@ impl MigrationCatalog {
             .get(version)
             .map(|index| &self.migrations[*index])
     }
-
-    /// Returns the catalog version at a history position for applied-order validation.
-    pub(crate) fn version_at(&self, position: usize) -> Option<&'static str> {
-        self.migrations.get(position).map(Migration::version)
-    }
 }
 
 /// Builds the default migration catalog shipped by the crate.

--- a/crates/db/src/migration/runner.rs
+++ b/crates/db/src/migration/runner.rs
@@ -14,8 +14,8 @@ CREATE TABLE IF NOT EXISTS migrations (
 );
 "#;
 
-/// Applies only migration versions missing from the database without inspecting SQL snapshot drift.
-pub fn apply_pending_migrations<T>(
+/// Aligns the applied version sequence for application startup without inspecting SQL drift.
+pub fn reconcile_database_versions<T>(
     connection: &mut Connection,
     catalog: &MigrationCatalog,
     timestamp_source: &T,
@@ -26,31 +26,30 @@ where
     ensure_migrations_table(connection)?;
 
     let applied_migrations = load_applied_migrations(connection)?;
-    validate_applied_history(&applied_migrations, catalog)?;
-    let pending_up_count = catalog
-        .target_versions()
+    let target_versions = catalog.target_versions();
+    validate_shared_history(&applied_migrations, target_versions, catalog)?;
+    let shared_version_count = applied_migrations.len().min(target_versions.len());
+    let pending_up_count = target_versions.len().saturating_sub(shared_version_count);
+    let pending_down_count = applied_migrations
         .len()
-        .saturating_sub(applied_migrations.len());
+        .saturating_sub(shared_version_count);
 
     ora_info!(
-        message = "evaluated pending migrations",
-        operation = "migration_apply_pending",
+        message = "evaluated application migration versions",
+        operation = "migration_version_reconciliation",
         applied_migration_count = applied_migrations.len(),
-        target_migration_count = catalog.target_versions().len(),
-        pending_up_count
+        target_migration_count = target_versions.len(),
+        pending_up_count,
+        pending_down_count
     );
 
-    apply_migration_suffix(
-        connection,
-        catalog,
-        timestamp_source,
-        applied_migrations.len(),
-    )?;
+    rollback_migration_suffix(connection, &applied_migrations, shared_version_count)?;
+    apply_migration_suffix(connection, catalog, timestamp_source, shared_version_count)?;
 
-    if pending_up_count == 0 {
+    if pending_up_count == 0 && pending_down_count == 0 {
         ora_info!(
-            message = "database already contains every target migration version",
-            operation = "migration_apply_pending"
+            message = "database already contains the target migration versions",
+            operation = "migration_version_reconciliation"
         );
     }
 
@@ -70,7 +69,7 @@ where
 
     let applied_migrations = load_applied_migrations(connection)?;
     let target_versions = catalog.target_versions();
-    validate_applied_history(&applied_migrations, catalog)?;
+    validate_shared_history(&applied_migrations, target_versions, catalog)?;
     let reconciliation_start =
         first_reconciliation_position(&applied_migrations, target_versions, catalog);
     let pending_up_count = target_versions.len().saturating_sub(reconciliation_start);
@@ -87,30 +86,7 @@ where
         pending_down_count
     );
 
-    if pending_down_count > 0 {
-        ora_info!(
-            message = "rolling back migration suffix",
-            operation = "migration_reconciliation",
-            rollback_count = pending_down_count
-        );
-
-        for applied_migration in applied_migrations.iter().skip(reconciliation_start).rev() {
-            execute_migration_step(
-                connection,
-                &applied_migration.version,
-                &applied_migration.down_sql,
-                MigrationDirection::Down,
-                |transaction| {
-                    transaction.execute(
-                        "DELETE FROM migrations WHERE version = ?1",
-                        params![applied_migration.version],
-                    )?;
-
-                    Ok(())
-                },
-            )?;
-        }
-    }
+    rollback_migration_suffix(connection, &applied_migrations, reconciliation_start)?;
 
     apply_migration_suffix(connection, catalog, timestamp_source, reconciliation_start)?;
 
@@ -119,6 +95,43 @@ where
             message = "database schema already matches the target migration prefix",
             operation = "migration_reconciliation"
         );
+    }
+
+    Ok(())
+}
+
+/// Rolls back an applied suffix in reverse order using the SQL snapshots stored in the database.
+fn rollback_migration_suffix(
+    connection: &mut Connection,
+    applied_migrations: &[AppliedMigration],
+    start: usize,
+) -> Result<(), DatabaseError> {
+    let rollback_count = applied_migrations.len().saturating_sub(start);
+    if rollback_count == 0 {
+        return Ok(());
+    }
+
+    ora_info!(
+        message = "rolling back migration suffix",
+        operation = "migration_rollback",
+        rollback_count
+    );
+
+    for applied_migration in applied_migrations.iter().skip(start).rev() {
+        execute_migration_step(
+            connection,
+            &applied_migration.version,
+            &applied_migration.down_sql,
+            MigrationDirection::Down,
+            |transaction| {
+                transaction.execute(
+                    "DELETE FROM migrations WHERE version = ?1",
+                    params![applied_migration.version],
+                )?;
+
+                Ok(())
+            },
+        )?;
     }
 
     Ok(())
@@ -216,12 +229,15 @@ fn load_applied_migrations(
         .map_err(DatabaseError::from)
 }
 
-/// Rejects unknown, missing, or reordered applied versions before schema mutation begins.
-fn validate_applied_history(
+/// Rejects unknown, missing, or reordered versions within the current target's shared prefix.
+fn validate_shared_history(
     applied_migrations: &[AppliedMigration],
+    target_versions: &[&str],
     catalog: &MigrationCatalog,
 ) -> Result<(), DatabaseError> {
-    for (position, applied) in applied_migrations.iter().enumerate() {
+    for (position, (applied, expected)) in
+        applied_migrations.iter().zip(target_versions).enumerate()
+    {
         if catalog.migration(&applied.version).is_none() {
             ora_error!(
                 message = "encountered unknown applied migration version",
@@ -238,8 +254,7 @@ fn validate_applied_history(
             });
         }
 
-        let expected = catalog.version_at(position).unwrap_or_default();
-        if applied.version != expected {
+        if applied.version != *expected {
             ora_error!(
                 message = "migration history diverged",
                 operation = "migration_reconciliation",
@@ -252,7 +267,7 @@ fn validate_applied_history(
             );
             return Err(DatabaseError::DivergedMigrationHistory {
                 position,
-                expected: expected.to_string(),
+                expected: (*expected).to_string(),
                 found: applied.version.clone(),
             });
         }

--- a/crates/db/src/tests.rs
+++ b/crates/db/src/tests.rs
@@ -168,6 +168,53 @@ fn applies_missing_migrations_in_order() {
     );
 }
 
+/// Verifies application bootstrap rolls back versions introduced by a newer application.
+#[test]
+fn bootstrap_rolls_back_migrations_newer_than_the_catalog_in_reverse_order() {
+    let temp_dir = TempDir::new().expect("create temporary directory");
+    let database_path = temp_dir.path().join("newer-than-catalog.sqlite3");
+    let migrations = vec![
+        sql_migration(
+            "0001",
+            "CREATE TABLE alpha (id INTEGER PRIMARY KEY); CREATE TABLE rollback_order (version TEXT NOT NULL);",
+            "DROP TABLE rollback_order; DROP TABLE alpha;",
+        ),
+        sql_migration(
+            "0002",
+            "CREATE TABLE beta (id INTEGER PRIMARY KEY);",
+            "INSERT INTO rollback_order (version) VALUES ('0002'); DROP TABLE beta;",
+        ),
+        sql_migration(
+            "0003",
+            "CREATE TABLE gamma (id INTEGER PRIMARY KEY);",
+            "INSERT INTO rollback_order (version) VALUES ('0003'); DROP TABLE gamma;",
+        ),
+    ];
+    let older_catalog =
+        MigrationCatalog::new(vec![migrations[0].clone()]).expect("build older catalog");
+    let newer_catalog = MigrationCatalog::new(migrations).expect("build newer catalog");
+
+    bootstrap_file_database(&database_path, &newer_catalog, 100).expect("apply newer catalog");
+    bootstrap_file_database(&database_path, &older_catalog, 200)
+        .expect("roll back versions absent from the older catalog");
+
+    let connection = Connection::open(&database_path).expect("open database");
+    assert_eq!(table_exists(&connection, "alpha"), true);
+    assert_eq!(table_exists(&connection, "beta"), false);
+    assert_eq!(table_exists(&connection, "gamma"), false);
+    assert_eq!(
+        load_text_column(
+            &connection,
+            "SELECT version FROM rollback_order ORDER BY rowid"
+        ),
+        vec!["0003".to_string(), "0002".to_string()]
+    );
+    assert_eq!(
+        load_applied_migrations(&connection),
+        vec![applied_from(&newer_catalog, "0001", 100)]
+    );
+}
+
 /// Verifies matching SQL snapshots make reconciliation a no-op regardless of the new clock value.
 #[test]
 fn unchanged_migration_content_is_a_no_op() {
@@ -424,7 +471,7 @@ fn shorter_target_rolls_back_the_applied_tail() {
     );
 }
 
-/// Verifies known versions in an illegal position and versions absent from the catalog stay errors.
+/// Verifies reordered or unknown versions inside the shared target prefix stay errors.
 #[test]
 fn rejects_reordered_and_unknown_applied_versions() {
     let temp_dir = TempDir::new().expect("create temporary directory");
@@ -452,7 +499,14 @@ fn rejects_reordered_and_unknown_applied_versions() {
     );
 
     let unknown_path = temp_dir.path().join("unknown.sqlite3");
-    bootstrap_file_database(&unknown_path, &expected, 100).expect("apply expected catalog");
+    let first_version = MigrationCatalog::new(vec![
+        expected
+            .migration("0001")
+            .expect("find first migration")
+            .clone(),
+    ])
+    .expect("build first-version catalog");
+    bootstrap_file_database(&unknown_path, &first_version, 100).expect("apply first migration");
     let connection = Connection::open(&unknown_path).expect("open database");
     connection
         .execute(

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -27,16 +27,18 @@ Ora keeps SQLite migration definitions in Rust code inside `ora-db` rather than 
 
 ## Application startup
 
-`DatabaseBootstrapper` validates that applied versions form a known, ordered history, then applies
-only the missing target tail. It does not compare persisted SQL snapshots and never executes a
-rollback. Packaged application startup therefore cannot rebuild user data merely because an old
-migration definition changed.
+`DatabaseBootstrapper` validates that the database and target have an identical shared version
+prefix. It applies a missing target tail in ascending order. If the database contains versions
+introduced by a newer application, it rolls that trailing suffix back in reverse order using the
+`down_sql` stored by the newer version. It does not compare persisted SQL snapshots for shared
+versions, so packaged application startup cannot rebuild user data merely because an old migration
+definition changed.
 
 ## Development reconciliation
 
 A catalog carries the full migration list plus an **active target prefix**, which must be a prefix of that list. Requiring a prefix keeps history linear and makes controlled rollback deterministic instead of branch-shaped. The explicit `reconcile_migration_history` tooling interface reconciles a database against that target:
 
-- Applied versions are validated against the complete catalog before any mutation. Unknown versions and versions in the wrong position remain hard errors; the runner never guesses, skips, or reorders history.
+- Applied versions in the shared target prefix are validated before any mutation. Unknown versions and versions in the wrong position within that prefix remain hard errors; versions in a trailing applied suffix are rollback input and need not exist in the current catalog.
 - Persisted and current `up_sql` and `down_sql` are compared from the beginning of the shared target prefix. `executed_at` is metadata and does not affect equality.
 - At the first SQL mismatch, the runner rolls back that migration and the complete applied suffix in reverse order. Rollback always executes the old `down_sql` stored in the database, never the possibly rewritten current definition.
 - The runner then applies the current target suffix in ascending order and records fresh SQL snapshots and timestamps.
@@ -59,7 +61,7 @@ plugin marketplace schema remains intact.
 `ora-db` emits structured events during database bootstrap and explicit reconciliation.
 
 - Database open and bootstrap lifecycle events carry an `operation` field (`database_open`, `database_bootstrap`).
-- Application bootstrap reports the pending `up` count. Explicit reconciliation reports applied and target migration counts plus pending `up` and `down` counts; rollback and apply phases log their own counts.
+- Application bootstrap and explicit reconciliation report applied and target migration counts plus pending `up` and `down` counts; rollback and apply phases log their own counts.
 - Migration step events include `migration_version` and `direction`.
 - Failures log at `ERROR` with `error.kind` and `error.message` before the original `DatabaseError` is returned to the caller.
 


### PR DESCRIPTION
## Summary

- reconcile application startup by migration version rather than only applying pending versions
- roll back database migration rows beyond the current catalog in reverse order using persisted `down_sql`
- keep shared-version SQL drift checks confined to the development reconciliation command
- document the startup/downgrade boundary and add a regression test that proves `0003` rolls back before `0002`

## Root cause

Startup validated every applied migration against the current catalog before doing any schema work. A migration introduced by a newer app was therefore rejected as `UnknownAppliedMigrationVersion`, even though its persisted `down_sql` was sufficient to remove it safely.

## Verification

- `cargo test -p ora-db`
- `task lint:crates`
- `task test:crates`

Closes #396