### PR TITLE
fix(chat): adopt the first reachable agent on a first run

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -156,4 +156,5 @@ itself; `Failing` is not, because the restart circuit is open for the rest of th
 stored preference naming an agent that is no longer reachable is carried forward unexamined rather
 than dropped — the frontend does not validate agent identities against a closed set — and a
 session's own binding is always reported as written, since that is what the conversation genuinely
-runs on.
+runs on. A first run that has never stored a preference adopts the first agent detection reports
+reaching, once, so later install or restart changes cannot silently move it.

--- a/packages/app-shell/src/app-shell.tsx
+++ b/packages/app-shell/src/app-shell.tsx
@@ -29,6 +29,7 @@ import type { CurrentUser } from "./lib/types";
 import { createAppQueryClient } from "./state/query-client";
 import { useGitIdentityUser } from "./state/hooks/use-git-identity";
 import { useGraphWorkflowRunLiveSync } from "./state/data/mock-workflow-runs";
+import { useDefaultAgentAdoption } from "./state/hooks/use-default-agent-adoption";
 import { useSessionUnreadSync } from "./state/hooks/use-session-unread-sync";
 import { useUiStore } from "./state/stores/ui-store";
 import { startThemeSubscription } from "./state/stores/settings-store";
@@ -78,6 +79,19 @@ export function AppShell({
       </AppI18nProvider>
     </QueryClientProvider>
   );
+}
+
+/**
+ * Points a first run at an agent, from inside the contracts client provider.
+ *
+ * A component rather than a call in `AppShellContent`: the provider this reads through is part of
+ * that component's own output, so a hook placed beside its other state hooks would run a render
+ * too early to reach a client. It is mounted next to the dialogs instead of inside a chat surface
+ * because the preference is app-wide — the session dialog reads it with no composer open.
+ */
+function DefaultAgentAdoption() {
+  useDefaultAgentAdoption();
+  return null;
 }
 
 /** Renders the shell inside providers so stateful hooks can consume the active locale. */
@@ -198,6 +212,7 @@ function AppShellContent({
                 </ResizablePanel>
               </ResizablePanelGroup>
               <SettingsDialog />
+              <DefaultAgentAdoption />
               <PluginOperationEventBridge />
               <SurfaceEventBridge />
               <SurfaceDownloadToaster />

--- a/packages/app-shell/src/state/hooks/use-default-agent-adoption.test.tsx
+++ b/packages/app-shell/src/state/hooks/use-default-agent-adoption.test.tsx
@@ -1,0 +1,171 @@
+import { act, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import type {
+  AgentStatus,
+  GetAgentRuntimeStatusResponse,
+} from "@ora/contracts";
+import {
+  createTestClient,
+  type TestHandlers,
+} from "../../test/contracts-transport";
+import {
+  createAgentRuntimeMemory,
+  agentRuntimeHandlers,
+} from "../../test/memory/agent-runtime";
+import { createPluginMemory, pluginHandlers } from "../../test/memory/plugins";
+import "../../i18n/i18n-instance";
+import { renderHookWithClient } from "../../test/hook-harness";
+import { agentRuntimeKeys } from "../data/agent-runtime";
+import { DEFAULT_SETTINGS, useSettingsStore } from "../stores/settings-store";
+import { useAgentRuntimeStatus } from "./use-agent-runtime-status";
+import { useDefaultAgentAdoption } from "./use-default-agent-adoption";
+import { AGENT_REF } from "../../test/agent-identity";
+
+/** State for this test surface; no unrelated domain fixtures are initialized. */
+function createFixtureState() {
+  return { ...createAgentRuntimeMemory(), ...createPluginMemory() };
+}
+
+type FixtureState = ReturnType<typeof createFixtureState>;
+
+/** Explicit domain composition for the behaviors exercised by this test file. */
+function createFixtureHandlers(state: FixtureState): TestHandlers {
+  return {
+    ...agentRuntimeHandlers(state),
+    ...pluginHandlers(state),
+  };
+}
+
+/** The installation this file describes: one that has never chosen an agent. */
+beforeEach(() => {
+  useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS } });
+});
+
+/** Replaces what the runtime reports about one agent, leaving the rest detected. */
+function reportOpenCode(status: AgentStatus) {
+  return (state: FixtureState) => {
+    const entry = state.agentRuntimeStatuses.find(
+      (candidate) => candidate.agentRef === AGENT_REF.opencode,
+    );
+    entry!.status = status;
+  };
+}
+
+/**
+ * Mounts the adoption hook and resolves once detection has answered.
+ *
+ * Every case here turns on what the runtime reports, so asserting before that query lands would
+ * be asserting against the loading answer instead of the behavior under test.
+ */
+async function renderAdoption(seed: (state: FixtureState) => void = () => {}) {
+  const state = createFixtureState();
+  seed(state);
+  const { result, queryClient } = renderHookWithClient(
+    () => {
+      useDefaultAgentAdoption();
+      return useAgentRuntimeStatus();
+    },
+    createTestClient(createFixtureHandlers(state)),
+  );
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return { state, queryClient };
+}
+
+/** Re-reports the seeded statuses after a case has mutated them. */
+async function refreshDetection(
+  queryClient: Awaited<ReturnType<typeof renderAdoption>>["queryClient"],
+) {
+  await act(() =>
+    queryClient.invalidateQueries({
+      queryKey: agentRuntimeKeys.agentRuntimeStatus,
+    }),
+  );
+}
+
+/** Waits for the stored preferences to settle on exactly this agent and nothing else. */
+async function expectAdopted(agentRef: string | null) {
+  await waitFor(() =>
+    expect(useSettingsStore.getState().settings).toEqual({
+      ...DEFAULT_SETTINGS,
+      agentCli: agentRef,
+    }),
+  );
+}
+
+describe("useDefaultAgentAdoption", () => {
+  it("adopts the first agent the runtime reports reaching", async () => {
+    await renderAdoption();
+
+    await expectAdopted(AGENT_REF.opencode);
+  });
+
+  it("passes over an agent nothing reaches", async () => {
+    await renderAdoption(reportOpenCode("unavailable"));
+
+    await expectAdopted(AGENT_REF.nga);
+  });
+
+  it("leaves a stored choice alone", async () => {
+    useSettingsStore.setState({
+      settings: { ...DEFAULT_SETTINGS, agentCli: AGENT_REF.claude },
+    });
+
+    await renderAdoption();
+
+    await expectAdopted(AGENT_REF.claude);
+  });
+
+  /**
+   * The whole installed catalog is the loading answer of the available-agent list, including
+   * agents nothing supervises. Adopting from it would store a default no session could be opened
+   * on, so the pending window must produce no preference at all.
+   */
+  it("adopts nothing while detection has not answered", async () => {
+    const state = createFixtureState();
+    const stalled = createTestClient({
+      ...createFixtureHandlers(state),
+      getAgentRuntimeStatus: () =>
+        new Promise<GetAgentRuntimeStatusResponse>(() => {}),
+    });
+    renderHookWithClient(() => useDefaultAgentAdoption(), stalled);
+
+    // Flush the render pass the installed-plugin query schedules, which is the one that would
+    // offer the catalog if the guard were missing.
+    await act(async () => {});
+    expect(useSettingsStore.getState().settings.agentCli).toBeNull();
+  });
+
+  /**
+   * Adoption is an initialization, not a fallback that keeps re-deciding: an agent arriving later
+   * is exactly the plugin install this must not silently follow.
+   */
+  it("keeps what it adopted when another agent becomes available", async () => {
+    const { state, queryClient } = await renderAdoption(
+      reportOpenCode("unavailable"),
+    );
+    await expectAdopted(AGENT_REF.nga);
+
+    reportOpenCode("ready")(state);
+    await refreshDetection(queryClient);
+
+    await expectAdopted(AGENT_REF.nga);
+  });
+
+  /**
+   * The ordinary first run: the shell paints while agent processes are still completing their
+   * handshake, so there is nothing to adopt yet and the first one to answer becomes the default.
+   */
+  it("waits for an installation that reaches no agent yet", async () => {
+    const { state, queryClient } = await renderAdoption((seeded) => {
+      seeded.agentRuntimeStatuses = [];
+    });
+    expect(useSettingsStore.getState().settings.agentCli).toBeNull();
+
+    state.agentRuntimeStatuses = [
+      { agentRef: AGENT_REF.claude, status: "ready" },
+    ];
+    await refreshDetection(queryClient);
+
+    await expectAdopted(AGENT_REF.claude);
+  });
+});

--- a/packages/app-shell/src/state/hooks/use-default-agent-adoption.ts
+++ b/packages/app-shell/src/state/hooks/use-default-agent-adoption.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useSettingsStore } from "../stores/settings-store";
+import { useAgentRuntimeStatus } from "./use-agent-runtime-status";
+import { useAvailableAgents } from "./use-available-agents";
+
+/**
+ * Gives an installation that has never chosen an agent one to start on.
+ *
+ * `settings.agentCli` begins unset, and every chat surface nobody has pointed anywhere resolves
+ * through it, so a first run opens on no agent at all: the picker names none, the send gate
+ * blocks, and starting a session reports that one must be picked — even when a single agent is
+ * installed and reachable and there is nothing to choose between. Adopting the first agent the
+ * runtime reports reaching is what makes that first message sendable.
+ *
+ * The preference is written rather than resolved as a fallback inside `useTargetAgentCli`, and
+ * that distinction is the whole design. A fallback would be re-derived on every render, so a
+ * package being installed, disabled, or restarted would move a user who never asked to move.
+ * Adoption happens once: afterwards `agentCli` holds a preference indistinguishable from one
+ * picked in the menu, which later availability changes may not touch.
+ *
+ * Nothing is adopted while detection is still in flight, because the whole installed catalog is
+ * `useAvailableAgents`' loading answer and adopting from it could store an agent no session could
+ * be opened on. An installation that reaches none keeps `null` and adopts the first one that
+ * arrives, which is the ordinary first-run sequence: agent processes are still completing their
+ * handshake while the shell paints.
+ */
+export function useDefaultAgentAdoption(): void {
+  const agentCli = useSettingsStore((state) => state.settings.agentCli);
+  const updateSettings = useSettingsStore((state) => state.updateSettings);
+  const { data: statuses } = useAgentRuntimeStatus();
+  const availableAgents = useAvailableAgents();
+  // Catalog order is the backend's stable identifier order, so which agent a fresh installation
+  // lands on does not depend on how quickly each one answered.
+  const adoptable = statuses === undefined ? undefined : availableAgents[0];
+
+  useEffect(() => {
+    if (agentCli !== null || adoptable === undefined) return;
+    updateSettings({ agentCli: adoptable.agentRef });
+  }, [agentCli, adoptable, updateSettings]);
+}

--- a/packages/app-shell/src/state/hooks/use-target-agent-cli.ts
+++ b/packages/app-shell/src/state/hooks/use-target-agent-cli.ts
@@ -34,6 +34,10 @@ export interface AgentSelection {
  * open, and using the first available agent as a fallback would silently change
  * the user's selection when a plugin is installed or removed. A surface that has
  * never chosen an agent therefore resolves to `null` instead of inventing one.
+ * Giving a first run something to send on is `useDefaultAgentAdoption`'s job:
+ * it writes the shared default once, so what arrives here is always a real
+ * preference rather than a guess this resolver would have to make again on
+ * every render.
  */
 export function useTargetAgentCli(selection: AgentSelection): string | null {
   const defaultAgentCli = useSettingsStore((state) => state.settings.agentCli);


### PR DESCRIPTION
## Summary
- A first install stored no agent preference, so new chats stayed unselected even when one agent was already reachable.
- Adopt the first reachable agent once after detection answers, instead of inventing a fallback on every render.
- Later plugin install, disable, or restart no longer silently moves an already stored default.

## Test plan
- [ ] Clear `ora.settings.v1` in WebView localStorage, restart Desktop, open a new chat, and confirm an agent is selected and send works.
- [ ] With no agent installed, confirm the marketplace hint still appears and nothing is auto-selected.
- [ ] Manually pick a different agent and confirm new chats follow that default.
- [ ] Disable or uninstall the adopted agent and confirm the stored choice is not replaced by another agent.
- [ ] Switch agents on an existing session and confirm the move still waits for the next message.

Made with [Cursor](https://cursor.com)