### PR TITLE
feat(db): support first-install SQL seeds

### DIFF
--- a/crates/db/src/migration/README.md
+++ b/crates/db/src/migration/README.md
@@ -12,6 +12,9 @@ This module owns Ora's linear, reversible SQLite schema history. Application boo
   visible identity. Soft-deleted rows do not reserve that identity, and local resources use the
   `local` namespace.
 - Applied rows record `version`, `up_sql`, `down_sql`, and an injected `executed_at` timestamp.
+- The default catalog carries a separate first-install SQL statement list. Public builds keep the
+  list empty; distribution patches may populate it without changing any versioned migration
+  snapshot. Its contents are omitted from `MigrationCatalog` debug output.
 - Migration `0005` is the Effect v2 model: stable Sources, immutable Revisions and explicit Heads;
   normalized Workspace Desired items; Surface and Consumer declarations/status; Managed ownership;
   current Conditions; durable reconcile/propagation requests; mutation Operations and recovery
@@ -52,6 +55,13 @@ reverse order and removes its bookkeeping rows. It does not compare persisted SQ
 shared versions, so changing a previously published migration definition cannot trigger a schema
 rebuild during packaged application startup.
 
+After a database with no prior migration rows reaches its target, application bootstrap executes
+the catalog's first-install SQL in one separate transaction. An existing database never runs that
+SQL, including when a later build first supplies a non-empty list. The SQL is data initialization,
+not migration history: it has no migration row, does not participate in drift comparison, and is
+not rolled back with a target suffix. If initialization fails, the already committed schema
+migrations remain applied and bootstrap returns the failure.
+
 ## Explicit development reconciliation
 
 `reconcile_database` first verifies that the applied and target histories have an identical shared version prefix. Unknown, skipped, or reordered versions inside that prefix are hard errors; an applied suffix beyond the target is rollback input and does not need to exist in the current catalog.
@@ -65,6 +75,9 @@ An applied version absent from the catalog inside the shared target prefix is an
 The public `reconcile_migration_history` interface opens and reconciles a database for explicit
 tooling. `cargo xtask reconcile-migrations DATA_DIRECTORY` calls it before `task run:desktop`
 starts the application; packaged application startup never calls this interface.
+
+Explicit reconciliation uses the same first-install rule when it opens a database with no applied
+migration history.
 
 The prototype catalog describes only the current schema. It does not carry migrations for retired tables or columns, and the bookkeeping table is intentionally not compatible with databases created before SQL snapshots were introduced. Development databases may be recreated; no compatibility bridge is provided.
 

--- a/crates/db/src/migration/catalog.rs
+++ b/crates/db/src/migration/catalog.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
 use crate::DatabaseError;
 
@@ -43,11 +43,28 @@ impl Migration {
 }
 
 /// Holds every migration definition plus the active target prefix the bootstrapper should enforce.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct MigrationCatalog {
     migrations: Vec<Migration>,
     target_versions: Vec<&'static str>,
     migrations_by_version: BTreeMap<&'static str, usize>,
+    first_install_sql: &'static [&'static str],
+}
+
+impl fmt::Debug for MigrationCatalog {
+    /// Reports catalog structure without rendering distribution-specific initialization SQL.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MigrationCatalog")
+            .field("migrations", &self.migrations)
+            .field("target_versions", &self.target_versions)
+            .field("migrations_by_version", &self.migrations_by_version)
+            .field(
+                "first_install_statement_count",
+                &self.first_install_sql.len(),
+            )
+            .finish()
+    }
 }
 
 impl MigrationCatalog {
@@ -76,7 +93,19 @@ impl MigrationCatalog {
             migrations,
             target_versions,
             migrations_by_version,
+            first_install_sql: &[],
         })
+    }
+
+    /// Attaches data initialization that runs only after a brand-new database reaches the target.
+    pub fn with_first_install_sql(mut self, statements: &'static [&'static str]) -> Self {
+        self.first_install_sql = statements;
+        self
+    }
+
+    /// Serializes the optional first-install statements without adding them to migration history.
+    pub(crate) fn first_install_sql(&self) -> String {
+        serialize_statements(self.first_install_sql)
     }
 
     /// Returns the active target versions the database should match after reconciliation.
@@ -94,7 +123,8 @@ impl MigrationCatalog {
 
 /// Builds the default migration catalog shipped by the crate.
 pub fn default_migration_catalog() -> Result<MigrationCatalog, DatabaseError> {
-    MigrationCatalog::new(schema::migrations())
+    Ok(MigrationCatalog::new(schema::migrations())?
+        .with_first_install_sql(schema::FIRST_INSTALL_SQL))
 }
 
 /// Produces stable, executable SQL from an ordered statement list.

--- a/crates/db/src/migration/runner.rs
+++ b/crates/db/src/migration/runner.rs
@@ -46,6 +46,10 @@ where
     rollback_migration_suffix(connection, &applied_migrations, shared_version_count)?;
     apply_migration_suffix(connection, catalog, timestamp_source, shared_version_count)?;
 
+    if applied_migrations.is_empty() && pending_up_count > 0 {
+        apply_first_install_data(connection, catalog)?;
+    }
+
     if pending_up_count == 0 && pending_down_count == 0 {
         ora_info!(
             message = "database already contains the target migration versions",
@@ -90,6 +94,10 @@ where
 
     apply_migration_suffix(connection, catalog, timestamp_source, reconciliation_start)?;
 
+    if applied_migrations.is_empty() && pending_up_count > 0 && pending_down_count == 0 {
+        apply_first_install_data(connection, catalog)?;
+    }
+
     if pending_up_count == 0 && pending_down_count == 0 {
         ora_info!(
             message = "database schema already matches the target migration prefix",
@@ -98,6 +106,27 @@ where
     }
 
     Ok(())
+}
+
+/// Initializes optional distribution data after a new database reaches its requested target.
+fn apply_first_install_data(
+    connection: &mut Connection,
+    catalog: &MigrationCatalog,
+) -> Result<(), DatabaseError> {
+    let sql = catalog.first_install_sql();
+    if sql.is_empty() {
+        return Ok(());
+    }
+
+    // Keeping distribution data outside migration snapshots lets an internal build patch its
+    // first-run defaults without creating SQL drift for databases created by another build.
+    execute_migration_step(
+        connection,
+        "first-install-data",
+        &sql,
+        MigrationDirection::Up,
+        |_| Ok(()),
+    )
 }
 
 /// Rolls back an applied suffix in reverse order using the SQL snapshots stored in the database.

--- a/crates/db/src/migration/schema.rs
+++ b/crates/db/src/migration/schema.rs
@@ -10,6 +10,12 @@ mod schema_v0007;
 mod schema_v0008;
 mod schema_v0009;
 
+/// Distribution-specific initialization applied only to a brand-new database.
+///
+/// Public builds intentionally ship no data initialization. Internal distributions may patch this
+/// list without changing versioned migration snapshots or the runner.
+pub(super) const FIRST_INSTALL_SQL: &[&str] = &[];
+
 /// Returns the ordered schema migrations shipped with the database crate.
 pub(super) fn migrations() -> Vec<Migration> {
     vec![

--- a/crates/db/src/tests.rs
+++ b/crates/db/src/tests.rs
@@ -201,6 +201,85 @@ fn marketplace_artifact_retrieval_migration_has_a_safe_default() {
     );
 }
 
+/// First-install SQL runs after a new database reaches the requested migration target.
+#[test]
+fn first_install_sql_runs_after_new_database_migrations() {
+    let temp_dir = TempDir::new().expect("create temporary directory");
+    let database_path = temp_dir.path().join("first-install.sqlite3");
+    let catalog = MigrationCatalog::new(vec![table_migration("0001", "alpha")])
+        .expect("build migration catalog")
+        .with_first_install_sql(&["INSERT INTO alpha (id) VALUES (7);"]);
+
+    bootstrap_file_database(&database_path, &catalog, 100)
+        .expect("bootstrap database with first-install data");
+
+    let connection = Connection::open(database_path).expect("open database");
+    assert_eq!(
+        connection
+            .query_row("SELECT id FROM alpha", [], |row| row.get::<_, i64>(0))
+            .expect("read first-install row"),
+        7,
+    );
+}
+
+/// Adding distribution defaults later must not mutate an already initialized database.
+#[test]
+fn existing_database_does_not_run_first_install_sql() {
+    let temp_dir = TempDir::new().expect("create temporary directory");
+    let database_path = temp_dir.path().join("existing.sqlite3");
+    let schema_only = MigrationCatalog::new(vec![table_migration("0001", "alpha")])
+        .expect("build schema-only catalog");
+    let with_defaults = MigrationCatalog::new(vec![table_migration("0001", "alpha")])
+        .expect("build distribution catalog")
+        .with_first_install_sql(&["INSERT INTO alpha (id) VALUES (7);"]);
+
+    bootstrap_file_database(&database_path, &schema_only, 100)
+        .expect("bootstrap existing database");
+    bootstrap_file_database(&database_path, &with_defaults, 200)
+        .expect("reopen with distribution defaults");
+
+    let connection = Connection::open(database_path).expect("open database");
+    assert_eq!(
+        connection
+            .query_row("SELECT COUNT(*) FROM alpha", [], |row| row.get::<_, i64>(0))
+            .expect("count first-install rows"),
+        0,
+    );
+}
+
+/// Explicit reconciliation applies first-install SQL for a database with no migration history.
+#[test]
+fn explicit_reconciliation_runs_first_install_sql_for_new_database() {
+    let temp_dir = TempDir::new().expect("create temporary directory");
+    let database_path = temp_dir.path().join("explicit-first-install.sqlite3");
+    let catalog = MigrationCatalog::new(vec![table_migration("0001", "alpha")])
+        .expect("build migration catalog")
+        .with_first_install_sql(&["INSERT INTO alpha (id) VALUES (7);"]);
+
+    reconcile_file_database(&database_path, &catalog, 100)
+        .expect("reconcile new database with first-install data");
+
+    let connection = Connection::open(database_path).expect("open database");
+    assert_eq!(
+        connection
+            .query_row("SELECT id FROM alpha", [], |row| row.get::<_, i64>(0))
+            .expect("read first-install row"),
+        7,
+    );
+}
+
+/// Catalog diagnostics expose only the first-install statement count, never their contents.
+#[test]
+fn migration_catalog_debug_redacts_first_install_sql() {
+    let catalog = MigrationCatalog::new(vec![table_migration("0001", "alpha")])
+        .expect("build migration catalog")
+        .with_first_install_sql(&["INSERT INTO alpha (id) VALUES (8675309);"]);
+
+    let rendered = format!("{catalog:?}");
+    assert!(rendered.contains("first_install_statement_count: 1"));
+    assert!(!rendered.contains("8675309"));
+}
+
 /// Verifies a database with a shorter valid prefix receives and snapshots only the missing tail.
 #[test]
 fn applies_missing_migrations_in_order() {

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -9,6 +9,9 @@ Ora keeps SQLite migration definitions in Rust code inside `ora-db` rather than 
 - The runner creates the `migrations` bookkeeping table with `version`, `up_sql`, `down_sql`, and `executed_at` before loading history.
 - Ordered statement lists are trimmed and joined into executable SQL snapshots. Both directions are persisted so explicit development reconciliation can detect either direction changing.
 - `MigrationCatalog` validates these invariants when it is built, so a duplicate or out-of-order version fails before any statement runs.
+- A catalog may carry first-install SQL outside the versioned snapshots. The public default is an
+  empty statement list; an internal distribution can patch that list without rewriting migration
+  history.
 
 ## Shipped catalog
 
@@ -22,8 +25,10 @@ Ora keeps SQLite migration definitions in Rust code inside `ora-db` rather than 
 | `0006`  | Generic Effect Scopes, Sources/Revisions, Desired State, Consumers/Targets, shared Resources, projections, ownership, statuses, Conditions, claims, Attempts, operation journals, receipts, and audit history. |
 | `0007`  | Immutable marketplace-source namespace bindings keyed by canonical Git URL.                                                                                                                                    |
 | `0008`  | Per-source `enabled` flag so a marketplace URL can be disabled without deleting its identity.                                                                                                                  |
+| `0009`  | Source-scoped tagged artifact retrieval configuration with Direct HTTPS as the migration default.                                                                                                              |
 
-`default_migration_catalog()` returns all migrations with every version as the active target.
+`default_migration_catalog()` returns all migrations with every version as the active target and
+the empty public first-install SQL list.
 
 ## Application startup
 
@@ -33,6 +38,12 @@ introduced by a newer application, it rolls that trailing suffix back in reverse
 `down_sql` stored by the newer version. It does not compare persisted SQL snapshots for shared
 versions, so packaged application startup cannot rebuild user data merely because an old migration
 definition changed.
+
+When the database had no migration rows before bootstrap and at least one target migration was
+applied, the runner executes first-install SQL after the target is complete. Those statements run
+in one separate transaction and are not recorded in `migrations`. Existing databases never receive
+them later. If their transaction fails, bootstrap fails while the schema migrations that already
+committed remain applied.
 
 ## Development reconciliation
 
@@ -44,6 +55,9 @@ A catalog carries the full migration list plus an **active target prefix**, whic
 - The runner then applies the current target suffix in ascending order and records fresh SQL snapshots and timestamps.
 - If content matches and the database is missing target versions, only the missing tail is applied. If the target is shorter, only the trailing applied versions are rolled back using their stored snapshots.
 - When versions and SQL snapshots already match the target, reconciliation is a no-op.
+
+Explicit development reconciliation follows the same first-install rule for a database with no
+applied migration history.
 
 `cargo xtask reconcile-migrations DATA_DIRECTORY` invokes this interface. `task run:desktop` runs
 that command against the repository `.data` directory immediately before starting Tauri, keeping


### PR DESCRIPTION
## Summary

- add a first-install SQL list to MigrationCatalog outside versioned migration snapshots
- execute configured statements only after a database with no migration history reaches its requested target
- keep the public FIRST_INSTALL_SQL list empty so internal distributions can inject defaults with a small patch
- prevent catalog Debug output from rendering injected SQL
- document transaction, retry, and existing-database behavior

## Testing

- cargo test -p ora-db
- task lint:crates
- task test

## Security

No enterprise seed values or credentials are included in this branch.