### PR TITLE
fix(chat): restore conversation timestamps from history instead of re…

### DIFF
--- a/crates/backend/src/agent_runtime/actor.rs
+++ b/crates/backend/src/agent_runtime/actor.rs
@@ -187,7 +187,7 @@ impl RuntimeActor {
                 self.reported_config_options.clone(),
             ));
             if events
-                .send(Ok(LoadSessionEvent::SessionUpdate { update }))
+                .send(Ok(LoadSessionEvent::session_update(update)))
                 .await
                 .is_err()
             {

--- a/crates/backend/src/agent_runtime/load_tests.rs
+++ b/crates/backend/src/agent_runtime/load_tests.rs
@@ -31,12 +31,21 @@ use pretty_assertions::assert_eq;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tempfile::TempDir;
+use time::format_description::well_known::Rfc3339;
 use time::macros::datetime;
 use tokio::sync::mpsc;
 
 const SESSION_ID: &str = "session-1";
 /// An agent identity no package in these fixtures supplies, so nothing supervises it.
 const AGENT: &str = "ora-space.opencode";
+const HISTORY_CLOCK: time::OffsetDateTime = datetime!(2026-09-02 09:15:00.000 +08:00);
+
+/// RFC 3339 stamp the fixture recorder writes onto every history line.
+fn history_recorded_at() -> String {
+    HISTORY_CLOCK
+        .format(&Rfc3339)
+        .expect("format fixture timestamp")
+}
 
 fn test_pool(root: &Path) -> RepositoryPool {
     // These tests drive the runtime directly rather than through `Backend`, so nothing else has
@@ -117,7 +126,7 @@ fn record_conversation(sessions_root: &Path, session: &Session) {
         SESSION_ID,
         0,
         &HistoryState::Writable,
-        FixedHistoryClock::new(datetime!(2026-09-02 09:15:00.000 +08:00)),
+        FixedHistoryClock::new(HISTORY_CLOCK),
     )
     .expect("open recorder");
     recorder.record_meta(session, Path::new("/project"));
@@ -170,14 +179,17 @@ fn a_session_whose_agent_is_unreachable_still_serves_its_transcript() {
                             update: SessionUpdate::UserMessageChunk(ContentChunk::new(
                                 ContentBlock::Text(TextContent::new("hello"))
                             )),
+                            recorded_at: Some(history_recorded_at()),
                         },
                         LoadSessionEvent::SessionUpdate {
                             update: SessionUpdate::AgentMessageChunk(ContentChunk::new(
                                 ContentBlock::Text(TextContent::new("hi"))
                             )),
+                            recorded_at: Some(history_recorded_at()),
                         },
                         LoadSessionEvent::TurnEnded {
                             stop_reason: StopReason::EndTurn,
+                            recorded_at: Some(history_recorded_at()),
                         },
                         LoadSessionEvent::Completed,
                     ],

--- a/crates/backend/src/agent_runtime/replay.rs
+++ b/crates/backend/src/agent_runtime/replay.rs
@@ -15,14 +15,19 @@ fn integrity_notice(integrity: HistoryIntegrity) -> Option<LoadSessionEvent> {
 
 /// Maps one durable record onto the load event the client renders, dropping bookkeeping records
 /// that only matter for persistence or provider handoff.
-fn map_record(record: HistoryRecord) -> Option<LoadSessionEvent> {
+///
+/// `recorded_at` is the history line's wall-clock stamp so replay can restore bubble times.
+/// Pending in-memory records pass `None` because they have not been written yet.
+fn map_record(record: HistoryRecord, recorded_at: Option<String>) -> Option<LoadSessionEvent> {
     match record {
-        HistoryRecord::Update { update } => {
-            Some(LoadSessionEvent::SessionUpdate { update: *update })
-        }
-        HistoryRecord::TurnEnded { stop_reason } => {
-            Some(LoadSessionEvent::TurnEnded { stop_reason })
-        }
+        HistoryRecord::Update { update } => Some(LoadSessionEvent::SessionUpdate {
+            update: *update,
+            recorded_at,
+        }),
+        HistoryRecord::TurnEnded { stop_reason } => Some(LoadSessionEvent::TurnEnded {
+            stop_reason,
+            recorded_at,
+        }),
         HistoryRecord::Gap { reason } => Some(LoadSessionEvent::HistoryNotice {
             notice: SessionHistoryNotice::UnrecordedContent { reason },
         }),
@@ -41,7 +46,7 @@ pub(super) fn recorded_replay(history: SessionHistory) -> impl Iterator<Item = L
         history
             .lines
             .into_iter()
-            .filter_map(|line| map_record(line.record)),
+            .filter_map(|line| map_record(line.record, Some(line.at))),
     )
 }
 
@@ -52,23 +57,23 @@ pub(super) fn replay_prefix(
     history: SessionHistory,
     pending: Vec<AssembledRecord>,
 ) -> Vec<LoadSessionEvent> {
-    let mut merged: Vec<(u32, HistoryRecord)> = history
+    let mut merged: Vec<(u32, HistoryRecord, Option<String>)> = history
         .lines
         .into_iter()
-        .map(|line| (line.seq, line.record))
+        .map(|line| (line.seq, line.record, Some(line.at)))
         .chain(
             pending
                 .into_iter()
-                .map(|record| (record.seq, record.record)),
+                .map(|record| (record.seq, record.record, None)),
         )
         .collect();
-    merged.sort_by_key(|(seq, _)| *seq);
+    merged.sort_by_key(|(seq, _, _)| *seq);
     let mut events: Vec<LoadSessionEvent> =
         integrity_notice(history.integrity).into_iter().collect();
     events.extend(
         merged
             .into_iter()
-            .filter_map(|(_, record)| map_record(record)),
+            .filter_map(|(_, record, recorded_at)| map_record(record, recorded_at)),
     );
     events
 }
@@ -82,9 +87,11 @@ mod tests {
     use serde_json::json;
     use std::num::NonZeroUsize;
 
-    /// Creates a history line whose timestamp is irrelevant to replay mapping.
+    const RECORDED_AT: &str = "2026-08-14T10:00:00+08:00";
+
+    /// Creates a history line stamped with the fixture time so replay must forward it.
     fn line(seq: u32, record: HistoryRecord) -> HistoryLine {
-        HistoryLine::new("2026-08-14T10:00:00+08:00", seq, record)
+        HistoryLine::new(RECORDED_AT, seq, record)
     }
 
     #[test]
@@ -110,6 +117,7 @@ mod tests {
                 },
                 LoadSessionEvent::TurnEnded {
                     stop_reason: StopReason::EndTurn,
+                    recorded_at: Some(RECORDED_AT.to_string()),
                 },
             ],
         );
@@ -178,9 +186,13 @@ mod tests {
         assert_eq!(
             events,
             vec![
-                LoadSessionEvent::SessionUpdate { update },
+                LoadSessionEvent::SessionUpdate {
+                    update,
+                    recorded_at: None,
+                },
                 LoadSessionEvent::TurnEnded {
                     stop_reason: StopReason::EndTurn,
+                    recorded_at: Some(RECORDED_AT.to_string()),
                 },
             ]
         );

--- a/crates/backend/src/agent_runtime/session_followers.rs
+++ b/crates/backend/src/agent_runtime/session_followers.rs
@@ -104,9 +104,7 @@ impl SessionFollowers {
     /// Mirrors one provider update to every view that still has the session open.
     pub(super) fn send_update(&mut self, update: &SessionUpdate) {
         self.followers.retain(|_, follower| {
-            let event = LoadSessionEvent::SessionUpdate {
-                update: update.clone(),
-            };
+            let event = LoadSessionEvent::session_update(update.clone());
             match follower.events.try_send(Ok(event)) {
                 Ok(()) => true,
                 Err(mpsc::error::TrySendError::Full(_)) => {
@@ -124,7 +122,7 @@ impl SessionFollowers {
             tokio::spawn(async move {
                 if follower
                     .events
-                    .send(Ok(LoadSessionEvent::TurnEnded { stop_reason }))
+                    .send(Ok(LoadSessionEvent::turn_ended(stop_reason)))
                     .await
                     .is_ok()
                 {
@@ -232,10 +230,8 @@ mod tests {
                     .map(|result| result.map_err(|error| error.to_string())),
             ],
             [
-                Some(Ok(LoadSessionEvent::SessionUpdate { update })),
-                Some(Ok(LoadSessionEvent::TurnEnded {
-                    stop_reason: StopReason::EndTurn,
-                })),
+                Some(Ok(LoadSessionEvent::session_update(update))),
+                Some(Ok(LoadSessionEvent::turn_ended(StopReason::EndTurn))),
                 Some(Ok(LoadSessionEvent::Completed)),
             ],
         );

--- a/crates/backend/src/agent_runtime/unavailable_session_tests.rs
+++ b/crates/backend/src/agent_runtime/unavailable_session_tests.rs
@@ -17,10 +17,18 @@ use pretty_assertions::assert_eq;
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
+use time::format_description::well_known::Rfc3339;
 use time::macros::datetime;
 
 const SESSION_ID: &str = "session-with-missing-agent";
 const MISSING_AGENT: &str = "ora-space.opencode";
+const HISTORY_CLOCK: time::OffsetDateTime = datetime!(2026-09-03 11:20:02.558 +08:00);
+
+fn history_recorded_at() -> String {
+    HISTORY_CLOCK
+        .format(&Rfc3339)
+        .expect("format fixture timestamp")
+}
 
 /// Opens a migrated repository used by the runtime and plugin host.
 fn test_pool(root: &Path) -> RepositoryPool {
@@ -74,7 +82,7 @@ fn seed_session(root: &Path, pool: &RepositoryPool) {
         SESSION_ID,
         0,
         &ora_domain::HistoryState::Writable,
-        FixedHistoryClock::new(datetime!(2026-09-03 11:20:02.558 +08:00)),
+        FixedHistoryClock::new(HISTORY_CLOCK),
     )
     .expect("open session history");
     assert_eq!(
@@ -122,9 +130,11 @@ fn loads_recorded_history_without_the_session_agent() {
                                         ContentBlock::Text(TextContent::new("previous question")),
                                     ),
                                 ),
+                            recorded_at: Some(history_recorded_at()),
                         },
                         LoadSessionEvent::TurnEnded {
                             stop_reason: StopReason::EndTurn,
+                            recorded_at: Some(history_recorded_at()),
                         },
                         LoadSessionEvent::Completed,
                     ],

--- a/crates/contracts/src/session.rs
+++ b/crates/contracts/src/session.rs
@@ -266,18 +266,55 @@ pub enum LoadSessionEvent {
     SessionUpdate {
         #[ts(type = "import(\"@agentclientprotocol/sdk\").SessionUpdate")]
         update: SessionUpdate,
+        /// RFC 3339 local time from the history line this update was replayed from.
+        ///
+        /// Live follow-on updates and in-memory pending records omit it so the
+        /// client stamps them with the wall clock instead of inventing a file time.
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            rename = "recordedAt"
+        )]
+        #[ts(optional)]
+        recorded_at: Option<String>,
     },
     PermissionRequest(SessionPermissionRequest),
     TurnEnded {
         #[serde(rename = "stopReason")]
         #[ts(type = "import(\"@agentclientprotocol/sdk\").StopReason")]
         stop_reason: StopReason,
+        /// RFC 3339 local time from the history line that closed this turn.
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            rename = "recordedAt"
+        )]
+        #[ts(optional)]
+        recorded_at: Option<String>,
     },
     /// Reports a known hole without pretending that the surviving transcript is continuous.
     HistoryNotice {
         notice: SessionHistoryNotice,
     },
     Completed,
+}
+
+impl LoadSessionEvent {
+    /// A session update with no history timestamp (live follow or session chrome).
+    pub fn session_update(update: SessionUpdate) -> Self {
+        Self::SessionUpdate {
+            update,
+            recorded_at: None,
+        }
+    }
+
+    /// A turn boundary with no history timestamp (live follow of an in-flight prompt).
+    pub fn turn_ended(stop_reason: StopReason) -> Self {
+        Self::TurnEnded {
+            stop_reason,
+            recorded_at: None,
+        }
+    }
 }
 
 /// Streams one prompt turn and ends with the provider's typed stop reason.

--- a/e2e/tests/desktop/core/session.rs
+++ b/e2e/tests/desktop/core/session.rs
@@ -398,7 +398,7 @@ mod tests {
         let mut stream = opening.await?;
         let mut updates = Vec::new();
         while let Some(event) = stream.recv().await {
-            if let LoadSessionEvent::SessionUpdate { update } = event? {
+            if let LoadSessionEvent::SessionUpdate { update, .. } = event? {
                 updates.push(update);
             }
         }

--- a/e2e/tests/desktop/core/session/tests/lifecycle.rs
+++ b/e2e/tests/desktop/core/session/tests/lifecycle.rs
@@ -208,7 +208,8 @@ fn workflow_cancellation_stops_the_live_node_session() -> TestResult {
             if matches!(
                 event,
                 LoadSessionEvent::SessionUpdate {
-                    update: SessionUpdate::AgentMessageChunk(_)
+                    update: SessionUpdate::AgentMessageChunk(_),
+                    ..
                 }
             ) {
                 break;

--- a/packages/chat/src/store.ts
+++ b/packages/chat/src/store.ts
@@ -300,7 +300,10 @@ export function createChatStore(
             if (configOptions) {
               staged.configOptions = configOptions;
             } else {
-              staged.applyUpdate(event.update);
+              staged.applyUpdate(
+                event.update,
+                recordedAtMillis(event.recordedAt),
+              );
               batchPreview =
                 (event.update.sessionUpdate === "user_message_chunk" ||
                   event.update.sessionUpdate === "agent_message_chunk" ||
@@ -313,7 +316,10 @@ export function createChatStore(
             // Preserve the final text batch while the turn is still live; ending it first would
             // make preview deliberately decline to publish a non-responding intermediate state.
             if (pendingPreviewTimer !== null) flushPendingPreview();
-            staged.endTurn(event.stopReason);
+            staged.endTurn(
+              event.stopReason,
+              recordedAtMillis(event.recordedAt),
+            );
           } else if (event.type === "history_notice") {
             staged.addHistoryNotice(event.notice);
           } else {
@@ -732,9 +738,9 @@ class HistoryBuilder {
     private readonly now: () => number,
   ) {}
 
-  applyUpdate(update: acp.SessionUpdate): void {
+  applyUpdate(update: acp.SessionUpdate, recordedAt?: number): void {
     if (update.sessionUpdate === "user_message_chunk") {
-      this.appendUserChunk(update);
+      this.appendUserChunk(update, recordedAt);
       return;
     }
     if (isConversationUpdate(update)) {
@@ -745,8 +751,10 @@ class HistoryBuilder {
       return;
     }
     if (isDeferredConversationUpdate(update)) return;
-    const turn = this.currentTurn();
-    this.replaceLast(applyAgentUpdate(turn, update, this.createId, this.now()));
+    const turn = this.currentTurn(recordedAt);
+    this.replaceLast(
+      applyAgentUpdate(turn, update, this.createId, this.timestamp(recordedAt)),
+    );
   }
 
   addPermission(request: SessionPermissionRequest): void {
@@ -759,7 +767,7 @@ class HistoryBuilder {
   }
 
   /** Settles the open turn with the outcome the record captured for it. */
-  endTurn(stopReason: acp.StopReason): void {
+  endTurn(stopReason: acp.StopReason, recordedAt?: number): void {
     const last = this.turns.at(-1);
     this.hasOpenTurn = false;
     if (last === undefined) return;
@@ -769,7 +777,11 @@ class HistoryBuilder {
       stopReason,
     };
     this.replaceLast(
-      settleActiveToolCalls(settled, impliedToolStatus(stopReason), this.now()),
+      settleActiveToolCalls(
+        settled,
+        impliedToolStatus(stopReason),
+        this.timestamp(recordedAt),
+      ),
     );
   }
 
@@ -821,7 +833,7 @@ class HistoryBuilder {
     };
   }
 
-  private appendUserChunk(chunk: acp.ContentChunk): void {
+  private appendUserChunk(chunk: acp.ContentChunk, recordedAt?: number): void {
     const last = this.turns.at(-1);
     const protocolMessageId = chunk.messageId ?? undefined;
     const continuesUser =
@@ -850,7 +862,7 @@ class HistoryBuilder {
       });
       return;
     }
-    const createdAt = this.now();
+    const createdAt = this.timestamp(recordedAt);
     this.turns.push({
       id: this.createId(),
       userMessage: {
@@ -874,10 +886,10 @@ class HistoryBuilder {
   }
 
   /** Ensures an agent update always has a turn, even before any user message replays. */
-  private currentTurn(): ChatTurn {
+  private currentTurn(recordedAt?: number): ChatTurn {
     const last = this.turns.at(-1);
     if (this.hasOpenTurn && last !== undefined) return last;
-    const createdAt = this.now();
+    const createdAt = this.timestamp(recordedAt);
     const turn: ChatTurn = {
       id: this.createId(),
       userMessage: {
@@ -900,6 +912,11 @@ class HistoryBuilder {
 
   private replaceLast(turn: ChatTurn): void {
     this.turns[this.turns.length - 1] = turn;
+  }
+
+  /** Prefers the history line's time when replay supplied one. */
+  private timestamp(recordedAt?: number): number {
+    return recordedAt ?? this.now();
   }
 }
 
@@ -1417,12 +1434,12 @@ export async function loadSessionConversation(
       if (configOptions) {
         staged.configOptions = configOptions;
       } else {
-        staged.applyUpdate(event.update);
+        staged.applyUpdate(event.update, recordedAtMillis(event.recordedAt));
       }
     } else if (event.type === "permission_request") {
       staged.addPermission(event);
     } else if (event.type === "turn_ended") {
-      staged.endTurn(event.stopReason);
+      staged.endTurn(event.stopReason, recordedAtMillis(event.recordedAt));
     } else {
       completed = true;
     }
@@ -1483,4 +1500,13 @@ function isAbortError(error: unknown): boolean {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Agent request failed";
+}
+
+/** Parses a history-line RFC 3339 stamp. Invalid or missing values fall through to `now()`. */
+function recordedAtMillis(recordedAt: string | undefined): number | undefined {
+  if (recordedAt === undefined || recordedAt.length === 0) {
+    return undefined;
+  }
+  const parsed = Date.parse(recordedAt);
+  return Number.isNaN(parsed) ? undefined : parsed;
 }

--- a/packages/chat/tests/store.test.ts
+++ b/packages/chat/tests/store.test.ts
@@ -15,6 +15,7 @@ function textEvent(
   role: "user_message_chunk" | "agent_message_chunk",
   text: string,
   messageId: string,
+  recordedAt?: string,
 ): LoadSessionEvent {
   return {
     type: "session_update",
@@ -23,6 +24,7 @@ function textEvent(
       messageId,
       content: { type: "text", text },
     },
+    ...(recordedAt === undefined ? {} : { recordedAt }),
   };
 }
 
@@ -109,6 +111,35 @@ test("loads provider history and reconstructs turns from message boundaries", as
     pendingPermissions: [],
     error: null,
   });
+});
+
+test("restores bubble times from recordedAt instead of the load clock", async () => {
+  const recordedAt = "2026-09-02T09:15:00+08:00";
+  const expected = Date.parse(recordedAt);
+  const client: ChatSessionClient = {
+    load: () =>
+      events([
+        textEvent("user_message_chunk", "hello", "user-1", recordedAt),
+        textEvent("agent_message_chunk", "hi", "agent-1", recordedAt),
+        { type: "turn_ended", stopReason: "end_turn", recordedAt },
+        { type: "completed" },
+      ]),
+    prompt: () => events<PromptSessionEvent>([]),
+    respondToPermission: async () => ({}),
+    setConfig: async () => ({ configOptions: [] }),
+  };
+  let nextId = 0;
+  const store = createChatStore(client, {
+    createId: () => `local-${++nextId}`,
+    now: () => 42,
+  });
+
+  await store.getState().loadSession("ora-1");
+
+  const conversation = store.getState().conversations["ora-1"];
+  assert.equal(conversation?.turns[0]?.createdAt, expected);
+  assert.equal(conversation?.turns[0]?.userMessage.createdAt, expected);
+  assert.equal(conversation?.turns[0]?.items[0]?.createdAt, expected);
 });
 
 test("publishes an active prompt incrementally while its session loads", async () => {

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -99,11 +99,22 @@ export type LoadSessionEvent =
   | {
     "type": "session_update";
     update: import("@agentclientprotocol/sdk").SessionUpdate;
+    /**
+     * RFC 3339 local time from the history line this update was replayed from.
+     *
+     * Live follow-on updates and in-memory pending records omit it so the
+     * client stamps them with the wall clock instead of inventing a file time.
+     */
+    recordedAt?: string;
   }
   | { "type": "permission_request" } & SessionPermissionRequest
   | {
     "type": "turn_ended";
     stopReason: import("@agentclientprotocol/sdk").StopReason;
+    /**
+     * RFC 3339 local time from the history line that closed this turn.
+     */
+    recordedAt?: string;
   }
   | { "type": "history_notice"; notice: SessionHistoryNotice }
   | { "type": "completed" };


### PR DESCRIPTION
…load time

When replaying a session's history on load, the frontend previously stamped every turn and bubble with the current wall clock. This caused all conversations to appear as 'just now' after restarting the app.

Plumb the history line's RFC 3339 recorded_at through the Rust replay path into the LoadSessionEvent contract so the chat store can parse and reuse the original timestamps instead of inventing new ones.

- Add optional recorded_at to SessionUpdate and TurnEnded events
- Thread the stamp through map_record and the actor load path
- Parse recordedAt in the chat store and use it for bubble times
- Add regression test that verifies restored timestamps match the file