### PR TITLE
feat: 完善插件详情与 Skill 来源操作

### DIFF
--- a/packages/app-shell/src/features/settings/atoms-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/atoms-settings.test.tsx
@@ -43,6 +43,7 @@ function createFixtureHandlers(state: FixtureState): TestHandlers {
 function renderSettings(
   kind: "agent" | "skill",
   configure?: (handlers: TestHandlers) => void,
+  onOpenPlugin?: (pluginId: string) => void,
 ) {
   const state = createFixtureState();
   if (kind === "agent") {
@@ -92,7 +93,11 @@ function renderSettings(
       <AppI18nProvider>
         <PlatformProvider adapter={createStubPlatform()}>
           <TooltipProvider>
-            {kind === "agent" ? <RolesSettings /> : <SkillsSettings />}
+            {kind === "agent" ? (
+              <RolesSettings />
+            ) : (
+              <SkillsSettings onOpenPlugin={onOpenPlugin} />
+            )}
           </TooltipProvider>
         </PlatformProvider>
       </AppI18nProvider>
@@ -137,14 +142,54 @@ describe("atom settings content", () => {
     );
   });
 
-  it("collapses long plugin sources to an icon and reveals the full id on hover", async () => {
+  it("opens a long plugin source from a compact button with a friendly tooltip", async () => {
     const user = userEvent.setup();
     const pluginId = "official/review-pack-with-a-name-that-does-not-fit";
+    const onOpenPlugin = vi.fn();
+    renderSettings(
+      "skill",
+      (handlers) => {
+        handlers.listSkills = async () => ({
+          skills: [
+            {
+              id: "plugin:" + pluginId + ":review",
+              namespace: pluginId,
+              name: "review",
+              description: "Reviews changes",
+              source: { kind: "plugin", pluginId },
+              availability: "available",
+            },
+          ],
+        });
+      },
+      onOpenPlugin,
+    );
+
+    const item = await screen.findByRole("listitem");
+    const sourceIcon = within(item).getByRole("button", {
+      name: "查看来源插件详情",
+    });
+    expect(within(item).queryByText(pluginId)).toBeNull();
+
+    await user.hover(sourceIcon);
+    const tooltip = await screen.findByText("查看来源插件详情");
+    expect(tooltip).toBeVisible();
+    expect(tooltip).toHaveTextContent("查看来源插件详情");
+    expect(tooltip).not.toHaveTextContent(pluginId);
+
+    await user.click(sourceIcon);
+    expect(onOpenPlugin).toHaveBeenCalledWith(pluginId);
+  });
+
+  it("uninstalls a source plugin after warning that all of its Skills are deleted", async () => {
+    const user = userEvent.setup();
+    const pluginId = "official/review-pack";
+    const uninstallPlugin = vi.fn(async () => ({ pluginId }));
     renderSettings("skill", (handlers) => {
       handlers.listSkills = async () => ({
         skills: [
           {
-            id: "plugin:" + pluginId + ":review",
+            id: `plugin:${pluginId}:review`,
             namespace: pluginId,
             name: "review",
             description: "Reviews changes",
@@ -154,20 +199,35 @@ describe("atom settings content", () => {
         ],
       });
       handlers.listInstalledPlugins = async () => ({ plugins: [] });
+      handlers.listAvailablePlugins = async () => ({
+        updatedAt: 0n,
+        plugins: [],
+      });
+      handlers.uninstallPlugin = uninstallPlugin;
     });
 
-    const item = await screen.findByRole("listitem");
-    const sourceIcon = within(item).getByRole("button", { name: pluginId });
-    expect(within(item).queryByText(pluginId)).toBeNull();
+    const deleteButton = await screen.findByRole("button", {
+      name: "删除该插件引入的所有 Skill",
+    });
+    await user.hover(deleteButton);
+    expect(await screen.findByText("删除该插件引入的所有 Skill")).toBeVisible();
+    await user.click(deleteButton);
 
-    await user.hover(sourceIcon);
-    const tooltip = await screen.findByText(pluginId);
-    expect(tooltip).toBeVisible();
-    expect(tooltip).toHaveClass(
-      "max-w-64",
-      "whitespace-normal",
-      "break-all",
-      "text-left",
+    const dialog = await screen.findByRole("alertdialog", {
+      name: `卸载“${pluginId}”？`,
+    });
+    expect(dialog).toHaveTextContent(
+      "这会卸载该插件，并删除它引入的所有 Skill。此操作无法撤销。",
+    );
+    await user.click(
+      within(dialog).getByRole("button", { name: "卸载并删除 Skills" }),
+    );
+
+    await waitFor(() =>
+      expect(uninstallPlugin).toHaveBeenCalledWith(
+        { pluginId, dataDisposition: "delete" },
+        undefined,
+      ),
     );
   });
 

--- a/packages/app-shell/src/features/settings/atoms-settings.tsx
+++ b/packages/app-shell/src/features/settings/atoms-settings.tsx
@@ -40,6 +40,7 @@ import {
 } from "@ora/ui";
 import {
   IconAlertTriangle,
+  IconLoader2,
   IconPencil,
   IconPlus,
   IconPuzzle,
@@ -51,12 +52,14 @@ import {
 } from "@tabler/icons-react";
 import { useContractsClient } from "../../contracts-client-context";
 import { localizeContractError } from "../../i18n/contract-error";
+import { useContractErrorToast } from "../../i18n/use-contract-error-toast";
 import {
   localizeSkillImportReason,
   localizeSkillImportResultReason,
   localizeSkillImportStatus,
 } from "../../i18n/skill-import-reason";
 import { useAgents } from "../../state/hooks/use-agents";
+import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
 import { useSkills } from "../../state/hooks/use-skills";
 import {
   useCreateAgent,
@@ -173,34 +176,11 @@ export function RolesSettings() {
 const EMPTY_SKILLS: Skill[] = [];
 const MAX_INLINE_PLUGIN_ID_LENGTH = 24;
 
-function PluginSourceBadge({ pluginId }: { pluginId: string }) {
-  if (pluginId.length <= MAX_INLINE_PLUGIN_ID_LENGTH) {
-    return (
-      <Badge variant="secondary" className="max-w-52 normal-case">
-        <IconPuzzle aria-hidden="true" />
-        {pluginId}
-      </Badge>
-    );
-  }
-  return (
-    <Tooltip>
-      <TooltipTrigger
-        aria-label={pluginId}
-        className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground"
-      >
-        <IconPuzzle className="size-3" aria-hidden="true" />
-      </TooltipTrigger>
-      <TooltipContent
-        align="end"
-        className="max-w-64 whitespace-normal break-all text-left"
-      >
-        {pluginId}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-export function SkillsSettings() {
+export function SkillsSettings({
+  onOpenPlugin,
+}: {
+  onOpenPlugin?: (pluginId: string) => void;
+}) {
   const { t } = useTranslation();
   const skillsQuery = useSkills();
   const createSkill = useCreateSkill();
@@ -212,6 +192,9 @@ export function SkillsSettings() {
   const [restoreName, setRestoreName] = useState<string | null>(null);
   const [recoverTarget, setRecoverTarget] = useState<Skill | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Skill | null>(null);
+  const [pluginDeleteTarget, setPluginDeleteTarget] = useState<string | null>(
+    null,
+  );
   const skills = skillsQuery.data ?? EMPTY_SKILLS;
   const unavailableCount = skills.filter(
     (skill) => skill.availability === "unavailable",
@@ -284,9 +267,14 @@ export function SkillsSettings() {
           if (!("source" in item) || item.source.kind !== "plugin") {
             return undefined;
           }
+          const pluginId = item.source.pluginId;
           return (
             <div className="flex max-w-full flex-wrap items-center justify-end gap-1.5">
-              <PluginSourceBadge pluginId={item.source.pluginId} />
+              <PluginSkillActions
+                pluginId={pluginId}
+                onOpen={() => onOpenPlugin?.(pluginId)}
+                onDelete={() => setPluginDeleteTarget(pluginId)}
+              />
             </div>
           );
         }}
@@ -328,6 +316,10 @@ export function SkillsSettings() {
           deleteSkill.mutateAsync({ skillId: item.id }).then(() => undefined)
         }
       />
+      <DeletePluginSkillsDialog
+        pluginId={pluginDeleteTarget}
+        onOpenChange={(open) => !open && setPluginDeleteTarget(null)}
+      />
       <SkillImportDialog
         open={importOpen}
         restoreName={restoreName}
@@ -339,6 +331,118 @@ export function SkillsSettings() {
         onCompleted={() => void invalidateSkills(queryClient)}
       />
     </>
+  );
+}
+
+/** Links a read-only skill to its owning plugin and offers package-wide removal. */
+function PluginSkillActions({
+  pluginId,
+  onOpen,
+  onDelete,
+}: {
+  pluginId: string;
+  onOpen: () => void;
+  onDelete: () => void;
+}) {
+  const { t } = useTranslation();
+  const compact = pluginId.length > MAX_INLINE_PLUGIN_ID_LENGTH;
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger
+          aria-label={t("settings.skills.viewSourcePlugin")}
+          className={cn(
+            "inline-flex h-6 shrink-0 items-center justify-center gap-1.5 rounded-full bg-secondary text-xs font-medium text-secondary-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+            compact ? "w-6" : "max-w-52 px-2",
+          )}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpen();
+          }}
+        >
+          <IconPuzzle className="size-3" aria-hidden="true" />
+          {!compact && <span className="truncate">{pluginId}</span>}
+        </TooltipTrigger>
+        <TooltipContent>{t("settings.skills.viewSourcePlugin")}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          aria-label={t("settings.skills.deletePluginSkills")}
+          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-destructive outline-none transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete();
+          }}
+        >
+          <IconTrash className="size-3.5" />
+        </TooltipTrigger>
+        <TooltipContent>
+          {t("settings.skills.deletePluginSkills")}
+        </TooltipContent>
+      </Tooltip>
+    </>
+  );
+}
+
+/** Confirms package removal because plugin-provided skills cannot be deleted independently. */
+function DeletePluginSkillsDialog({
+  pluginId,
+  onOpenChange,
+}: {
+  pluginId: string | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const showContractError = useContractErrorToast();
+  const queryClient = useQueryClient();
+  const mutations = usePluginMutations(pluginId ?? "");
+  const uninstalling = mutations.uninstall.isPending;
+
+  return (
+    <AlertDialog open={pluginId !== null} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("settings.skills.deletePluginTitle", {
+              pluginId: pluginId ?? "",
+            })}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("settings.skills.deletePluginDescription")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={uninstalling}>
+            {t("common.cancel")}
+          </AlertDialogCancel>
+          <Button
+            variant="destructive"
+            disabled={uninstalling}
+            onClick={() =>
+              mutations.uninstall.mutate("delete", {
+                onError: (cause) =>
+                  showContractError(
+                    cause,
+                    t("settings.plugins.uninstallFailed"),
+                  ),
+                onSuccess: () => {
+                  void invalidateSkills(queryClient);
+                  onOpenChange(false);
+                },
+              })
+            }
+          >
+            {uninstalling ? (
+              <IconLoader2 className="animate-spin" />
+            ) : (
+              <IconTrash />
+            )}
+            {t("settings.skills.deletePluginConfirm")}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 

--- a/packages/app-shell/src/features/settings/plugin-readme-view.tsx
+++ b/packages/app-shell/src/features/settings/plugin-readme-view.tsx
@@ -1,24 +1,51 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { AvailablePlugin } from "@ora/contracts";
+import type {
+  AvailablePlugin,
+  InstalledPlugin,
+  InstallOutcome,
+} from "@ora/contracts";
 import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
+  Button,
+  toast,
 } from "@ora/ui";
+import {
+  IconArrowBigUpLines,
+  IconDownload,
+  IconLoader2,
+  IconTrash,
+} from "@tabler/icons-react";
 import { localizeContractError } from "../../i18n/contract-error";
+import { useContractErrorToast } from "../../i18n/use-contract-error-toast";
+import { useInstallPlugin } from "../../state/hooks/use-install-plugin";
+import { usePluginMutations } from "../../state/hooks/use-plugin-mutations";
 import { usePluginReadme } from "../../state/hooks/use-plugin-readme";
+import { useUpdatePlugin } from "../../state/hooks/use-update-plugin";
 import { MarkdownDocument } from "../chat/markdown-message";
+import { PluginDownloadProgress } from "./plugin-download-progress";
 import { PluginLogo } from "./plugin-logo";
 
 /** The marketplace detail page: breadcrumb back navigation plus the listing's rendered README. */
 export function PluginReadmeView({
   plugin,
+  installed,
   onBack,
 }: {
   plugin: AvailablePlugin;
+  installed: InstalledPlugin | undefined;
   onBack: () => void;
 }) {
   const { t } = useTranslation();
@@ -40,16 +67,19 @@ export function PluginReadmeView({
         </BreadcrumbList>
       </Breadcrumb>
 
-      <header className="flex items-start gap-3">
-        <PluginLogo logo={plugin.logo} />
-        <span className="min-w-0 flex-1">
-          <span className="block text-lg font-semibold">
-            {plugin.title || plugin.name}
-          </span>
-          <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-            {plugin.id} · {plugin.version} · {plugin.kind}
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start">
+        <span className="flex min-w-0 flex-1 items-start gap-3">
+          <PluginLogo logo={plugin.logo} />
+          <span className="min-w-0 flex-1">
+            <span className="block text-lg font-semibold">
+              {plugin.title || plugin.name}
+            </span>
+            <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+              {plugin.id} · {plugin.version} · {plugin.kind}
+            </span>
           </span>
         </span>
+        <PluginDetailAction plugin={plugin} installed={installed} />
       </header>
 
       {readme.isLoading ? (
@@ -73,5 +103,169 @@ export function PluginReadmeView({
         </article>
       )}
     </div>
+  );
+}
+
+/** Offers the one package action relevant to the listing's current installation state. */
+function PluginDetailAction({
+  plugin,
+  installed,
+}: {
+  plugin: AvailablePlugin;
+  installed: InstalledPlugin | undefined;
+}) {
+  const { t } = useTranslation();
+  const showContractError = useContractErrorToast();
+  const install = useInstallPlugin(plugin.id);
+  const update = useUpdatePlugin(plugin.id);
+  const mutations = usePluginMutations(
+    plugin.id,
+    installed?.kind === "agent" ? installed.id : undefined,
+  );
+  const [uninstallOpen, setUninstallOpen] = useState(false);
+  const [deleteData, setDeleteData] = useState(true);
+  const uninstalling = mutations.uninstall.isPending;
+  const incompatible = plugin.compatibility === "incompatible";
+  const hasUpdate =
+    installed !== undefined && plugin.version !== installed.version;
+
+  const failInstall = (cause: unknown) => {
+    showContractError(cause, t("settings.plugins.installFailed"));
+  };
+  const succeedInstall = (response: { outcome: InstallOutcome }) => {
+    toast.success(
+      response.outcome.state === "installed_with_command_conflict"
+        ? t("settings.plugins.installCommandConflict", {
+            pluginId: response.outcome.conflictPluginId,
+          })
+        : t("settings.plugins.installSuccess"),
+    );
+  };
+  const failUpdate = (cause: unknown) => {
+    showContractError(cause, t("settings.plugins.updateFailed"));
+  };
+  const failUninstall = (cause: unknown) => {
+    showContractError(cause, t("settings.plugins.uninstallFailed"));
+  };
+
+  if (install.isPending) {
+    return (
+      <Button disabled className="shrink-0 disabled:opacity-100">
+        <PluginDownloadProgress
+          progress={install.progress}
+          label={t("settings.plugins.downloadProgress")}
+        />
+        {t("settings.plugins.installing")}
+      </Button>
+    );
+  }
+  if (update.isPending) {
+    return (
+      <Button disabled className="shrink-0 disabled:opacity-100">
+        <PluginDownloadProgress
+          progress={update.progress}
+          label={t("settings.plugins.downloadProgress")}
+        >
+          <IconArrowBigUpLines className="size-3.5" />
+        </PluginDownloadProgress>
+        {t("settings.plugins.updating")}
+      </Button>
+    );
+  }
+  if (installed === undefined) {
+    return (
+      <Button
+        variant="outline"
+        className="shrink-0"
+        disabled={incompatible}
+        onClick={() =>
+          install.mutate(
+            {},
+            { onError: failInstall, onSuccess: succeedInstall },
+          )
+        }
+      >
+        <IconDownload />
+        {t("settings.plugins.install")}
+      </Button>
+    );
+  }
+  if (hasUpdate) {
+    return (
+      <Button
+        className="shrink-0"
+        onClick={() => update.mutate({}, { onError: failUpdate })}
+      >
+        <IconArrowBigUpLines />
+        {t("settings.plugins.update")}
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+        disabled={uninstalling}
+        onClick={() => setUninstallOpen(true)}
+      >
+        {uninstalling ? (
+          <IconLoader2 className="animate-spin" />
+        ) : (
+          <IconTrash />
+        )}
+        {t(
+          uninstalling
+            ? "settings.plugins.uninstalling"
+            : "settings.plugins.uninstall",
+        )}
+      </Button>
+      <AlertDialog
+        open={uninstallOpen}
+        onOpenChange={(open) => {
+          setUninstallOpen(open);
+          if (open) setDeleteData(true);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("settings.plugins.uninstallTitle", {
+                name: plugin.title || plugin.name,
+              })}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("settings.plugins.uninstallDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={deleteData}
+              onChange={(event) => setDeleteData(event.target.checked)}
+            />
+            {t("settings.plugins.deleteConfigurationData")}
+          </label>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={uninstalling}>
+              {t("common.cancel")}
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={uninstalling}
+              onClick={() =>
+                mutations.uninstall.mutate(deleteData ? "delete" : "retain", {
+                  onError: failUninstall,
+                  onSuccess: () => setUninstallOpen(false),
+                })
+              }
+            >
+              {t("settings.plugins.uninstall")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/packages/app-shell/src/features/settings/plugins-settings.test.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.test.tsx
@@ -848,6 +848,59 @@ it("opens the README page when a marketplace card is clicked", async () => {
   ).toBeInTheDocument();
 });
 
+/** An uninstalled listing keeps the marketplace install command available on its detail page. */
+it("installs an uninstalled plugin from its detail header", async () => {
+  const user = userEvent.setup();
+  const { state, client } = clientWithWeather();
+  renderSettings(client);
+
+  await user.click(await screen.findByText("Weather"));
+  await user.click(await screen.findByRole("button", { name: /安装|Install/ }));
+
+  await waitFor(() => expect(state.installedPlugins).toHaveLength(1));
+  expect(
+    await screen.findByRole("button", { name: /卸载|Uninstall/ }),
+  ).toBeInTheDocument();
+});
+
+/** An older installed release exposes update, then changes to uninstall after refreshing. */
+it("updates an outdated plugin from its detail header", async () => {
+  const user = userEvent.setup();
+  const { state, client } = clientWithWeather();
+  state.installedPlugins.push({ ...weatherInstalled(), version: "1.1.0" });
+  renderSettings(client);
+
+  await user.click(await screen.findByText("Weather"));
+  await user.click(await screen.findByRole("button", { name: /更新|Update/ }));
+
+  await waitFor(() => expect(state.installedPlugins[0]?.version).toBe("1.2.0"));
+  expect(
+    await screen.findByRole("button", { name: /卸载|Uninstall/ }),
+  ).toBeInTheDocument();
+});
+
+/** A current installed release uses the existing confirmation flow before uninstalling. */
+it("uninstalls a current plugin from its detail header", async () => {
+  const user = userEvent.setup();
+  const { state, client } = clientWithWeather();
+  state.installedPlugins.push(weatherInstalled());
+  renderSettings(client);
+
+  await user.click(await screen.findByText("Weather"));
+  await user.click(
+    await screen.findByRole("button", { name: /卸载|Uninstall/ }),
+  );
+  const dialog = await screen.findByRole("alertdialog");
+  await user.click(
+    within(dialog).getByRole("button", { name: /卸载|Uninstall/ }),
+  );
+
+  await waitFor(() => expect(state.installedPlugins).toHaveLength(0));
+  expect(
+    await screen.findByRole("button", { name: /安装|Install/ }),
+  ).toBeInTheDocument();
+});
+
 /** The README page breadcrumb returns to the marketplace grid. */
 it("returns from the README page to the marketplace grid", async () => {
   const user = userEvent.setup();

--- a/packages/app-shell/src/features/settings/plugins-settings.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.tsx
@@ -185,6 +185,7 @@ export function PluginsSettings({
     return (
       <PluginReadmeView
         plugin={readmePlugin}
+        installed={installedById.get(readmePlugin.id)}
         onBack={() => setReadmePlugin(null)}
       />
     );

--- a/packages/app-shell/src/features/settings/plugins-settings.tsx
+++ b/packages/app-shell/src/features/settings/plugins-settings.tsx
@@ -67,10 +67,14 @@ const MARKETPLACE_KIND_LABELS: Record<string, string> = {
  */
 export function PluginsSettings({
   onNavigationGuardChange,
+  detailPluginId = null,
+  onDetailClose,
 }: {
   onNavigationGuardChange?: (
     guard: PluginConfigurationNavigationGuard | null,
   ) => void;
+  detailPluginId?: string | null;
+  onDetailClose?: () => void;
 }) {
   const { t } = useTranslation();
   const showContractError = useContractErrorToast();
@@ -181,12 +185,19 @@ export function PluginsSettings({
     }
   };
 
-  if (readmePlugin !== null) {
+  const detailPlugin =
+    (detailPluginId === null ? undefined : availableById.get(detailPluginId)) ??
+    readmePlugin;
+
+  if (detailPlugin !== null && detailPlugin !== undefined) {
     return (
       <PluginReadmeView
-        plugin={readmePlugin}
-        installed={installedById.get(readmePlugin.id)}
-        onBack={() => setReadmePlugin(null)}
+        plugin={detailPlugin}
+        installed={installedById.get(detailPlugin.id)}
+        onBack={() => {
+          setReadmePlugin(null);
+          onDetailClose?.();
+        }}
       />
     );
   }

--- a/packages/app-shell/src/features/settings/settings-dialog.test.tsx
+++ b/packages/app-shell/src/features/settings/settings-dialog.test.tsx
@@ -16,6 +16,7 @@ import {
   type TestHandlers,
 } from "../../test/contracts-transport";
 import { createPluginMemory, pluginHandlers } from "../../test/memory/plugins";
+import { createSkillMemory, skillHandlers } from "../../test/memory/skills";
 import {
   createSettingsMemory,
   settingsHandlers,
@@ -25,7 +26,11 @@ import { SettingsDialog } from "./settings-dialog";
 
 /** State for this test surface; no unrelated domain fixtures are initialized. */
 function createFixtureState() {
-  return { ...createPluginMemory(), ...createSettingsMemory() };
+  return {
+    ...createPluginMemory(),
+    ...createSettingsMemory(),
+    ...createSkillMemory(),
+  };
 }
 
 type FixtureState = ReturnType<typeof createFixtureState>;
@@ -35,6 +40,7 @@ function createFixtureHandlers(state: FixtureState): TestHandlers {
   return {
     ...pluginHandlers(state),
     ...settingsHandlers(state),
+    ...skillHandlers(state),
   };
 }
 
@@ -248,6 +254,44 @@ describe("SettingsDialog developer options", () => {
     expect(
       screen.queryByRole("heading", { name: "Appearance" }),
     ).not.toBeInTheDocument();
+    expect(useUiStore.getState().settingsCategory).toBe("plugins");
+  });
+
+  it("navigates from a plugin-provided Skill to the source plugin details", async () => {
+    const state = createFixtureState();
+    state.availablePlugins.push({
+      id: "official/weather",
+      name: "weather",
+      title: "Weather",
+      kind: "skill",
+      namespace: "official",
+      sourceUrl: "https://github.com/ora-space/marketplace",
+      version: "1.2.0",
+      description: "Weather skills",
+      logo: null,
+      compatibility: "compatible",
+    });
+    state.skills.push({
+      id: "plugin:official/weather:forecast",
+      namespace: "official/weather",
+      name: "forecast",
+      description: "Read the forecast",
+      source: { kind: "plugin", pluginId: "official/weather" },
+      availability: "available",
+    });
+    const user = userEvent.setup();
+    renderDialog(createTestClient(createFixtureHandlers(state)));
+
+    await user.click(screen.getByRole("button", { name: "Skills" }));
+    await user.click(
+      await screen.findByRole("button", {
+        name: "View source plugin details",
+      }),
+    );
+
+    expect(
+      await screen.findByText("official/weather · 1.2.0 · skill"),
+    ).toBeInTheDocument();
     expect(useUiStore.getState().settingsCategory).toBe("plugins");
   });
 });

--- a/packages/app-shell/src/features/settings/settings-dialog.tsx
+++ b/packages/app-shell/src/features/settings/settings-dialog.tsx
@@ -69,6 +69,7 @@ export function SettingsDialog() {
   const updateSettings = useSettingsStore((s) => s.updateSettings);
   const [pendingNavigation, setPendingNavigation] =
     useState<PendingSettingsNavigation | null>(null);
+  const [pluginDetailId, setPluginDetailId] = useState<string | null>(null);
   const pluginConfigurationGuard =
     useRef<PluginConfigurationNavigationGuard | null>(null);
   const developerMode = useDeveloperMode();
@@ -85,7 +86,10 @@ export function SettingsDialog() {
   const applyNavigation = (navigation: PendingSettingsNavigation) => {
     setPendingNavigation(null);
     if (navigation.kind === "close") setOpen(false);
-    else setCategory(navigation.category);
+    else {
+      if (navigation.category !== "plugins") setPluginDetailId(null);
+      setCategory(navigation.category);
+    }
   };
 
   /** Defers Settings navigation while the active plugin editor owns unsaved input. */
@@ -190,10 +194,19 @@ export function SettingsDialog() {
                   />
                 )}
                 {category === "roles" && <RolesSettings />}
-                {category === "skills" && <SkillsSettings />}
+                {category === "skills" && (
+                  <SkillsSettings
+                    onOpenPlugin={(pluginId) => {
+                      setPluginDetailId(pluginId);
+                      setCategory("plugins");
+                    }}
+                  />
+                )}
                 {category === "plugins" && (
                   <PluginsSettings
                     onNavigationGuardChange={registerPluginConfigurationGuard}
+                    detailPluginId={pluginDetailId}
+                    onDetailClose={() => setPluginDetailId(null)}
                   />
                 )}
                 {category === "proxy" && <ProxySettings />}

--- a/packages/app-shell/src/features/settings/translations/skills.ts
+++ b/packages/app-shell/src/features/settings/translations/skills.ts
@@ -96,6 +96,12 @@ export const skillTranslations = {
     "settings.skills.importRestoreMissing":
       "导入内容里没有名为“{{name}}”的技能。",
     "settings.skills.importCompletedWithFailures": "{{count}} 个技能导入失败。",
+    "settings.skills.viewSourcePlugin": "查看来源插件详情",
+    "settings.skills.deletePluginSkills": "删除该插件引入的所有 Skill",
+    "settings.skills.deletePluginTitle": "卸载“{{pluginId}}”？",
+    "settings.skills.deletePluginDescription":
+      "这会卸载该插件，并删除它引入的所有 Skill。此操作无法撤销。",
+    "settings.skills.deletePluginConfirm": "卸载并删除 Skills",
     "settings.skills.importStatus.ready": "待导入",
     "settings.skills.importStatus.conflict": "同名冲突",
     "settings.skills.importStatus.invalid": "无效",
@@ -239,6 +245,13 @@ export const skillTranslations = {
       "This import does not include a skill named “{{name}}”.",
     "settings.skills.importCompletedWithFailures":
       "{{count}} skill(s) failed to import.",
+    "settings.skills.viewSourcePlugin": "View source plugin details",
+    "settings.skills.deletePluginSkills":
+      "Delete all Skills provided by this plugin",
+    "settings.skills.deletePluginTitle": "Uninstall {{pluginId}}?",
+    "settings.skills.deletePluginDescription":
+      "This uninstalls the plugin and deletes every Skill it provides. This cannot be undone.",
+    "settings.skills.deletePluginConfirm": "Uninstall and delete Skills",
     "settings.skills.importStatus.ready": "Ready",
     "settings.skills.importStatus.conflict": "Name conflict",
     "settings.skills.importStatus.invalid": "Invalid",


### PR DESCRIPTION
## 变更内容

- 在插件详情标题区域根据安装状态展示安装、更新或卸载按钮，并复用现有插件生命周期、下载进度、错误提示和卸载确认逻辑。
- 将插件提供的 Skill 来源标记改为可点击按钮，可直接跳转到对应插件详情。
- 将来源按钮的提示改为用户友好的文案，并在右侧增加删除按钮。
- 删除操作会明确提示并卸载来源插件，同时删除该插件引入的全部 Skill。
- 补充中英文文案以及插件详情、跨设置页面导航和插件 Skill 删除流程的测试。

## 提交组织

按功能提交后紧跟对应测试提交的方式组织：

1. 插件详情生命周期操作
2. 插件详情生命周期测试
3. 插件 Skill 来源管理
4. 插件 Skill 操作测试

## 验证

- task lint:frontend 通过
- 插件设置相关测试 30 项通过
- Skill 与设置导航相关测试 24 项通过
- 完整前端测试运行了 1322 项；首次有 3 项无关的异步/超时测试波动，单独重跑对应 3 个文件共 116 项全部通过