### PR TITLE
feat(plugin): add source-scoped S3 artifact retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,6 +3574,7 @@ version = "0.0.0"
 dependencies = [
  "flate2",
  "futures",
+ "hmac",
  "pretty_assertions",
  "quick-xml",
  "rcgen",
@@ -3586,6 +3587,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.20",
+ "time",
  "tokio",
  "tokio-rustls",
  "unicode-normalization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ cron = "0.12"
 derive_more = "2"
 futures = "0.3"
 flate2 = "1"
+hmac = "0.12"
 futures-util = { version = "0.3", features = ["sink"] }
 gray_matter = { version = "0.3", default-features = false, features = ["yaml"] }
 libc = "0.2"

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -2053,7 +2053,7 @@ mod tests {
             .expect("resolve marketplace manifest")
             .expect("Tavily listing is present in staged registry");
         assert_eq!(
-            manifest.url().map(|url| url.as_url().to_string()),
+            manifest.url().map(|locator| locator.as_str().to_string()),
             Some(
                 "https://github.com/ora-space/tavily-search-mcp/releases/download/v0.1.0/ora-space.tavily-search-v0.1.0.orax"
                     .to_string()

--- a/crates/backend/src/marketplace_sources.rs
+++ b/crates/backend/src/marketplace_sources.rs
@@ -1,4 +1,9 @@
-use ora_contracts::MarketplaceSource;
+mod artifact_retrieval;
+
+use artifact_retrieval::{ArtifactRetrievalError, StoredArtifactRetrieval};
+use ora_contracts::{
+    MarketplaceArtifactRetrieval, MarketplaceSource, UpdateMarketplaceSourceRequest,
+};
 use ora_db::{
     PluginMarketplaceSourceRecord, SqlitePluginMarketplaceSourceRepository,
     SqlitePluginSourceNamespaceRepository,
@@ -24,6 +29,8 @@ pub(crate) enum MarketplaceSourceStoreError {
     NotFound(String),
     #[error("marketplace source repository operation failed: {0}")]
     Repository(#[from] ora_db::DatabaseError),
+    #[error("invalid marketplace artifact retrieval configuration: {0}")]
+    ArtifactRetrieval(#[from] ArtifactRetrievalError),
     /// A persisted binding holds a namespace this version cannot represent, so the source cannot
     /// be used without either inventing a new identity for it or silently changing an existing
     /// one — both of which would detach its already-installed plugins.
@@ -37,6 +44,25 @@ pub(crate) struct MarketplaceSourceStore {
     repository: SqlitePluginMarketplaceSourceRepository,
     namespaces: SqlitePluginSourceNamespaceRepository,
     sources_root: PathBuf,
+}
+
+/// Keeps the secret-bearing retrieval state beside its redacted public source projection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ConfiguredMarketplaceSource {
+    source: MarketplaceSource,
+    artifact_retrieval: StoredArtifactRetrieval,
+}
+
+impl ConfiguredMarketplaceSource {
+    /// Returns the redacted source fields safe for contracts and ordinary diagnostics.
+    pub(crate) fn source(&self) -> &MarketplaceSource {
+        &self.source
+    }
+
+    /// Builds S3 signing configuration only for the S3 SigV4 retrieval variant.
+    pub(crate) fn s3_config(&self) -> Option<ora_utils::http::S3Config> {
+        self.artifact_retrieval.s3_config()
+    }
 }
 
 impl MarketplaceSourceStore {
@@ -59,16 +85,36 @@ impl MarketplaceSourceStore {
                 branch: DEFAULT_MARKETPLACE_BRANCH.to_owned(),
                 use_proxy: false,
                 enabled: true,
+                artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
             };
-            store.insert(default_source, /*position*/ 0, now_ms)?;
+            store.insert(
+                default_source,
+                StoredArtifactRetrieval::DirectHttps,
+                /*position*/ 0,
+                now_ms,
+            )?;
         }
         Ok(store)
     }
 
     /// Returns the current source list in source-precedence order.
     pub(crate) fn list(&self) -> Result<Vec<MarketplaceSource>, MarketplaceSourceStoreError> {
-        let sources = self.repository.list_sources()?;
-        Ok(sources.iter().map(source_spec).collect())
+        Ok(self
+            .configured_sources()?
+            .into_iter()
+            .map(|configured| configured.source)
+            .collect())
+    }
+
+    /// Returns validated source configuration including secret-bearing retrieval state.
+    pub(crate) fn configured_sources(
+        &self,
+    ) -> Result<Vec<ConfiguredMarketplaceSource>, MarketplaceSourceStoreError> {
+        self.repository
+            .list_sources()?
+            .into_iter()
+            .map(configured_source)
+            .collect()
     }
 
     /// Validates, persists, and returns one additional source appended to the current ordering.
@@ -94,7 +140,12 @@ impl MarketplaceSourceStore {
             .map(|existing| existing.position)
             .max()
             .map_or(0, |highest| highest + 1);
-        self.insert(source, position, now_ms)?;
+        self.insert(
+            source,
+            StoredArtifactRetrieval::DirectHttps,
+            position,
+            now_ms,
+        )?;
         self.list()
     }
 
@@ -120,38 +171,44 @@ impl MarketplaceSourceStore {
     /// existing binding so installed plugins stay attached.
     pub(crate) fn update(
         &self,
-        current_url: &str,
-        source: MarketplaceSource,
+        request: UpdateMarketplaceSourceRequest,
         now_ms: i64,
     ) -> Result<Vec<MarketplaceSource>, MarketplaceSourceStoreError> {
         let current = self.repository.list_sources()?;
-        let Some(existing) = current.iter().find(|row| row.url == current_url).cloned() else {
-            return Err(MarketplaceSourceStoreError::NotFound(
-                current_url.to_owned(),
-            ));
+        let Some(existing) = current.iter().find(|row| row.url == request.url).cloned() else {
+            return Err(MarketplaceSourceStoreError::NotFound(request.url));
         };
-        let new_canonical = canonical_repository_url(&source.url);
+        let new_canonical = canonical_repository_url(&request.new_url);
         if current.iter().any(|row| {
-            row.url != current_url && canonical_repository_url(&row.url) == new_canonical
+            row.url != request.url && canonical_repository_url(&row.url) == new_canonical
         }) {
-            return Err(MarketplaceSourceStoreError::Duplicate(source.url));
+            return Err(MarketplaceSourceStoreError::Duplicate(request.new_url));
         }
+        let existing_retrieval = StoredArtifactRetrieval::parse(&existing.artifact_retrieval)?;
+        let artifact_retrieval =
+            StoredArtifactRetrieval::updated(&existing_retrieval, request.artifact_retrieval)?;
+        let source = MarketplaceSource {
+            url: request.new_url,
+            branch: request.branch,
+            use_proxy: request.use_proxy,
+            enabled: request.enabled,
+            artifact_retrieval: artifact_retrieval.public(),
+        };
         let namespace = self.namespace_for(&source.url, now_ms)?;
         checked_source(&source, namespace, &self.sources_root)?;
         if !self.repository.update_source(
-            current_url,
+            &request.url,
             &PluginMarketplaceSourceRecord {
                 url: source.url,
                 branch: source.branch,
                 use_proxy: source.use_proxy,
                 enabled: source.enabled,
+                artifact_retrieval: artifact_retrieval.to_json()?,
                 position: existing.position,
             },
             now_ms,
         )? {
-            return Err(MarketplaceSourceStoreError::NotFound(
-                current_url.to_owned(),
-            ));
+            return Err(MarketplaceSourceStoreError::NotFound(request.url));
         }
         self.list()
     }
@@ -194,6 +251,7 @@ impl MarketplaceSourceStore {
     fn insert(
         &self,
         source: MarketplaceSource,
+        artifact_retrieval: StoredArtifactRetrieval,
         position: i64,
         now_ms: i64,
     ) -> Result<(), MarketplaceSourceStoreError> {
@@ -206,6 +264,7 @@ impl MarketplaceSourceStore {
                 branch: source.branch,
                 use_proxy: source.use_proxy,
                 enabled: source.enabled,
+                artifact_retrieval: artifact_retrieval.to_json()?,
                 position,
             },
             now_ms,
@@ -229,13 +288,20 @@ fn checked_source(
 }
 
 /// Projects one durable row back to the frontend-facing wire shape.
-fn source_spec(source: &PluginMarketplaceSourceRecord) -> MarketplaceSource {
-    MarketplaceSource {
-        url: source.url.clone(),
-        branch: source.branch.clone(),
-        use_proxy: source.use_proxy,
-        enabled: source.enabled,
-    }
+fn configured_source(
+    source: PluginMarketplaceSourceRecord,
+) -> Result<ConfiguredMarketplaceSource, MarketplaceSourceStoreError> {
+    let artifact_retrieval = StoredArtifactRetrieval::parse(&source.artifact_retrieval)?;
+    Ok(ConfiguredMarketplaceSource {
+        source: MarketplaceSource {
+            url: source.url,
+            branch: source.branch,
+            use_proxy: source.use_proxy,
+            enabled: source.enabled,
+            artifact_retrieval: artifact_retrieval.public(),
+        },
+        artifact_retrieval,
+    })
 }
 
 #[cfg(test)]
@@ -278,6 +344,7 @@ mod tests {
             branch: "main".to_owned(),
             use_proxy: false,
             enabled: true,
+            artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
         }
     }
 
@@ -295,6 +362,7 @@ mod tests {
                 branch: DEFAULT_MARKETPLACE_BRANCH.to_owned(),
                 use_proxy: false,
                 enabled: true,
+                artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
             }]
         );
     }
@@ -308,6 +376,7 @@ mod tests {
             branch: "main".to_owned(),
             use_proxy: true,
             enabled: true,
+            artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
         };
 
         let sources = store.add(added.clone(), 2).expect("add source");
@@ -316,12 +385,14 @@ mod tests {
 
         let updated = store
             .update(
-                &added.url,
-                MarketplaceSource {
+                UpdateMarketplaceSourceRequest {
                     url: added.url.clone(),
+                    new_url: added.url.clone(),
                     branch: "release".to_owned(),
                     use_proxy: false,
                     enabled: false,
+                    artifact_retrieval:
+                        ora_contracts::MarketplaceArtifactRetrievalUpdate::DirectHttps,
                 },
                 3,
             )
@@ -333,11 +404,109 @@ mod tests {
                 branch: "release".to_owned(),
                 use_proxy: false,
                 enabled: false,
+                artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
             }
         );
 
         let remaining = store.delete(&added.url).expect("delete source");
         assert_eq!(remaining.len(), 1);
+    }
+
+    /// S3 credentials are replaced as one pair and can be preserved without crossing the query contract.
+    #[test]
+    fn updates_and_preserves_s3_retrieval_credentials() {
+        let temp = TempDir::new().expect("create temp directory");
+        let pool = open_pool(&temp);
+        let store = store_with_pool(&temp, pool.clone());
+        let source = third_party("https://github.com/example/private-marketplace");
+        store.add(source.clone(), 2).expect("add source");
+
+        store
+            .update(
+                UpdateMarketplaceSourceRequest {
+                    url: source.url.clone(),
+                    new_url: source.url.clone(),
+                    branch: source.branch.clone(),
+                    use_proxy: false,
+                    enabled: true,
+                    artifact_retrieval:
+                        ora_contracts::MarketplaceArtifactRetrievalUpdate::S3SigV4 {
+                            endpoint: "https://s3.example.com:443".to_owned(),
+                            bucket: "plugins".to_owned(),
+                            region: "region-1".to_owned(),
+                            credentials: ora_contracts::MarketplaceS3CredentialsUpdate::Replace {
+                                access_key_id: "access".to_owned(),
+                                secret_access_key: "secret".to_owned(),
+                            },
+                        },
+                },
+                3,
+            )
+            .expect("enable S3 retrieval");
+        let public = store.list().expect("list redacted sources");
+        assert_eq!(
+            public[1].artifact_retrieval,
+            MarketplaceArtifactRetrieval::S3SigV4 {
+                endpoint: "https://s3.example.com".to_owned(),
+                bucket: "plugins".to_owned(),
+                region: "region-1".to_owned(),
+            }
+        );
+
+        store
+            .update(
+                UpdateMarketplaceSourceRequest {
+                    url: source.url.clone(),
+                    new_url: source.url.clone(),
+                    branch: source.branch,
+                    use_proxy: false,
+                    enabled: true,
+                    artifact_retrieval:
+                        ora_contracts::MarketplaceArtifactRetrievalUpdate::S3SigV4 {
+                            endpoint: "https://objects.example.com".to_owned(),
+                            bucket: "plugins-v2".to_owned(),
+                            region: "region-2".to_owned(),
+                            credentials: ora_contracts::MarketplaceS3CredentialsUpdate::Preserve,
+                        },
+                },
+                4,
+            )
+            .expect("preserve S3 credentials");
+
+        let records = SqlitePluginMarketplaceSourceRepository::new(pool.clone())
+            .list_sources()
+            .expect("load persisted source");
+        let persisted = StoredArtifactRetrieval::parse(&records[1].artifact_retrieval)
+            .expect("parse retrieval");
+        assert_eq!(
+            persisted,
+            StoredArtifactRetrieval::S3SigV4 {
+                endpoint: "https://objects.example.com".to_owned(),
+                bucket: "plugins-v2".to_owned(),
+                region: "region-2".to_owned(),
+                access_key_id: "access".to_owned(),
+                secret_access_key: "secret".to_owned(),
+            }
+        );
+
+        store
+            .update(
+                UpdateMarketplaceSourceRequest {
+                    url: source.url.clone(),
+                    new_url: source.url,
+                    branch: "main".to_owned(),
+                    use_proxy: false,
+                    enabled: true,
+                    artifact_retrieval:
+                        ora_contracts::MarketplaceArtifactRetrievalUpdate::DirectHttps,
+                },
+                5,
+            )
+            .expect("switch back to Direct HTTPS");
+        let records = SqlitePluginMarketplaceSourceRepository::new(pool)
+            .list_sources()
+            .expect("reload Direct HTTPS source");
+        assert_eq!(records[1].artifact_retrieval, r#"{"type":"direct_https"}"#);
     }
 
     #[test]
@@ -352,9 +521,21 @@ mod tests {
             branch: "main".to_owned(),
             use_proxy: false,
             enabled: true,
+            artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
         };
         let sources = store
-            .update(&original.url, renamed.clone(), 3)
+            .update(
+                UpdateMarketplaceSourceRequest {
+                    url: original.url.clone(),
+                    new_url: renamed.url.clone(),
+                    branch: renamed.branch.clone(),
+                    use_proxy: renamed.use_proxy,
+                    enabled: renamed.enabled,
+                    artifact_retrieval:
+                        ora_contracts::MarketplaceArtifactRetrievalUpdate::DirectHttps,
+                },
+                3,
+            )
             .expect("rename source");
 
         assert!(sources.contains(&renamed));
@@ -372,12 +553,14 @@ mod tests {
 
         assert!(matches!(
             store.update(
-                &second.url,
-                MarketplaceSource {
-                    url: "https://github.com/example/first.git".to_owned(),
+                UpdateMarketplaceSourceRequest {
+                    url: second.url.clone(),
+                    new_url: "https://github.com/example/first.git".to_owned(),
                     branch: "main".to_owned(),
                     use_proxy: false,
                     enabled: true,
+                    artifact_retrieval:
+                        ora_contracts::MarketplaceArtifactRetrievalUpdate::DirectHttps,
                 },
                 4,
             ),
@@ -416,6 +599,7 @@ mod tests {
                     branch: DEFAULT_MARKETPLACE_BRANCH.to_owned(),
                     use_proxy: false,
                     enabled: true,
+                    artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
                 },
                 2,
             ),
@@ -443,6 +627,7 @@ mod tests {
                     branch: DEFAULT_MARKETPLACE_BRANCH.to_owned(),
                     use_proxy: false,
                     enabled: true,
+                    artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
                 },
                 3,
             )

--- a/crates/backend/src/marketplace_sources/artifact_retrieval.rs
+++ b/crates/backend/src/marketplace_sources/artifact_retrieval.rs
@@ -1,0 +1,313 @@
+use std::fmt;
+
+use ora_contracts::{
+    MarketplaceArtifactRetrieval, MarketplaceArtifactRetrievalUpdate,
+    MarketplaceS3CredentialsUpdate,
+};
+use ora_utils::http::S3Config;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+
+#[cfg(test)]
+const DIRECT_HTTPS_JSON: &str = r#"{"type":"direct_https"}"#;
+
+const MAX_ENDPOINT_BYTES: usize = 2048;
+const MAX_BUCKET_BYTES: usize = 255;
+const MAX_REGION_BYTES: usize = 128;
+const MAX_CREDENTIAL_BYTES: usize = 1024;
+
+/// Holds the complete persisted artifact-retrieval state for one marketplace source.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum StoredArtifactRetrieval {
+    DirectHttps,
+    #[serde(rename = "s3_sigv4")]
+    S3SigV4 {
+        endpoint: String,
+        bucket: String,
+        region: String,
+        access_key_id: String,
+        secret_access_key: String,
+    },
+}
+
+impl fmt::Debug for StoredArtifactRetrieval {
+    /// Omits the entire credential pair so debug output remains safe by construction.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DirectHttps => formatter.write_str("DirectHttps"),
+            Self::S3SigV4 {
+                endpoint,
+                bucket,
+                region,
+                ..
+            } => formatter
+                .debug_struct("S3SigV4")
+                .field("endpoint", endpoint)
+                .field("bucket", bucket)
+                .field("region", region)
+                .field("credentials", &"[redacted]")
+                .finish(),
+        }
+    }
+}
+
+impl StoredArtifactRetrieval {
+    /// Parses persisted JSON and revalidates every value before it enters runtime configuration.
+    pub(super) fn parse(json: &str) -> Result<Self, ArtifactRetrievalError> {
+        let retrieval: Self = serde_json::from_str(json)
+            .map_err(|_| ArtifactRetrievalError::InvalidPersistedConfiguration)?;
+        retrieval.validated()
+    }
+
+    /// Applies an editor update, preserving a credential pair only for an existing S3 source.
+    pub(super) fn updated(
+        existing: &Self,
+        update: MarketplaceArtifactRetrievalUpdate,
+    ) -> Result<Self, ArtifactRetrievalError> {
+        let retrieval = match update {
+            MarketplaceArtifactRetrievalUpdate::DirectHttps => Self::DirectHttps,
+            MarketplaceArtifactRetrievalUpdate::S3SigV4 {
+                endpoint,
+                bucket,
+                region,
+                credentials,
+            } => {
+                let (access_key_id, secret_access_key) = match credentials {
+                    MarketplaceS3CredentialsUpdate::Preserve => match existing {
+                        Self::S3SigV4 {
+                            access_key_id,
+                            secret_access_key,
+                            ..
+                        } => (access_key_id.clone(), secret_access_key.clone()),
+                        Self::DirectHttps => {
+                            return Err(ArtifactRetrievalError::CredentialsRequired);
+                        }
+                    },
+                    MarketplaceS3CredentialsUpdate::Replace {
+                        access_key_id,
+                        secret_access_key,
+                    } => (access_key_id, secret_access_key),
+                };
+                Self::S3SigV4 {
+                    endpoint,
+                    bucket,
+                    region,
+                    access_key_id,
+                    secret_access_key,
+                }
+            }
+        };
+        retrieval.validated()
+    }
+
+    /// Serializes the complete durable representation written to SQLite.
+    pub(super) fn to_json(&self) -> Result<String, ArtifactRetrievalError> {
+        serde_json::to_string(self)
+            .map_err(|_| ArtifactRetrievalError::InvalidPersistedConfiguration)
+    }
+
+    /// Projects a source configuration without exposing its credential pair.
+    pub(super) fn public(&self) -> MarketplaceArtifactRetrieval {
+        match self {
+            Self::DirectHttps => MarketplaceArtifactRetrieval::DirectHttps,
+            Self::S3SigV4 {
+                endpoint,
+                bucket,
+                region,
+                ..
+            } => MarketplaceArtifactRetrieval::S3SigV4 {
+                endpoint: endpoint.clone(),
+                bucket: bucket.clone(),
+                region: region.clone(),
+            },
+        }
+    }
+
+    /// Builds the generic downloader configuration when this source uses S3 SigV4.
+    pub(super) fn s3_config(&self) -> Option<S3Config> {
+        match self {
+            Self::DirectHttps => None,
+            Self::S3SigV4 {
+                endpoint,
+                bucket,
+                region,
+                access_key_id,
+                secret_access_key,
+            } => {
+                let parsed = Url::parse(endpoint)
+                    .unwrap_or_else(|_| unreachable!("stored endpoints are validated"));
+                let host = parsed
+                    .host_str()
+                    .unwrap_or_else(|| unreachable!("stored endpoints have a host"));
+                let authority = match parsed.port() {
+                    Some(port) => format!("{host}:{port}"),
+                    None => host.to_owned(),
+                };
+                Some(S3Config::new(
+                    authority,
+                    bucket.clone(),
+                    region.clone(),
+                    access_key_id.clone(),
+                    secret_access_key.clone(),
+                ))
+            }
+        }
+    }
+
+    /// Normalizes the endpoint and rejects incomplete or ambiguous S3 states.
+    fn validated(self) -> Result<Self, ArtifactRetrievalError> {
+        match self {
+            Self::DirectHttps => Ok(Self::DirectHttps),
+            Self::S3SigV4 {
+                endpoint,
+                bucket,
+                region,
+                access_key_id,
+                secret_access_key,
+            } => {
+                let endpoint = validated_endpoint(&endpoint)?;
+                validate_scalar("bucket", &bucket, MAX_BUCKET_BYTES)?;
+                if bucket.contains('/') || bucket.contains('\\') {
+                    return Err(ArtifactRetrievalError::InvalidField("bucket"));
+                }
+                validate_scalar("region", &region, MAX_REGION_BYTES)?;
+                validate_scalar("access key id", &access_key_id, MAX_CREDENTIAL_BYTES)?;
+                validate_scalar(
+                    "secret access key",
+                    &secret_access_key,
+                    MAX_CREDENTIAL_BYTES,
+                )?;
+                Ok(Self::S3SigV4 {
+                    endpoint,
+                    bucket,
+                    region,
+                    access_key_id,
+                    secret_access_key,
+                })
+            }
+        }
+    }
+}
+
+/// Reports invalid source-scoped artifact retrieval without rendering credential values.
+#[derive(Debug, Error)]
+pub(crate) enum ArtifactRetrievalError {
+    #[error("persisted artifact retrieval configuration is invalid")]
+    InvalidPersistedConfiguration,
+    #[error("S3 credentials are required when enabling S3 SigV4 retrieval")]
+    CredentialsRequired,
+    #[error("invalid artifact retrieval field: {0}")]
+    InvalidField(&'static str),
+}
+
+/// Validates and canonicalizes an HTTPS origin used as an S3-compatible endpoint.
+fn validated_endpoint(value: &str) -> Result<String, ArtifactRetrievalError> {
+    if value.len() > MAX_ENDPOINT_BYTES {
+        return Err(ArtifactRetrievalError::InvalidField("endpoint"));
+    }
+    let endpoint =
+        Url::parse(value).map_err(|_| ArtifactRetrievalError::InvalidField("endpoint"))?;
+    if endpoint.scheme() != "https"
+        || endpoint.host_str().is_none()
+        || matches!(endpoint.host(), Some(url::Host::Ipv6(_)))
+        || !endpoint.username().is_empty()
+        || endpoint.password().is_some()
+        || endpoint.path() != "/"
+        || endpoint.query().is_some()
+        || endpoint.fragment().is_some()
+    {
+        return Err(ArtifactRetrievalError::InvalidField("endpoint"));
+    }
+    Ok(endpoint.origin().ascii_serialization())
+}
+
+/// Applies shared non-empty, bounded, and printable-text constraints to one S3 scalar.
+fn validate_scalar(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<(), ArtifactRetrievalError> {
+    if value.is_empty()
+        || value.len() > max_bytes
+        || value.trim() != value
+        || value.chars().any(char::is_control)
+    {
+        return Err(ArtifactRetrievalError::InvalidField(field));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    /// Direct HTTPS has one compact durable and public representation.
+    #[test]
+    fn direct_https_round_trips() {
+        let retrieval = StoredArtifactRetrieval::parse(DIRECT_HTTPS_JSON).unwrap();
+        assert_eq!(retrieval, StoredArtifactRetrieval::DirectHttps);
+        assert_eq!(retrieval.to_json().unwrap(), DIRECT_HTTPS_JSON);
+        assert_eq!(
+            retrieval.public(),
+            MarketplaceArtifactRetrieval::DirectHttps
+        );
+    }
+
+    /// Enabling S3 requires replacement credentials and canonicalizes the endpoint origin.
+    #[test]
+    fn enabling_s3_requires_complete_credentials() {
+        let missing = StoredArtifactRetrieval::updated(
+            &StoredArtifactRetrieval::DirectHttps,
+            MarketplaceArtifactRetrievalUpdate::S3SigV4 {
+                endpoint: "https://s3.example.com".to_owned(),
+                bucket: "plugins".to_owned(),
+                region: "region-1".to_owned(),
+                credentials: MarketplaceS3CredentialsUpdate::Preserve,
+            },
+        );
+        assert!(matches!(
+            missing,
+            Err(ArtifactRetrievalError::CredentialsRequired)
+        ));
+
+        let configured = StoredArtifactRetrieval::updated(
+            &StoredArtifactRetrieval::DirectHttps,
+            MarketplaceArtifactRetrievalUpdate::S3SigV4 {
+                endpoint: "https://s3.example.com:443".to_owned(),
+                bucket: "plugins".to_owned(),
+                region: "region-1".to_owned(),
+                credentials: MarketplaceS3CredentialsUpdate::Replace {
+                    access_key_id: "access".to_owned(),
+                    secret_access_key: "secret".to_owned(),
+                },
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            configured.public(),
+            MarketplaceArtifactRetrieval::S3SigV4 {
+                endpoint: "https://s3.example.com".to_owned(),
+                bucket: "plugins".to_owned(),
+                region: "region-1".to_owned(),
+            }
+        );
+    }
+
+    /// Debug output never contains either member of the credential pair.
+    #[test]
+    fn debug_redacts_credentials() {
+        let retrieval = StoredArtifactRetrieval::S3SigV4 {
+            endpoint: "https://s3.example.com".to_owned(),
+            bucket: "plugins".to_owned(),
+            region: "region-1".to_owned(),
+            access_key_id: "visible-only-to-signer".to_owned(),
+            secret_access_key: "never-render-this".to_owned(),
+        };
+        let rendered = format!("{retrieval:?}");
+        assert!(!rendered.contains("visible-only-to-signer"));
+        assert!(!rendered.contains("never-render-this"));
+    }
+}

--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -2,7 +2,9 @@ use crate::app_event::AppEventPublisher;
 use crate::clock::SystemClock;
 use crate::effect_worker::EffectWorkerHandle;
 use crate::error::{BackendError, ErrorClassification};
-use crate::marketplace_sources::{MarketplaceSourceStore, MarketplaceSourceStoreError};
+use crate::marketplace_sources::{
+    ConfiguredMarketplaceSource, MarketplaceSourceStore, MarketplaceSourceStoreError,
+};
 use crate::proxy;
 use crate::user_config::UserConfigApi;
 use gitlancer::{CliGitRunner, Git};
@@ -13,12 +15,12 @@ use ora_contracts::{
     EmptyErrorParams, ImportPluginRequest, ImportPluginResponse, InstallOutcome,
     InstallPluginRequest, InstallPluginResponse, ListAvailablePluginsRequest,
     ListAvailablePluginsResponse, ListInstalledPluginsRequest, ListInstalledPluginsResponse,
-    ListMarketplaceSourcesRequest, ListMarketplaceSourcesResponse, PluginHostCompatibility,
-    PublicError, ReadPluginReadmeRequest, ReadPluginReadmeResponse, ScanPluginsRequest,
-    ScanPluginsResponse, StopPluginRequest, StopPluginResponse, SyncAvailablePluginsRequest,
-    SyncAvailablePluginsResponse, UninstallPluginRequest, UninstallPluginResponse,
-    UpdateMarketplaceSourceRequest, UpdateMarketplaceSourceResponse, UpdatePluginRequest,
-    UpdatePluginResponse,
+    ListMarketplaceSourcesRequest, ListMarketplaceSourcesResponse, MarketplaceArtifactRetrieval,
+    PluginHostCompatibility, PublicError, ReadPluginReadmeRequest, ReadPluginReadmeResponse,
+    ScanPluginsRequest, ScanPluginsResponse, StopPluginRequest, StopPluginResponse,
+    SyncAvailablePluginsRequest, SyncAvailablePluginsResponse, UninstallPluginRequest,
+    UninstallPluginResponse, UpdateMarketplaceSourceRequest, UpdateMarketplaceSourceResponse,
+    UpdatePluginRequest, UpdatePluginResponse,
 };
 use ora_db::{
     PluginSkillProjection, RepositoryPool, SqliteEffectRepository,
@@ -40,7 +42,9 @@ use ora_plugin_manager::{
 };
 use ora_plugin_manifest::PluginManifest;
 use ora_plugin_registry::{RegistryEntry, RegistryError, RegistryIndex, RegistrySync};
-use ora_utils::http::{ProgressCallback, ProxyConfig, ReqwestDownloader};
+use ora_utils::http::{
+    ProgressCallback, ProxyConfig, ReqwestDownloader, S3AwareDownloader, S3Config,
+};
 use ora_utils::url::canonical_repository_url;
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -310,7 +314,7 @@ impl PluginApi {
         let enabled_urls: HashSet<String> = self
             .enabled_marketplace_sources()?
             .into_iter()
-            .map(|source| canonical_repository_url(&source.url))
+            .map(|source| canonical_repository_url(&source.source().url))
             .collect();
         response
             .plugins
@@ -344,6 +348,7 @@ impl PluginApi {
                     branch: request.branch,
                     use_proxy: request.use_proxy,
                     enabled: true,
+                    artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
                 },
                 self.clock.now_timestamp_millis(),
             )
@@ -370,16 +375,7 @@ impl PluginApi {
     ) -> Result<UpdateMarketplaceSourceResponse, BackendError> {
         let sources = self
             .marketplace_sources
-            .update(
-                &request.url,
-                ora_contracts::MarketplaceSource {
-                    url: request.new_url,
-                    branch: request.branch,
-                    use_proxy: request.use_proxy,
-                    enabled: request.enabled,
-                },
-                self.clock.now_timestamp_millis(),
-            )
+            .update(request, self.clock.now_timestamp_millis())
             .map_err(map_marketplace_source_error)?;
         Ok(UpdateMarketplaceSourceResponse { sources })
     }
@@ -392,13 +388,13 @@ impl PluginApi {
     ) -> Result<SyncAvailablePluginsResponse, BackendError> {
         let git = Git::new(CliGitRunner);
         let registry_sources = self.prepared_registry_sources()?;
-        for (source, _) in &registry_sources {
+        for (source, _, _) in &registry_sources {
             RegistrySync::sync(&git, source)
                 .map_err(|error| BackendError::internal("failed to sync plugin registry", error))?;
         }
         let synced: Vec<&ora_plugin_registry::RegistrySource> = registry_sources
             .iter()
-            .map(|(source, _use_proxy)| source)
+            .map(|(source, _use_proxy, _s3_config)| source)
             .collect();
         let build =
             RegistryIndex::build_all(&synced, ora_logging::clock::now_local().unix_timestamp());
@@ -475,13 +471,13 @@ impl PluginApi {
     /// Returns configured marketplace sources that currently participate in listing and sync.
     fn enabled_marketplace_sources(
         &self,
-    ) -> Result<Vec<ora_contracts::MarketplaceSource>, BackendError> {
+    ) -> Result<Vec<ConfiguredMarketplaceSource>, BackendError> {
         Ok(self
             .marketplace_sources
-            .list()
+            .configured_sources()
             .map_err(map_marketplace_source_error)?
             .into_iter()
-            .filter(|source| source.enabled)
+            .filter(|source| source.source().enabled)
             .collect())
     }
 
@@ -496,7 +492,7 @@ impl PluginApi {
             .iter()
             .map(|source| {
                 self.marketplace_sources
-                    .registry_source(source, now_ms)
+                    .registry_source(source.source(), now_ms)
                     .map_err(map_marketplace_source_error)
             })
             .collect()
@@ -505,13 +501,14 @@ impl PluginApi {
     /// Binds every enabled marketplace source to a registry checkout, applying proxy policy.
     fn prepared_registry_sources(
         &self,
-    ) -> Result<Vec<(ora_plugin_registry::RegistrySource, bool)>, BackendError> {
+    ) -> Result<Vec<(ora_plugin_registry::RegistrySource, bool, Option<S3Config>)>, BackendError>
+    {
         let configured = self.enabled_marketplace_sources()?;
         let proxy_settings = self.user_config.network_proxy_settings()?;
         let mut registry_sources = Vec::with_capacity(configured.len());
 
         for (source, mut registry_source) in configured.iter().zip(self.registry_sources()?) {
-            if source.use_proxy {
+            if source.source().use_proxy {
                 let git_env = proxy::git_proxy_env(proxy_settings.as_ref())?.ok_or_else(|| {
                     BackendError::invalid_proxy_settings(
                         "a marketplace source uses the proxy but no proxy is configured",
@@ -519,7 +516,11 @@ impl PluginApi {
                 })?;
                 registry_source = registry_source.with_git_env(git_env);
             }
-            registry_sources.push((registry_source, source.use_proxy));
+            registry_sources.push((
+                registry_source,
+                source.source().use_proxy,
+                source.s3_config(),
+            ));
         }
 
         Ok(registry_sources)
@@ -704,7 +705,7 @@ impl PluginApi {
         request: InstallPluginRequest,
         progress: Option<ProgressCallback>,
     ) -> Result<InstallPluginResponse, BackendError> {
-        let (manifest, namespace, use_proxy) =
+        let (manifest, namespace, use_proxy, s3_config) =
             self.resolve_marketplace_release(&request.plugin_id)?;
         let release_source = self.select_marketplace_release(&manifest)?;
         match release_source.download() {
@@ -714,9 +715,11 @@ impl PluginApi {
             ora_utils::http::DownloadSource::Local(path) => {
                 ora_info!(plugin_id = %request.plugin_id, path = %path.display(), "installing marketplace plugin from local source");
             }
+            ora_utils::http::DownloadSource::S3 { key } => {
+                ora_info!(plugin_id = %request.plugin_id, key = %key, "installing marketplace plugin from object store");
+            }
         }
-        let download_proxy = self.download_proxy_for(use_proxy)?;
-        let installer = Installer::new(ReqwestDownloader::new(download_proxy));
+        let installer = self.marketplace_installer(use_proxy, s3_config)?;
         match progress {
             Some(progress) => {
                 installer
@@ -754,7 +757,7 @@ impl PluginApi {
         &self,
         request: UpdatePluginRequest,
     ) -> Result<UpdatePluginResponse, BackendError> {
-        let (manifest, namespace, use_proxy) =
+        let (manifest, namespace, use_proxy, s3_config) =
             self.resolve_marketplace_release(&request.plugin_id)?;
         let release_source = self.select_marketplace_release(&manifest)?;
         match release_source.download() {
@@ -763,6 +766,9 @@ impl PluginApi {
             }
             ora_utils::http::DownloadSource::Local(path) => {
                 ora_info!(plugin_id = %request.plugin_id, path = %path.display(), "updating marketplace plugin from local source");
+            }
+            ora_utils::http::DownloadSource::S3 { key } => {
+                ora_info!(plugin_id = %request.plugin_id, key = %key, "updating marketplace plugin from object store");
             }
         }
         // The package directory is replaced while the plugin may be running, so the process is
@@ -773,8 +779,7 @@ impl PluginApi {
             })
             .await
             .map_err(BackendError::from)?;
-        let download_proxy = self.download_proxy_for(use_proxy)?;
-        Installer::new(ReqwestDownloader::new(download_proxy))
+        self.marketplace_installer(use_proxy, s3_config)?
             .update(&manifest, &namespace, release_source, &self.home_directory)
             .await
             .map_err(|error| self.map_update_error("failed to update plugin", error))?;
@@ -794,7 +799,7 @@ impl PluginApi {
     fn resolve_marketplace_release(
         &self,
         plugin_id: &str,
-    ) -> Result<(PluginManifest, PluginNamespace, bool), BackendError> {
+    ) -> Result<(PluginManifest, PluginNamespace, bool, Option<S3Config>), BackendError> {
         let registry_sources = self.prepared_registry_sources()?;
         // A malformed identifier can never name a registry entry, so it is reported the same way
         // as an unknown one instead of leaking the id grammar as a separate error class.
@@ -805,13 +810,18 @@ impl PluginApi {
                 "marketplace plugin id is not a valid `<namespace>/<name>`",
             )
         })?;
-        for (source, use_proxy) in &registry_sources {
+        for (source, use_proxy, s3_config) in &registry_sources {
             if let Some(manifest) =
                 RegistryIndex::resolve_manifest(source, &plugin_id).map_err(|error| {
                     BackendError::internal("failed to resolve plugin release manifest", error)
                 })?
             {
-                return Ok((manifest, source.namespace().clone(), *use_proxy));
+                return Ok((
+                    manifest,
+                    source.namespace().clone(),
+                    *use_proxy,
+                    s3_config.clone(),
+                ));
             }
         }
         Err(BackendError::new(
@@ -869,6 +879,19 @@ impl PluginApi {
                 "a marketplace source uses the proxy but no proxy is configured",
             )
         })
+    }
+
+    /// Builds a source-scoped downloader that signs only the configured S3 endpoint and bucket.
+    fn marketplace_installer(
+        &self,
+        use_proxy: bool,
+        s3_config: Option<S3Config>,
+    ) -> Result<Installer<S3AwareDownloader>, BackendError> {
+        let download_proxy = self.download_proxy_for(use_proxy)?;
+        Ok(Installer::new(S3AwareDownloader::new(
+            ReqwestDownloader::new(download_proxy),
+            s3_config,
+        )))
     }
 
     /// Imports a local `.orax` release archive: verifies and extracts it, refreshes the installed
@@ -1057,6 +1080,11 @@ fn map_marketplace_source_error(error: MarketplaceSourceStoreError) -> BackendEr
             ErrorClassification::NotFound,
             PublicError::InvalidRequest(EmptyErrorParams {}),
             format!("plugin marketplace source was not found: {url}"),
+        ),
+        MarketplaceSourceStoreError::ArtifactRetrieval(error) => BackendError::new(
+            ErrorClassification::InvalidRequest,
+            PublicError::InvalidRequest(EmptyErrorParams {}),
+            format!("invalid marketplace artifact retrieval: {error}"),
         ),
         error => BackendError::internal(
             "failed to persist configured plugin marketplace sources",

--- a/crates/contracts/src/plugin.rs
+++ b/crates/contracts/src/plugin.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 use ts_rs::TS;
 
 /// Describes the kind-specific contribution of one installed plugin, discriminated by `kind`.
@@ -301,6 +301,98 @@ pub struct ReadPluginReadmeResponse {
     pub readme: Option<String>,
 }
 
+/// Describes how one marketplace source retrieves its `.orax` release artifacts.
+///
+/// The S3 variant deliberately excludes credentials: source queries may populate editors and
+/// logs, so secrets remain write-only outside the backend persistence boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+#[ts(export_to = "plugin.ts")]
+pub enum MarketplaceArtifactRetrieval {
+    DirectHttps,
+    #[serde(rename = "s3_sigv4")]
+    #[ts(rename = "s3_sigv4")]
+    S3SigV4 {
+        endpoint: String,
+        bucket: String,
+        region: String,
+    },
+}
+
+/// Selects whether an S3 source update retains or atomically replaces its credential pair.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "action",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+#[ts(export_to = "plugin.ts")]
+pub enum MarketplaceS3CredentialsUpdate {
+    Preserve,
+    Replace {
+        access_key_id: String,
+        secret_access_key: String,
+    },
+}
+
+impl fmt::Debug for MarketplaceS3CredentialsUpdate {
+    /// Prevents request diagnostics from rendering either member of the credential pair.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Preserve => formatter.write_str("Preserve"),
+            Self::Replace { .. } => formatter
+                .debug_struct("Replace")
+                .field("credentials", &"[redacted]")
+                .finish(),
+        }
+    }
+}
+
+/// Carries the complete artifact-retrieval state submitted by the source editor.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+#[ts(export_to = "plugin.ts")]
+pub enum MarketplaceArtifactRetrievalUpdate {
+    DirectHttps,
+    #[serde(rename = "s3_sigv4")]
+    #[ts(rename = "s3_sigv4")]
+    S3SigV4 {
+        endpoint: String,
+        bucket: String,
+        region: String,
+        credentials: MarketplaceS3CredentialsUpdate,
+    },
+}
+
+impl fmt::Debug for MarketplaceArtifactRetrievalUpdate {
+    /// Keeps source metadata useful in diagnostics while delegating credential redaction.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DirectHttps => formatter.write_str("DirectHttps"),
+            Self::S3SigV4 {
+                endpoint,
+                bucket,
+                region,
+                credentials,
+            } => formatter
+                .debug_struct("S3SigV4")
+                .field("endpoint", endpoint)
+                .field("bucket", bucket)
+                .field("region", region)
+                .field("credentials", credentials)
+                .finish(),
+        }
+    }
+}
+
 /// Lists one configured marketplace source repository and its tracked branch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -314,6 +406,8 @@ pub struct MarketplaceSource {
     pub use_proxy: bool,
     /// Whether this source participates in marketplace sync, listing, and install.
     pub enabled: bool,
+    /// Release-artifact retrieval policy, with S3 credentials omitted.
+    pub artifact_retrieval: MarketplaceArtifactRetrieval,
 }
 
 /// Requests the configured marketplace source repositories.
@@ -361,6 +455,7 @@ pub struct UpdateMarketplaceSourceRequest {
     pub branch: String,
     pub use_proxy: bool,
     pub enabled: bool,
+    pub artifact_retrieval: MarketplaceArtifactRetrievalUpdate,
 }
 
 /// Returns the source list immediately after one source is updated.
@@ -644,6 +739,9 @@ pub(crate) fn export(config: &ts_rs::Config) -> Result<(), ts_rs::ExportError> {
     SyncAvailablePluginsResponse::export(config)?;
     ReadPluginReadmeRequest::export(config)?;
     ReadPluginReadmeResponse::export(config)?;
+    MarketplaceArtifactRetrieval::export(config)?;
+    MarketplaceS3CredentialsUpdate::export(config)?;
+    MarketplaceArtifactRetrievalUpdate::export(config)?;
     MarketplaceSource::export(config)?;
     ListMarketplaceSourcesRequest::export(config)?;
     ListMarketplaceSourcesResponse::export(config)?;
@@ -689,11 +787,13 @@ mod tests {
         ImportPluginResponse, InstallOutcome, InstallPluginRequest, InstallPluginResponse,
         InstalledPlugin, InstalledPluginContribution, ListAvailablePluginsRequest,
         ListAvailablePluginsResponse, ListInstalledPluginsRequest, ListInstalledPluginsResponse,
-        ListMarketplaceSourcesRequest, ListMarketplaceSourcesResponse, MarketplaceSource,
-        PluginConfigurationSummary, PluginInstallationValidity, PluginRuntimeStatus,
-        ReadPluginReadmeRequest, ReadPluginReadmeResponse, SyncAvailablePluginsRequest,
-        SyncAvailablePluginsResponse, UpdateMarketplaceSourceRequest,
-        UpdateMarketplaceSourceResponse, UpdatePluginRequest, UpdatePluginResponse,
+        ListMarketplaceSourcesRequest, ListMarketplaceSourcesResponse,
+        MarketplaceArtifactRetrieval, MarketplaceArtifactRetrievalUpdate,
+        MarketplaceS3CredentialsUpdate, MarketplaceSource, PluginConfigurationSummary,
+        PluginInstallationValidity, PluginRuntimeStatus, ReadPluginReadmeRequest,
+        ReadPluginReadmeResponse, SyncAvailablePluginsRequest, SyncAvailablePluginsResponse,
+        UpdateMarketplaceSourceRequest, UpdateMarketplaceSourceResponse, UpdatePluginRequest,
+        UpdatePluginResponse,
     };
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -975,6 +1075,7 @@ mod tests {
             branch: "main".to_string(),
             use_proxy: false,
             enabled: true,
+            artifact_retrieval: MarketplaceArtifactRetrieval::DirectHttps,
         };
         assert_eq!(
             serde_json::to_value(ListMarketplaceSourcesRequest {}).unwrap(),
@@ -990,7 +1091,8 @@ mod tests {
                     "url": "https://github.com/example/marketplace",
                     "branch": "main",
                     "useProxy": false,
-                    "enabled": true
+                    "enabled": true,
+                    "artifactRetrieval": { "type": "direct_https" }
                 }]
             })
         );
@@ -1017,7 +1119,8 @@ mod tests {
                     "url": "https://github.com/example/marketplace",
                     "branch": "main",
                     "useProxy": false,
-                    "enabled": true
+                    "enabled": true,
+                    "artifactRetrieval": { "type": "direct_https" }
                 }]
             })
         );
@@ -1028,6 +1131,15 @@ mod tests {
                 branch: "release".to_string(),
                 use_proxy: true,
                 enabled: false,
+                artifact_retrieval: MarketplaceArtifactRetrievalUpdate::S3SigV4 {
+                    endpoint: "https://s3.example.com".to_string(),
+                    bucket: "plugins".to_string(),
+                    region: "region-1".to_string(),
+                    credentials: MarketplaceS3CredentialsUpdate::Replace {
+                        access_key_id: "access".to_string(),
+                        secret_access_key: "secret".to_string(),
+                    },
+                },
             })
             .unwrap(),
             json!({
@@ -1035,7 +1147,18 @@ mod tests {
                 "newUrl": "https://github.com/example/marketplace.git",
                 "branch": "release",
                 "useProxy": true,
-                "enabled": false
+                "enabled": false,
+                "artifactRetrieval": {
+                    "type": "s3_sigv4",
+                    "endpoint": "https://s3.example.com",
+                    "bucket": "plugins",
+                    "region": "region-1",
+                    "credentials": {
+                        "action": "replace",
+                        "accessKeyId": "access",
+                        "secretAccessKey": "secret"
+                    }
+                }
             })
         );
         assert_eq!(
@@ -1045,6 +1168,25 @@ mod tests {
             .unwrap(),
             json!({ "sources": [] })
         );
+        let request = UpdateMarketplaceSourceRequest {
+            url: "https://github.com/example/marketplace".to_string(),
+            new_url: "https://github.com/example/marketplace.git".to_string(),
+            branch: "release".to_string(),
+            use_proxy: true,
+            enabled: false,
+            artifact_retrieval: MarketplaceArtifactRetrievalUpdate::S3SigV4 {
+                endpoint: "https://s3.example.com".to_string(),
+                bucket: "plugins".to_string(),
+                region: "region-1".to_string(),
+                credentials: MarketplaceS3CredentialsUpdate::Replace {
+                    access_key_id: "debug-access-key".to_string(),
+                    secret_access_key: "debug-secret-key".to_string(),
+                },
+            },
+        };
+        let rendered = format!("{request:?}");
+        assert!(!rendered.contains("debug-access-key"));
+        assert!(!rendered.contains("debug-secret-key"));
         assert_eq!(
             serde_json::to_value(DeleteMarketplaceSourceRequest {
                 url: "https://github.com/example/marketplace".to_string(),

--- a/crates/db/src/effect_repository_tests.rs
+++ b/crates/db/src/effect_repository_tests.rs
@@ -1,3 +1,5 @@
+mod declaration;
+
 use crate::{
     DatabaseBootstrapper, DatabaseLocation, PluginSkillProjection, RepositoryPool,
     SqliteEffectRepository, SqliteSkillRepository, TimestampSource, default_migration_catalog,

--- a/crates/db/src/effect_repository_tests/declaration.rs
+++ b/crates/db/src/effect_repository_tests/declaration.rs
@@ -1,0 +1,64 @@
+use super::{declaration, fixture};
+use crate::SqliteEffectRepository;
+use ora_effect::LocalTimestamp;
+use pretty_assertions::assert_eq;
+use rusqlite::params;
+
+/// Replays the commit order of agent startup racing a worker that sampled its clock later.
+#[test]
+fn unchanged_declarations_preserve_consumer_timestamps_when_committed_out_of_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_directory, pool, workspace) = fixture();
+    let repository = SqliteEffectRepository::new(pool.clone());
+
+    // Startup can race before any Workspace exists, or after Targets have already been paired.
+    for (identity, workspaces) in [
+        ("official/no-workspace", &[][..]),
+        ("official/with-workspace", std::slice::from_ref(&workspace)),
+    ] {
+        let consumer = declaration(identity);
+        let revision =
+            repository.declare_consumer(&consumer, workspaces, LocalTimestamp::from_millis(20))?;
+        for timestamp in [30, 10, 25] {
+            assert_eq!(
+                repository.declare_consumer(
+                    &consumer,
+                    workspaces,
+                    LocalTimestamp::from_millis(timestamp),
+                )?,
+                revision,
+            );
+        }
+
+        let stored = pool.with_connection(|connection| {
+            connection
+                .query_row(
+                    "SELECT current_revision_id, lifecycle, created_at, updated_at,
+                            (SELECT COUNT(*) FROM effect_consumer_revisions WHERE consumer_id = ?1)
+                     FROM effect_consumers WHERE id = ?1",
+                    params![consumer.consumer.storage_key()],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, i64>(4)?,
+                        ))
+                    },
+                )
+                .map_err(Into::into)
+        })?;
+        assert_eq!(
+            stored,
+            (
+                revision.as_str().to_string(),
+                "declared".to_string(),
+                20,
+                30,
+                1
+            ),
+        );
+    }
+    Ok(())
+}

--- a/crates/db/src/migration/README.md
+++ b/crates/db/src/migration/README.md
@@ -7,7 +7,7 @@ This module owns Ora's linear, reversible SQLite schema history. Application boo
 - `MigrationCatalog` requires unique, strictly increasing versions.
 - The active target must be a prefix of the complete catalog. This makes controlled rollback deterministic and rejects branch-shaped histories.
 - Every migration contains ordered up and down statements. Their trimmed, joined SQL is the stable executable snapshot used for comparison and rollback.
-- The default catalog contains eight dependency-ordered modules: workspace core and application configuration, Agent/Skill catalog, workflows, Git lifecycle bookkeeping, Workspace Effect state, durable plugin marketplace source configuration, the immutable marketplace-source namespace bindings, and the per-source marketplace enabled flag.
+- The default catalog contains nine dependency-ordered modules: workspace core and application configuration, Agent/Skill catalog, workflows, Git lifecycle bookkeeping, Workspace Effect state, durable plugin marketplace source configuration, the immutable marketplace-source namespace bindings, the per-source marketplace enabled flag, and source-scoped artifact retrieval configuration.
 - Skills, configurable agents, and workflows use `(namespace, name)` as their case-insensitive
   visible identity. Soft-deleted rows do not reserve that identity, and local resources use the
   `local` namespace.
@@ -28,6 +28,9 @@ This module owns Ora's linear, reversible SQLite schema history. Application boo
 - Migration `0008` adds an `enabled` flag to marketplace sources. Disabling a source keeps its URL,
   branch, proxy policy, position, and namespace binding, but drops it from marketplace sync,
   listing, and install until it is enabled again.
+- Migration `0009` adds the tagged `artifact_retrieval` JSON configuration. Existing sources
+  default to Direct HTTPS; the S3 SigV4 variant keeps endpoint, bucket, region, and the credential
+  pair together instead of spreading them across nullable columns.
 - A reconcile request carries its own scheduling state: `pending`, `claimed`, `blocked`, or
   `retry_scheduled`, plus the lease that proves who currently owns the surface and the
   `request_token` that fences that owner's writes. Only one worker can hold a surface, an expired

--- a/crates/db/src/migration/schema.rs
+++ b/crates/db/src/migration/schema.rs
@@ -8,6 +8,7 @@ mod schema_v0005;
 mod schema_v0006;
 mod schema_v0007;
 mod schema_v0008;
+mod schema_v0009;
 
 /// Returns the ordered schema migrations shipped with the database crate.
 pub(super) fn migrations() -> Vec<Migration> {
@@ -20,5 +21,6 @@ pub(super) fn migrations() -> Vec<Migration> {
         schema_v0006::migration(),
         schema_v0007::migration(),
         schema_v0008::migration(),
+        schema_v0009::migration(),
     ]
 }

--- a/crates/db/src/migration/schema/schema_v0009.rs
+++ b/crates/db/src/migration/schema/schema_v0009.rs
@@ -7,8 +7,7 @@ ALTER TABLE plugin_marketplace_source
         CHECK (
             CASE WHEN json_valid(artifact_retrieval)
                 THEN json_type(artifact_retrieval) = 'object'
-                    AND COALESCE(json_extract(artifact_retrieval, '$.type'), '')
-                        IN ('direct_https', 's3_sigv4')
+                    AND json_extract(artifact_retrieval, '$.type') IS NOT NULL
                 ELSE 0
             END
         );

--- a/crates/db/src/migration/schema/schema_v0009.rs
+++ b/crates/db/src/migration/schema/schema_v0009.rs
@@ -1,0 +1,24 @@
+use super::Migration;
+
+const UP_STATEMENTS: &[&str] = &[r#"
+ALTER TABLE plugin_marketplace_source
+    ADD COLUMN artifact_retrieval TEXT NOT NULL
+        DEFAULT '{"type":"direct_https"}'
+        CHECK (
+            CASE WHEN json_valid(artifact_retrieval)
+                THEN json_type(artifact_retrieval) = 'object'
+                    AND COALESCE(json_extract(artifact_retrieval, '$.type'), '')
+                        IN ('direct_https', 's3_sigv4')
+                ELSE 0
+            END
+        );
+"#];
+
+const DOWN_STATEMENTS: &[&str] = &[r#"
+ALTER TABLE plugin_marketplace_source DROP COLUMN artifact_retrieval;
+"#];
+
+/// Adds the tagged artifact-retrieval configuration while preserving existing sources as HTTPS.
+pub fn migration() -> Migration {
+    Migration::new("0009", UP_STATEMENTS, DOWN_STATEMENTS)
+}

--- a/crates/db/src/repository/README.md
+++ b/crates/db/src/repository/README.md
@@ -6,7 +6,7 @@ This module implements `ora-application` persistence ports on SQLite and exposes
 
 - Concrete repositories map projects, workspaces, worktree-task labels, sessions, workflow runs,
   skills, configurable agents, plugin marketplace sources (URL, branch, `use_proxy`, `enabled`,
-  and precedence position), worktrees, and typed user preferences between SQL rows and application
+  tagged `artifact_retrieval` JSON, and precedence position), worktrees, and typed user preferences between SQL rows and application
   values. Marketplace source updates replace editable fields in place so disable/edit does not mint
   a second identity for an already-installed plugin's namespace.
 - `SqliteEffectRepository` stores normalized Desired selections, source state, surface descriptors,

--- a/crates/db/src/repository/effect/declaration.rs
+++ b/crates/db/src/repository/effect/declaration.rs
@@ -142,9 +142,13 @@ fn upsert_consumer_revision(
     if let Some((revision_id, digest)) = current
         && digest == declaration_digest.as_str()
     {
+        // Agent startup and the Effect worker sample time before acquiring the write lock.
+        // An unchanged declaration can therefore arrive after one with a later timestamp;
+        // preserve the latest audit time so replay cannot violate updated_at >= created_at.
         transaction.execute(
             "UPDATE effect_consumers
-             SET lifecycle = 'declared', adapter_id = ?2, updated_at = ?3 WHERE id = ?1",
+             SET lifecycle = 'declared', adapter_id = ?2, updated_at = MAX(updated_at, ?3)
+             WHERE id = ?1",
             params![&consumer_id, declaration.adapter.as_str(), updated_at,],
         )?;
         return Ok((consumer_id, ConsumerRevisionId::new(revision_id), false));

--- a/crates/db/src/repository/marketplace_source.rs
+++ b/crates/db/src/repository/marketplace_source.rs
@@ -1,10 +1,12 @@
+use std::fmt;
+
 use rusqlite::{Row, params};
 
 use crate::DatabaseError;
 use crate::repository::{RepositoryPool, connection::bool_to_sqlite};
 
 /// One durable plugin marketplace source row, ordered by the user-visible position.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct PluginMarketplaceSourceRecord {
     /// HTTPS Git repository URL. Duplicate-free primary key.
     pub url: String,
@@ -14,8 +16,25 @@ pub struct PluginMarketplaceSourceRecord {
     pub use_proxy: bool,
     /// Whether this source participates in marketplace sync, listing, and install.
     pub enabled: bool,
+    /// Tagged JSON describing direct HTTPS or source-scoped S3 SigV4 artifact retrieval.
+    pub artifact_retrieval: String,
     /// Stable ordering position used to resolve duplicate plugin ids across sources.
     pub position: i64,
+}
+
+impl fmt::Debug for PluginMarketplaceSourceRecord {
+    /// Redacts the retrieval JSON because its S3 variant contains persisted credentials.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PluginMarketplaceSourceRecord")
+            .field("url", &self.url)
+            .field("branch", &self.branch)
+            .field("use_proxy", &self.use_proxy)
+            .field("enabled", &self.enabled)
+            .field("artifact_retrieval", &"[redacted]")
+            .field("position", &self.position)
+            .finish()
+    }
 }
 
 /// Persists the user-editable plugin marketplace source list in SQLite.
@@ -33,7 +52,7 @@ impl SqlitePluginMarketplaceSourceRepository {
     pub fn list_sources(&self) -> Result<Vec<PluginMarketplaceSourceRecord>, DatabaseError> {
         self.pool.with_connection(|connection| {
             let mut statement = connection.prepare(
-                "SELECT url, branch, use_proxy, enabled, position
+                "SELECT url, branch, use_proxy, enabled, artifact_retrieval, position
                  FROM plugin_marketplace_source
                  ORDER BY position",
             )?;
@@ -57,13 +76,14 @@ impl SqlitePluginMarketplaceSourceRepository {
         self.pool.with_connection(|connection| {
             connection.execute(
                 "INSERT INTO plugin_marketplace_source (
-                    url, branch, use_proxy, enabled, position, created_at, updated_at
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+                    url, branch, use_proxy, enabled, artifact_retrieval, position, created_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
                 params![
                     record.url.as_str(),
                     record.branch.as_str(),
                     bool_to_sqlite(record.use_proxy),
                     bool_to_sqlite(record.enabled),
+                    record.artifact_retrieval.as_str(),
                     record.position,
                     now_ms,
                 ],
@@ -85,13 +105,15 @@ impl SqlitePluginMarketplaceSourceRepository {
         self.pool.with_connection(|connection| {
             let updated = connection.execute(
                 "UPDATE plugin_marketplace_source
-                 SET url = ?1, branch = ?2, use_proxy = ?3, enabled = ?4, updated_at = ?5
-                 WHERE url = ?6",
+                 SET url = ?1, branch = ?2, use_proxy = ?3, enabled = ?4,
+                     artifact_retrieval = ?5, updated_at = ?6
+                 WHERE url = ?7",
                 params![
                     record.url.as_str(),
                     record.branch.as_str(),
                     bool_to_sqlite(record.use_proxy),
                     bool_to_sqlite(record.enabled),
+                    record.artifact_retrieval.as_str(),
                     now_ms,
                     url,
                 ],
@@ -120,6 +142,7 @@ fn map_marketplace_source_row(
         branch: row.get("branch")?,
         use_proxy: row.get::<_, i64>("use_proxy")? != 0,
         enabled: row.get::<_, i64>("enabled")? != 0,
+        artifact_retrieval: row.get("artifact_retrieval")?,
         position: row.get("position")?,
     })
 }

--- a/crates/db/src/tests.rs
+++ b/crates/db/src/tests.rs
@@ -144,7 +144,7 @@ fn runtime_tables_use_direct_workspace_ownership() {
     );
 }
 
-/// Existing marketplace rows receive Direct HTTPS retrieval and invalid tagged JSON is rejected.
+/// Existing marketplace rows receive Direct HTTPS while future tagged variants remain extensible.
 #[test]
 fn marketplace_artifact_retrieval_migration_has_a_safe_default() {
     let pool = with_trace_logging(|| {
@@ -180,6 +180,15 @@ fn marketplace_artifact_retrieval_migration_has_a_safe_default() {
         .expect("read retrieval default"),
         r#"{"type":"direct_https"}"#,
     );
+    pool.with_connection(|connection| {
+        connection.execute(
+            "UPDATE plugin_marketplace_source
+             SET artifact_retrieval = '{\"type\":\"future_retrieval\"}'",
+            [],
+        )?;
+        Ok(())
+    })
+    .expect("accept future tagged retrieval variant");
     assert!(
         pool.with_connection(|connection| {
             connection.execute(

--- a/crates/db/src/tests.rs
+++ b/crates/db/src/tests.rs
@@ -144,6 +144,54 @@ fn runtime_tables_use_direct_workspace_ownership() {
     );
 }
 
+/// Existing marketplace rows receive Direct HTTPS retrieval and invalid tagged JSON is rejected.
+#[test]
+fn marketplace_artifact_retrieval_migration_has_a_safe_default() {
+    let pool = with_trace_logging(|| {
+        DatabaseBootstrapper::new(FixedTimestampSource { now: 1 })
+            .bootstrap_repository_pool(
+                &DatabaseLocation::in_memory(),
+                &default_migration_catalog().expect("build migration catalog"),
+            )
+            .expect("bootstrap database")
+    });
+
+    pool.with_connection(|connection| {
+        connection.execute(
+            "INSERT INTO plugin_marketplace_source (
+                url, branch, use_proxy, enabled, position, created_at, updated_at
+             ) VALUES ('https://example.com/marketplace', 'main', 0, 1, 0, 1, 1)",
+            [],
+        )?;
+        Ok(())
+    })
+    .expect("insert source using migration default");
+
+    assert_eq!(
+        pool.with_connection(|connection| {
+            connection
+                .query_row(
+                    "SELECT artifact_retrieval FROM plugin_marketplace_source",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .map_err(Into::into)
+        })
+        .expect("read retrieval default"),
+        r#"{"type":"direct_https"}"#,
+    );
+    assert!(
+        pool.with_connection(|connection| {
+            connection.execute(
+                "UPDATE plugin_marketplace_source SET artifact_retrieval = '{}'",
+                [],
+            )?;
+            Ok(())
+        })
+        .is_err()
+    );
+}
+
 /// Verifies a database with a shorter valid prefix receives and snapshots only the missing tail.
 #[test]
 fn applies_missing_migrations_in_order() {

--- a/crates/plugin-manager/README.md
+++ b/crates/plugin-manager/README.md
@@ -47,6 +47,9 @@ orchestrates checksum-verified installs of new plugin releases.
   `HttpDownload`), verify its SHA-256 while downloading, and safely extract it into
   `<data-dir>/plugins/installed/<namespace>/<name>/<version>` with `ora-utils::archive`, where the
   namespace is supplied by the caller as the identity of the installing marketplace source.
+- Convert a manifest `ReleaseLocator` into a transport-neutral `DownloadSource`: HTTPS locators
+  remain URLs and object-key locators become S3 requests. Source-specific endpoint, bucket,
+  credentials, proxy, and request signing stay outside this crate in the backend/downloader layer.
 - Update an installed plugin release by refusing no-op and downgrade attempts (the marketplace
   manifest must declare a higher version than the highest installed SemVer directory), then
   downloading, verifying, and extracting the new release into its version directory and retiring

--- a/crates/plugin-manager/src/install.rs
+++ b/crates/plugin-manager/src/install.rs
@@ -3,7 +3,9 @@
 use crate::discovery::installed_root;
 use crate::limits::package_extract_limits;
 use ora_domain::{PluginId, PluginNamespace};
-use ora_plugin_manifest::{HookTarget, PluginKind, PluginManifest, PluginReleaseSource};
+use ora_plugin_manifest::{
+    HookTarget, PluginKind, PluginManifest, PluginReleaseSource, ReleaseLocator,
+};
 use ora_utils::archive::{ArchiveFormat, extract_archive};
 use ora_utils::hash;
 use ora_utils::http::{
@@ -178,12 +180,9 @@ pub fn select_release(
     host_target: HostTarget<'_>,
 ) -> Result<ResolvedReleaseSource, InstallError> {
     match manifest.release_source() {
-        Some(PluginReleaseSource::Universal { url, sha256 }) => {
-            Ok(ResolvedReleaseSource::universal(
-                DownloadSource::Url(url.as_url().clone()),
-                *sha256.as_bytes(),
-            ))
-        }
+        Some(PluginReleaseSource::Universal { url, sha256 }) => Ok(
+            ResolvedReleaseSource::universal(download_source(url), *sha256.as_bytes()),
+        ),
         Some(PluginReleaseSource::Targets(targets)) => {
             let HostTarget::Triple(host_target) = host_target else {
                 return Err(InstallError::UnsupportedHost);
@@ -195,12 +194,22 @@ pub fn select_release(
                     target: host_target.to_string(),
                 })?;
             Ok(ResolvedReleaseSource::targeted(
-                DownloadSource::Url(entry.url().as_url().clone()),
+                download_source(entry.url()),
                 *entry.sha256().as_bytes(),
                 entry.target().clone(),
             ))
         }
         None => Err(InstallError::MissingRelease),
+    }
+}
+
+/// Maps a marketplace locator onto the download source the installer injects.
+fn download_source(locator: &ReleaseLocator) -> DownloadSource {
+    match locator {
+        ReleaseLocator::Https(url) => DownloadSource::Url(url.as_url().clone()),
+        ReleaseLocator::ObjectKey(key) => DownloadSource::S3 {
+            key: key.as_str().to_owned(),
+        },
     }
 }
 
@@ -660,7 +669,7 @@ mod tests {
         installed_id,
     };
     use futures::executor::block_on;
-    use ora_domain::{PluginId, PluginNamespace};
+    use ora_domain::PluginNamespace;
     use ora_plugin_manifest::{HookTarget, PluginManifest};
     use ora_utils::http::{DownloadSource, LocalFileDownloader};
     use pretty_assertions::assert_eq;
@@ -1314,6 +1323,42 @@ mod tests {
         .unwrap();
         super::select_release(&manifest, HostTarget::Unsupported)
             .expect("universal release does not need a host");
+    }
+
+    /// A universal object-key listing resolves to an S3 download source rather than an HTTPS URL.
+    #[test]
+    fn select_release_maps_an_object_key_to_s3() {
+        let digest = format!("{}{}", "ab".repeat(31), "ab");
+        let manifest = PluginManifest::parse(&format!(
+            "resolver = 1\nidentifier = \"weather\"\nkind = \"agent\"\nversion = \"1.0.0\"\ndescription = \"Weather\"\nurl = \"ora-space.opencode-v0.1.3.orax\"\nsha256 = \"{digest}\"\n"
+        ))
+        .unwrap();
+        let source = super::select_release(&manifest, HostTarget::Unsupported)
+            .expect("object-key universal release");
+        assert_eq!(
+            source.download(),
+            &DownloadSource::S3 {
+                key: "ora-space.opencode-v0.1.3.orax".to_owned(),
+            }
+        );
+    }
+
+    /// An HTTPS listing still resolves to a URL download source.
+    #[test]
+    fn select_release_maps_https_to_a_url() {
+        let digest = format!("{}{}", "ab".repeat(31), "ab");
+        let manifest = PluginManifest::parse(&format!(
+            "resolver = 1\nidentifier = \"weather\"\nkind = \"agent\"\nversion = \"1.0.0\"\ndescription = \"Weather\"\nurl = \"https://example.com/weather.orax\"\nsha256 = \"{digest}\"\n"
+        ))
+        .unwrap();
+        let source = super::select_release(&manifest, HostTarget::Unsupported)
+            .expect("https universal release");
+        match source.download() {
+            DownloadSource::Url(url) => {
+                assert_eq!(url.as_str(), "https://example.com/weather.orax");
+            }
+            other => panic!("expected a URL source, got {other:?}"),
+        }
     }
 
     /// A targeted release cannot be selected when the compiled host is not a plugin target.

--- a/crates/plugin-manifest/README.md
+++ b/crates/plugin-manifest/README.md
@@ -23,6 +23,9 @@ forms accept an optional human-readable `title` that falls back to the identifie
 - Pair kind-specific sections with the matching `kind`: optional `[workbench]` (page-visible
   method names) for workbench plugins, required `[webview]` (`start_url`, `allowed_origins`,
   download policy) for webview plugins. Agent, skill, MCP, and hook plugins reject both sections.
+- Model each release `url` as a `ReleaseLocator`: either an absolute HTTPS URL or a validated S3
+  object key. The parser does not choose a retrieval mode; the marketplace source that owns the
+  manifest decides whether that locator is usable.
 - Model the resolver-one release source as a mutually exclusive union: one universal `url` +
   `sha256` pair installable on every host, or one or more unique `[[targets]]` entries each carrying
   an exact Rust target triple (`HookTarget`) from a known rustc allowlist, URL, and digest. The
@@ -48,7 +51,8 @@ forms accept an optional human-readable `title` that falls back to the identifie
   published the entry (`ora-domain::PluginNamespace`), so a residual `namespace` key in an older
   manifest is just another ignored unknown field.
 - No filesystem access, fixed manifest filename, source-path diagnostics, or input-size policy.
-- No network access, download, repository probing, or release checksum calculation.
+- No network access, download, repository probing, S3 signing, source-configuration lookup, or
+  release checksum calculation.
 - No plugin installation, discovery, execution, update selection, or integration with
   `ora-plugin-manager`.
 - No host policy for kind-specific packages: workbench page files on disk, webview origin

--- a/crates/plugin-manifest/src/error.rs
+++ b/crates/plugin-manifest/src/error.rs
@@ -1,6 +1,7 @@
 use crate::{
     DownloadActionError, HookTargetError, MethodNameError, PathPrefixError, PluginKind,
-    PluginKindError, PluginNameError, Sha256DigestError, UrlError, WebviewUrlError,
+    PluginKindError, PluginNameError, ReleaseLocatorError, Sha256DigestError, UrlError,
+    WebviewUrlError,
 };
 use ora_utils::{GitBranchNameError, SlugError};
 use std::{fmt, ops::Range};
@@ -176,6 +177,8 @@ pub enum InvalidFieldReason {
     NonAscii,
     #[error(transparent)]
     InvalidUrl(#[from] UrlError),
+    #[error(transparent)]
+    InvalidReleaseLocator(#[from] ReleaseLocatorError),
     #[error(transparent)]
     InvalidSha256(#[from] Sha256DigestError),
     #[error(transparent)]

--- a/crates/plugin-manifest/src/lib.rs
+++ b/crates/plugin-manifest/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod enums;
 mod error;
+mod locator;
 mod manifest;
 mod name;
 mod sha256;
@@ -13,6 +14,7 @@ mod workbench;
 
 pub use enums::{PluginKind, PluginKindError};
 pub use error::{InvalidFieldReason, ManifestError, ManifestField, RuleField};
+pub use locator::{ObjectKey, ObjectKeyError, ReleaseLocator, ReleaseLocatorError};
 pub use manifest::{
     PluginArtifact, PluginDependencies, PluginHead, PluginManifest, PluginReleaseSource,
     PluginReleaseTarget,

--- a/crates/plugin-manifest/src/locator.rs
+++ b/crates/plugin-manifest/src/locator.rs
@@ -1,0 +1,211 @@
+//! Release locators for marketplace `url` fields: an HTTPS download or an S3 object key.
+
+use crate::urls::{ReleaseUrl, UrlError, strip_markdown_link};
+use std::fmt;
+use thiserror::Error;
+
+/// Maximum accepted object-key length; S3 allows more, but marketplace keys stay well below this.
+const MAX_OBJECT_KEY_BYTES: usize = 1024;
+
+/// Where a marketplace release archive can be fetched from.
+///
+/// HTTPS URLs are fetched verbatim. Object keys are resolved against the host's configured
+/// object-store endpoint at install time, so a listing can name a package without baking a
+/// signed URL into Git.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReleaseLocator {
+    /// A credential-free HTTPS URL, optionally carrying a signing query.
+    Https(ReleaseUrl),
+    /// An object-store key resolved by the installer against a configured bucket.
+    ObjectKey(ObjectKey),
+}
+
+impl ReleaseLocator {
+    /// Parses a marketplace `url` value as HTTPS when it uses that scheme, otherwise as an object key.
+    ///
+    /// Non-HTTPS schemes (`http://`, `s3://`, …) are rejected rather than being mistaken for keys.
+    pub fn parse(value: &str) -> Result<Self, ReleaseLocatorError> {
+        let unwrapped = strip_markdown_link(value);
+        if unwrapped.starts_with("https://") {
+            return Ok(Self::Https(ReleaseUrl::parse(value)?));
+        }
+        // Non-HTTPS schemes must not be mistaken for object keys; reuse URL validation so
+        // `http://` reports NotHttps instead of an object-key error.
+        if unwrapped.contains("://") {
+            return match ReleaseUrl::parse(value) {
+                Ok(_) => {
+                    unreachable!("a locator containing a non-https scheme cannot parse as HTTPS")
+                }
+                Err(error) => Err(error.into()),
+            };
+        }
+        Ok(Self::ObjectKey(ObjectKey::parse(unwrapped)?))
+    }
+
+    /// Returns the locator as the original HTTPS URL or object-key string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Https(url) => url.as_str(),
+            Self::ObjectKey(key) => key.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for ReleaseLocator {
+    /// Writes the HTTPS URL or object key.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Holds a validated object-store key used as a marketplace release locator.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ObjectKey(String);
+
+impl ObjectKey {
+    /// Parses an object key, rejecting traversal, schemes, and absolute paths.
+    pub fn parse(value: &str) -> Result<Self, ObjectKeyError> {
+        if value.is_empty() {
+            return Err(ObjectKeyError::Empty);
+        }
+        if value.len() > MAX_OBJECT_KEY_BYTES {
+            return Err(ObjectKeyError::TooLong {
+                max_bytes: MAX_OBJECT_KEY_BYTES,
+                actual_bytes: value.len(),
+            });
+        }
+        if value.chars().next().is_some_and(char::is_whitespace)
+            || value.chars().next_back().is_some_and(char::is_whitespace)
+        {
+            return Err(ObjectKeyError::LeadingOrTrailingWhitespace);
+        }
+        if value.chars().any(char::is_control) {
+            return Err(ObjectKeyError::ContainsControlCharacter);
+        }
+        if value.contains("://") {
+            return Err(ObjectKeyError::SchemeNotAllowed);
+        }
+        if value.starts_with('/') || value.starts_with('\\') {
+            return Err(ObjectKeyError::Absolute);
+        }
+        if value.split(['/', '\\']).any(|segment| segment == "..") {
+            return Err(ObjectKeyError::ParentSegment);
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    /// Returns the key as written in the manifest.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ObjectKey {
+    /// Writes the object key.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Describes why a marketplace `url` field could not be parsed as a locator.
+#[derive(Debug, Error)]
+pub enum ReleaseLocatorError {
+    #[error(transparent)]
+    Url(#[from] UrlError),
+    #[error(transparent)]
+    ObjectKey(#[from] ObjectKeyError),
+}
+
+/// Describes why an object-store key was rejected.
+#[derive(Debug, Error)]
+pub enum ObjectKeyError {
+    #[error("field must not be empty")]
+    Empty,
+    #[error("field exceeds {max_bytes} bytes: {actual_bytes}")]
+    TooLong {
+        max_bytes: usize,
+        actual_bytes: usize,
+    },
+    #[error("field must not contain leading or trailing whitespace")]
+    LeadingOrTrailingWhitespace,
+    #[error("field must not contain control characters")]
+    ContainsControlCharacter,
+    #[error("object key must not contain a URL scheme")]
+    SchemeNotAllowed,
+    #[error("object key must not be an absolute path")]
+    Absolute,
+    #[error("object key must not contain a parent-directory segment")]
+    ParentSegment,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ObjectKey, ObjectKeyError, ReleaseLocator, ReleaseLocatorError};
+    use crate::urls::UrlError;
+    use pretty_assertions::assert_eq;
+
+    /// HTTPS release URLs stay HTTPS locators, including Markdown wrappers.
+    #[test]
+    fn parses_https_urls_as_https_locators() {
+        let locator = ReleaseLocator::parse("https://example.com/plugin.orax").expect("https");
+        assert_eq!(locator.as_str(), "https://example.com/plugin.orax");
+        assert!(matches!(locator, ReleaseLocator::Https(_)));
+
+        let wrapped = ReleaseLocator::parse(
+            "[https://example.com/plugin.orax](https://example.com/plugin.orax)",
+        )
+        .expect("markdown https");
+        assert_eq!(wrapped.as_str(), "https://example.com/plugin.orax");
+    }
+
+    /// A bare object key is accepted and round-trips.
+    #[test]
+    fn parses_object_keys() {
+        let locator = ReleaseLocator::parse("ora-space.opencode-v0.1.3.orax").expect("object key");
+        assert_eq!(locator.as_str(), "ora-space.opencode-v0.1.3.orax");
+        assert!(matches!(locator, ReleaseLocator::ObjectKey(_)));
+
+        let nested = ReleaseLocator::parse("plugins/ora-space.opencode-v0.1.3.orax")
+            .expect("nested object key");
+        assert_eq!(nested.as_str(), "plugins/ora-space.opencode-v0.1.3.orax");
+    }
+
+    /// `http://` and other schemes are rejected instead of being treated as keys.
+    #[test]
+    fn rejects_non_https_schemes() {
+        assert!(matches!(
+            ReleaseLocator::parse("http://example.com/plugin.orax"),
+            Err(ReleaseLocatorError::Url(UrlError::NotHttps))
+        ));
+        assert!(matches!(
+            ReleaseLocator::parse("s3://bucket/plugin.orax"),
+            Err(ReleaseLocatorError::Url(UrlError::NotHttps))
+        ));
+    }
+
+    /// Object-key validation rejects empty, absolute, traversing, and oversized values.
+    #[test]
+    fn rejects_invalid_object_keys() {
+        assert!(matches!(ObjectKey::parse(""), Err(ObjectKeyError::Empty)));
+        assert!(matches!(
+            ObjectKey::parse("/absolute.orax"),
+            Err(ObjectKeyError::Absolute)
+        ));
+        assert!(matches!(
+            ObjectKey::parse("plugins/../secret.orax"),
+            Err(ObjectKeyError::ParentSegment)
+        ));
+        assert!(matches!(
+            ObjectKey::parse(" leading.orax"),
+            Err(ObjectKeyError::LeadingOrTrailingWhitespace)
+        ));
+        let too_long = "a".repeat(1025);
+        assert!(matches!(
+            ObjectKey::parse(&too_long),
+            Err(ObjectKeyError::TooLong {
+                max_bytes: 1024,
+                actual_bytes: 1025
+            })
+        ));
+    }
+}

--- a/crates/plugin-manifest/src/manifest.rs
+++ b/crates/plugin-manifest/src/manifest.rs
@@ -2,7 +2,7 @@ use crate::webview::RawWebview;
 use crate::workbench::RawWorkbench;
 use crate::{
     HomepageUrl, HookTarget, InvalidFieldReason, ManifestError, ManifestField, PluginKind,
-    PluginName, PluginWebview, PluginWorkbench, ReleaseUrl, RepositoryUrl, Sha256Digest,
+    PluginName, PluginWebview, PluginWorkbench, ReleaseLocator, RepositoryUrl, Sha256Digest,
 };
 use ora_utils::GitBranchName;
 use semver::{Version, VersionReq};
@@ -30,7 +30,7 @@ pub struct PluginManifest {
     pub(crate) description: String,
     pub(crate) homepage: Option<HomepageUrl>,
     pub(crate) license: Option<String>,
-    pub(crate) url: Option<ReleaseUrl>,
+    pub(crate) url: Option<ReleaseLocator>,
     pub(crate) sha256: Option<Sha256Digest>,
     pub(crate) head: Option<PluginHead>,
     pub(crate) dependencies: Option<PluginDependencies>,
@@ -111,7 +111,7 @@ impl PluginManifest {
                 .map_err(|reason| invalid_field(ManifestField::License, reason))?;
         }
         let url = url
-            .map(|value| ReleaseUrl::parse(&value))
+            .map(|value| ReleaseLocator::parse(&value))
             .transpose()
             .map_err(|reason| invalid_field(ManifestField::Url, reason.into()))?;
         let sha256 = sha256
@@ -233,8 +233,8 @@ impl PluginManifest {
         self.license.as_deref()
     }
 
-    /// Returns the release package URL when this manifest declares one.
-    pub fn url(&self) -> Option<&ReleaseUrl> {
+    /// Returns the release package locator when this manifest declares one.
+    pub fn url(&self) -> Option<&ReleaseLocator> {
         self.url.as_ref()
     }
 
@@ -244,7 +244,7 @@ impl PluginManifest {
     }
 
     /// Returns the download metadata for a marketplace release manifest.
-    pub fn release(&self) -> Option<(&ReleaseUrl, &Sha256Digest)> {
+    pub fn release(&self) -> Option<(&ReleaseLocator, &Sha256Digest)> {
         match (self.url.as_ref(), self.sha256.as_ref()) {
             (Some(url), Some(sha256)) => Some((url, sha256)),
             _ => None,
@@ -386,14 +386,14 @@ fn validate_kind_sections(
 
 /// Models the mutually exclusive resolver-one release source.
 ///
-/// A release is either one universal URL/digest pair installable on every host target, or one or
-/// more unique exact-target artifacts. Modeling the two as one enum keeps URL-selection
-/// precedence unambiguous: a manifest can never carry both forms.
+/// A release is either one universal locator/digest pair installable on every host target, or one
+/// or more unique exact-target artifacts. Modeling the two as one enum keeps download-source
+/// selection unambiguous: a manifest can never carry both forms.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PluginReleaseSource {
-    /// One URL/digest pair installable on every host target the plugin's Ora version supports.
+    /// One locator/digest pair installable on every host target the plugin's Ora version supports.
     Universal {
-        url: ReleaseUrl,
+        url: ReleaseLocator,
         sha256: Sha256Digest,
     },
     /// One or more exact-target artifacts, each carrying its own URL and digest.
@@ -404,7 +404,7 @@ pub enum PluginReleaseSource {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PluginReleaseTarget {
     pub(crate) target: HookTarget,
-    pub(crate) url: ReleaseUrl,
+    pub(crate) url: ReleaseLocator,
     pub(crate) sha256: Sha256Digest,
 }
 
@@ -414,8 +414,8 @@ impl PluginReleaseTarget {
         &self.target
     }
 
-    /// Returns the download URL of this target artifact.
-    pub fn url(&self) -> &ReleaseUrl {
+    /// Returns the download locator of this target artifact.
+    pub fn url(&self) -> &ReleaseLocator {
         &self.url
     }
 
@@ -462,7 +462,7 @@ impl TryFrom<RawArtifact> for PluginArtifact {
 /// target-specific native binaries (see [`PluginKind::may_ship_targeted_artifact`]), whose
 /// host-compatibility the host must check before download.
 fn validate_release_source(
-    url: Option<&ReleaseUrl>,
+    url: Option<&ReleaseLocator>,
     sha256: Option<&Sha256Digest>,
     targets: Option<&[RawReleaseTarget]>,
     kind: PluginKind,
@@ -541,7 +541,7 @@ fn validate_release_source(
                 InvalidFieldReason::Duplicate,
             ));
         }
-        let url = ReleaseUrl::parse(&raw.url).map_err(|reason| {
+        let url = ReleaseLocator::parse(&raw.url).map_err(|reason| {
             invalid_field(ManifestField::ReleaseTargetUrl { index }, reason.into())
         })?;
         let sha256 = Sha256Digest::parse(&raw.sha256).map_err(|reason| {

--- a/crates/plugin-manifest/src/tests.rs
+++ b/crates/plugin-manifest/src/tests.rs
@@ -2,7 +2,7 @@ use crate::{
     DownloadAction, DownloadDisposition, DownloadPolicy, DownloadRule, HomepageUrl,
     HookTargetError, InvalidFieldReason, ManifestError, ManifestField, MethodName, MethodNameError,
     Origin, PageMatcher, PathPrefix, PluginDependencies, PluginHead, PluginKind, PluginManifest,
-    PluginName, PluginReleaseSource, PluginWebview, PluginWorkbench, ReleaseUrl, RepositoryUrl,
+    PluginName, PluginReleaseSource, PluginWebview, PluginWorkbench, ReleaseLocator, RepositoryUrl,
     RuleField, Sha256Digest, StartUrl,
 };
 use ora_utils::{GitBranchName, GitBranchNameError};
@@ -73,10 +73,10 @@ fn parses_complete_manifest_into_full_domain_object() {
         )),
         license: Some("MIT".to_owned()),
         url: Some(success(
-            ReleaseUrl::parse(
+            ReleaseLocator::parse(
                 "https://github.com/user/ora-weather/releases/download/v1.2.0/ora-weather.orax?signature=abc",
             ),
-            "release URL",
+            "release locator",
         )),
         sha256: Some(success(Sha256Digest::parse(DIGEST), "digest")),
         head: Some(PluginHead {
@@ -93,10 +93,10 @@ fn parses_complete_manifest_into_full_domain_object() {
         webview: None,
         release_source: Some(PluginReleaseSource::Universal {
             url: success(
-                ReleaseUrl::parse(
+                ReleaseLocator::parse(
                     "https://github.com/user/ora-weather/releases/download/v1.2.0/ora-weather.orax?signature=abc",
                 ),
-                "release URL",
+                "release locator",
             ),
             sha256: success(Sha256Digest::parse(DIGEST), "digest"),
         }),
@@ -330,7 +330,7 @@ sha256 = "18263de8e26fab1ea64d6c24913f0815d2151e0ae49cea9ef8aa46f453798558"
         Some("https://github.com/ora-space/opencode-agent")
     );
     assert_eq!(
-        manifest.url().map(ReleaseUrl::as_str),
+        manifest.url().map(ReleaseLocator::as_str),
         Some(
             "https://github.com/ora-space/opencode-agent/releases/download/v0.1.2/ora-space.opencode-v0.1.2.orax"
         )
@@ -340,6 +340,65 @@ sha256 = "18263de8e26fab1ea64d6c24913f0815d2151e0ae49cea9ef8aa46f453798558"
         Some("18263de8e26fab1ea64d6c24913f0815d2151e0ae49cea9ef8aa46f453798558".to_owned())
     );
     assert!(manifest.release().is_some());
+}
+
+/// A marketplace listing may name an object-store key instead of an HTTPS URL.
+#[test]
+fn parses_marketplace_manifest_with_object_key_url() {
+    let source = r#"resolver = 1
+title = "OpenCode"
+identifier = "ora-space.opencode"
+kind = "agent"
+version = "0.1.3"
+description = "Ora Space OpenCode Agent"
+url = "ora-space.opencode-v0.1.3.orax"
+sha256 = "af8a0bc8e8287e280f398a20cd483f02dc40ce8591acade4b5a260082406335d"
+"#;
+    let manifest = success(
+        PluginManifest::parse(source),
+        "object-key marketplace manifest",
+    );
+
+    assert_eq!(
+        manifest.url().map(ReleaseLocator::as_str),
+        Some("ora-space.opencode-v0.1.3.orax")
+    );
+    assert!(matches!(manifest.url(), Some(ReleaseLocator::ObjectKey(_))));
+    assert!(manifest.release().is_some());
+}
+
+/// `http://` release locators are still rejected so a key cannot smuggle a cleartext URL.
+#[test]
+fn rejects_http_release_locator() {
+    let source = MINIMAL_MANIFEST.replace(
+        "https://example.com/ora-weather.orax",
+        "http://example.com/ora-weather.orax",
+    );
+    let Err(ManifestError::InvalidField { field, reason }) = PluginManifest::parse(&source) else {
+        panic!("expected http release locator rejection");
+    };
+    assert_eq!(field, ManifestField::Url);
+    assert!(matches!(
+        reason,
+        InvalidFieldReason::InvalidReleaseLocator(_)
+    ));
+}
+
+/// Parent-directory object keys are rejected so a listing cannot traverse the bucket prefix.
+#[test]
+fn rejects_parent_segment_object_key() {
+    let source = MINIMAL_MANIFEST.replace(
+        "https://example.com/ora-weather.orax",
+        "plugins/../secret.orax",
+    );
+    let Err(ManifestError::InvalidField { field, reason }) = PluginManifest::parse(&source) else {
+        panic!("expected parent-segment object key rejection");
+    };
+    assert_eq!(field, ManifestField::Url);
+    assert!(matches!(
+        reason,
+        InvalidFieldReason::InvalidReleaseLocator(_)
+    ));
 }
 
 /// Verifies unsupported resolver versions take priority over semantic field validation.
@@ -1149,6 +1208,22 @@ fn parses_targeted_hook_manifest() {
     assert_eq!(targets[0].target().as_str(), "x86_64-pc-windows-msvc");
     assert_eq!(targets[0].url().as_str(), "https://example.com/rtk.orax");
     assert_eq!(manifest.artifact(), None);
+}
+
+/// Targeted release entries accept object keys the same way universal listings do.
+#[test]
+fn parses_targeted_hook_manifest_with_object_key() {
+    let source =
+        TARGETED_HOOK_MANIFEST.replace("https://example.com/rtk.orax", "hooks/rtk-v0.1.0.orax");
+    let manifest = success(
+        PluginManifest::parse(&source),
+        "targeted hook manifest with object key",
+    );
+    let Some(PluginReleaseSource::Targets(targets)) = manifest.release_source() else {
+        panic!("expected a targeted release source");
+    };
+    assert_eq!(targets[0].url().as_str(), "hooks/rtk-v0.1.0.orax");
+    assert!(matches!(targets[0].url(), ReleaseLocator::ObjectKey(_)));
 }
 
 /// Unknown rustc triples never enter the domain model, so a packaging typo cannot look like a

--- a/crates/plugin-manifest/src/urls.rs
+++ b/crates/plugin-manifest/src/urls.rs
@@ -146,7 +146,7 @@ pub enum UrlError {
 ///
 /// Marketplace authors write link-valued fields as Markdown links, so the validators strip the
 /// wrapper before applying HTTPS invariants to the embedded URL.
-fn strip_markdown_link(value: &str) -> &str {
+pub(crate) fn strip_markdown_link(value: &str) -> &str {
     let Some(rest) = value.strip_prefix('[') else {
         return value;
     };

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -9,18 +9,20 @@ workspace = true
 [features]
 default = ["validation"]
 archive = ["dep:zip", "dep:tar", "dep:flate2"]
-http = ["dep:url", "dep:sha2"]
+http = ["dep:url", "dep:sha2", "dep:hmac"]
 http-reqwest = [
     "http",
     "dep:reqwest",
     "dep:rustls",
     "dep:rustls-platform-verifier",
     "dep:tokio",
+    "dep:time",
 ]
 validation = ["dep:sha2", "dep:quick-xml"]
 
 [dependencies]
 flate2 = { workspace = true, optional = true }
+hmac = { workspace = true, optional = true }
 quick-xml = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
@@ -31,6 +33,7 @@ sha2 = { workspace = true, optional = true }
 tar = { workspace = true, optional = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["time"] }
 unicode-normalization = { workspace = true }
 url = { workspace = true, optional = true }

--- a/crates/utils/src/http.rs
+++ b/crates/utils/src/http.rs
@@ -12,6 +12,7 @@ mod error;
 mod local;
 mod progress;
 mod proxy;
+mod s3;
 mod target;
 mod types;
 
@@ -28,6 +29,9 @@ pub use progress::Progress;
 pub use proxy::{Proxy, ProxyAuth, ProxyBypass, ProxyConfig, resolve_proxy};
 #[cfg(feature = "http-reqwest")]
 pub use reqwest::ReqwestDownloader;
+#[cfg(feature = "http-reqwest")]
+pub use s3::S3AwareDownloader;
+pub use s3::{S3Config, SigningTime, path_style_object_key, path_style_object_url, sign_get};
 pub use types::{
     Checksum, DownloadOptions, DownloadOutcome, DownloadRequest, DownloadSource, HashAlgorithm,
     HttpDownload, ProgressCallback,

--- a/crates/utils/src/http/README.md
+++ b/crates/utils/src/http/README.md
@@ -7,7 +7,7 @@ Generic, domain-free download capability used by crates that fetch release artif
 
 - `HttpDownload`: the uniform, injectable trait that a download operation must implement; callers
   run the returned future on their own runtime.
-- Data types: `DownloadRequest`, `DownloadSource` (`Url` / `Local`), `Checksum` (+ `HashAlgorithm`),
+- Data types: `DownloadRequest`, `DownloadSource` (`Url` / `S3` / `Local`), `Checksum` (+ `HashAlgorithm`),
   `DownloadOutcome`, `DownloadOptions` (byte limits, timeouts, retries) and `Progress`/`CancelToken`
   for streaming feedback.
 - `LocalFileDownloader`: an offline implementation that copies a local file or `file://` URL to a
@@ -16,12 +16,18 @@ Generic, domain-free download capability used by crates that fetch release artif
 - `ReqwestDownloader` (`http-reqwest` feature): streams remote HTTP(S) responses to a verified
   destination with per-phase timeouts, retry/backoff+jitter, progress callbacks, cancellation, byte
   limits, and checksum verification.
+- `S3AwareDownloader` (`http-reqwest` feature): wraps the network downloader with an optional,
+  caller-provided `S3Config`. An S3 object key is resolved as a path-style HTTPS URL and signed
+  with SigV4; a full HTTPS URL is signed only when it belongs to that exact endpoint and bucket.
+  Foreign HTTPS URLs in S3 mode are rejected instead of silently falling back to unsigned access.
 - Proxy resolution (`ProxyConfig` + `resolve_proxy`): an explicit proxy, then per-scheme
   environment variables (`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`), honoring `NO_PROXY` and a bypass
   list; otherwise a direct connection. Platform system-proxy reading is not yet implemented.
 
 ## Non-responsibilities
 
+- Choosing a marketplace source or storing credentials. S3 configuration is supplied per operation;
+  this domain-free module has no global provider defaults or credential discovery chain.
 - Choosing a concrete transport: only `http` is shipped by default; the network backend is opt-in.
 - Redirect-target validation, resume, and digital-signature verification. The reqwest backend uses
   Rustls with a platform-aware verifier. On Windows, certificate-chain verification delegates to
@@ -36,3 +42,4 @@ Generic, domain-free download capability used by crates that fetch release artif
 - A checksum mismatch or an exceeded byte limit aborts the whole copy with a structured
   `DownloadError` instead of a partial write.
 - The digest is carried as raw bytes so hex parsing stays in the domain layer that reads a manifest.
+- `Debug` output for S3 configuration never renders the access-key or secret-key values.

--- a/crates/utils/src/http/local.rs
+++ b/crates/utils/src/http/local.rs
@@ -62,6 +62,9 @@ fn resolve_source_path(source: &DownloadSource) -> Result<PathBuf, DownloadError
                 "scheme {scheme:?} is not supported by the local downloader"
             ))),
         },
+        DownloadSource::S3 { .. } => Err(DownloadError::InvalidSource(
+            "S3 object-key sources are not supported by the local downloader".to_owned(),
+        )),
     }
 }
 
@@ -126,6 +129,9 @@ fn source_url_for_error(source: &DownloadSource) -> Url {
         DownloadSource::Url(url) => url.clone(),
         DownloadSource::Local(path) => {
             Url::from_file_path(path).unwrap_or_else(|_| fallback_file_url())
+        }
+        DownloadSource::S3 { .. } => {
+            Url::parse("https://s3.invalid/").unwrap_or_else(|_| fallback_file_url())
         }
     }
 }

--- a/crates/utils/src/http/reqwest.rs
+++ b/crates/utils/src/http/reqwest.rs
@@ -70,6 +70,24 @@ impl ReqwestDownloader {
         &self,
         request: DownloadRequest,
     ) -> Result<DownloadOutcome, DownloadError> {
+        self.download_signed(request, &[]).await
+    }
+
+    /// Runs one download with extra request headers, used by SigV4-signed S3 GETs.
+    pub(crate) async fn download_with_headers(
+        &self,
+        request: DownloadRequest,
+        extra_headers: &[(String, String)],
+    ) -> Result<DownloadOutcome, DownloadError> {
+        self.download_signed(request, extra_headers).await
+    }
+
+    /// Resolves the URL and drives retries, attaching `extra_headers` to every attempt.
+    async fn download_signed(
+        &self,
+        request: DownloadRequest,
+        extra_headers: &[(String, String)],
+    ) -> Result<DownloadOutcome, DownloadError> {
         let url = match &request.source {
             DownloadSource::Url(url) => url.clone(),
             DownloadSource::Local(_) => {
@@ -77,9 +95,18 @@ impl ReqwestDownloader {
                     "local sources require the local downloader".to_owned(),
                 ));
             }
+            DownloadSource::S3 { .. } => {
+                return Err(DownloadError::InvalidSource(
+                    "S3 object-key sources require the S3-aware downloader".to_owned(),
+                ));
+            }
         };
 
-        let operation = async { self.attempt_with_retries(&request, &url).await };
+        let extra_headers = extra_headers.to_vec();
+        let operation = async {
+            self.attempt_with_retries(&request, &url, &extra_headers)
+                .await
+        };
         match request.options.total_timeout {
             Some(total) => tokio::time::timeout(total, operation).await.map_err(|_| {
                 DownloadError::Timeout {
@@ -95,6 +122,7 @@ impl ReqwestDownloader {
         &self,
         request: &DownloadRequest,
         url: &Url,
+        extra_headers: &[(String, String)],
     ) -> Result<DownloadOutcome, DownloadError> {
         let mut attempts: u32 = 0;
         loop {
@@ -106,7 +134,7 @@ impl ReqwestDownloader {
                 ))
                 .await;
             }
-            match self.single_attempt(request, url).await {
+            match self.single_attempt(request, url, extra_headers).await {
                 Ok(outcome) => return Ok(outcome),
                 Err(error) if is_retryable(&error) && attempts < request.options.max_retries => {
                     attempts += 1;
@@ -121,6 +149,7 @@ impl ReqwestDownloader {
         &self,
         request: &DownloadRequest,
         url: &Url,
+        extra_headers: &[(String, String)],
     ) -> Result<DownloadOutcome, DownloadError> {
         let client = self.build_client(&request.options, url)?;
         let temporary = temporary_sibling(&request.destination);
@@ -129,7 +158,11 @@ impl ReqwestDownloader {
                 .map_err(|error| io_error(&request.destination, error))?;
         }
 
-        let mut response = client.get(url.clone()).send().await.map_err(|error| {
+        let mut builder = client.get(url.clone());
+        for (name, value) in extra_headers {
+            builder = builder.header(name.as_str(), value.as_str());
+        }
+        let mut response = builder.send().await.map_err(|error| {
             remove_temporary(&temporary);
             network_error(url, error)
         })?;

--- a/crates/utils/src/http/s3.rs
+++ b/crates/utils/src/http/s3.rs
@@ -1,0 +1,276 @@
+//! S3-compatible download support: path-style object URLs, SigV4 signing, and a downloader that
+//! signs object-key sources and path-style HTTPS URLs that target the configured bucket.
+
+mod sign;
+
+#[cfg(feature = "http-reqwest")]
+mod downloader;
+
+use std::fmt;
+use url::Url;
+
+pub use sign::{SigningTime, sign_get};
+
+#[cfg(feature = "http-reqwest")]
+pub use downloader::S3AwareDownloader;
+
+use super::error::DownloadError;
+
+/// Connection parameters for one S3-compatible endpoint.
+///
+/// Secrets are never written by [`Debug`]; callers must also keep them out of logs.
+#[derive(Clone, Eq, PartialEq)]
+pub struct S3Config {
+    endpoint: String,
+    bucket: String,
+    region: String,
+    access_key: String,
+    secret_key: String,
+}
+
+impl S3Config {
+    /// Builds a config from the endpoint host, bucket, region, and credentials.
+    ///
+    /// `endpoint` is a hostname (and optional port) without a scheme, for example
+    /// `s3.example.com`.
+    pub fn new(
+        endpoint: impl Into<String>,
+        bucket: impl Into<String>,
+        region: impl Into<String>,
+        access_key: impl Into<String>,
+        secret_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            bucket: bucket.into(),
+            region: region.into(),
+            access_key: access_key.into(),
+            secret_key: secret_key.into(),
+        }
+    }
+
+    /// Returns the S3-compatible hostname (no scheme).
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Returns the bucket that object keys are resolved against.
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    /// Returns the SigV4 region name.
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    /// Returns the access key id.
+    pub fn access_key(&self) -> &str {
+        &self.access_key
+    }
+
+    /// Returns the secret access key.
+    pub fn secret_key(&self) -> &str {
+        &self.secret_key
+    }
+}
+
+impl fmt::Debug for S3Config {
+    /// Redacts credentials so a dumped config cannot leak secrets.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("S3Config")
+            .field("endpoint", &self.endpoint)
+            .field("bucket", &self.bucket)
+            .field("region", &self.region)
+            .field("access_key", &"[redacted]")
+            .field("secret_key", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Builds a path-style HTTPS URL `https://{endpoint}/{bucket}/{key}` without string-joining paths.
+pub fn path_style_object_url(
+    endpoint: &str,
+    bucket: &str,
+    key: &str,
+) -> Result<Url, DownloadError> {
+    if bucket.is_empty() {
+        return Err(DownloadError::InvalidSource(
+            "S3 bucket must not be empty".to_owned(),
+        ));
+    }
+    if key.is_empty() {
+        return Err(DownloadError::InvalidSource(
+            "S3 object key must not be empty".to_owned(),
+        ));
+    }
+    let mut url = Url::parse("https://placeholder.invalid").map_err(|error| {
+        DownloadError::InvalidSource(format!("failed to parse S3 base URL: {error}"))
+    })?;
+    set_endpoint_host(&mut url, endpoint)?;
+    {
+        let mut segments = url.path_segments_mut().map_err(|()| {
+            DownloadError::InvalidSource("S3 URL cannot accept path segments".to_owned())
+        })?;
+        segments.clear();
+        segments.push(bucket);
+        for segment in key.split('/') {
+            segments.push(segment);
+        }
+    }
+    Ok(url)
+}
+
+/// Returns the object key when `url` is a path-style HTTPS URL for `endpoint`/`bucket`.
+///
+/// Matches `https://{endpoint}/{bucket}/{key…}` (optional port on the endpoint). Other hosts,
+/// buckets, schemes, or a URL that stops at the bucket root yield `None` so callers can fall
+/// back to an unsigned download.
+pub fn path_style_object_key(url: &Url, endpoint: &str, bucket: &str) -> Option<String> {
+    if url.scheme() != "https"
+        || bucket.is_empty()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return None;
+    }
+    let (expected_host, expected_port) = split_host_port(endpoint);
+    if url.host_str() != Some(expected_host) {
+        return None;
+    }
+    if !ports_match(url.port(), expected_port) {
+        return None;
+    }
+    let mut segments = url.path_segments()?;
+    let first = segments.next()?;
+    if first != bucket {
+        return None;
+    }
+    let key_segments: Vec<&str> = segments.filter(|segment| !segment.is_empty()).collect();
+    if key_segments.is_empty() {
+        return None;
+    }
+    // `Url` already collapses `.` / `..` path segments before we read them, so a listing cannot
+    // smuggle a parent-directory hop past the bucket prefix without changing the first segment.
+    Some(key_segments.join("/"))
+}
+
+/// Compares an optional URL port with an endpoint's optional port, treating the HTTPS default
+/// as equivalent to an omitted port.
+fn ports_match(url_port: Option<u16>, endpoint_port: Option<u16>) -> bool {
+    match (url_port, endpoint_port) {
+        (None, None) => true,
+        (Some(actual), Some(expected)) => actual == expected,
+        // `Url::port()` omits the scheme default (443 for HTTPS); an endpoint written without a
+        // port means the same default.
+        (None, Some(443)) | (Some(443), None) => true,
+        _ => false,
+    }
+}
+
+/// Applies `endpoint` as a hostname, optionally with a numeric port (`host:port`).
+fn set_endpoint_host(url: &mut Url, endpoint: &str) -> Result<(), DownloadError> {
+    let (host, port) = split_host_port(endpoint);
+    url.set_host(Some(host)).map_err(|error| {
+        DownloadError::InvalidSource(format!("invalid S3 endpoint host {host}: {error}"))
+    })?;
+    if let Some(port) = port
+        && url.set_port(Some(port)).is_err()
+    {
+        return Err(DownloadError::InvalidSource(format!(
+            "invalid S3 endpoint port {port}"
+        )));
+    }
+    Ok(())
+}
+
+/// Splits `host` or `host:port` without treating the last colon of a non-numeric suffix as a port.
+fn split_host_port(endpoint: &str) -> (&str, Option<u16>) {
+    let Some((host, port)) = endpoint.rsplit_once(':') else {
+        return (endpoint, None);
+    };
+    if host.is_empty() {
+        return (endpoint, None);
+    }
+    match port.parse::<u16>() {
+        Ok(port) => (host, Some(port)),
+        Err(_) => (endpoint, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{S3Config, path_style_object_key, path_style_object_url};
+    use pretty_assertions::assert_eq;
+    use url::Url;
+
+    /// Path-style URLs join bucket and key as URL segments, preserving nested keys.
+    #[test]
+    fn builds_path_style_object_urls() {
+        let url = path_style_object_url("s3.example.com", "my-bucket", "plugins/pkg.orax").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://s3.example.com/my-bucket/plugins/pkg.orax"
+        );
+    }
+
+    /// An endpoint with a port is preserved so loopback tests can address a bound listener.
+    #[test]
+    fn builds_path_style_urls_with_a_port() {
+        let url = path_style_object_url("localhost:8443", "bucket", "pkg.orax").unwrap();
+        assert_eq!(url.as_str(), "https://localhost:8443/bucket/pkg.orax");
+    }
+
+    /// A marketplace-style path URL yields the key after the bucket segment.
+    #[test]
+    fn extracts_object_key_from_path_style_url() {
+        let url = Url::parse(
+            "https://s3.example.com/plugin-artifacts/agent/example.codeagent-v0.5.1.orax",
+        )
+        .unwrap();
+        assert_eq!(
+            path_style_object_key(&url, "s3.example.com", "plugin-artifacts").as_deref(),
+            Some("agent/example.codeagent-v0.5.1.orax")
+        );
+    }
+
+    /// Foreign hosts, wrong buckets, bare bucket URLs, and parent segments do not extract.
+    #[test]
+    fn rejects_non_matching_path_style_urls() {
+        let foreign =
+            Url::parse("https://github.com/org/repo/releases/download/v1/pkg.orax").unwrap();
+        assert_eq!(
+            path_style_object_key(&foreign, "s3.example.com", "bucket"),
+            None
+        );
+
+        let wrong_bucket = Url::parse("https://s3.example.com/other-bucket/pkg.orax").unwrap();
+        assert_eq!(
+            path_style_object_key(&wrong_bucket, "s3.example.com", "bucket"),
+            None
+        );
+
+        let bucket_only = Url::parse("https://s3.example.com/bucket").unwrap();
+        assert_eq!(
+            path_style_object_key(&bucket_only, "s3.example.com", "bucket"),
+            None
+        );
+    }
+
+    /// Debug output redacts both credential fields.
+    #[test]
+    fn debug_redacts_credentials() {
+        let config = S3Config::new(
+            "s3.example.com",
+            "bucket",
+            "us-east-1",
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        );
+        let rendered = format!("{config:?}");
+        assert!(rendered.contains("[redacted]"));
+        assert!(!rendered.contains("AKIDEXAMPLE"));
+        assert!(!rendered.contains("wJalrXUtnFEMI"));
+    }
+}

--- a/crates/utils/src/http/s3/downloader.rs
+++ b/crates/utils/src/http/s3/downloader.rs
@@ -1,0 +1,71 @@
+//! Network downloader that signs S3 object-key sources and path-style bucket HTTPS URLs.
+
+use std::future::Future;
+
+use super::{S3Config, SigningTime, path_style_object_key, path_style_object_url, sign_get};
+use crate::http::error::DownloadError;
+use crate::http::reqwest::ReqwestDownloader;
+use crate::http::types::{DownloadOutcome, DownloadRequest, DownloadSource, HttpDownload};
+
+/// Downloads HTTPS URLs unsigned in direct mode, or signs only the configured path-style bucket.
+///
+/// Construct one per proxy configuration and optional S3 endpoint. A missing S3 config rejects
+/// object-key sources instead of issuing an unsigned GET of a relative path. A path-style HTTPS
+/// URL that does not match the configured endpoint and bucket is rejected in S3 mode so source
+/// content cannot silently bypass the user's selected trust boundary.
+#[derive(Clone, Debug)]
+pub struct S3AwareDownloader {
+    http: ReqwestDownloader,
+    s3: Option<S3Config>,
+}
+
+impl S3AwareDownloader {
+    /// Wraps `http` and optionally signs object-key downloads with `s3`.
+    pub fn new(http: ReqwestDownloader, s3: Option<S3Config>) -> Self {
+        Self { http, s3 }
+    }
+
+    /// Signs a GET for `key` against the configured bucket and streams it through `http`.
+    async fn download_signed_object(
+        &self,
+        request: DownloadRequest,
+        key: &str,
+    ) -> Result<DownloadOutcome, DownloadError> {
+        let config = self.s3.as_ref().ok_or_else(|| {
+            DownloadError::InvalidSource("S3 object-key download is not configured".to_owned())
+        })?;
+        let url = path_style_object_url(config.endpoint(), config.bucket(), key)?;
+        let headers = sign_get(config, &url, SigningTime::now_utc());
+        let mut signed = request;
+        signed.source = DownloadSource::Url(url);
+        self.http.download_with_headers(signed, &headers).await
+    }
+}
+
+impl HttpDownload for S3AwareDownloader {
+    #[allow(clippy::manual_async_fn)] // match the trait's explicit `+ Send` future bound
+    fn download(
+        &self,
+        request: DownloadRequest,
+    ) -> impl Future<Output = Result<DownloadOutcome, DownloadError>> + Send {
+        async move {
+            match request.source.clone() {
+                DownloadSource::Local(_) => self.http.download(request).await,
+                DownloadSource::Url(url) => {
+                    let Some(config) = self.s3.as_ref() else {
+                        return self.http.download(request).await;
+                    };
+                    let Some(key) = path_style_object_key(&url, config.endpoint(), config.bucket())
+                    else {
+                        return Err(DownloadError::InvalidSource(
+                            "S3 source URL does not belong to the configured endpoint and bucket"
+                                .to_owned(),
+                        ));
+                    };
+                    self.download_signed_object(request, &key).await
+                }
+                DownloadSource::S3 { key } => self.download_signed_object(request, &key).await,
+            }
+        }
+    }
+}

--- a/crates/utils/src/http/s3/sign.rs
+++ b/crates/utils/src/http/s3/sign.rs
@@ -1,0 +1,268 @@
+//! AWS Signature Version 4 request-header signing for S3-compatible GET requests.
+//!
+//! The timestamp is injected so tests can pin a documented signing instant. SigV4 timestamps are
+//! UTC because the protocol requires the `YYYYMMDD'T'HHMMSS'Z'` form; this is not an Ora clock.
+
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use super::S3Config;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// SHA-256 of the empty payload, used for GET requests that send no body.
+pub(crate) const EMPTY_PAYLOAD_SHA256: &str =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+const SERVICE: &str = "s3";
+const REQUEST_TYPE: &str = "aws4_request";
+const SIGNED_HEADERS: &str = "host;x-amz-content-sha256;x-amz-date";
+
+/// UTC instant used to build `x-amz-date` and the credential-scope date stamp.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SigningTime {
+    year: i32,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+impl SigningTime {
+    /// Builds a signing instant from a UTC civil datetime.
+    pub fn from_utc(year: i32, month: u8, day: u8, hour: u8, minute: u8, second: u8) -> Self {
+        Self {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        }
+    }
+
+    /// Captures the current UTC time for a live request.
+    #[cfg(feature = "http-reqwest")]
+    pub fn now_utc() -> Self {
+        let now = time::OffsetDateTime::now_utc();
+        Self {
+            year: now.year(),
+            month: u8::from(now.month()),
+            day: now.day(),
+            hour: now.hour(),
+            minute: now.minute(),
+            second: now.second(),
+        }
+    }
+
+    /// Returns the `YYYYMMDD'T'HHMMSS'Z'` timestamp used as `x-amz-date`.
+    pub fn amz_date(self) -> String {
+        format!(
+            "{:04}{:02}{:02}T{:02}{:02}{:02}Z",
+            self.year, self.month, self.day, self.hour, self.minute, self.second
+        )
+    }
+
+    /// Returns the `YYYYMMDD` credential-scope date stamp.
+    pub fn date_stamp(self) -> String {
+        format!("{:04}{:02}{:02}", self.year, self.month, self.day)
+    }
+}
+
+/// Signs a path-style S3 GET of `url` using `config` at `when`.
+///
+/// `url` must already be the path-style object URL (`https://endpoint/bucket/key`). The returned
+/// headers include `host`, `x-amz-date`, `x-amz-content-sha256`, and `authorization`.
+pub fn sign_get(config: &S3Config, url: &Url, when: SigningTime) -> Vec<(String, String)> {
+    let amz_date = when.amz_date();
+    let date_stamp = when.date_stamp();
+    let host = host_header(url);
+    let canonical_request = canonical_get_request(url, &host, &amz_date);
+    let scope = credential_scope(&date_stamp, config.region());
+    let string_to_sign = string_to_sign(&amz_date, &scope, &canonical_request);
+    let signing_key = signing_key(config.secret_key(), &date_stamp, config.region());
+    let signature = hex_encode(&hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+    let authorization = format!(
+        "{ALGORITHM} Credential={}/{scope}, SignedHeaders={SIGNED_HEADERS}, Signature={signature}",
+        config.access_key()
+    );
+    vec![
+        ("host".to_owned(), host),
+        ("x-amz-date".to_owned(), amz_date),
+        (
+            "x-amz-content-sha256".to_owned(),
+            EMPTY_PAYLOAD_SHA256.to_owned(),
+        ),
+        ("authorization".to_owned(), authorization),
+    ]
+}
+
+/// Builds the SigV4 canonical request for a GET with an empty payload.
+pub(crate) fn canonical_get_request(url: &Url, host: &str, amz_date: &str) -> String {
+    let canonical_uri = canonical_uri(url);
+    format!(
+        "GET\n{canonical_uri}\n\nhost:{host}\nx-amz-content-sha256:{EMPTY_PAYLOAD_SHA256}\nx-amz-date:{amz_date}\n\n{SIGNED_HEADERS}\n{EMPTY_PAYLOAD_SHA256}"
+    )
+}
+
+/// Returns the URI path used in the canonical request, defaulting to `/`.
+fn canonical_uri(url: &Url) -> String {
+    let path = url.path();
+    if path.is_empty() {
+        "/".to_owned()
+    } else {
+        path.to_owned()
+    }
+}
+
+/// Formats the Host header, omitting the default HTTPS port.
+fn host_header(url: &Url) -> String {
+    let host = url.host_str().unwrap_or_default();
+    match url.port() {
+        Some(port) if port != 443 => format!("{host}:{port}"),
+        _ => host.to_owned(),
+    }
+}
+
+/// Returns `{date}/{region}/s3/aws4_request`.
+fn credential_scope(date_stamp: &str, region: &str) -> String {
+    format!("{date_stamp}/{region}/{SERVICE}/{REQUEST_TYPE}")
+}
+
+/// Builds the SigV4 string-to-sign from a canonical request.
+fn string_to_sign(amz_date: &str, scope: &str, canonical_request: &str) -> String {
+    let hashed = hex_encode(&Sha256::digest(canonical_request.as_bytes()));
+    format!("{ALGORITHM}\n{amz_date}\n{scope}\n{hashed}")
+}
+
+/// Derives the SigV4 signing key from the secret, date, and region.
+fn signing_key(secret_key: &str, date_stamp: &str, region: &str) -> [u8; 32] {
+    let date_key = hmac_sha256(
+        format!("AWS4{secret_key}").as_bytes(),
+        date_stamp.as_bytes(),
+    );
+    let region_key = hmac_sha256(&date_key, region.as_bytes());
+    let service_key = hmac_sha256(&region_key, SERVICE.as_bytes());
+    hmac_sha256(&service_key, REQUEST_TYPE.as_bytes())
+}
+
+/// HMAC-SHA256; the algorithm accepts any key length so construction cannot fail.
+fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut mac = match HmacSha256::new_from_slice(key) {
+        Ok(mac) => mac,
+        Err(_) => unreachable!("HMAC-SHA256 accepts a key of any length"),
+    };
+    mac.update(data);
+    mac.finalize().into_bytes().into()
+}
+
+/// Encodes `bytes` as lowercase hexadecimal.
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        EMPTY_PAYLOAD_SHA256, SigningTime, canonical_get_request, credential_scope, hex_encode,
+        sign_get,
+    };
+    use crate::http::s3::S3Config;
+    use pretty_assertions::assert_eq;
+    use url::Url;
+
+    fn example_config() -> S3Config {
+        S3Config::new(
+            "s3.example.com",
+            "my-bucket",
+            "us-east-1",
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        )
+    }
+
+    fn example_url() -> Url {
+        Url::parse("https://s3.example.com/my-bucket/plugins/pkg.orax").unwrap()
+    }
+
+    fn example_time() -> SigningTime {
+        SigningTime::from_utc(2013, 5, 24, 0, 0, 0)
+    }
+
+    /// The canonical request matches the SigV4 GET layout for a path-style object URL.
+    #[test]
+    fn builds_the_canonical_get_request() {
+        let url = example_url();
+        let canonical = canonical_get_request(&url, "s3.example.com", "20130524T000000Z");
+        assert_eq!(
+            canonical,
+            format!(
+                "GET\n/my-bucket/plugins/pkg.orax\n\nhost:s3.example.com\nx-amz-content-sha256:{EMPTY_PAYLOAD_SHA256}\nx-amz-date:20130524T000000Z\n\nhost;x-amz-content-sha256;x-amz-date\n{EMPTY_PAYLOAD_SHA256}"
+            )
+        );
+        assert_eq!(
+            credential_scope("20130524", "us-east-1"),
+            "20130524/us-east-1/s3/aws4_request"
+        );
+    }
+
+    /// Signed headers name the host, empty-payload hash, date, and a 64-character signature.
+    #[test]
+    fn signs_a_path_style_get() {
+        let headers = sign_get(&example_config(), &example_url(), example_time());
+        let authorization = header_value(&headers, "authorization");
+        assert!(authorization.starts_with(
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature="
+        ));
+        let signature = authorization.rsplit("Signature=").next().unwrap_or("");
+        assert_eq!(signature.len(), 64);
+        assert!(signature.chars().all(|ch| ch.is_ascii_hexdigit()));
+        assert_eq!(header_value(&headers, "host"), "s3.example.com");
+        assert_eq!(header_value(&headers, "x-amz-date"), "20130524T000000Z");
+        assert_eq!(
+            header_value(&headers, "x-amz-content-sha256"),
+            EMPTY_PAYLOAD_SHA256
+        );
+    }
+
+    /// Changing the secret produces a different signature so the HMAC chain is not a no-op.
+    #[test]
+    fn signature_depends_on_the_secret_key() {
+        let original = sign_get(&example_config(), &example_url(), example_time());
+        let other = S3Config::new(
+            "s3.example.com",
+            "my-bucket",
+            "us-east-1",
+            "AKIDEXAMPLE",
+            "different-secret",
+        );
+        let changed = sign_get(&other, &example_url(), example_time());
+        assert_ne!(
+            header_value(&original, "authorization"),
+            header_value(&changed, "authorization")
+        );
+    }
+
+    /// Hex encoding is lowercase so it matches the SigV4 alphabet.
+    #[test]
+    fn hex_encode_is_lowercase() {
+        assert_eq!(hex_encode(&[0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+    }
+
+    fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> &'a str {
+        headers
+            .iter()
+            .find(|(header, _)| header == name)
+            .map(|(_, value)| value.as_str())
+            .unwrap_or("")
+    }
+}

--- a/crates/utils/src/http/tests.rs
+++ b/crates/utils/src/http/tests.rs
@@ -66,7 +66,27 @@ fn copies_local_file_and_reports_bytes() {
     assert_eq!(fs::read(&destination).unwrap(), payload);
 }
 
-/// Succeeds when the provided SHA-256 matches the copied artifact.
+/// Object-key sources are rejected by the local downloader instead of being treated as paths.
+#[test]
+fn rejects_s3_object_key_sources() {
+    let temp_dir = TempDir::new().unwrap();
+    let destination = temp_dir.path().join("out.bin");
+    let error = download(request(
+        DownloadSource::S3 {
+            key: "pkg.orax".to_owned(),
+        },
+        &destination,
+        None,
+        None,
+    ))
+    .unwrap_err();
+    match error {
+        DownloadError::InvalidSource(message) => {
+            assert!(message.contains("S3"));
+        }
+        other => panic!("expected invalid source, got {other:?}"),
+    }
+}
 #[test]
 fn verifies_correct_sha256() {
     let temp_dir = TempDir::new().unwrap();
@@ -544,5 +564,238 @@ mod reqwest_integration {
             message.contains(" <- "),
             "expected a cause chain joined by ' <- ', got: {message}"
         );
+    }
+
+    /// An object-key download signs the GET and still verifies the payload checksum.
+    #[tokio::test]
+    async fn downloads_s3_object_key_with_signed_headers() {
+        use crate::http::{S3AwareDownloader, S3Config};
+        use std::sync::{Arc, Mutex};
+
+        let payload: &'static [u8] = b"s3 object payload";
+        let captured: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+        let (url, ca_root) = serve_https_once_capturing(payload, Arc::clone(&captured)).await;
+        let port = url.port().unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let destination = temp_dir.path().join("pkg.orax");
+        let config = S3Config::new(
+            format!("localhost:{port}"),
+            "bucket",
+            "dgg",
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        );
+        let downloader = S3AwareDownloader::new(
+            ReqwestDownloader::new(Default::default()).with_extra_tls_root(ca_root),
+            Some(config),
+        );
+
+        let outcome = downloader
+            .download(DownloadRequest {
+                source: DownloadSource::S3 {
+                    key: "pkg.orax".to_owned(),
+                },
+                destination: destination.clone(),
+                checksum: Some(Checksum::sha256(sha256_bytes(payload))),
+                options: DownloadOptions {
+                    max_retries: 0,
+                    ..DownloadOptions::default()
+                },
+                progress: None,
+                cancel: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.bytes, payload.len() as u64);
+        assert_eq!(std::fs::read(&destination).unwrap(), payload);
+        let request = captured.lock().unwrap().clone();
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: aws4-hmac-sha256"),
+            "expected a SigV4 authorization header, got: {request}"
+        );
+        assert!(
+            request.to_ascii_lowercase().contains("x-amz-date:"),
+            "expected x-amz-date, got: {request}"
+        );
+    }
+
+    /// A path-style HTTPS URL that targets the configured bucket is signed like an object key.
+    #[tokio::test]
+    async fn downloads_path_style_bucket_https_url_with_signed_headers() {
+        use crate::http::{S3AwareDownloader, S3Config, path_style_object_url};
+        use std::sync::{Arc, Mutex};
+
+        let payload: &'static [u8] = b"path style s3 payload";
+        let captured: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+        let (listener_url, ca_root) =
+            serve_https_once_capturing(payload, Arc::clone(&captured)).await;
+        let port = listener_url.port().unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let destination = temp_dir.path().join("pkg.orax");
+        let endpoint = format!("localhost:{port}");
+        let config = S3Config::new(
+            endpoint.clone(),
+            "plugin-artifacts",
+            "dgg",
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        );
+        let source_url = path_style_object_url(
+            &endpoint,
+            "plugin-artifacts",
+            "agent/example.codeagent-v0.5.1.orax",
+        )
+        .unwrap();
+        let downloader = S3AwareDownloader::new(
+            ReqwestDownloader::new(Default::default()).with_extra_tls_root(ca_root),
+            Some(config),
+        );
+
+        let outcome = downloader
+            .download(DownloadRequest {
+                source: DownloadSource::Url(source_url),
+                destination: destination.clone(),
+                checksum: Some(Checksum::sha256(sha256_bytes(payload))),
+                options: DownloadOptions {
+                    max_retries: 0,
+                    ..DownloadOptions::default()
+                },
+                progress: None,
+                cancel: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.bytes, payload.len() as u64);
+        assert_eq!(std::fs::read(&destination).unwrap(), payload);
+        let request = captured.lock().unwrap().clone();
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: aws4-hmac-sha256"),
+            "expected a SigV4 authorization header, got: {request}"
+        );
+        assert!(
+            request.contains("plugin-artifacts/agent/example.codeagent-v0.5.1.orax"),
+            "expected the nested object path in the request line, got: {request}"
+        );
+    }
+
+    /// S3 mode rejects a foreign HTTPS locator instead of silently bypassing SigV4.
+    #[tokio::test]
+    async fn rejects_foreign_https_url_in_s3_mode() {
+        use crate::http::{S3AwareDownloader, S3Config};
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let downloader = S3AwareDownloader::new(
+            ReqwestDownloader::new(Default::default()),
+            Some(S3Config::new(
+                "s3.example.com",
+                "plugin-artifacts",
+                "region-1",
+                "access",
+                "secret",
+            )),
+        );
+        let error = downloader
+            .download(DownloadRequest {
+                source: DownloadSource::Url(
+                    Url::parse("https://downloads.example.com/plugin.orax").unwrap(),
+                ),
+                destination: temp_dir.path().join("plugin.orax"),
+                checksum: None,
+                options: DownloadOptions::default(),
+                progress: None,
+                cancel: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, DownloadError::InvalidSource(_)));
+    }
+
+    /// Object-key sources fail closed when no S3 endpoint is configured.
+    #[tokio::test]
+    async fn rejects_s3_object_key_without_config() {
+        use crate::http::S3AwareDownloader;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let destination = temp_dir.path().join("pkg.orax");
+        let downloader = S3AwareDownloader::new(ReqwestDownloader::new(Default::default()), None);
+        let error = downloader
+            .download(DownloadRequest {
+                source: DownloadSource::S3 {
+                    key: "pkg.orax".to_owned(),
+                },
+                destination,
+                checksum: None,
+                options: DownloadOptions {
+                    max_retries: 0,
+                    ..DownloadOptions::default()
+                },
+                progress: None,
+                cancel: None,
+            })
+            .await
+            .unwrap_err();
+        match error {
+            DownloadError::InvalidSource(message) => {
+                assert!(message.contains("not configured"));
+            }
+            other => panic!("expected invalid source, got {other:?}"),
+        }
+    }
+
+    /// Serves one HTTPS response and records the raw request for header assertions.
+    async fn serve_https_once_capturing(
+        body: &'static [u8],
+        captured: std::sync::Arc<std::sync::Mutex<String>>,
+    ) -> (Url, rustls::pki_types::CertificateDer<'static>) {
+        let ca_key = rcgen::KeyPair::generate().unwrap();
+        let mut ca_params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![
+            rcgen::KeyUsagePurpose::KeyCertSign,
+            rcgen::KeyUsagePurpose::CrlSign,
+        ];
+        let ca = rcgen::CertifiedIssuer::self_signed(ca_params, ca_key).unwrap();
+        let server_key = rcgen::KeyPair::generate().unwrap();
+        let mut server_params =
+            rcgen::CertificateParams::new(vec!["localhost".to_owned()]).unwrap();
+        server_params.key_usages = vec![rcgen::KeyUsagePurpose::DigitalSignature];
+        server_params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ServerAuth];
+        let server_cert = server_params.signed_by(&server_key, &ca).unwrap();
+        let private_key = rustls::pki_types::PrivatePkcs8KeyDer::from(server_key.serialize_der());
+        let server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![server_cert.der().clone()], private_key.into())
+            .unwrap();
+        let acceptor = TlsAcceptor::from(Arc::new(server_config));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let Ok(mut socket) = acceptor.accept(socket).await else {
+                return;
+            };
+            let mut buffer = [0_u8; 8192];
+            let bytes_read = socket.read(&mut buffer).await.unwrap();
+            let request = String::from_utf8_lossy(&buffer[..bytes_read]).into_owned();
+            *captured.lock().unwrap() = request;
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/octet-stream\r\n\r\n",
+                body.len()
+            );
+            socket.write_all(header.as_bytes()).await.unwrap();
+            socket.write_all(body).await.unwrap();
+            let _flush_result = socket.flush().await;
+        });
+        (
+            Url::parse(&format!("https://localhost:{port}/pkg.orax")).unwrap(),
+            ca.der().clone(),
+        )
     }
 }

--- a/crates/utils/src/http/types.rs
+++ b/crates/utils/src/http/types.rs
@@ -36,6 +36,8 @@ pub enum DownloadSource {
     Url(Url),
     /// A local path (`file://` semantics without a URL).
     Local(PathBuf),
+    /// An object-store key resolved by an S3-aware downloader against its configured bucket.
+    S3 { key: String },
 }
 
 /// One self-contained download operation.

--- a/docs/desktop-runtime.md
+++ b/docs/desktop-runtime.md
@@ -46,6 +46,25 @@ and leaves the `Ready` status in place, because the verified bytes are still on 
 therefore only reported when nothing was installable to begin with, and a failed installation
 restores `Ready` so the user can retry.
 
+## Plugin marketplace artifact retrieval
+
+Each configured plugin marketplace source independently selects how its `.orax` release artifacts
+are retrieved. `Direct HTTPS` fetches an absolute HTTPS locator without request signing. `S3 SigV4`
+accepts an object key, or a path-style HTTPS locator belonging to the configured endpoint and
+bucket, and signs the request with that source's region and static credential pair. An S3 source
+rejects foreign HTTPS locators instead of falling back to unsigned retrieval.
+
+The source editor exposes the modes as “HTTPS 直接获取” and “S3 签名获取”. S3 endpoint, bucket,
+region, Access Key ID, and Secret Access Key are one complete configuration; existing credentials
+are write-only and can be preserved or atomically replaced, but are never returned by the source
+query contract or rendered in debug output. The current implementation stores this pair in the
+local SQLite database as plaintext configuration. It does not yet provide OS-keychain encryption,
+temporary credentials, or a provider credential chain.
+
+Both modes keep the source's proxy selection and the common download pipeline. SigV4 authenticates
+the request but does not establish package integrity: every artifact must still pass the release
+manifest's SHA-256 before installation.
+
 The static manifest advertises an AppImage for Linux, which the updater can only install into an
 AppImage installation. A `deb` or `rpm` installation, or a build running as a bare executable, is
 reported as `ManualUpdate` with the reason instead, before any download is spent; the shell then

--- a/docs/effect-skill-state.md
+++ b/docs/effect-skill-state.md
@@ -52,6 +52,10 @@ An unchanged Consumer declaration does not touch Target status or requests. New 
 paired with existing Workspaces immediately, while every worker pass converges existing Consumer
 declarations into Workspaces created later.
 
+Agent startup and the Effect worker can persist the same Consumer declaration in a different
+order from their sampled timestamps. Replaying an unchanged declaration preserves the latest
+Consumer audit timestamp so startup cannot fail the database's timestamp ordering constraint.
+
 ## Filesystem safety and recovery
 
 Filesystem Resources use Workspace roots plus validated portable relative paths. Path construction

--- a/packages/app-shell/src/features/settings/plugin-sources-manager.test.tsx
+++ b/packages/app-shell/src/features/settings/plugin-sources-manager.test.tsx
@@ -44,6 +44,7 @@ it("renders configured marketplace sources", async () => {
     branch: "main",
     useProxy: false,
     enabled: true,
+    artifactRetrieval: { type: "direct_https" },
   });
   const client = createMockClient(state);
 
@@ -74,6 +75,7 @@ it("adds a marketplace source through the backend", async () => {
         branch: "main",
         useProxy: false,
         enabled: true,
+        artifactRetrieval: { type: "direct_https" },
       },
     ]),
   );
@@ -86,6 +88,7 @@ it("removes a marketplace source through the backend", async () => {
     branch: "main",
     useProxy: false,
     enabled: true,
+    artifactRetrieval: { type: "direct_https" },
   });
   const client = createMockClient(state);
   const deleteSource = vi.spyOn(client.plugin, "deleteSource");
@@ -113,6 +116,7 @@ it("edits a marketplace source URL and branch", async () => {
     branch: "main",
     useProxy: false,
     enabled: true,
+    artifactRetrieval: { type: "direct_https" },
   });
   const client = createMockClient(state);
   const user = userEvent.setup();
@@ -136,8 +140,73 @@ it("edits a marketplace source URL and branch", async () => {
         branch: "release",
         useProxy: false,
         enabled: true,
+        artifactRetrieval: { type: "direct_https" },
       },
     ]),
+  );
+});
+
+it("configures S3 SigV4 retrieval without returning credentials", async () => {
+  const state = createMockClientState();
+  state.marketplaceSources.push({
+    url: "https://github.com/ora-space/marketplace",
+    branch: "main",
+    useProxy: false,
+    enabled: true,
+    artifactRetrieval: { type: "direct_https" },
+  });
+  const client = createMockClient(state);
+  const updateSource = vi.spyOn(client.plugin, "updateSource");
+  const user = userEvent.setup();
+
+  renderManager(client);
+
+  await user.click(await screen.findByRole("button", { name: /编辑|Edit/ }));
+  const dialog = await screen.findByRole("dialog");
+  await user.click(
+    within(dialog).getByLabelText(/插件包获取方式|Plugin package retrieval/),
+  );
+  await user.click(await screen.findByRole("option", { name: /S3.*SigV4/i }));
+  await user.type(
+    within(dialog).getByLabelText(/S3 Endpoint/i),
+    "https://s3.example.com",
+  );
+  await user.type(within(dialog).getByLabelText(/^Bucket$/i), "plugins");
+  await user.type(within(dialog).getByLabelText(/^Region$/i), "region-1");
+  await user.type(within(dialog).getByLabelText(/Access Key ID/i), "access");
+  await user.type(
+    within(dialog).getByLabelText(/Secret Access Key/i),
+    "secret",
+  );
+  await user.click(within(dialog).getByRole("button", { name: /保存|Save/ }));
+
+  await waitFor(() =>
+    expect(updateSource).toHaveBeenCalledWith({
+      url: "https://github.com/ora-space/marketplace",
+      newUrl: "https://github.com/ora-space/marketplace",
+      branch: "main",
+      useProxy: false,
+      enabled: true,
+      artifactRetrieval: {
+        type: "s3_sigv4",
+        endpoint: "https://s3.example.com",
+        bucket: "plugins",
+        region: "region-1",
+        credentials: {
+          action: "replace",
+          accessKeyId: "access",
+          secretAccessKey: "secret",
+        },
+      },
+    }),
+  );
+  await waitFor(() =>
+    expect(state.marketplaceSources[0]?.artifactRetrieval).toEqual({
+      type: "s3_sigv4",
+      endpoint: "https://s3.example.com",
+      bucket: "plugins",
+      region: "region-1",
+    }),
   );
 });
 
@@ -148,6 +217,7 @@ it("disables a marketplace source without removing it", async () => {
     branch: "main",
     useProxy: false,
     enabled: true,
+    artifactRetrieval: { type: "direct_https" },
   });
   const client = createMockClient(state);
   const user = userEvent.setup();
@@ -163,6 +233,7 @@ it("disables a marketplace source without removing it", async () => {
         branch: "main",
         useProxy: false,
         enabled: false,
+        artifactRetrieval: { type: "direct_https" },
       },
     ]),
   );

--- a/packages/app-shell/src/features/settings/plugin-sources-manager.tsx
+++ b/packages/app-shell/src/features/settings/plugin-sources-manager.tsx
@@ -15,6 +15,10 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
   Switch,
   toast,
 } from "@ora/ui";
@@ -24,7 +28,11 @@ import {
   IconPlus,
   IconTrash,
 } from "@tabler/icons-react";
-import type { MarketplaceSource } from "@ora/contracts";
+import type {
+  MarketplaceArtifactRetrieval,
+  MarketplaceArtifactRetrievalUpdate,
+  MarketplaceSource,
+} from "@ora/contracts";
 import { useContractErrorToast } from "../../i18n/use-contract-error-toast";
 import {
   useAddMarketplaceSource,
@@ -76,7 +84,7 @@ export function PluginSourcesManager({ onBack }: { onBack: () => void }) {
     source: MarketplaceSource,
     patch: Partial<
       Pick<MarketplaceSource, "url" | "branch" | "useProxy" | "enabled">
-    >,
+    > & { artifactRetrieval?: MarketplaceArtifactRetrievalUpdate },
     onSuccess?: () => void,
   ) => {
     updateSource.mutate(
@@ -86,6 +94,9 @@ export function PluginSourcesManager({ onBack }: { onBack: () => void }) {
         branch: patch.branch ?? source.branch,
         useProxy: patch.useProxy ?? source.useProxy,
         enabled: patch.enabled ?? source.enabled,
+        artifactRetrieval:
+          patch.artifactRetrieval ??
+          preservedArtifactRetrieval(source.artifactRetrieval),
       },
       {
         onSuccess: () => {
@@ -269,11 +280,15 @@ export function PluginSourcesManager({ onBack }: { onBack: () => void }) {
           onOpenChange={(open) => {
             if (!open) setEditing(null);
           }}
-          onSave={(nextUrl, nextBranch) =>
-            patchSource(editing, { url: nextUrl, branch: nextBranch }, () => {
-              setEditing(null);
-              toast.success(t("settings.plugins.sourceUpdated"));
-            })
+          onSave={(nextUrl, nextBranch, artifactRetrieval) =>
+            patchSource(
+              editing,
+              { url: nextUrl, branch: nextBranch, artifactRetrieval },
+              () => {
+                setEditing(null);
+                toast.success(t("settings.plugins.sourceUpdated"));
+              },
+            )
           }
         />
       )}
@@ -285,10 +300,14 @@ interface SourceEditDialogProps {
   source: MarketplaceSource;
   pending: boolean;
   onOpenChange: (open: boolean) => void;
-  onSave: (url: string, branch: string) => void;
+  onSave: (
+    url: string,
+    branch: string,
+    artifactRetrieval: MarketplaceArtifactRetrievalUpdate,
+  ) => void;
 }
 
-/** Edits one marketplace source's Git URL and tracked branch. */
+/** Edits one marketplace source's Git identity and artifact retrieval policy. */
 function SourceEditDialog({
   source,
   pending,
@@ -298,7 +317,57 @@ function SourceEditDialog({
   const { t } = useTranslation();
   const [url, setUrl] = useState(source.url);
   const [branch, setBranch] = useState(source.branch);
-  const canSave = url.trim() !== "" && branch.trim() !== "";
+  const [retrievalType, setRetrievalType] = useState(
+    source.artifactRetrieval.type,
+  );
+  const [endpoint, setEndpoint] = useState(
+    source.artifactRetrieval.type === "s3_sigv4"
+      ? source.artifactRetrieval.endpoint
+      : "",
+  );
+  const [bucket, setBucket] = useState(
+    source.artifactRetrieval.type === "s3_sigv4"
+      ? source.artifactRetrieval.bucket
+      : "",
+  );
+  const [region, setRegion] = useState(
+    source.artifactRetrieval.type === "s3_sigv4"
+      ? source.artifactRetrieval.region
+      : "",
+  );
+  const [accessKeyId, setAccessKeyId] = useState("");
+  const [secretAccessKey, setSecretAccessKey] = useState("");
+  const keepsCredentials =
+    source.artifactRetrieval.type === "s3_sigv4" &&
+    accessKeyId === "" &&
+    secretAccessKey === "";
+  const hasReplacementCredentials =
+    accessKeyId.trim() !== "" && secretAccessKey.trim() !== "";
+  const canSave =
+    url.trim() !== "" &&
+    branch.trim() !== "" &&
+    (retrievalType === "direct_https" ||
+      (endpoint.trim() !== "" &&
+        bucket.trim() !== "" &&
+        region.trim() !== "" &&
+        (keepsCredentials || hasReplacementCredentials)));
+
+  const artifactRetrieval = (): MarketplaceArtifactRetrievalUpdate => {
+    if (retrievalType === "direct_https") return { type: "direct_https" };
+    return {
+      type: "s3_sigv4",
+      endpoint: endpoint.trim(),
+      bucket: bucket.trim(),
+      region: region.trim(),
+      credentials: keepsCredentials
+        ? { action: "preserve" }
+        : {
+            action: "replace",
+            accessKeyId: accessKeyId.trim(),
+            secretAccessKey: secretAccessKey.trim(),
+          },
+    };
+  };
 
   return (
     <Dialog open onOpenChange={onOpenChange}>
@@ -323,6 +392,73 @@ function SourceEditDialog({
           </label>
           <label className="space-y-1.5">
             <span className="text-sm font-medium">
+              {t("settings.plugins.artifactRetrieval")}
+            </span>
+            <Select
+              value={retrievalType}
+              onValueChange={(value) =>
+                setRetrievalType(value as MarketplaceArtifactRetrieval["type"])
+              }
+            >
+              <SelectTrigger
+                className="w-full"
+                aria-label={t("settings.plugins.artifactRetrieval")}
+              >
+                <span className="flex-1 text-left">
+                  {retrievalType === "direct_https"
+                    ? t("settings.plugins.artifactRetrievalDirectHttps")
+                    : t("settings.plugins.artifactRetrievalS3SigV4")}
+                </span>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="direct_https">
+                  {t("settings.plugins.artifactRetrievalDirectHttps")}
+                </SelectItem>
+                <SelectItem value="s3_sigv4">
+                  {t("settings.plugins.artifactRetrievalS3SigV4")}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </label>
+          {retrievalType === "s3_sigv4" && (
+            <div className="space-y-3 rounded-md border border-border/70 p-3">
+              <SourceField
+                label={t("settings.plugins.s3Endpoint")}
+                value={endpoint}
+                onChange={setEndpoint}
+              />
+              <SourceField
+                label={t("settings.plugins.s3Bucket")}
+                value={bucket}
+                onChange={setBucket}
+              />
+              <SourceField
+                label={t("settings.plugins.s3Region")}
+                value={region}
+                onChange={setRegion}
+              />
+              <SourceField
+                label={t("settings.plugins.s3AccessKeyId")}
+                value={accessKeyId}
+                onChange={setAccessKeyId}
+                autoComplete="off"
+              />
+              <SourceField
+                label={t("settings.plugins.s3SecretAccessKey")}
+                value={secretAccessKey}
+                onChange={setSecretAccessKey}
+                type="password"
+                autoComplete="new-password"
+              />
+              {source.artifactRetrieval.type === "s3_sigv4" && (
+                <p className="text-xs text-muted-foreground">
+                  {t("settings.plugins.s3CredentialsPreserved")}
+                </p>
+              )}
+            </div>
+          )}
+          <label className="space-y-1.5">
+            <span className="text-sm font-medium">
               {t("settings.plugins.sourceBranch")}
             </span>
             <Input
@@ -339,7 +475,9 @@ function SourceEditDialog({
           </Button>
           <Button
             disabled={pending || !canSave}
-            onClick={() => onSave(url.trim(), branch.trim())}
+            onClick={() =>
+              onSave(url.trim(), branch.trim(), artifactRetrieval())
+            }
           >
             {pending ? t("settings.plugins.savingSource") : t("common.save")}
           </Button>
@@ -347,4 +485,45 @@ function SourceEditDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+interface SourceFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: "password";
+  autoComplete?: string;
+}
+
+/** Renders one labeled marketplace source field with consistent credential behavior. */
+function SourceField({
+  label,
+  value,
+  onChange,
+  type,
+  autoComplete,
+}: SourceFieldProps) {
+  return (
+    <label className="space-y-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      <Input
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        aria-label={label}
+        autoComplete={autoComplete}
+      />
+    </label>
+  );
+}
+
+/** Converts a redacted source projection into an update that keeps any persisted credentials. */
+function preservedArtifactRetrieval(
+  retrieval: MarketplaceArtifactRetrieval,
+): MarketplaceArtifactRetrievalUpdate {
+  if (retrieval.type === "direct_https") return retrieval;
+  return {
+    ...retrieval,
+    credentials: { action: "preserve" },
+  };
 }

--- a/packages/app-shell/src/i18n/i18n-instance.ts
+++ b/packages/app-shell/src/i18n/i18n-instance.ts
@@ -799,6 +799,16 @@ export const translationResources = {
     "settings.plugins.sourceUrl": "Git URL",
     "settings.plugins.sourceUseProxy": "使用代理",
     "settings.plugins.sourceBranch": "分支",
+    "settings.plugins.artifactRetrieval": "插件包获取方式",
+    "settings.plugins.artifactRetrievalDirectHttps": "HTTPS 直接获取",
+    "settings.plugins.artifactRetrievalS3SigV4": "S3 签名获取（SigV4）",
+    "settings.plugins.s3Endpoint": "S3 Endpoint",
+    "settings.plugins.s3Bucket": "Bucket",
+    "settings.plugins.s3Region": "Region",
+    "settings.plugins.s3AccessKeyId": "Access Key ID",
+    "settings.plugins.s3SecretAccessKey": "Secret Access Key",
+    "settings.plugins.s3CredentialsPreserved":
+      "凭据不会回显；两项均留空可保留当前凭据，填写时必须同时替换。",
     "settings.plugins.addSource": "添加来源",
     "settings.plugins.editSource": "编辑",
     "settings.plugins.editSourceDescription":
@@ -2400,6 +2410,16 @@ export const translationResources = {
     "settings.plugins.sourceUrl": "Git URL",
     "settings.plugins.sourceUseProxy": "Use proxy",
     "settings.plugins.sourceBranch": "Branch",
+    "settings.plugins.artifactRetrieval": "Plugin package retrieval",
+    "settings.plugins.artifactRetrievalDirectHttps": "Direct HTTPS",
+    "settings.plugins.artifactRetrievalS3SigV4": "S3 SigV4",
+    "settings.plugins.s3Endpoint": "S3 endpoint",
+    "settings.plugins.s3Bucket": "Bucket",
+    "settings.plugins.s3Region": "Region",
+    "settings.plugins.s3AccessKeyId": "Access Key ID",
+    "settings.plugins.s3SecretAccessKey": "Secret Access Key",
+    "settings.plugins.s3CredentialsPreserved":
+      "Credentials are never displayed. Leave both fields blank to keep them, or fill both to replace them.",
     "settings.plugins.addSource": "Add source",
     "settings.plugins.editSource": "Edit",
     "settings.plugins.editSourceDescription":

--- a/packages/app-shell/src/state/hooks/use-marketplace-sources.ts
+++ b/packages/app-shell/src/state/hooks/use-marketplace-sources.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { UpdateMarketplaceSourceRequest } from "@ora/contracts";
 import { useContractsClient } from "../../contracts-client-context";
 import { queryKeys } from "./query-keys";
 
@@ -56,26 +57,8 @@ export function useUpdateMarketplaceSource() {
   const client = useContractsClient();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({
-      url,
-      newUrl,
-      branch,
-      useProxy,
-      enabled,
-    }: {
-      url: string;
-      newUrl: string;
-      branch: string;
-      useProxy: boolean;
-      enabled: boolean;
-    }) =>
-      client.plugin.updateSource({
-        url,
-        newUrl,
-        branch,
-        useProxy,
-        enabled,
-      }),
+    mutationFn: (request: UpdateMarketplaceSourceRequest) =>
+      client.plugin.updateSource(request),
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: queryKeys.marketplaceSources }),
   });

--- a/packages/app-shell/src/test/mock-client.ts
+++ b/packages/app-shell/src/test/mock-client.ts
@@ -542,6 +542,7 @@ export function createMockClient(state: MockClientState): ContractsClient {
           branch: req.branch,
           useProxy: req.useProxy,
           enabled: true,
+          artifactRetrieval: { type: "direct_https" } as const,
         };
         state.marketplaceSources.push(source);
         return { sources: [...state.marketplaceSources] };
@@ -570,6 +571,15 @@ export function createMockClient(state: MockClientState): ContractsClient {
           branch: req.branch,
           useProxy: req.useProxy,
           enabled: req.enabled,
+          artifactRetrieval:
+            req.artifactRetrieval.type === "direct_https"
+              ? req.artifactRetrieval
+              : {
+                  type: "s3_sigv4" as const,
+                  endpoint: req.artifactRetrieval.endpoint,
+                  bucket: req.artifactRetrieval.bucket,
+                  region: req.artifactRetrieval.region,
+                },
         };
         return { sources: [...state.marketplaceSources] };
       },

--- a/packages/contracts/src/plugin.ts
+++ b/packages/contracts/src/plugin.ts
@@ -260,6 +260,39 @@ export type ListMarketplaceSourcesResponse = {
 };
 
 /**
+ * Describes how one marketplace source retrieves its `.orax` release artifacts.
+ *
+ * The S3 variant deliberately excludes credentials: source queries may populate editors and
+ * logs, so secrets remain write-only outside the backend persistence boundary.
+ */
+export type MarketplaceArtifactRetrieval = { "type": "direct_https" } | {
+  "type": "s3_sigv4";
+  endpoint: string;
+  bucket: string;
+  region: string;
+};
+
+/**
+ * Carries the complete artifact-retrieval state submitted by the source editor.
+ */
+export type MarketplaceArtifactRetrievalUpdate = { "type": "direct_https" } | {
+  "type": "s3_sigv4";
+  endpoint: string;
+  bucket: string;
+  region: string;
+  credentials: MarketplaceS3CredentialsUpdate;
+};
+
+/**
+ * Selects whether an S3 source update retains or atomically replaces its credential pair.
+ */
+export type MarketplaceS3CredentialsUpdate = { "action": "preserve" } | {
+  "action": "replace";
+  accessKeyId: string;
+  secretAccessKey: string;
+};
+
+/**
  * Lists one configured marketplace source repository and its tracked branch.
  */
 export type MarketplaceSource = {
@@ -279,6 +312,10 @@ export type MarketplaceSource = {
    * Whether this source participates in marketplace sync, listing, and install.
    */
   enabled: boolean;
+  /**
+   * Release-artifact retrieval policy, with S3 credentials omitted.
+   */
+  artifactRetrieval: MarketplaceArtifactRetrieval;
 };
 
 /**
@@ -500,6 +537,7 @@ export type UpdateMarketplaceSourceRequest = {
   branch: string;
   useProxy: boolean;
   enabled: boolean;
+  artifactRetrieval: MarketplaceArtifactRetrievalUpdate;
 };
 
 /**


### PR DESCRIPTION
## Summary

- add source-scoped Direct HTTPS and S3 SigV4 artifact retrieval modes for plugin marketplaces
- persist the tagged retrieval configuration in one JSON column and keep credentials write-only across contracts and diagnostics
- support validated object-key release locators, strict path-style S3 signing, and the existing checksum/install pipeline
- add marketplace source editor fields, generated contracts, migration coverage, downloader tests, and runtime documentation

## Security boundaries

- no provider-specific global defaults or embedded credentials
- S3 mode rejects HTTPS locators outside its configured endpoint and bucket
- source queries and Debug output do not render the credential pair
- static credentials remain plaintext in local SQLite; credential-store migration is intentionally deferred

## Testing

- task lint:crates
- task lint:frontend
- task test
- cargo test -p ora-backend marketplace_sources::tests::updates_and_preserves_s3_retrieval_credentials