### PR TITLE
fix: disable right-click in non-listening areas

### DIFF
--- a/packages/app-shell/src/app-shell.tsx
+++ b/packages/app-shell/src/app-shell.tsx
@@ -35,6 +35,7 @@ import { startThemeSubscription } from "./state/stores/settings-store";
 import { useTranslation } from "react-i18next";
 import { WorkflowRuntimeProvider } from "./features/workflow-run/workflow-runtime-context";
 import { AppEventGate } from "./state/app-event-gate";
+import { useSuppressNativeContextMenu } from "./lib/suppress-native-context-menu";
 export { AppEventGate } from "./state/app-event-gate";
 
 interface AppShellProps {
@@ -86,6 +87,10 @@ function AppShellContent({
   platform,
   user: injectedUser,
 }: AppShellProps) {
+  // Right-click stays inside Ora: suppress the browser/OS context menu on every
+  // surface without its own listener, while custom menus (Base UI triggers)
+  // keep working because they stop propagation before this document listener.
+  useSuppressNativeContextMenu();
   // Mirror theme onto <html> for the shell's lifetime.
   useEffect(() => startThemeSubscription(), []);
   // Track which sessions finished a turn while the user was looking elsewhere.

--- a/packages/app-shell/src/features/chat/chat-view.test.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.test.tsx
@@ -2140,6 +2140,26 @@ describe("ChatView", () => {
     );
   });
 
+  it("suppresses the OS context menu across the conversation area", () => {
+    renderWithI18n(
+      <ChatView
+        turns={[]}
+        userName="Eric"
+        isResponding={false}
+        error={null}
+        onSend={() => {}}
+      />,
+    );
+
+    const pane = screen.getByRole("main");
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(pane, event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("keeps the disabled hint shut when the pointer never left the enabled composer", async () => {
     const user = userEvent.setup();
     const view = renderWithI18n(

--- a/packages/app-shell/src/features/chat/chat-view.tsx
+++ b/packages/app-shell/src/features/chat/chat-view.tsx
@@ -161,6 +161,10 @@ export function ChatView({
   return (
     <main
       className={`flex min-h-0 flex-1 flex-col bg-background ${isEmpty ? "overflow-y-auto" : ""}`}
+      // Right-click stays inside Ora: suppress the browser/OS context menu (Refresh,
+      // Back, Inspect) across the whole pane. Per-item menus like the chat file link's
+      // are opened by their own inner triggers before this bubbles, so they keep working.
+      onContextMenu={(event) => event.preventDefault()}
     >
       {isEmpty ? (
         // `mt-auto` here and `mb-auto` on the composer slot split the free space

--- a/packages/app-shell/src/lib/suppress-native-context-menu.test.tsx
+++ b/packages/app-shell/src/lib/suppress-native-context-menu.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useSuppressNativeContextMenu } from "./suppress-native-context-menu";
+
+/** Renders a surface that suppresses the native context menu while mounted. */
+function SuppressedSurface() {
+  useSuppressNativeContextMenu();
+  return <div data-testid="surface" />;
+}
+
+function dispatchContextMenu(): MouseEvent {
+  const event = new MouseEvent("contextmenu", {
+    bubbles: true,
+    cancelable: true,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe("useSuppressNativeContextMenu", () => {
+  it("suppresses the native context menu while mounted and restores it after unmount", () => {
+    const { unmount } = render(<SuppressedSurface />);
+
+    expect(dispatchContextMenu().defaultPrevented).toBe(true);
+
+    unmount();
+    expect(dispatchContextMenu().defaultPrevented).toBe(false);
+  });
+});

--- a/packages/app-shell/src/lib/suppress-native-context-menu.ts
+++ b/packages/app-shell/src/lib/suppress-native-context-menu.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+/**
+ * Suppresses the browser/OS right-click context menu (e.g. Refresh, Back,
+ * Inspect Element) across the whole window. Surfaces that provide their own
+ * context menu (Base UI ContextMenu triggers) call stopPropagation before this
+ * document-level listener runs, so those custom menus keep working while every
+ * area without a right-click listener shows nothing.
+ */
+export function useSuppressNativeContextMenu(): void {
+  useEffect(() => {
+    function onContextMenu(event: MouseEvent): void {
+      event.preventDefault();
+    }
+    document.addEventListener("contextmenu", onContextMenu);
+    return () => document.removeEventListener("contextmenu", onContextMenu);
+  }, []);
+}


### PR DESCRIPTION
  - 全应用带自定义右键菜单的只有 3 处：workspace 树行、session 树行、聊天文件链接（均用 Base UI ContextMenu）。
  - 其余所有区域（聊天空白/输入区、diff、文件查看、设置弹窗、工作流编辑/运行、侧边栏背景等）都没有右键监听，现在已禁用右键功能。