### PR TITLE
feat(chat): 记住每个 Agent 新建会话所用的模型

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -43,6 +43,8 @@ Pre-session models come from `agent/list_models`, called on demand with the Work
 
 The frontend query cache controls repeated discovery. A model selected before a session exists is local intent sent with `startSession` or `switchSessionAgent`; the backend applies it only when the newly-created session reports the exact value. The response always carries that session's authoritative configuration options.
 
+The frontend also remembers, per agent and in browser storage alone, the model last picked for a chat that had not started yet, so the next such chat on that agent opens on it instead of the agent's own default. A remembered model is offered only while the agent's current catalog still lists it, and a session that already exists ignores it entirely: an ongoing conversation follows the configuration options its agent reports for that session.
+
 ## Session History
 
 Ora records every conversation itself, in one append-only JSONL file per Session under the configured sessions root. This is what lets a conversation outlive one provider: it is replayed without asking the agent to recite it, and it can be handed to a different agent entirely. The file format, its ordering rules, and its failure semantics belong to [`ora-history`](../crates/history/README.md); this section covers only when the runtime uses them.

--- a/packages/app-shell/src/features/chat/model-selector.test.tsx
+++ b/packages/app-shell/src/features/chat/model-selector.test.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_SETTINGS,
 } from "../../state/stores/settings-store";
 import { usePendingAgentStore } from "../../state/stores/pending-agent-store";
+import { useAgentModelPreferenceStore } from "../../state/stores/agent-model-preference-store";
 import type { AgentStatus } from "@ora/contracts";
 import { ModelSelector } from "./model-selector";
 import { queryKeys } from "../../state/hooks/query-keys";
@@ -32,7 +33,8 @@ beforeEach(() => {
   useSettingsStore.setState({
     settings: { ...DEFAULT_SETTINGS, agentCli: AGENT_REF.opencode },
   });
-  usePendingAgentStore.setState({ selections: {} });
+  usePendingAgentStore.setState({ selections: {}, switches: {}, models: {} });
+  useAgentModelPreferenceStore.setState({ models: {} });
 });
 
 /** Replaces what the runtime reports about OpenCode, leaving every other agent detected. */
@@ -87,7 +89,7 @@ function renderModelSelector(
       </AppI18nProvider>
     </Wrapper>,
   );
-  return { queryClient, state, discover };
+  return { queryClient, state, discover, chatStore };
 }
 
 /** The collapsed trigger, which names the agent this surface is currently on. */
@@ -432,5 +434,136 @@ describe("ModelSelector with no agent package installed", () => {
     await user.click(within(menu).getByText(hint));
     expect(useUiStore.getState().settingsOpen).toBe(true);
     expect(useUiStore.getState().settingsCategory).toBe("plugins");
+  });
+});
+
+/** Opens the picker, clicks the named model, and lets the menu close on the pick. */
+async function pickModel(
+  user: ReturnType<typeof userEvent.setup>,
+  modelLabel: string,
+) {
+  await user.click(picker());
+  const menu = await screen.findByRole("menu");
+  await waitFor(() =>
+    expect(within(menu).queryByText(modelLabel)).not.toBeNull(),
+  );
+  await user.click(within(menu).getByText(modelLabel));
+}
+
+/** A second agent whose catalog shares no model with OpenCode's. */
+function claudeModels(state: MockClientState) {
+  state.agentModelsByCli = {
+    [AGENT_REF.claude]: [
+      {
+        id: "model",
+        name: "Model",
+        category: "model",
+        type: "select",
+        currentValue: "claude/sonnet",
+        options: [
+          { value: "claude/sonnet", name: "Sonnet" },
+          { value: "claude/opus", name: "Opus" },
+        ],
+      },
+    ],
+  };
+}
+
+describe("ModelSelector remembered model for not-yet-started chats", () => {
+  it("opens a new chat on the model last picked for its agent", async () => {
+    const user = userEvent.setup();
+    renderModelSelector();
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    await pickModel(user, "Small Pickle");
+    await waitFor(() =>
+      expect(within(picker()).queryByText("Small Pickle")).not.toBeNull(),
+    );
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t2", "p1"));
+
+    await waitFor(() =>
+      expect(within(picker()).queryByText("Small Pickle")).not.toBeNull(),
+    );
+  });
+
+  it("remembers one model per agent instead of one across agents", async () => {
+    const user = userEvent.setup();
+    renderModelSelector(claudeModels);
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+    await pickModel(user, "Small Pickle");
+    await pickAgent(user, /Claude Code/);
+    await pickModel(user, "Opus");
+    await waitFor(() =>
+      expect(within(picker()).queryByText("Opus")).not.toBeNull(),
+    );
+
+    // An untouched surface follows the agent picked most recently, so this one
+    // opens on Claude Code and must show Claude Code's remembered model.
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t2", "p1"));
+    await waitFor(() =>
+      expect(within(picker()).queryByText("Opus")).not.toBeNull(),
+    );
+
+    await pickAgent(user, /OpenCode/);
+
+    await waitFor(() =>
+      expect(within(picker()).queryByText("Small Pickle")).not.toBeNull(),
+    );
+  });
+
+  it("falls back to the agent's default when the remembered model is gone", async () => {
+    useAgentModelPreferenceStore.setState({
+      models: { [AGENT_REF.opencode]: "opencode/retired-pickle" },
+    });
+    renderModelSelector();
+
+    act(() => useWorkspaceSelectionStore.getState().selectTask("t1", "p1"));
+
+    await waitFor(() =>
+      expect(within(picker()).queryByText("Big Pickle")).not.toBeNull(),
+    );
+  });
+
+  it("leaves a session that has already started on its own model", async () => {
+    useAgentModelPreferenceStore.setState({
+      models: { [AGENT_REF.opencode]: "opencode/small-pickle" },
+    });
+    const { chatStore } = renderModelSelector((state) => {
+      state.sessions = [
+        {
+          id: "s1",
+          workspaceId: "workspace-t1",
+          title: "Started chat",
+          agentRef: AGENT_REF.opencode,
+          status: "running",
+          historyState: { type: "writable" },
+        },
+      ];
+    });
+
+    act(() => {
+      chatStore.getState().initializeSession("s1");
+      chatStore.getState().setConfigOptions("s1", [
+        {
+          id: "model",
+          name: "Model",
+          category: "model",
+          type: "select",
+          currentValue: "opencode/big-pickle",
+          options: [
+            { value: "opencode/big-pickle", name: "Big Pickle" },
+            { value: "opencode/small-pickle", name: "Small Pickle" },
+          ],
+        },
+      ]);
+      useWorkspaceSelectionStore.getState().selectSession("s1", "t1", "p1");
+    });
+
+    await waitFor(() =>
+      expect(within(picker()).queryByText("Big Pickle")).not.toBeNull(),
+    );
+    expect(within(picker()).queryByText("Small Pickle")).toBeNull();
   });
 });

--- a/packages/app-shell/src/features/chat/model-selector.tsx
+++ b/packages/app-shell/src/features/chat/model-selector.tsx
@@ -37,6 +37,7 @@ import {
   pendingModelKey,
   usePendingSwitch,
 } from "../../state/stores/pending-agent-store";
+import { useAgentModelPreferenceStore } from "../../state/stores/agent-model-preference-store";
 import { currentValueName, findModelOption, selectableValues } from "@ora/chat";
 import { PluginLogoMark } from "../settings/plugin-logo";
 import { useAgentModels } from "../../state/hooks/use-agent-models";
@@ -51,6 +52,12 @@ import { useWorkspaces } from "../../state/hooks/use-workspaces";
  * whatever the chosen agent reported for this session, so the model list has three
  * states rather than two — still arriving, genuinely offering no choice, or a real
  * set to pick from.
+ *
+ * A chat that has not started yet opens on the model the user last picked for
+ * the agent it is pointed at, so the choice does not have to be repeated for
+ * every new chat. That memory belongs to unstarted chats alone: an ongoing
+ * conversation follows the configuration its own agent reports and is untouched
+ * by picks made anywhere else.
  *
  * With a session selected, choosing a different agent moves that conversation onto
  * it rather than only changing the default for the next one. Ora owns the
@@ -189,6 +196,17 @@ export function ModelSelector({
   const setPendingModel = usePendingAgentStore(
     (state) => state.setPendingModel,
   );
+  // Only a chat with no session behind it opens on a remembered preference. A
+  // session that exists — including one carrying a recorded agent move — is
+  // authoritative about the model it runs on, so it neither reads this nor
+  // writes to it, and a pick made on some other surface can never move it.
+  const isUnstartedChat = sessionId === undefined && boundSession === undefined;
+  const rememberedModel = useAgentModelPreferenceStore((state) =>
+    agentCli === null ? undefined : state.models[agentCli],
+  );
+  const rememberModel = useAgentModelPreferenceStore(
+    (state) => state.rememberModel,
+  );
   const modelValues = usesPersistedOptions
     ? modelOption
       ? selectableValues(modelOption).map((value) => ({
@@ -207,11 +225,22 @@ export function ModelSelector({
   const discoveredDefault =
     discoveredModels.find((model) => model.default)?.id ??
     discoveredModels[0]?.id;
+  // A remembered preference is only honoured while the agent still offers that
+  // model: catalogs move with plugin versions, and naming a model this agent no
+  // longer has would both mislabel the trigger and be dropped by the backend,
+  // which applies a model intent only when the new session reports that exact
+  // value. Falling through to the agent's own default keeps the label and the
+  // first send agreeing.
+  const preferredModel =
+    isUnstartedChat &&
+    discoveredModels.some((model) => model.id === rememberedModel)
+      ? rememberedModel
+      : undefined;
   const selectedValue = usesPersistedOptions
     ? modelOption?.type === "select"
       ? modelOption.currentValue
       : undefined
-    : (pendingModel ?? discoveredDefault);
+    : (pendingModel ?? preferredModel ?? discoveredDefault);
   // Three states rather than two, because "not answered yet" must not read as
   // "this agent offers no models". A persisted session has said nothing until
   // its conversation is loaded — and replay seeds empty options first, which is
@@ -275,6 +304,10 @@ export function ModelSelector({
   const selectModel = (value: string) => {
     if (!usesPersistedOptions) {
       if (intentKey !== null) setPendingModel(intentKey, value);
+      // Recorded alongside the surface-local intent rather than instead of it:
+      // the intent is consumed by this chat's first send, while the preference
+      // outlives it so the *next* new chat on this agent opens here too.
+      if (isUnstartedChat && agentCli !== null) rememberModel(agentCli, value);
       return;
     }
     if (activeSessionId !== null && modelOption !== null) {

--- a/packages/app-shell/src/features/workspace/workspace-view.test.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-view.test.tsx
@@ -22,6 +22,7 @@ import {
   createMockClientState,
 } from "../../test/mock-client";
 import { usePendingAgentStore } from "../../state/stores/pending-agent-store";
+import { useAgentModelPreferenceStore } from "../../state/stores/agent-model-preference-store";
 import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
 import { useDraftSessionsStore } from "../../state/stores/draft-sessions-store";
 import { useComposerInputStore } from "../../state/stores/composer-input-store";
@@ -57,7 +58,10 @@ beforeEach(() => {
   // nothing has handshaken, or an earlier test's list would answer for it.
   // Agent picks outlive a render, so a test that leaves one recorded would hand
   // the next one a surface already pointing somewhere it never chose.
-  usePendingAgentStore.setState({ selections: {}, switches: {} });
+  usePendingAgentStore.setState({ selections: {}, switches: {}, models: {} });
+  // Remembered per agent and persisted, so a preference one test records would
+  // otherwise decide which model the next test's first send starts on.
+  useAgentModelPreferenceStore.setState({ models: {} });
   useSettingsStore.setState({
     settings: { ...DEFAULT_SETTINGS, agentCli: AGENT_REF.opencode },
   });
@@ -1268,6 +1272,60 @@ describe("WorkspaceView", () => {
       ]),
     );
     expect(setConfig).not.toHaveBeenCalled();
+  });
+
+  it("starts an untouched chat on the model remembered for its agent", async () => {
+    const user = userEvent.setup();
+    useAgentModelPreferenceStore.setState({
+      models: { [AGENT_REF.opencode]: "opencode/small-pickle" },
+    });
+    const state = createMockClientState();
+    state.projects = [{ id: "p1", name: "Ora" }];
+    const baseClient = createMockClient(state);
+    const started: StartSessionRequest[] = [];
+    const client: ContractsClient = {
+      ...baseClient,
+      session: {
+        ...baseClient.session,
+        start: async (request, options) => {
+          started.push(request);
+          return baseClient.session.start(request, options);
+        },
+      },
+    };
+    const Wrapper = createHookWrapper(
+      client,
+      createTestQueryClient(),
+      createChatStore(client.session),
+    );
+    useWorkspaceSelectionStore.getState().selectProject("p1");
+
+    render(
+      <Wrapper>
+        <AppI18nProvider>
+          <PlatformProvider adapter={createStubPlatform()}>
+            <TooltipProvider>
+              <WorkspaceView userName="Eric" />
+            </TooltipProvider>
+          </PlatformProvider>
+        </AppI18nProvider>
+      </Wrapper>,
+    );
+
+    // The picker is never opened: what the surface is labelled with has to be
+    // what the send asks for, or the first turn silently runs on another model.
+    await user.type(await screen.findByRole("textbox"), "hello");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expect(started).toEqual([
+        {
+          workspaceId: "workspace-p1",
+          agentRef: AGENT_REF.opencode,
+          model: "opencode/small-pickle",
+        },
+      ]),
+    );
   });
 
   it("says the model list is still arriving while a selected session replays", async () => {

--- a/packages/app-shell/src/features/workspace/workspace-view.tsx
+++ b/packages/app-shell/src/features/workspace/workspace-view.tsx
@@ -32,6 +32,7 @@ import {
   pendingModelKey,
   usePendingAgentStore,
 } from "../../state/stores/pending-agent-store";
+import { useAgentModelPreferenceStore } from "../../state/stores/agent-model-preference-store";
 import { useWorkspaceSelectionStore } from "../../state/stores/workspace-selection-store";
 import { conversationKeyFor } from "../../state/stores/conversation-key";
 import { useComposerPluginSelectionStore } from "../../state/stores/composer-plugin-selection-store";
@@ -374,10 +375,20 @@ export function WorkspaceView({ userName }: WorkspaceViewProps) {
         throw new Error("No workspace is available for this chat");
       }
       const modelKey = pendingModelKey(selection, targetAgentCli);
+      // Falls back to the preference the picker is already labelling this
+      // surface with, so a chat started without opening the picker begins on
+      // the model shown rather than on the agent's own default. A remembered
+      // model the agent no longer offers is not filtered here: the backend
+      // applies an intent only when the new session reports that exact value,
+      // which lands on the same default the label falls back to.
+      const model =
+        usePendingAgentStore.getState().models[modelKey] ??
+        useAgentModelPreferenceStore.getState().models[targetAgentCli] ??
+        null;
       started = await client.session.start({
         workspaceId: selectedWorkspaceId,
         agentRef: targetAgentCli,
-        model: usePendingAgentStore.getState().models[modelKey] ?? null,
+        model,
       });
       usePendingAgentStore.getState().clearPendingModel(modelKey);
     } catch (error) {

--- a/packages/app-shell/src/state/stores/agent-model-preference-store.ts
+++ b/packages/app-shell/src/state/stores/agent-model-preference-store.ts
@@ -1,0 +1,62 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+export const AGENT_MODEL_PREFERENCE_STORAGE_KEY =
+  "ora.agent-model-preference.v1";
+
+interface AgentModelPreferenceState {
+  /** The model last chosen for each agent, keyed by that agent's namespaced ref. */
+  models: Record<string, string>;
+  /** Records the model a user picked for an agent, replacing any earlier one. */
+  rememberModel: (agentRef: string, model: string) => void;
+}
+
+/**
+ * Remembers, per agent, which model the user last started a chat on.
+ *
+ * Scope is deliberately narrow: this answers "what should a chat that has not
+ * started yet open on", nothing else. A persisted session carries its own model
+ * in the configuration its agent reports, so an ongoing conversation never reads
+ * or writes here and cannot be moved by a pick made on some other surface.
+ *
+ * Keyed by agent rather than by chat surface, which is what makes it a
+ * preference instead of an intent: `usePendingAgentStore` already holds "what is
+ * this one unstarted surface set to" and is discarded once that chat starts.
+ * This outlives the send, so the next new chat on the same agent opens where the
+ * last one did — and switching agents shows each agent's own last model instead
+ * of a value that only made sense for the other one.
+ *
+ * Persisted to localStorage only: which model a machine's user prefers is a
+ * client convenience the backend has no concept of. Stored values are open
+ * strings and are never validated here — catalogs change with plugin versions,
+ * so the picker checks a remembered model against the live catalog before
+ * offering it.
+ */
+export const useAgentModelPreferenceStore = create<AgentModelPreferenceState>()(
+  persist(
+    (set) => ({
+      models: {},
+      rememberModel: (agentRef, model) =>
+        set((state) => ({ models: { ...state.models, [agentRef]: model } })),
+    }),
+    {
+      name: AGENT_MODEL_PREFERENCE_STORAGE_KEY,
+      storage: createJSONStorage(() => window.localStorage),
+      // Tolerate partial or corrupt persisted state: a missing map is the same
+      // situation as a first run, and every consumer already handles an agent
+      // with no remembered model.
+      merge: (persisted, current) => {
+        const persistedModels = (
+          persisted as Partial<AgentModelPreferenceState> | undefined
+        )?.models;
+        return {
+          ...current,
+          models:
+            persistedModels !== null && typeof persistedModels === "object"
+              ? persistedModels
+              : {},
+        };
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## 问题

在还没开始的会话里选好模型后，这个选择会被"发送并创建会话"这一步消耗掉。于是每开一个新会话，模型都退回该 Agent 自己的默认值，用户得反复重选。

## 方案

把它按 **Agent** 记在 localStorage 里（新增 `agent-model-preference-store`，key `ora.agent-model-preference.v1`），未开始的会话据此打开。

范围刻意收窄：

- **只作用于未开始的会话**：`sessionId === undefined && boundSession === undefined`。已存在的会话——包括记录了待切换 Agent 的那种——仍以自身 configOptions 为准，既不读也不写这份偏好，正在聊天的界面不受任何影响。这里比 `usesPersistedOptions` 更严格，因为待切换 Agent 的已有会话也会走"未持久化"分支，但它仍是一个正在进行的会话。
- **按 Agent 而非按 surface 记忆**，这正是它与已有 `pendingModelStore` 的分工：后者记的是"这一个未开始的界面当前选了什么"，首次发送后即清空；前者跨会话存活。
- **目录变化时自动失效**：插件升级会改动模型目录，只有当前 Agent 仍提供该模型时才沿用，否则回落到 Agent 默认值。
- **首次发送走同一条兜底**：`session.start` 的 model 也补上偏好，否则会出现"标签显示 Small Pickle、但用户没点开过选择器就直接发送，后端却按 Agent 默认模型建会话"的不一致。发送时不做目录校验是安全的——后端只在新会话确实报告了该值时才应用 intent，落点与标签的回落一致。

## 测试

`model-selector.test.tsx` 新增 4 个用例：跨新会话记忆、按 Agent 各记各的、目录中已消失的模型回落默认、已开始的会话不受影响；`workspace-view.test.tsx` 新增 1 个：未点开选择器直接发送也使用记忆的模型。逐个反向验证过——回退实现后其中 3 个会失败。

`task lint:frontend` 通过。app-shell 全量测试在本机满并行下有 2–4 个文件超时失败，但失败文件每次都不同（含与本改动完全无关的 `markdown-message.test.tsx`），单独重跑全部通过，属机器负载抖动。

## 范围外

侧边栏 "+" 直接建会话的 `useCreateSession` 仍传 `model: null`，未跟随该偏好——它不经过新建会话的输入界面。如需一并跟随可另开一个改动。
