### PR TITLE
refactor(error): drop implicit conversions that diverge from explicit mapping

### DIFF
--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -30,12 +30,27 @@ pub enum DesktopBootstrapError {
 }
 
 /// Serializes the transport-neutral contract directly across the Tauri command seam.
+///
+/// Deliberately has no `From<BackendError>` impl, and one must not be added. Such an impl makes
+/// `?` compile inside commands that already own a `RequestLifecycle`, and the conversion has no
+/// lifecycle to reach, so it must mint a throwaway one to complete against. That silently breaks
+/// both request invariants documented in `docs/runtime-logging.md`: the request records two
+/// completion events instead of one (a `failure` under the throwaway id, plus an `abandoned` one
+/// at `DEBUG` when the real lifecycle drops unclaimed), and the id handed to the frontend stops
+/// matching the request span, so the id the user is asked to quote for support resolves to a
+/// record carrying neither the real operation name nor its duration. Requiring an explicit choice
+/// between the two constructors below keeps that decision visible in review.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct CommandError(ContractError);
 
 impl CommandError {
     /// Completes one Tauri request and projects its typed public payload.
+    ///
+    /// Only for seams that have no ambient lifecycle to complete against, such as managed-state
+    /// accessors and surface commands. A command that owns a lifecycle must use
+    /// [`Self::from_backend_with_lifecycle`] instead, so the request keeps one id and one
+    /// completion event.
     pub fn from_backend(error: BackendError) -> Self {
         let lifecycle = RequestLifecycle::start("tauri_command", &UuidRequestIdGenerator);
         Self::from_backend_with_lifecycle(error, &lifecycle)
@@ -45,11 +60,5 @@ impl CommandError {
     pub fn from_backend_with_lifecycle(error: BackendError, lifecycle: &RequestLifecycle) -> Self {
         lifecycle.complete_failure(&error);
         Self(error.contract_error(lifecycle.request_id()))
-    }
-}
-
-impl From<BackendError> for CommandError {
-    fn from(error: BackendError) -> Self {
-        Self::from_backend(error)
     }
 }

--- a/crates/application/src/error.rs
+++ b/crates/application/src/error.rs
@@ -107,9 +107,17 @@ pub enum ApplicationError {
         #[source]
         source: std::io::Error,
     },
+    /// Carries worktree lifecycle failures that have no more specific application meaning.
+    ///
+    /// Deliberately has no `#[from]`, and one must not be added. `#[from]` collapses *every*
+    /// source variant onto this one, but `NotARepository` and `BaseBranchNotFound` each have a
+    /// dedicated application error carrying a user-readable message, so a `?` or `.into()` taking
+    /// the generated `From` would silently downgrade both into this generic "operation failed"
+    /// case — with no compile-time or runtime warning. Convert through
+    /// [`ApplicationError::from_task_worktree_provisioner_error`] instead, which fans the source
+    /// variants out correctly.
     #[error(transparent)]
     TaskWorktreeProvisioner {
-        #[from]
         source: TaskWorktreeProvisionerError,
     },
     #[error("workspace diff operation failed")]
@@ -562,5 +570,48 @@ impl PartialEq for ApplicationError {
             ) => left_wf == right_wf && left_v == right_v,
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApplicationError;
+    use crate::TaskWorktreeProvisionerError;
+    use pretty_assertions::assert_eq;
+
+    /// Pins the fan-out that a `#[from]` on `TaskWorktreeProvisioner` would silently collapse.
+    ///
+    /// `NotARepository` and `BaseBranchNotFound` each reach the frontend as their own
+    /// `InvalidRequest` public error, so only `OperationFailed` may land on the internal
+    /// provisioner variant. A derived `From` would route all three to that internal case.
+    #[test]
+    fn worktree_provisioner_errors_keep_their_dedicated_application_variants() {
+        let mapped = [
+            TaskWorktreeProvisionerError::NotARepository,
+            TaskWorktreeProvisionerError::BaseBranchNotFound {
+                branch_name: "main".to_owned(),
+            },
+            TaskWorktreeProvisionerError::operation_failed(
+                "create task worktree",
+                std::io::Error::other("worktree add failed"),
+            ),
+        ]
+        .map(ApplicationError::from_task_worktree_provisioner_error);
+
+        assert_eq!(
+            mapped,
+            [
+                ApplicationError::TaskWorktreeRequiresGitRepository,
+                ApplicationError::TaskBaseBranchNotFound {
+                    branch_name: "main".to_owned(),
+                },
+                ApplicationError::TaskWorktreeProvisioner {
+                    source: TaskWorktreeProvisionerError::operation_failed(
+                        "create task worktree",
+                        std::io::Error::other("worktree add failed"),
+                    ),
+                },
+            ]
+        );
     }
 }


### PR DESCRIPTION
处理 #201 中的两条 From-impl 隐患（C#1 与评论补充的 `#[from]` 分歧）。两处都是**当前无调用方**的死代码，删除对运行时行为零影响；它们的危害在于只要将来有人写一个 `?`，就会静默生效且无任何编译期或运行期告警。

## 1. `impl From<BackendError> for CommandError`

`apps/desktop/src-tauri/src/error.rs`

这个 impl 让 `?` 能在**已经持有 `RequestLifecycle` 的命令**里编译通过。但转换拿不到那个 lifecycle，只能新建一个throwaway 的来完成，于是同时打破 `docs/runtime-logging.md` 里写明的两条不变量：

- **L61「每个请求恰好记录一条完成事件」**：实际会有两条 —— 一条 `outcome="failure"`（挂在 throwaway id 上，`operation="tauri_command"`、`duration_ms≈0`），加一条 `outcome="abandoned"`（真 lifecycle 析构时补的，DEBUG 级）。`AtomicBool` 的 exactly-once 保护在这里失效，因为是两个互不相识的 `Arc`。
- **L59「同一标识符关联 span、错误载荷与完成事件」**：返回前端的 id 变成 throwaway 的那个。`formatter.rs:67` 是 `visitor.request_id.or(scope.request_id)`，事件字段优先、span 的被丢弃，所以真 id 在那行日志里完全不出现。

实际后果落在排查链路上：错误 toast 的文案是「请提供请求编号 {{requestId}} 以便排查」并附「下载日志」按钮（`use-contract-error-toast.ts`）。用户报上来的编号会指向一条既没有真实命令名、也没有真实耗时的空壳记录；而带着这些信息的那条是 DEBUG 级，默认 `info` 日志级别（`lib.rs:123`）下根本没写进文件。

保留 `from_backend` —— 它的 6 个调用点（`state.rs` ×5、`surface/error.rs`、`update/commands.rs`）确实都没有可用的 lifecycle，逐个确认过。

## 2. `#[from]` on `ApplicationError::TaskWorktreeProvisioner`

`crates/application/src/error.rs`

`#[from]` 把源枚举的**所有**变体都映射到泛化的 provisioner 变体，而手写的 `from_task_worktree_provisioner_error` 是分流的。走 derive 出来的 `From` 会造成：

| 源变体 | 正确路径 | `#[from]` 路径 |
|---|---|---|
| `NotARepository` | `WorktreeRequiresGitRepository` / InvalidRequest | `InternalError` / **Internal** |
| `BaseBranchNotFound{branch_name}` | `TaskBaseBranchNotFound{branch_name}` / InvalidRequest | `InternalError` / **Internal**（丢 `branch_name`） |
| `OperationFailed` | `TaskWorktreeProvisioner` / Internal | 一致 |

分类从 `InvalidRequest` 降级成 `Internal` 会连带把完成日志从 INFO 抬到 ERROR（`request_lifecycle.rs:122` 的分级），并让前端因 `code === "internal_error"` 命中 `hasDiagnosticRequestId`，对一个纯粹的用户输入问题弹出「下载日志」提示。

去掉 `#[from]` 后 `#[error(transparent)]` 与名为 `source` 的字段仍然维持原有的 Display 和 source 链行为，只是不再生成那个分歧的 `From`。

## 改动

- 删除两个 impl，并把「为什么不能加回来」写在各自类型/变体的文档注释上 —— 那是别人想加回来时会先看的位置。
- 新增一个测试固定 worktree provisioner 的三路分流。注意它守的是映射函数本身，不是 `#[from]` 的缺席（后者只有 trybuild 类编译失败测试能守，考虑到 rustc 版本敏感、依赖不在 workspace 里，没有引入）。

## 验证

| 检查 | 结果 |
|---|---|
| `task test:crates`（含 fmt / rust-size / clippy `-D warnings`） | ✅ |
| `task test:tauri` | ✅ 57 passed |
| `cargo check -p ora-desktop --all-targets`（删除前后对比） | ✅ 证明两个 impl 均无调用方 |

过程中 `ora-utils` 的 `http::tests::reqwest_integration::probe_reports_a_refused_connection` 偶发失败过一次。已确认与本 PR 无关：`ora-utils` 不依赖任何 `ora-*` crate，原始代码跑同一命令通过，带改动重跑也通过。根因是该用例单跑就要 2.01s 而超时预算正好 2s —— `probe` 把 `build_client`（Windows 下加载系统证书库）算进了同一个 `tokio::time::timeout` 预算里，负载稍高就会返回 `Timeout` 而非 `Network`。已单独记录，不在本 PR 处理。

## 未包含

#201 的 C#3（`agent_runtime/support.rs` 的 `runtime_internal` 字符串映射）**未处理**。它现在有 13 个 code、33 个调用点，其中 18 处静默落到 `InternalError`，且 `BackendError::new` 无 source 会丢底层诊断。修它需要先决定 `agent_start_failed`、`agent_event_overflow` 等缺失的 code 是新增契约变体还是有意归为 internal —— 属于契约决策，适合单独一个 PR。

Refs #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
