### PR TITLE
Show plugin update download progress

### DIFF
--- a/apps/desktop/src-tauri/src/commands/plugin.rs
+++ b/apps/desktop/src-tauri/src/commands/plugin.rs
@@ -13,13 +13,43 @@ use tauri::{AppHandle, Emitter, State};
 const PLUGIN_INSTALL_PROGRESS_EVENT: &str = "plugin-install-progress";
 const PLUGIN_PROGRESS_EVENT_INTERVAL: u64 = 1024 * 1024;
 
-/// Carries byte-level marketplace package progress to the plugin card that started the install.
+/// Carries byte-level marketplace package progress to the plugin card that started the operation.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PluginInstallProgressEvent {
     plugin_id: String,
     downloaded: u64,
     total: Option<u64>,
+}
+
+/// Builds the shared throttled event callback used by marketplace installs and updates.
+///
+/// Emission is throttled to whole intervals so a fast transfer cannot flood the webview, while
+/// the terminal snapshot always reaches the card that started the operation.
+fn plugin_transfer_progress(
+    app: AppHandle,
+    plugin_id: String,
+) -> ora_utils::http::ProgressCallback {
+    let last_emitted = Arc::new(AtomicU64::new(0));
+    Arc::new(move |progress: ora_utils::http::Progress| {
+        let previous = last_emitted.load(Ordering::Relaxed);
+        let complete = progress.total == Some(progress.bytes);
+        if previous != 0
+            && progress.bytes < previous.saturating_add(PLUGIN_PROGRESS_EVENT_INTERVAL)
+            && !complete
+        {
+            return;
+        }
+        last_emitted.store(progress.bytes, Ordering::Relaxed);
+        let event = PluginInstallProgressEvent {
+            plugin_id: plugin_id.clone(),
+            downloaded: progress.bytes,
+            total: progress.total,
+        };
+        if let Err(error) = app.emit(PLUGIN_INSTALL_PROGRESS_EVENT, event) {
+            ora_logging::ora_warn!(message = "Failed to emit plugin transfer progress", error = %error);
+        }
+    })
 }
 
 backend_command!(
@@ -135,27 +165,7 @@ pub async fn install_plugin(
     app: AppHandle,
     request: InstallPluginRequest,
 ) -> Result<InstallPluginResponse, CommandError> {
-    let plugin_id = request.plugin_id.clone();
-    let last_emitted = Arc::new(AtomicU64::new(0));
-    let progress = Arc::new(move |progress: ora_utils::http::Progress| {
-        let previous = last_emitted.load(Ordering::Relaxed);
-        let complete = progress.total == Some(progress.bytes);
-        if previous != 0
-            && progress.bytes < previous.saturating_add(PLUGIN_PROGRESS_EVENT_INTERVAL)
-            && !complete
-        {
-            return;
-        }
-        last_emitted.store(progress.bytes, Ordering::Relaxed);
-        let event = PluginInstallProgressEvent {
-            plugin_id: plugin_id.clone(),
-            downloaded: progress.bytes,
-            total: progress.total,
-        };
-        if let Err(error) = app.emit(PLUGIN_INSTALL_PROGRESS_EVENT, event) {
-            ora_logging::ora_warn!(message = "Failed to emit plugin install progress", error = %error);
-        }
-    });
+    let progress = plugin_transfer_progress(app, request.plugin_id.clone());
 
     run_async_backend(
         "install_plugin",
@@ -166,13 +176,25 @@ pub async fn install_plugin(
     )
     .await
 }
-async_backend_command!(
-    update_plugin,
-    UpdatePluginRequest,
-    UpdatePluginResponse,
-    plugins.update,
-    "Updates one installed plugin to the version its marketplace source publishes."
-);
+
+/// Updates one marketplace plugin and emits throttled byte-level download progress.
+#[tauri::command]
+pub async fn update_plugin(
+    state: State<'_, DesktopState>,
+    app: AppHandle,
+    request: UpdatePluginRequest,
+) -> Result<UpdatePluginResponse, CommandError> {
+    let progress = plugin_transfer_progress(app, request.plugin_id.clone());
+
+    run_async_backend(
+        "update_plugin",
+        state
+            .backend
+            .plugins()
+            .update_with_progress(request, progress),
+    )
+    .await
+}
 async_backend_command!(
     import_plugin,
     ImportPluginRequest,

--- a/crates/backend/src/plugin.rs
+++ b/crates/backend/src/plugin.rs
@@ -1,3 +1,4 @@
+mod marketplace;
 mod operations;
 pub use operations::Plugins;
 
@@ -16,21 +17,20 @@ use ora_contracts::{
     ActivatePluginRequest, ActivatePluginResponse, AddMarketplaceSourceRequest,
     AddMarketplaceSourceResponse, DeleteMarketplaceSourceRequest, DeleteMarketplaceSourceResponse,
     EmptyErrorParams, ImportPluginRequest, ImportPluginResponse, InstallOutcome,
-    InstallPluginRequest, InstallPluginResponse, ListAvailablePluginsRequest,
-    ListAvailablePluginsResponse, ListInstalledPluginsRequest, ListInstalledPluginsResponse,
-    ListMarketplaceSourcesRequest, ListMarketplaceSourcesResponse, MarketplaceArtifactRetrieval,
-    PluginHostCompatibility, PublicError, ReadPluginReadmeRequest, ReadPluginReadmeResponse,
-    ScanPluginsRequest, ScanPluginsResponse, StopPluginRequest, StopPluginResponse,
-    SyncAvailablePluginsRequest, SyncAvailablePluginsResponse, UninstallPluginRequest,
-    UninstallPluginResponse, UpdateMarketplaceSourceRequest, UpdateMarketplaceSourceResponse,
-    UpdatePluginRequest, UpdatePluginResponse,
+    ListAvailablePluginsRequest, ListAvailablePluginsResponse, ListInstalledPluginsRequest,
+    ListInstalledPluginsResponse, ListMarketplaceSourcesRequest, ListMarketplaceSourcesResponse,
+    MarketplaceArtifactRetrieval, PluginHostCompatibility, PublicError, ReadPluginReadmeRequest,
+    ReadPluginReadmeResponse, ScanPluginsRequest, ScanPluginsResponse, StopPluginRequest,
+    StopPluginResponse, SyncAvailablePluginsRequest, SyncAvailablePluginsResponse,
+    UninstallPluginRequest, UninstallPluginResponse, UpdateMarketplaceSourceRequest,
+    UpdateMarketplaceSourceResponse,
 };
 use ora_db::{
     PluginSkillProjection, RepositoryPool, SqliteEffectRepository,
     SqlitePluginMarketplaceSourceRepository, SqlitePluginSourceNamespaceRepository,
     SqliteSkillRepository, SqliteWorkspaceRepository,
 };
-use ora_domain::{PluginId, PluginNamespace};
+use ora_domain::PluginId;
 use ora_effect::{ConsumerDeclaration, ConsumerIdentity, ConsumerKind, Digest};
 use ora_logging::{ora_debug, ora_info, ora_warn};
 use ora_plugin_config::ConfigurationService;
@@ -39,15 +39,9 @@ use ora_plugin_lifecycle::{
     PluginGenerationKey, PluginGenerationLease, PluginLifecycle, PluginLifecycleConfig,
     PluginLifecycleError, PluginNotificationSink, PluginRuntimeTimeouts,
 };
-use ora_plugin_manager::{
-    HostTarget, InstallError, Installer, PluginContribution, PluginManager, UpdateError,
-    select_release,
-};
-use ora_plugin_manifest::PluginManifest;
+use ora_plugin_manager::{Installer, PluginContribution, PluginManager};
 use ora_plugin_registry::{RegistryEntry, RegistryError, RegistryIndex, RegistrySync};
-use ora_utils::http::{
-    ProgressCallback, ProxyConfig, ReqwestDownloader, S3AwareDownloader, S3Config,
-};
+use ora_utils::http::{ProxyConfig, ReqwestDownloader, S3Config};
 use ora_utils::url::canonical_repository_url;
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -675,223 +669,6 @@ impl PluginApi {
         self.notify_mcp_desired_changed();
         Ok(response)
     }
-    /// Installs a marketplace plugin by resolving its release manifest from the synced sources and
-    /// downloading, verifying, and extracting its package through the network-backed installer.
-    ///
-    /// The source registries are read only for the release `url`/`sha256` (the cached index
-    /// carries display fields only), so this returns NotFound when the identifier is not in any
-    /// checkout.
-    pub(crate) async fn install(
-        &self,
-        request: InstallPluginRequest,
-    ) -> Result<InstallPluginResponse, BackendError> {
-        self.install_package(request, /*progress*/ None).await
-    }
-
-    /// Installs a marketplace plugin and forwards network transfer progress to the host shell.
-    pub(crate) async fn install_with_progress(
-        &self,
-        request: InstallPluginRequest,
-        progress: ProgressCallback,
-    ) -> Result<InstallPluginResponse, BackendError> {
-        self.install_package(request, Some(progress)).await
-    }
-
-    /// Keeps release resolution and finalization identical for observed and unobserved installs.
-    async fn install_package(
-        &self,
-        request: InstallPluginRequest,
-        progress: Option<ProgressCallback>,
-    ) -> Result<InstallPluginResponse, BackendError> {
-        let (manifest, namespace, use_proxy, s3_config) =
-            self.resolve_marketplace_release(&request.plugin_id)?;
-        let release_source = self.select_marketplace_release(&manifest)?;
-        match release_source.download() {
-            ora_utils::http::DownloadSource::Url(url) => {
-                ora_info!(plugin_id = %request.plugin_id, url = %url, "installing marketplace plugin");
-            }
-            ora_utils::http::DownloadSource::Local(path) => {
-                ora_info!(plugin_id = %request.plugin_id, path = %path.display(), "installing marketplace plugin from local source");
-            }
-            ora_utils::http::DownloadSource::S3 { key } => {
-                ora_info!(plugin_id = %request.plugin_id, key = %key, "installing marketplace plugin from object store");
-            }
-        }
-        let installer = self.marketplace_installer(use_proxy, s3_config)?;
-        match progress {
-            Some(progress) => {
-                installer
-                    .install_with_progress(
-                        &manifest,
-                        &namespace,
-                        release_source,
-                        &self.home_directory,
-                        progress,
-                    )
-                    .await
-            }
-            None => {
-                installer
-                    .install(&manifest, &namespace, release_source, &self.home_directory)
-                    .await
-            }
-        }
-        .map_err(|error| self.map_install_error("failed to install plugin", error))?;
-        let outcome = self.finalize_new_install(&request.plugin_id).await?;
-        ora_info!(plugin_id = %request.plugin_id, outcome = ?outcome, "installed marketplace plugin");
-        Ok(InstallPluginResponse {
-            plugin_id: request.plugin_id,
-            outcome,
-        })
-    }
-
-    /// Updates one installed marketplace plugin to the version its source publishes.
-    ///
-    /// The source resolution and proxy policy are identical to an install: the winning
-    /// marketplace source decides whether the download goes through the configured proxy. The
-    /// running process is stopped before its package is replaced, and the installed snapshot is
-    /// rescanned afterwards so the new version becomes effective without a restart.
-    pub(crate) async fn update(
-        &self,
-        request: UpdatePluginRequest,
-    ) -> Result<UpdatePluginResponse, BackendError> {
-        let (manifest, namespace, use_proxy, s3_config) =
-            self.resolve_marketplace_release(&request.plugin_id)?;
-        let release_source = self.select_marketplace_release(&manifest)?;
-        match release_source.download() {
-            ora_utils::http::DownloadSource::Url(url) => {
-                ora_info!(plugin_id = %request.plugin_id, url = %url, "updating marketplace plugin");
-            }
-            ora_utils::http::DownloadSource::Local(path) => {
-                ora_info!(plugin_id = %request.plugin_id, path = %path.display(), "updating marketplace plugin from local source");
-            }
-            ora_utils::http::DownloadSource::S3 { key } => {
-                ora_info!(plugin_id = %request.plugin_id, key = %key, "updating marketplace plugin from object store");
-            }
-        }
-        // The package directory is replaced while the plugin may be running, so the process is
-        // stopped first; stopping a webview/skill/MCP/hook package is a no-op.
-        self.lifecycle
-            .stop_plugin(StopPluginRequest {
-                plugin_id: request.plugin_id.clone(),
-            })
-            .await
-            .map_err(BackendError::from)?;
-        self.marketplace_installer(use_proxy, s3_config)?
-            .update(&manifest, &namespace, release_source, &self.home_directory)
-            .await
-            .map_err(|error| self.map_update_error("failed to update plugin", error))?;
-        self.finalize_new_install(&request.plugin_id).await?;
-        ora_info!(plugin_id = %request.plugin_id, "updated marketplace plugin");
-        Ok(UpdatePluginResponse {
-            plugin_id: request.plugin_id,
-        })
-    }
-
-    /// Resolves the release manifest for one marketplace identifier across the configured sources.
-    ///
-    /// The id names the namespace of the source that published it, so only that source can
-    /// answer: the returned namespace and proxy policy always belong to the entry's own
-    /// repository, and an install or update can never be redirected by reordering the source list
-    /// or by another source publishing the same `identifier`.
-    fn resolve_marketplace_release(
-        &self,
-        plugin_id: &str,
-    ) -> Result<(PluginManifest, PluginNamespace, bool, Option<S3Config>), BackendError> {
-        let registry_sources = self.prepared_registry_sources()?;
-        // A malformed identifier can never name a registry entry, so it is reported the same way
-        // as an unknown one instead of leaking the id grammar as a separate error class.
-        let plugin_id = PluginId::parse(plugin_id).map_err(|_| {
-            BackendError::new(
-                ErrorClassification::NotFound,
-                PublicError::PluginNotFound(EmptyErrorParams {}),
-                "marketplace plugin id is not a valid `<namespace>/<name>`",
-            )
-        })?;
-        for (source, use_proxy, s3_config) in &registry_sources {
-            if let Some(manifest) =
-                RegistryIndex::resolve_manifest(source, &plugin_id).map_err(|error| {
-                    BackendError::internal("failed to resolve plugin release manifest", error)
-                })?
-            {
-                return Ok((
-                    manifest,
-                    source.namespace().clone(),
-                    *use_proxy,
-                    s3_config.clone(),
-                ));
-            }
-        }
-        Err(BackendError::new(
-            ErrorClassification::NotFound,
-            PublicError::PluginNotFound(EmptyErrorParams {}),
-            "marketplace plugin was not found in the registry",
-        ))
-    }
-
-    /// Selects the downloadable release for `manifest` against the current host.
-    ///
-    /// Universal releases ignore the host. Targeted Hook releases require a supported triple and
-    /// an exact artifact match so a wrong-architecture package is refused before download.
-    fn select_marketplace_release(
-        &self,
-        manifest: &PluginManifest,
-    ) -> Result<ora_plugin_manager::ResolvedReleaseSource, BackendError> {
-        let host_target = ora_plugin_registry::current_host_target();
-        select_release(manifest, HostTarget::from_option(host_target.as_ref()))
-            .map_err(|error| self.map_install_error("failed to select plugin release", error))
-    }
-
-    /// Maps installer failures that describe host incompatibility onto the public contract error.
-    fn map_install_error(&self, context: &'static str, error: InstallError) -> BackendError {
-        match error {
-            InstallError::NoArtifactForTarget { .. }
-            | InstallError::MissingRelease
-            | InstallError::UnsupportedHost
-            | InstallError::TargetMismatch { .. }
-            | InstallError::MissingArtifactTarget => BackendError::new(
-                ErrorClassification::Unprocessable,
-                PublicError::PluginHostIncompatible(EmptyErrorParams {}),
-                format!("{error}"),
-            ),
-            error => BackendError::internal(context, error),
-        }
-    }
-
-    /// Maps update failures, preserving host-incompatibility from the nested install path.
-    fn map_update_error(&self, context: &'static str, error: UpdateError) -> BackendError {
-        match error {
-            UpdateError::Install(install_error) => self.map_install_error(context, install_error),
-            error => BackendError::internal(context, error),
-        }
-    }
-
-    /// Returns the downloader proxy configuration for one marketplace source's proxy policy.
-    fn download_proxy_for(&self, use_proxy: bool) -> Result<ProxyConfig, BackendError> {
-        if !use_proxy {
-            return Ok(ProxyConfig::default());
-        }
-        let proxy_settings = self.settings.network_proxy_settings()?;
-        proxy::download_proxy(proxy_settings.as_ref())?.ok_or_else(|| {
-            BackendError::invalid_proxy_settings(
-                "a marketplace source uses the proxy but no proxy is configured",
-            )
-        })
-    }
-
-    /// Builds a source-scoped downloader that signs only the configured S3 endpoint and bucket.
-    fn marketplace_installer(
-        &self,
-        use_proxy: bool,
-        s3_config: Option<S3Config>,
-    ) -> Result<Installer<S3AwareDownloader>, BackendError> {
-        let download_proxy = self.download_proxy_for(use_proxy)?;
-        Ok(Installer::new(S3AwareDownloader::new(
-            ReqwestDownloader::new(download_proxy),
-            s3_config,
-        )))
-    }
-
     /// Imports a local `.orax` release archive: verifies and extracts it, refreshes the installed
     /// snapshot so the plugin is immediately usable without a restart.
     pub(crate) async fn import(

--- a/crates/backend/src/plugin/marketplace.rs
+++ b/crates/backend/src/plugin/marketplace.rs
@@ -2,6 +2,7 @@
 //!
 //! Install and update share one release-resolution and installer-construction path so a source's
 //! namespace, proxy policy, and object-store scoping can never diverge between the two operations.
+//! Both expose an observed variant that forwards byte-level transfer progress to the host shell.
 
 use super::PluginApi;
 use crate::error::{BackendError, ErrorClassification};
@@ -100,6 +101,25 @@ impl PluginApi {
         &self,
         request: UpdatePluginRequest,
     ) -> Result<UpdatePluginResponse, BackendError> {
+        self.update_package(request, /*progress*/ None).await
+    }
+
+    /// Updates a marketplace plugin and forwards network transfer progress to the host shell.
+    pub(crate) async fn update_with_progress(
+        &self,
+        request: UpdatePluginRequest,
+        progress: ProgressCallback,
+    ) -> Result<UpdatePluginResponse, BackendError> {
+        self.update_package(request, Some(progress)).await
+    }
+
+    /// Keeps release resolution, process stopping, and finalization identical for observed and
+    /// unobserved updates.
+    async fn update_package(
+        &self,
+        request: UpdatePluginRequest,
+        progress: Option<ProgressCallback>,
+    ) -> Result<UpdatePluginResponse, BackendError> {
         let (manifest, namespace, use_proxy, s3_config) =
             self.resolve_marketplace_release(&request.plugin_id)?;
         let release_source = self.select_marketplace_release(&manifest)?;
@@ -122,10 +142,26 @@ impl PluginApi {
             })
             .await
             .map_err(BackendError::from)?;
-        self.marketplace_installer(use_proxy, s3_config)?
-            .update(&manifest, &namespace, release_source, &self.home_directory)
-            .await
-            .map_err(|error| self.map_update_error("failed to update plugin", error))?;
+        let installer = self.marketplace_installer(use_proxy, s3_config)?;
+        match progress {
+            Some(progress) => {
+                installer
+                    .update_with_progress(
+                        &manifest,
+                        &namespace,
+                        release_source,
+                        &self.home_directory,
+                        progress,
+                    )
+                    .await
+            }
+            None => {
+                installer
+                    .update(&manifest, &namespace, release_source, &self.home_directory)
+                    .await
+            }
+        }
+        .map_err(|error| self.map_update_error("failed to update plugin", error))?;
         self.finalize_new_install(&request.plugin_id).await?;
         ora_info!(plugin_id = %request.plugin_id, "updated marketplace plugin");
         Ok(UpdatePluginResponse {

--- a/crates/backend/src/plugin/marketplace.rs
+++ b/crates/backend/src/plugin/marketplace.rs
@@ -1,0 +1,239 @@
+//! Marketplace package transfer: release resolution, download, install, and update.
+//!
+//! Install and update share one release-resolution and installer-construction path so a source's
+//! namespace, proxy policy, and object-store scoping can never diverge between the two operations.
+
+use super::PluginApi;
+use crate::error::{BackendError, ErrorClassification};
+use crate::proxy;
+use ora_contracts::{
+    EmptyErrorParams, InstallPluginRequest, InstallPluginResponse, PublicError, StopPluginRequest,
+    UpdatePluginRequest, UpdatePluginResponse,
+};
+use ora_domain::{PluginId, PluginNamespace};
+use ora_logging::ora_info;
+use ora_plugin_manager::{HostTarget, InstallError, Installer, UpdateError, select_release};
+use ora_plugin_manifest::PluginManifest;
+use ora_plugin_registry::RegistryIndex;
+use ora_utils::http::{
+    ProgressCallback, ProxyConfig, ReqwestDownloader, S3AwareDownloader, S3Config,
+};
+
+impl PluginApi {
+    /// Installs a marketplace plugin by resolving its release manifest from the synced sources and
+    /// downloading, verifying, and extracting its package through the network-backed installer.
+    ///
+    /// The source registries are read only for the release `url`/`sha256` (the cached index
+    /// carries display fields only), so this returns NotFound when the identifier is not in any
+    /// checkout.
+    pub(crate) async fn install(
+        &self,
+        request: InstallPluginRequest,
+    ) -> Result<InstallPluginResponse, BackendError> {
+        self.install_package(request, /*progress*/ None).await
+    }
+
+    /// Installs a marketplace plugin and forwards network transfer progress to the host shell.
+    pub(crate) async fn install_with_progress(
+        &self,
+        request: InstallPluginRequest,
+        progress: ProgressCallback,
+    ) -> Result<InstallPluginResponse, BackendError> {
+        self.install_package(request, Some(progress)).await
+    }
+
+    /// Keeps release resolution and finalization identical for observed and unobserved installs.
+    async fn install_package(
+        &self,
+        request: InstallPluginRequest,
+        progress: Option<ProgressCallback>,
+    ) -> Result<InstallPluginResponse, BackendError> {
+        let (manifest, namespace, use_proxy, s3_config) =
+            self.resolve_marketplace_release(&request.plugin_id)?;
+        let release_source = self.select_marketplace_release(&manifest)?;
+        match release_source.download() {
+            ora_utils::http::DownloadSource::Url(url) => {
+                ora_info!(plugin_id = %request.plugin_id, url = %url, "installing marketplace plugin");
+            }
+            ora_utils::http::DownloadSource::Local(path) => {
+                ora_info!(plugin_id = %request.plugin_id, path = %path.display(), "installing marketplace plugin from local source");
+            }
+            ora_utils::http::DownloadSource::S3 { key } => {
+                ora_info!(plugin_id = %request.plugin_id, key = %key, "installing marketplace plugin from object store");
+            }
+        }
+        let installer = self.marketplace_installer(use_proxy, s3_config)?;
+        match progress {
+            Some(progress) => {
+                installer
+                    .install_with_progress(
+                        &manifest,
+                        &namespace,
+                        release_source,
+                        &self.home_directory,
+                        progress,
+                    )
+                    .await
+            }
+            None => {
+                installer
+                    .install(&manifest, &namespace, release_source, &self.home_directory)
+                    .await
+            }
+        }
+        .map_err(|error| self.map_install_error("failed to install plugin", error))?;
+        let outcome = self.finalize_new_install(&request.plugin_id).await?;
+        ora_info!(plugin_id = %request.plugin_id, outcome = ?outcome, "installed marketplace plugin");
+        Ok(InstallPluginResponse {
+            plugin_id: request.plugin_id,
+            outcome,
+        })
+    }
+
+    /// Updates one installed marketplace plugin to the version its source publishes.
+    ///
+    /// The source resolution and proxy policy are identical to an install: the winning
+    /// marketplace source decides whether the download goes through the configured proxy. The
+    /// running process is stopped before its package is replaced, and the installed snapshot is
+    /// rescanned afterwards so the new version becomes effective without a restart.
+    pub(crate) async fn update(
+        &self,
+        request: UpdatePluginRequest,
+    ) -> Result<UpdatePluginResponse, BackendError> {
+        let (manifest, namespace, use_proxy, s3_config) =
+            self.resolve_marketplace_release(&request.plugin_id)?;
+        let release_source = self.select_marketplace_release(&manifest)?;
+        match release_source.download() {
+            ora_utils::http::DownloadSource::Url(url) => {
+                ora_info!(plugin_id = %request.plugin_id, url = %url, "updating marketplace plugin");
+            }
+            ora_utils::http::DownloadSource::Local(path) => {
+                ora_info!(plugin_id = %request.plugin_id, path = %path.display(), "updating marketplace plugin from local source");
+            }
+            ora_utils::http::DownloadSource::S3 { key } => {
+                ora_info!(plugin_id = %request.plugin_id, key = %key, "updating marketplace plugin from object store");
+            }
+        }
+        // The package directory is replaced while the plugin may be running, so the process is
+        // stopped first; stopping a webview/skill/MCP/hook package is a no-op.
+        self.lifecycle
+            .stop_plugin(StopPluginRequest {
+                plugin_id: request.plugin_id.clone(),
+            })
+            .await
+            .map_err(BackendError::from)?;
+        self.marketplace_installer(use_proxy, s3_config)?
+            .update(&manifest, &namespace, release_source, &self.home_directory)
+            .await
+            .map_err(|error| self.map_update_error("failed to update plugin", error))?;
+        self.finalize_new_install(&request.plugin_id).await?;
+        ora_info!(plugin_id = %request.plugin_id, "updated marketplace plugin");
+        Ok(UpdatePluginResponse {
+            plugin_id: request.plugin_id,
+        })
+    }
+
+    /// Resolves the release manifest for one marketplace identifier across the configured sources.
+    ///
+    /// The id names the namespace of the source that published it, so only that source can
+    /// answer: the returned namespace and proxy policy always belong to the entry's own
+    /// repository, and an install or update can never be redirected by reordering the source list
+    /// or by another source publishing the same `identifier`.
+    fn resolve_marketplace_release(
+        &self,
+        plugin_id: &str,
+    ) -> Result<(PluginManifest, PluginNamespace, bool, Option<S3Config>), BackendError> {
+        let registry_sources = self.prepared_registry_sources()?;
+        // A malformed identifier can never name a registry entry, so it is reported the same way
+        // as an unknown one instead of leaking the id grammar as a separate error class.
+        let plugin_id = PluginId::parse(plugin_id).map_err(|_| {
+            BackendError::new(
+                ErrorClassification::NotFound,
+                PublicError::PluginNotFound(EmptyErrorParams {}),
+                "marketplace plugin id is not a valid `<namespace>/<name>`",
+            )
+        })?;
+        for (source, use_proxy, s3_config) in &registry_sources {
+            if let Some(manifest) =
+                RegistryIndex::resolve_manifest(source, &plugin_id).map_err(|error| {
+                    BackendError::internal("failed to resolve plugin release manifest", error)
+                })?
+            {
+                return Ok((
+                    manifest,
+                    source.namespace().clone(),
+                    *use_proxy,
+                    s3_config.clone(),
+                ));
+            }
+        }
+        Err(BackendError::new(
+            ErrorClassification::NotFound,
+            PublicError::PluginNotFound(EmptyErrorParams {}),
+            "marketplace plugin was not found in the registry",
+        ))
+    }
+
+    /// Selects the downloadable release for `manifest` against the current host.
+    ///
+    /// Universal releases ignore the host. Targeted Hook releases require a supported triple and
+    /// an exact artifact match so a wrong-architecture package is refused before download.
+    fn select_marketplace_release(
+        &self,
+        manifest: &PluginManifest,
+    ) -> Result<ora_plugin_manager::ResolvedReleaseSource, BackendError> {
+        let host_target = ora_plugin_registry::current_host_target();
+        select_release(manifest, HostTarget::from_option(host_target.as_ref()))
+            .map_err(|error| self.map_install_error("failed to select plugin release", error))
+    }
+
+    /// Maps installer failures that describe host incompatibility onto the public contract error.
+    fn map_install_error(&self, context: &'static str, error: InstallError) -> BackendError {
+        match error {
+            InstallError::NoArtifactForTarget { .. }
+            | InstallError::MissingRelease
+            | InstallError::UnsupportedHost
+            | InstallError::TargetMismatch { .. }
+            | InstallError::MissingArtifactTarget => BackendError::new(
+                ErrorClassification::Unprocessable,
+                PublicError::PluginHostIncompatible(EmptyErrorParams {}),
+                format!("{error}"),
+            ),
+            error => BackendError::internal(context, error),
+        }
+    }
+
+    /// Maps update failures, preserving host-incompatibility from the nested install path.
+    fn map_update_error(&self, context: &'static str, error: UpdateError) -> BackendError {
+        match error {
+            UpdateError::Install(install_error) => self.map_install_error(context, install_error),
+            error => BackendError::internal(context, error),
+        }
+    }
+
+    /// Returns the downloader proxy configuration for one marketplace source's proxy policy.
+    fn download_proxy_for(&self, use_proxy: bool) -> Result<ProxyConfig, BackendError> {
+        if !use_proxy {
+            return Ok(ProxyConfig::default());
+        }
+        let proxy_settings = self.settings.network_proxy_settings()?;
+        proxy::download_proxy(proxy_settings.as_ref())?.ok_or_else(|| {
+            BackendError::invalid_proxy_settings(
+                "a marketplace source uses the proxy but no proxy is configured",
+            )
+        })
+    }
+
+    /// Builds a source-scoped downloader that signs only the configured S3 endpoint and bucket.
+    fn marketplace_installer(
+        &self,
+        use_proxy: bool,
+        s3_config: Option<S3Config>,
+    ) -> Result<Installer<S3AwareDownloader>, BackendError> {
+        let download_proxy = self.download_proxy_for(use_proxy)?;
+        Ok(Installer::new(S3AwareDownloader::new(
+            ReqwestDownloader::new(download_proxy),
+            s3_config,
+        )))
+    }
+}

--- a/crates/backend/src/plugin/operations.rs
+++ b/crates/backend/src/plugin/operations.rs
@@ -199,6 +199,18 @@ impl Plugins {
         Ok(response)
     }
 
+    /// Updates one installed marketplace plugin while forwarding download progress to a host
+    /// callback, reconciling the agent set on the same terms as an unobserved update.
+    pub async fn update_with_progress(
+        &self,
+        request: UpdatePluginRequest,
+        progress: ProgressCallback,
+    ) -> Result<UpdatePluginResponse, BackendError> {
+        let response = self.host.update_with_progress(request, progress).await?;
+        self.agent_runtime.sync_plugin_agents();
+        Ok(response)
+    }
+
     /// Imports one local release archive and reconciles the agent set afterwards.
     ///
     /// The agent set is reconciled so the imported package supplies a reachable agent in this

--- a/crates/plugin-manager/src/install.rs
+++ b/crates/plugin-manager/src/install.rs
@@ -409,6 +409,34 @@ where
         source: ResolvedReleaseSource,
         data_dir: &Path,
     ) -> Result<InstalledPackage, UpdateError> {
+        self.update_package(
+            manifest, namespace, source, data_dir, /*progress*/ None,
+        )
+        .await
+    }
+
+    /// Updates a release while forwarding byte-level network download progress to the caller.
+    pub async fn update_with_progress(
+        &self,
+        manifest: &PluginManifest,
+        namespace: &PluginNamespace,
+        source: ResolvedReleaseSource,
+        data_dir: &Path,
+        progress: ProgressCallback,
+    ) -> Result<InstalledPackage, UpdateError> {
+        self.update_package(manifest, namespace, source, data_dir, Some(progress))
+            .await
+    }
+
+    /// Shares update validation and retirement between observed and unobserved transfers.
+    async fn update_package(
+        &self,
+        manifest: &PluginManifest,
+        namespace: &PluginNamespace,
+        source: ResolvedReleaseSource,
+        data_dir: &Path,
+        progress: Option<ProgressCallback>,
+    ) -> Result<InstalledPackage, UpdateError> {
         let name = manifest.name();
         let id = installed_id(namespace, name.as_str());
         let plugin_root = installed_root(data_dir)
@@ -443,7 +471,9 @@ where
                 available: manifest.version().to_string(),
             });
         }
-        let package_dir = self.install(manifest, namespace, source, data_dir).await?;
+        let package_dir = self
+            .install_package(manifest, namespace, source, data_dir, progress)
+            .await?;
         retire_stale_versions(&id.canonical(), &plugin_root, &package_dir)?;
         Ok(InstalledPackage { package_dir, id })
     }
@@ -671,15 +701,41 @@ mod tests {
     use futures::executor::block_on;
     use ora_domain::PluginNamespace;
     use ora_plugin_manifest::{HookTarget, PluginManifest};
-    use ora_utils::http::{DownloadSource, LocalFileDownloader};
+    use ora_utils::http::{
+        DownloadError, DownloadOutcome, DownloadRequest, DownloadSource, HttpDownload,
+        LocalFileDownloader, Progress,
+    };
     use pretty_assertions::assert_eq;
     use sha2::{Digest, Sha256};
     use std::fs::{self, File};
+    use std::future::Future;
     use std::io::Write;
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
     use zip::ZipWriter;
     use zip::write::SimpleFileOptions;
+
+    /// Emits a deterministic snapshot before delegating to the real local-file copy path.
+    #[derive(Clone, Copy)]
+    struct ProgressReportingLocalDownloader;
+
+    impl HttpDownload for ProgressReportingLocalDownloader {
+        fn download(
+            &self,
+            request: DownloadRequest,
+        ) -> impl Future<Output = Result<DownloadOutcome, DownloadError>> + Send {
+            async move {
+                if let Some(progress) = &request.progress {
+                    progress(Progress {
+                        bytes: 3,
+                        total: Some(4),
+                    });
+                }
+                LocalFileDownloader.download(request).await
+            }
+        }
+    }
 
     /// Computes the SHA-256 digest of a file as raw bytes for the manifest.
     fn sha256_file(path: &Path) -> [u8; 32] {
@@ -1439,12 +1495,20 @@ mod tests {
         let manifest =
             PluginManifest::parse(&manifest_with_digest("weather", "1.0.0", digest)).unwrap();
 
-        let package = block_on(Installer::new(LocalFileDownloader).update(
-            &manifest,
-            &PluginNamespace::official(),
-            ResolvedReleaseSource::universal(DownloadSource::Local(release_path), digest),
-            temp_dir.path(),
-        ))
+        let recorded_progress = Arc::new(Mutex::new(Vec::new()));
+        let progress = {
+            let recorded_progress = Arc::clone(&recorded_progress);
+            Arc::new(move |snapshot| recorded_progress.lock().unwrap().push(snapshot))
+        };
+        let package = block_on(
+            Installer::new(ProgressReportingLocalDownloader).update_with_progress(
+                &manifest,
+                &PluginNamespace::official(),
+                ResolvedReleaseSource::universal(DownloadSource::Local(release_path), digest),
+                temp_dir.path(),
+                progress,
+            ),
+        )
         .unwrap();
 
         let new_package = temp_dir
@@ -1462,6 +1526,13 @@ mod tests {
             }
         );
         assert!(new_package.join("main.js").is_file());
+        assert_eq!(
+            *recorded_progress.lock().unwrap(),
+            vec![Progress {
+                bytes: 3,
+                total: Some(4),
+            }]
+        );
         assert!(
             !temp_dir
                 .path()

--- a/packages/app-shell/src/features/settings/plugin-download-progress.tsx
+++ b/packages/app-shell/src/features/settings/plugin-download-progress.tsx
@@ -1,0 +1,80 @@
+import type { PluginInstallProgress } from "../../platform";
+import type { ReactNode } from "react";
+
+/** Converts byte-level package transfer progress into a bounded percentage. */
+function pluginDownloadPercentage(
+  progress: PluginInstallProgress | null,
+): number | null {
+  if (progress?.total === null || progress === null || progress.total <= 0) {
+    return null;
+  }
+  return Math.min(
+    100,
+    Math.round((progress.downloaded / progress.total) * 100),
+  );
+}
+
+/** Renders determinate or indeterminate package progress inside a plugin action button. */
+export function PluginDownloadProgress({
+  progress,
+  label,
+  children,
+}: {
+  progress: PluginInstallProgress | null;
+  label: string;
+  children?: ReactNode;
+}) {
+  const value = pluginDownloadPercentage(progress);
+  const radius = 11;
+  const circumference = 2 * Math.PI * radius;
+  const offset =
+    value === null ? 0 : circumference * (1 - Math.max(0, value) / 100);
+
+  return (
+    <span
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={value ?? undefined}
+      className="relative grid size-7 place-items-center"
+    >
+      <svg
+        viewBox="0 0 28 28"
+        aria-hidden="true"
+        className={
+          value === null
+            ? "size-7 -rotate-90 animate-spin"
+            : "size-7 -rotate-90"
+        }
+      >
+        <circle
+          cx="14"
+          cy="14"
+          r={radius}
+          fill="none"
+          strokeWidth="2.5"
+          className="stroke-muted"
+        />
+        <circle
+          cx="14"
+          cy="14"
+          r={radius}
+          fill="none"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeDasharray={
+            value === null ? `18 ${circumference}` : circumference
+          }
+          strokeDashoffset={offset}
+          className="stroke-primary transition-[stroke-dashoffset] duration-300 ease-out"
+        />
+      </svg>
+      {children !== undefined && (
+        <span className="absolute inset-0 grid place-items-center">
+          {children}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/app-shell/src/features/settings/plugin-manager.tsx
+++ b/packages/app-shell/src/features/settings/plugin-manager.tsx
@@ -27,7 +27,6 @@ import {
   IconArrowBigUpLines,
   IconDots,
   IconLoader2,
-  IconProgressDown,
   IconRefresh,
   IconSearch,
   IconSettingsBolt,
@@ -40,6 +39,7 @@ import { PluginLogo } from "./plugin-logo";
 import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
 import { usePluginScan } from "../../state/hooks/use-plugin-scan";
 import { useUpdatePlugin } from "../../state/hooks/use-update-plugin";
+import { PluginDownloadProgress } from "./plugin-download-progress";
 
 /** The installed-plugin manager exposes package lifecycle commands without process start/stop. */
 export function PluginManager({
@@ -236,13 +236,27 @@ function InstalledPluginRow({
 
         {hasUpdate && (
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
             disabled={busy}
+            className={update.isPending ? "disabled:opacity-100" : undefined}
             onClick={() => update.mutate({}, { onError: failUpdate })}
           >
-            {update.isPending ? <IconProgressDown /> : <IconArrowBigUpLines />}
-            {t("settings.plugins.update")}
+            {update.isPending ? (
+              <PluginDownloadProgress
+                progress={update.progress}
+                label={t("settings.plugins.downloadProgress")}
+              >
+                <IconArrowBigUpLines className="size-3.5" />
+              </PluginDownloadProgress>
+            ) : (
+              <IconArrowBigUpLines />
+            )}
+            {t(
+              update.isPending
+                ? "settings.plugins.updating"
+                : "settings.plugins.update",
+            )}
           </Button>
         )}
 

--- a/packages/app-shell/src/features/settings/plugin-operation-event-bridge.test.tsx
+++ b/packages/app-shell/src/features/settings/plugin-operation-event-bridge.test.tsx
@@ -47,3 +47,39 @@ it("records install progress independently of the marketplace page lifecycle", a
   view.unmount();
   expect(stop).toHaveBeenCalledOnce();
 });
+
+it("records update progress in the same durable operation state as installs", async () => {
+  let report: ((progress: PluginInstallProgress) => void) | undefined;
+  const platform = {
+    ...createStubPlatform(),
+    pluginMarketplace: {
+      onInstallProgress: vi.fn(async (listener) => {
+        report = listener;
+        return () => undefined;
+      }),
+    },
+  };
+  usePluginOperationStore.getState().begin("official/weather", "update");
+  render(
+    <PlatformProvider adapter={platform}>
+      <PluginOperationEventBridge />
+    </PlatformProvider>,
+  );
+  await act(async () => Promise.resolve());
+
+  act(() => {
+    report?.({ pluginId: "official/weather", downloaded: 75, total: 100 });
+  });
+
+  expect(usePluginOperationStore.getState().activities).toEqual({
+    "official/weather": {
+      state: "pending",
+      kind: "update",
+      progress: {
+        pluginId: "official/weather",
+        downloaded: 75,
+        total: 100,
+      },
+    },
+  });
+});

--- a/packages/app-shell/src/features/settings/plugin-operation-event-bridge.tsx
+++ b/packages/app-shell/src/features/settings/plugin-operation-event-bridge.tsx
@@ -13,7 +13,7 @@ export function PluginOperationEventBridge() {
     void pluginMarketplace
       .onInstallProgress((progress) => {
         if (!disposed) {
-          usePluginOperationStore.getState().reportInstallProgress(progress);
+          usePluginOperationStore.getState().reportTransferProgress(progress);
         }
       })
       .then((stop) => {

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -249,6 +249,91 @@ it("shows marketplace plugin download progress", async () => {
   expect(document.querySelector('[data-slot="progress"]')).toBeNull();
 });
 
+/** Marketplace updates reuse the durable byte-progress presentation used by installs. */
+it("shows marketplace plugin update download progress", async () => {
+  const user = userEvent.setup();
+  const { state, client, handlers } = clientWithWeather();
+  state.installedPlugins.push({
+    ...weatherInstalled(),
+    version: "1.1.0",
+  });
+  vi.spyOn(handlers, "updatePlugin").mockImplementation(
+    () => new Promise<never>(() => undefined),
+  );
+  let reportProgress:
+    | ((progress: {
+        pluginId: string;
+        downloaded: number;
+        total: number | null;
+      }) => void)
+    | undefined;
+  const platform: PlatformAdapter = {
+    ...createStubPlatform(),
+    pluginMarketplace: {
+      onInstallProgress: async (listener) => {
+        reportProgress = listener;
+        return () => undefined;
+      },
+    },
+  };
+  renderSettings(client, platform);
+
+  await user.click(await screen.findByRole("button", { name: /更新|Update/ }));
+  act(() => {
+    reportProgress?.({
+      pluginId: "official/weather",
+      downloaded: 3,
+      total: 4,
+    });
+  });
+
+  const progress = await screen.findByRole("progressbar", {
+    name: /插件下载进度|Plugin download progress/,
+  });
+  expect(progress).toHaveAttribute("aria-valuenow", "75");
+  const updateIcon = progress.querySelector(".tabler-icon-arrow-big-up-lines");
+  expect(updateIcon).toBeInTheDocument();
+  expect(updateIcon).not.toHaveClass("animate-bounce");
+});
+
+/** The installed-plugin update action stays visually light instead of drawing a box around it. */
+it("renders the managed plugin update action without an outline", async () => {
+  const user = userEvent.setup();
+  const { state, client } = clientWithWeather();
+  state.installedPlugins.push({
+    ...weatherInstalled(),
+    version: "1.1.0",
+  });
+  renderSettings(client);
+
+  await openManagePlugins(user);
+
+  expect(
+    await screen.findByRole("button", { name: /更新|Update/ }),
+  ).not.toHaveClass("border-border");
+});
+
+/** The managed update action names the active operation instead of retaining its idle label. */
+it("labels a managed plugin update as updating while it downloads", async () => {
+  const user = userEvent.setup();
+  const { state, client, handlers } = clientWithWeather();
+  state.installedPlugins.push({
+    ...weatherInstalled(),
+    version: "1.1.0",
+  });
+  vi.spyOn(handlers, "updatePlugin").mockImplementation(
+    () => new Promise<never>(() => undefined),
+  );
+  renderSettings(client);
+  await openManagePlugins(user);
+
+  await user.click(await screen.findByRole("button", { name: /更新|Update/ }));
+
+  expect(
+    await screen.findByRole("button", { name: /更新中|Updating/ }),
+  ).toBeDisabled();
+});
+
 /** A sync control pulls the marketplace source through the backend. */
 it("syncs the marketplace through the backend", async () => {
   const user = userEvent.setup();

--- a/packages/app-shell/src/features/settings/plugins-settings.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.tsx
@@ -20,7 +20,6 @@ import {
   IconCheck,
   IconDownload,
   IconLoader2,
-  IconProgressDown,
   IconRefresh,
   IconSearch,
   IconSettings,
@@ -39,6 +38,7 @@ import { PluginManager } from "./plugin-manager";
 import { PluginReadmeView } from "./plugin-readme-view";
 import { PluginConfigurationEditor } from "./plugin-configuration-editor";
 import type { PluginConfigurationNavigationGuard } from "./plugin-configuration-editor";
+import { PluginDownloadProgress } from "./plugin-download-progress";
 
 /** The registry kind order shown in the marketplace, mirroring the contracts docs. */
 const MARKETPLACE_KIND_ORDER = [
@@ -333,17 +333,6 @@ function AvailablePluginCard({
   const showContractError = useContractErrorToast();
   const install = useInstallPlugin(plugin.id);
   const update = useUpdatePlugin(plugin.id);
-  const downloadPercentage =
-    install.progress?.total !== null &&
-    install.progress?.total !== undefined &&
-    install.progress.total > 0
-      ? Math.min(
-          100,
-          Math.round(
-            (install.progress.downloaded / install.progress.total) * 100,
-          ),
-        )
-      : null;
   const hasUpdate = plugin.version !== installed?.version;
   const incompatible = plugin.compatibility === "incompatible";
 
@@ -404,8 +393,8 @@ function AvailablePluginCard({
             className="shrink-0 disabled:opacity-100"
             aria-label={t("settings.plugins.installing")}
           >
-            <CircularDownloadProgress
-              value={downloadPercentage}
+            <PluginDownloadProgress
+              progress={install.progress}
               label={t("settings.plugins.downloadProgress")}
             />
           </Button>
@@ -414,10 +403,15 @@ function AvailablePluginCard({
             variant="ghost"
             size="icon"
             disabled
-            className="shrink-0"
+            className="shrink-0 disabled:opacity-100"
             aria-label={t("settings.plugins.updating")}
           >
-            <IconProgressDown />
+            <PluginDownloadProgress
+              progress={update.progress}
+              label={t("settings.plugins.downloadProgress")}
+            >
+              <IconArrowBigUpLines className="size-3.5" />
+            </PluginDownloadProgress>
           </Button>
         ) : installed === undefined ? (
           <Button
@@ -497,63 +491,6 @@ function CompletedInstallIcon({
             : "size-3.5 stroke-[2.5]"
         }
       />
-    </span>
-  );
-}
-
-/** Renders determinate or indeterminate package progress inside the marketplace action button. */
-function CircularDownloadProgress({
-  value,
-  label,
-}: {
-  value: number | null;
-  label: string;
-}) {
-  const radius = 11;
-  const circumference = 2 * Math.PI * radius;
-  const offset =
-    value === null ? 0 : circumference * (1 - Math.max(0, value) / 100);
-
-  return (
-    <span
-      role="progressbar"
-      aria-label={label}
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-valuenow={value ?? undefined}
-      className="relative grid size-7 place-items-center"
-    >
-      <svg
-        viewBox="0 0 28 28"
-        aria-hidden="true"
-        className={
-          value === null
-            ? "size-7 -rotate-90 animate-spin"
-            : "size-7 -rotate-90"
-        }
-      >
-        <circle
-          cx="14"
-          cy="14"
-          r={radius}
-          fill="none"
-          strokeWidth="2.5"
-          className="stroke-muted"
-        />
-        <circle
-          cx="14"
-          cy="14"
-          r={radius}
-          fill="none"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          strokeDasharray={
-            value === null ? `18 ${circumference}` : circumference
-          }
-          strokeDashoffset={offset}
-          className="stroke-primary transition-[stroke-dashoffset] duration-300 ease-out"
-        />
-      </svg>
     </span>
   );
 }

--- a/packages/app-shell/src/state/hooks/use-update-plugin.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-update-plugin.test.tsx
@@ -1,12 +1,16 @@
 import { act, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createTestClient,
   type TestHandlers,
 } from "../../test/contracts-transport";
 import { createPluginMemory, pluginHandlers } from "../../test/memory/plugins";
 import "../../i18n/i18n-instance";
-import { renderHookWithClient } from "../../test/hook-harness";
+import {
+  createTestQueryClient,
+  renderHookWithClient,
+} from "../../test/hook-harness";
+import { usePluginOperationStore } from "../stores/plugin-operation-store";
 import { useUpdatePlugin } from "./use-update-plugin";
 
 /** State for this test surface; no unrelated domain fixtures are initialized. */
@@ -22,6 +26,10 @@ function createFixtureHandlers(state: FixtureState): TestHandlers {
     ...pluginHandlers(state),
   };
 }
+
+afterEach(() => {
+  act(() => usePluginOperationStore.setState({ activities: {} }));
+});
 
 describe("useUpdatePlugin", () => {
   it("updates an installed plugin and refreshes the installed surface", async () => {
@@ -70,5 +78,57 @@ describe("useUpdatePlugin", () => {
       id: "official/weather",
       version: "1.1.0",
     });
+  });
+
+  it("keeps update progress across unmount and rejects a duplicate start", async () => {
+    const state = createFixtureState();
+    const handlers: TestHandlers = createFixtureHandlers(state);
+    const client = createTestClient(handlers);
+    let resolveUpdate: ((response: { pluginId: string }) => void) | undefined;
+    // The update stays in flight so the durable operation state, not the query cache, is what
+    // carries progress across the unmount below.
+    const update = vi.spyOn(handlers, "updatePlugin").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        }),
+    );
+    const queryClient = createTestQueryClient();
+    const first = renderHookWithClient(
+      () => useUpdatePlugin("official/weather"),
+      client,
+      queryClient,
+    );
+
+    act(() => first.result.current.mutate({}));
+    await waitFor(() => expect(update).toHaveBeenCalledOnce());
+    act(() => {
+      usePluginOperationStore.getState().reportTransferProgress({
+        pluginId: "official/weather",
+        downloaded: 4,
+        total: 10,
+      });
+    });
+    expect(first.result.current.progress).toEqual({
+      pluginId: "official/weather",
+      downloaded: 4,
+      total: 10,
+    });
+    first.unmount();
+
+    const second = renderHookWithClient(
+      () => useUpdatePlugin("official/weather"),
+      client,
+      queryClient,
+    );
+    expect(second.result.current.isPending).toBe(true);
+    expect(second.result.current.progress?.downloaded).toBe(4);
+    act(() => second.result.current.mutate({}));
+    expect(update).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      resolveUpdate?.({ pluginId: "official/weather" });
+    });
+    await waitFor(() => expect(second.result.current.isPending).toBe(false));
   });
 });

--- a/packages/app-shell/src/state/hooks/use-update-plugin.ts
+++ b/packages/app-shell/src/state/hooks/use-update-plugin.ts
@@ -45,5 +45,9 @@ export function useUpdatePlugin(pluginId: string) {
     isPending: activity?.state === "pending" && activity.kind === "update",
     mutate,
     mutateAsync,
+    progress:
+      activity?.state === "pending" && activity.kind === "update"
+        ? activity.progress
+        : null,
   };
 }

--- a/packages/app-shell/src/state/stores/plugin-operation-store.ts
+++ b/packages/app-shell/src/state/stores/plugin-operation-store.ts
@@ -16,8 +16,8 @@ interface PluginOperationState {
   activities: Record<string, PluginOperationActivity>;
   /** Starts an operation only when the same plugin has no conflicting work in flight. */
   begin: (pluginId: string, kind: PluginOperationKind) => boolean;
-  /** Retains native install transfer progress across settings-page navigation. */
-  reportInstallProgress: (progress: PluginInstallProgress) => void;
+  /** Retains native package transfer progress across settings-page navigation. */
+  reportTransferProgress: (progress: PluginInstallProgress) => void;
   /** Briefly records install success so the completion glyph can animate after query refresh. */
   completeInstall: (pluginId: string) => void;
   /** Clears the exact completion after its glyph animation ends. */
@@ -42,15 +42,19 @@ export const usePluginOperationStore = create<PluginOperationState>(
       }));
       return true;
     },
-    reportInstallProgress: (progress) => {
+    reportTransferProgress: (progress) => {
       const activity = get().activities[progress.pluginId];
-      if (activity?.state !== "pending" || activity.kind !== "install") return;
+      if (
+        activity?.state !== "pending" ||
+        (activity.kind !== "install" && activity.kind !== "update")
+      )
+        return;
       set((state) => ({
         activities: {
           ...state.activities,
           [progress.pluginId]: {
             state: "pending",
-            kind: "install",
+            kind: activity.kind,
             progress,
           },
         },

--- a/xtask/rust-size-baseline.json
+++ b/xtask/rust-size-baseline.json
@@ -22,8 +22,8 @@
     },
     "crates/backend/src/plugin.rs": {
       "owner": "ora-backend",
-      "lines": 1053,
-      "split_plan": "Split private plugin-host configuration and gateway/projection responsibilities while retaining Plugins as the public operations interface. Preserve registry identity, runtime synchronization and Effect generation semantics."
+      "lines": 840,
+      "split_plan": "Marketplace release resolution and package transfer now live in plugin/marketplace.rs. Split the remaining private plugin-host configuration and gateway/projection responsibilities while retaining Plugins as the public operations interface. Preserve registry identity, runtime synchronization and Effect generation semantics."
     },
     "crates/backend/src/workflow/run/executor.rs": {
       "owner": "ora-backend",


### PR DESCRIPTION
已完成手工验证，可合入

本 PR 取代 #536。原分支是在集成重构落地之前拉出的，无法在不回退部分重构的前提下 rebase 到当前 `main`。本分支基于当前 `main` 重新拉出，拆成两个便于审阅的提交。

> [!NOTE]
> 手工验证过程中发现 Windows 上 agent 插件更新存在一个既有缺陷（更新后前端仍显示旧版本、再点报 `AlreadyUpToDate`），已记录为 #543。该缺陷与本 PR 无关：它是 agent supervisor 自动重启与包退役之间的竞态，在重构前后、有无下载进度都同样存在，本 PR 未改动那条路径。
>
> 它影响本 PR 在 Windows 上的手工验证方式：包越大越必现，codex（约 450MB）每次都失败，因此**用 codex 只能验证到进度环本身正常显示，验证不了更新成功后的收尾**；小包或 universal 包有机会赢下竞态，可用于验证完整生命周期，但结果不稳定。

## 这个改动做了什么

更新 marketplace 插件时只显示一个静态图标，大包看起来像卡住了。现在更新会复用安装已有的持久化操作状态上报字节级传输进度——正是这份状态让传输在设置页切换后仍然可见。

## 提交拆分

**1. `refactor(plugin): extract marketplace package transfer into its own module`** —— 无行为变化

`crates/backend/src/plugin.rs` 挂着一条已评审的规模例外，其 split plan 要求拆分职责。Marketplace 的 release 解析与包传输是其中自成一体的一块：它们是 release manifest 查找、host target 选择、代理/对象存储 installer 构造，以及 install/update 错误映射的唯一调用方。移到 `plugin/marketplace.rs` 后，plugin.rs 从 1053 行降到 840 生产行，因此同步下调 `xtask/rust-size-baseline.json`，避免已清理的债务重新长回来。代码为原样搬移。

**2. `feat(plugins): show update download progress`** —— 特性本身

- `Installer::update_with_progress` 把回调传进它本来就为安装执行的那次下载。
- `PluginApi::update_with_progress` 与 `Plugins::update_with_progress` 与安装侧一一对称，因此带进度的更新在 agent 集合 reconcile 上与不带进度的更新完全一致。
- 安装与更新在 `commands/plugin.rs` 共用同一个节流进度发射器；`update_plugin` 改为显式命令，以便接收 `AppHandle`。
- 环形进度指示器从 marketplace 卡片中抽出为 `PluginDownloadProgress`，marketplace 卡片与已安装插件管理器渲染同一个控件。操作 store 对两种操作都记录进度，因此改名为 `reportTransferProgress`。

契约无变化：`updatePlugin` 端点及其 DTO 未改动，无需重新生成任何绑定产物。

## 本地已跑的门禁

| 门禁 | 结果 |
|---|---|
| `cargo fmt --all -- --check` | 通过 |
| `check:rust-size` | 通过 —— 672 个文件，7 条已评审例外 |
| `cargo clippy --workspace --exclude ora-desktop --exclude ora-desktop-tests -- -D warnings` | 通过 |
| `cargo clippy --package ora-desktop -- -D warnings` | 通过 |
| `cargo test --workspace --exclude ora-desktop --exclude ora-desktop-tests` | 1224 passed，0 failed |
| `cargo test --package ora-desktop` | 57 passed |
| `check:features` | 通过 |
| `@ora/app-shell` 与 `@ora/desktop` lint（tsc + eslint） | 通过 |
| `@ora/app-shell` test（clean-stderr） | 143 个文件，1290 项测试通过 |

`check:contracts` 未跑通：它失败在从配置的 registry 镜像下载 `npm:ts-to-zod` 这一步，不是 schema 不一致。本分支未改动 `packages/contracts/`。

新增测试覆盖三个层次的更新进度：installer 在更新过程中转发字节快照；操作 store 在组件卸载后保留更新进度并拒绝重复启动；marketplace 卡片与已安装插件管理器都渲染带更新图标的进度环。

Refs #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
