### PR TITLE
feat(workflow): 支持 Agent 节点显式配置 MCP

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -64,8 +64,8 @@ pub use workflow::{
     UpdateWorkflowResult, UuidWorkflowIdGenerator, WorkflowIdGenerator, WorkflowRepository,
 };
 pub use workflow_run::{
-    AdvanceWorkflowRunResult, AgentConfig, AgentExecutor, AgentOutputContract, AgentSkill,
-    AgentSkillDelivery, AgentSkillDeliveryError, AgentSkillDeliveryProvider,
+    AdvanceWorkflowRunResult, AgentConfig, AgentExecutor, AgentMcp, AgentOutputContract,
+    AgentSkill, AgentSkillDelivery, AgentSkillDeliveryError, AgentSkillDeliveryProvider,
     BindWorkflowNodeSessionResult, CancelWorkflowRunResult, CreateWorkflowRunHandler,
     DeleteWorkflowRunHandler, DeleteWorkflowRunResult, EngineError, ExecutionContext, FileChange,
     GetWorkflowRunHandler, GraphError, ListWorkflowNodeRunsHandler,

--- a/crates/application/src/workflow_run.rs
+++ b/crates/application/src/workflow_run.rs
@@ -8,8 +8,8 @@ mod ports;
 mod tests;
 
 pub use engine::{
-    AdvanceWorkflowRunResult, AgentConfig, AgentExecutor, AgentOutputContract, AgentSkill,
-    AgentSkillDelivery, AgentSkillDeliveryError, AgentSkillDeliveryProvider,
+    AdvanceWorkflowRunResult, AgentConfig, AgentExecutor, AgentMcp, AgentOutputContract,
+    AgentSkill, AgentSkillDelivery, AgentSkillDeliveryError, AgentSkillDeliveryProvider,
     BindWorkflowNodeSessionResult, CancelWorkflowRunResult, EngineError, ExecutionContext,
     FileChange, GraphError, MaterializedSkillBinding, NodeExecutor, NodeRunToStart, NodeType,
     RestartWorkflowRunResult, SkillDiscoveryRoots, SkillMaterializationReceipt,

--- a/crates/application/src/workflow_run/engine.rs
+++ b/crates/application/src/workflow_run/engine.rs
@@ -6,6 +6,7 @@
 
 // The design places the run engine in `engine/engine.rs`, so the nested module name matches the
 // containing directory on purpose.
+mod agent_config;
 mod branch_projection;
 mod condition;
 #[allow(clippy::module_inception)]
@@ -20,6 +21,7 @@ mod variable_pool;
 mod variable_template;
 mod variable_value;
 
+pub use agent_config::AgentMcp;
 pub use engine::{
     EngineError, NodeExecutor, WorkflowRunCallback, WorkflowRunEngine, WorkflowValidationError,
 };

--- a/crates/application/src/workflow_run/engine/README.md
+++ b/crates/application/src/workflow_run/engine/README.md
@@ -36,7 +36,7 @@ real Ora session.
 
 Exported from `workflow_run::engine`: `WorkflowRunEngine`, `WorkflowRunControlHandler`,
 `NodeExecutor`, `WorkflowRunCallback`, `WorkflowRunEngineRepository`, `WorkflowGraph`,
-`WorkflowGraphNode`, `AgentConfig`, `AgentExecutor`, `AgentSkill`, `NodeType`, `GraphError`,
+`WorkflowGraphNode`, `AgentConfig`, `AgentExecutor`, `AgentSkill`, `AgentMcp`, `NodeType`, `GraphError`,
 `UnknownNodeType`, `AgentSkillDeliveryProvider`, `SkillMaterializationReceipt`,
 `WorkflowRunPayload`, and the repository outcome enums including
 `BindWorkflowNodeSessionResult`.
@@ -72,3 +72,5 @@ test-only stub.
 `InvalidNode`, `UnknownNodeType`, `DanglingEdge`, `CycleDetected`, `MultipleStartNodes`, and
 `DuplicateNodeId`. An empty graph is legal; unsupported-but-known node types fail later at
 workflow start rather than at parse.
+
+Agent MCP bindings are parsed and validated by `agent_config`; absent bindings default to an empty node allowlist. Runtime availability remains a Session setup responsibility.

--- a/crates/application/src/workflow_run/engine/agent_config.rs
+++ b/crates/application/src/workflow_run/engine/agent_config.rs
@@ -1,0 +1,154 @@
+//! Agent execution contracts retain author intent independently of installed catalogs.
+
+use serde::{Deserialize, Deserializer, de::Error};
+use std::collections::HashSet;
+
+/// Whether an agent adds a structured variable beside its stable scalar `{node}.output`.
+///
+/// `Text` and `StructuredTextExposure` remain only to read snapshots written by the previous
+/// contract shape; current graphs use `None` for text-only output and `Structured` for both.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentOutputContract {
+    /// The node exposes only its stable `{node}.output` variable.
+    None,
+    /// Legacy spelling for a text-only node; its value is exposed as `{node}.output`.
+    Text,
+    /// The node exposes raw text as `{node}.output` and a validated object as
+    /// `{node}.structured_output`.
+    Structured {
+        schema: serde_json::Value,
+        text_exposure: StructuredTextExposure,
+    },
+}
+
+/// Legacy structured-output text setting retained only for snapshot decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StructuredTextExposure {
+    /// Only `{node}.structured_output` is written; the raw text is withheld.
+    StructuredOnly,
+    /// Both `{node}.structured_output` and `{node}.text` are written.
+    IncludeFinalText,
+}
+
+/// The executable contract of an `agent` node.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentConfig {
+    pub executor: AgentExecutor,
+    pub role_id: Option<String>,
+    pub skills: Vec<AgentSkill>,
+    pub mcps: Vec<AgentMcp>,
+    pub prompt: String,
+    /// When true the node is a persistent interactive session: its first turn pauses at
+    /// `Pending` (awaiting input) instead of completing, and the user drives completion.
+    pub interactive: bool,
+    /// Optional structured parsing performed in addition to persisting the raw output.
+    pub output_contract: Option<AgentOutputContract>,
+}
+
+/// The agent CLI and model an `agent` node must run with.
+///
+/// `agent_cli` stays a string here; validating it as an agent identity and checking
+/// runtime availability happens in the session driver (phase 4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentExecutor {
+    pub agent_cli: String,
+    pub model_id: String,
+}
+
+/// One skill an agent node declares; only `enabled` skills are materialized at start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentSkill {
+    pub skill_id: String,
+    pub enabled: bool,
+}
+
+/// One node-local MCP binding; disabled bindings remain portable with the workflow.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentMcp {
+    pub mcp_id: String,
+    pub enabled: bool,
+}
+
+/// Rejects ambiguous bindings before a frozen graph can reach the session runtime.
+pub(super) fn deserialize_bindings<'de, D>(deserializer: D) -> Result<Vec<AgentMcp>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let bindings = Vec::<AgentMcp>::deserialize(deserializer)?;
+    let mut ids = HashSet::new();
+    for binding in &bindings {
+        if binding.mcp_id.trim().is_empty() || !ids.insert(&binding.mcp_id) {
+            return Err(D::Error::custom(
+                "MCP bindings require nonempty, unique IDs",
+            ));
+        }
+    }
+    Ok(bindings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AgentMcp;
+    use crate::WorkflowGraph;
+    use pretty_assertions::assert_eq;
+    use serde_json::{Value, json};
+
+    /// Parses the same wire envelope that publish and import/export persist.
+    fn parse_config(config: Value) -> Result<WorkflowGraph, crate::GraphError> {
+        WorkflowGraph::parse(&json!({"nodes": [{"id": "agent", "data": {"kind": "agent", "agentConfig": config}}], "edges": []}).to_string())
+    }
+
+    /// Both enabled and disabled bindings survive parsing; legacy drafts default to no MCPs.
+    #[test]
+    fn retains_bindings_and_defaults_legacy_graphs_to_empty() {
+        let bindings = json!([{"mcpId": "official/tools", "enabled": true}, {"mcpId": "local/tools", "enabled": false}]);
+        let graph = parse_config(json!({"mcps": bindings})).unwrap();
+        assert_eq!(
+            graph
+                .node("agent")
+                .unwrap()
+                .agent_config
+                .as_ref()
+                .unwrap()
+                .mcps,
+            vec![
+                AgentMcp {
+                    mcp_id: "official/tools".into(),
+                    enabled: true
+                },
+                AgentMcp {
+                    mcp_id: "local/tools".into(),
+                    enabled: false
+                },
+            ]
+        );
+        let legacy = parse_config(json!({})).unwrap();
+        assert_eq!(
+            legacy
+                .node("agent")
+                .unwrap()
+                .agent_config
+                .as_ref()
+                .unwrap()
+                .mcps,
+            Vec::<AgentMcp>::new()
+        );
+    }
+
+    /// Bad author intent is rejected instead of being silently replaced with an empty allowlist.
+    #[test]
+    fn rejects_ambiguous_or_malformed_bindings() {
+        for bindings in [
+            json!(null),
+            json!({}),
+            json!([{"mcpId": " ", "enabled": true}]),
+            json!([{"mcpId": "a", "enabled": true}, {"mcpId": "a", "enabled": false}]),
+            json!([{"mcpId": 12, "enabled": true}]),
+            json!([{"mcpId": "a", "enabled": "true"}]),
+            json!([{"mcpId": "a"}]),
+        ] {
+            assert!(parse_config(json!({"mcps": bindings})).is_err());
+        }
+    }
+}

--- a/crates/application/src/workflow_run/engine/graph.rs
+++ b/crates/application/src/workflow_run/engine/graph.rs
@@ -1,3 +1,7 @@
+pub use super::agent_config::{
+    AgentConfig, AgentExecutor, AgentOutputContract, AgentSkill, StructuredTextExposure,
+};
+use super::agent_config::{AgentMcp, deserialize_bindings};
 use crate::workflow_run::engine::condition::{ConditionConfig, WireConditionCase};
 use crate::workflow_run::engine::node_type::{NodeType, UnknownNodeType};
 use crate::workflow_run::engine::structured_output::validate_structured_output_schema;
@@ -129,33 +133,6 @@ pub struct WorkflowGlobalVariable {
     pub value: Option<serde_json::Value>,
 }
 
-/// Whether an agent adds a structured variable beside its stable scalar `{node}.output`.
-///
-/// `Text` and `StructuredTextExposure` remain only to read snapshots written by the previous
-/// contract shape; current graphs use `None` for text-only output and `Structured` for both.
-#[derive(Debug, Clone, PartialEq)]
-pub enum AgentOutputContract {
-    /// The node exposes only its stable `{node}.output` variable.
-    None,
-    /// Legacy spelling for a text-only node; its value is exposed as `{node}.output`.
-    Text,
-    /// The node exposes raw text as `{node}.output` and a validated object as
-    /// `{node}.structured_output`.
-    Structured {
-        schema: serde_json::Value,
-        text_exposure: StructuredTextExposure,
-    },
-}
-
-/// Legacy structured-output text setting retained only for snapshot decoding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StructuredTextExposure {
-    /// Only `{node}.structured_output` is written; the raw text is withheld.
-    StructuredOnly,
-    /// Both `{node}.structured_output` and `{node}.text` are written.
-    IncludeFinalText,
-}
-
 /// The result bindings of an `output` node, each resolving a variable selector to a named result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputConfig {
@@ -167,37 +144,6 @@ pub struct OutputConfig {
 pub struct OutputBinding {
     pub name: String,
     pub variable_selector: VariableSelector,
-}
-
-/// The executable contract of an `agent` node.
-#[derive(Debug, Clone, PartialEq)]
-pub struct AgentConfig {
-    pub executor: AgentExecutor,
-    pub role_id: Option<String>,
-    pub skills: Vec<AgentSkill>,
-    pub prompt: String,
-    /// When true the node is a persistent interactive session: its first turn pauses at
-    /// `Pending` (awaiting input) instead of completing, and the user drives completion.
-    pub interactive: bool,
-    /// Optional structured parsing performed in addition to persisting the raw output.
-    pub output_contract: Option<AgentOutputContract>,
-}
-
-/// The agent CLI and model an `agent` node must run with.
-///
-/// `agent_cli` stays a string here; validating it as an agent identity and checking
-/// runtime availability happens in the session driver (phase 4).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentExecutor {
-    pub agent_cli: String,
-    pub model_id: String,
-}
-
-/// One skill an agent node declares; only `enabled` skills are materialized at start.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentSkill {
-    pub skill_id: String,
-    pub enabled: bool,
 }
 
 /// Structural failures discovered while deserializing and validating a frozen graph.
@@ -330,6 +276,8 @@ struct WireAgentConfig {
     role_id: Option<String>,
     #[serde(default)]
     skills: Vec<WireAgentSkill>,
+    #[serde(default, deserialize_with = "deserialize_bindings")]
+    mcps: Vec<AgentMcp>,
     #[serde(default)]
     prompt: Option<String>,
     #[serde(default)]
@@ -397,6 +345,7 @@ impl WireAgentConfig {
                     .unwrap_or_default(),
             },
             role_id: self.role_id,
+            mcps: self.mcps,
             skills: self
                 .skills
                 .into_iter()

--- a/crates/application/src/workflow_run/engine/tests.rs
+++ b/crates/application/src/workflow_run/engine/tests.rs
@@ -206,6 +206,7 @@ fn parses_agent_config_into_the_model() {
         instruction: None,
         input_variables: Vec::new(),
         agent_config: Some(AgentConfig {
+            mcps: Vec::new(),
             executor: AgentExecutor {
                 agent_cli: "open_code".to_string(),
                 model_id: "model-1".to_string(),

--- a/crates/backend/src/agent_runtime.rs
+++ b/crates/backend/src/agent_runtime.rs
@@ -43,7 +43,10 @@ use title_acquisition::TitleAcquisition;
 
 use crate::clock::SystemClock;
 use crate::plugin::PluginApi;
-use crate::session_setup::{AgentSessionBarriers, BarrierReason, LiveMcpState, SessionMcpHost};
+use crate::session_setup::{
+    AgentSessionBarriers, BarrierReason, LiveMcpState, SessionMcpHost, SessionMcpSelection,
+    SessionMcpSelectionSource,
+};
 use crate::task::resolve_workspace_cwd;
 use crate::{BackendError, ErrorClassification};
 use agent_client_protocol_schema::v1::AvailableCommand;
@@ -54,7 +57,7 @@ use agent_client_protocol_schema::v1::{
     SessionConfigId, SessionConfigOption, SessionConfigOptionValue,
 };
 use connection::{ConnectionStatus, ConnectionSupervisor, ConnectionSupervisors};
-use ora_application::{Clock, SessionIdGenerator, SessionRepository, UuidSessionIdGenerator};
+use ora_application::{Clock, SessionRepository};
 use ora_contracts::{
     CancelSessionPromptRequest, CancelSessionPromptResponse, DeleteSessionResponse,
     LoadSessionEvent, LoadSessionRequest, PromptSessionEvent, PromptSessionRequest,
@@ -65,8 +68,7 @@ use ora_contracts::{
 use ora_contracts::{EmptyErrorParams, PublicError};
 use ora_db::{RepositoryPool, SqliteSessionRepository};
 use ora_domain::{
-    AgentRef, AuditFields, HistoryState, PluginId, Session, SessionId, SessionStatus, SessionTitle,
-    WorkspaceId,
+    AgentRef, HistoryState, PluginId, Session, SessionId, SessionStatus, SessionTitle, WorkspaceId,
 };
 use ora_history::{binding_needs_handoff, read_session_history};
 use ora_logging::ora_debug;
@@ -157,6 +159,7 @@ pub(crate) struct AgentRuntimeManager {
 }
 
 struct ManagerInner {
+    mcp_selections: Arc<dyn SessionMcpSelectionSource>,
     pool: RepositoryPool,
     actors: RwLock<HashMap<SessionId, RuntimeActorHandle>>,
     /// Workflow sessions stay unpublished here until their durable node-run binding exists.
@@ -282,6 +285,7 @@ enum SessionVisibility {
 
 /// Groups the fixed dependencies the agent runtime is constructed from.
 pub(crate) struct AgentRuntimeSetup {
+    pub mcp_selections: Arc<dyn SessionMcpSelectionSource>,
     /// Owns the processes behind plugin-provided agents and the set of installed packages.
     pub plugin_host: Arc<PluginApi>,
     pub pool: RepositoryPool,
@@ -297,6 +301,7 @@ impl AgentRuntimeManager {
     /// Builds the manager, reconciles stale rows, and immediately starts the shared supervisor.
     pub(crate) fn new(setup: AgentRuntimeSetup) -> Result<Self, BackendError> {
         let AgentRuntimeSetup {
+            mcp_selections,
             plugin_host,
             pool,
             home_directory,
@@ -313,6 +318,7 @@ impl AgentRuntimeManager {
             ConnectionSupervisors::start(plugin_host, pool.clone(), home_directory, clock);
         Ok(Self {
             inner: Arc::new(ManagerInner {
+                mcp_selections,
                 pool,
                 actors: RwLock::new(HashMap::new()),
                 unpublished_workflow_sessions: RwLock::new(HashSet::new()),
@@ -335,114 +341,26 @@ impl AgentRuntimeManager {
         &self,
         request: StartSessionRequest,
     ) -> Result<StartSessionResponse, BackendError> {
-        self.start_session_with_visibility(request, SessionVisibility::Published)
-            .await
+        self.start_session_with_visibility(
+            request,
+            SessionVisibility::Published,
+            self.inner.session_mcp.clone(),
+        )
+        .await
     }
 
     /// Starts a workflow-owned session while keeping it out of ordinary list snapshots.
     pub(crate) async fn start_workflow_node_session(
         &self,
         request: StartSessionRequest,
+        selection: SessionMcpSelection,
     ) -> Result<StartSessionResponse, BackendError> {
-        self.start_session_with_visibility(request, SessionVisibility::UnpublishedWorkflow)
-            .await
-    }
-
-    /// Runs the only path allowed to create and persist a provider session.
-    async fn start_session_with_visibility(
-        &self,
-        request: StartSessionRequest,
-        visibility: SessionVisibility,
-    ) -> Result<StartSessionResponse, BackendError> {
-        let workspace_id = WorkspaceId::new(request.workspace_id);
-        let agent_ref = domain_agent_ref(request.agent_ref)?;
-        let cwd = self.workspace_cwd(&workspace_id)?;
-        let session_id = UuidSessionIdGenerator::new().generate_session_id();
-        let start::PendingProviderSession {
-            release,
-            agent_session_id,
-            list_session_supported,
-            channel,
-            available_commands,
-            config_options,
-            mcp_revision,
-        } = self
-            .create_provider_session(&session_id, &agent_ref, &cwd, request.model.as_deref())
-            .await?;
-        let mut persisted = false;
-        let unpublished = matches!(visibility, SessionVisibility::UnpublishedWorkflow);
-
-        if unpublished {
-            self.unpublished_workflow_sessions_write()?
-                .insert(session_id.clone());
-        }
-        let result = async {
-            let _lifecycle = self.inner.lifecycle.lock().await;
-            let supervisor = self.inner.connections.for_agent(&agent_ref)?;
-            let now = self.inner.clock.now_timestamp_millis();
-            let session = Session::new(
-                session_id.clone(),
-                workspace_id,
-                agent_ref,
-                agent_session_id,
-                SessionStatus::Running,
-                AuditFields::new(now, now, false),
-            );
-            let mut opened = self.open_recorder(&session)?;
-            let outcome = match opened.failure.take() {
-                Some(reason) => RecordOutcome::JustFailed { reason },
-                None => opened.recorder.record_meta(&session, &cwd),
-            };
-            SqliteSessionRepository::new(self.inner.pool.clone())
-                .create_session(session.clone())
-                .map_err(|source| {
-                    BackendError::internal("failed to persist agent CLI session", source)
-                })?;
-            persisted = true;
-            let session = self.settle_record(session, outcome);
-            let title_acquisition = TitleAcquisition::awaiting_first_prompt(list_session_supported);
-            self.insert_actor(
-                session.clone(),
-                ActorSetup {
-                    cwd,
-                    connection: supervisor,
-                    channel: Some(channel),
-                    recorder: opened.recorder,
-                    handoff: HandoffDebt::Settled,
-                    title_acquisition,
-                    live_mcp: LiveMcpState::Active(mcp_revision),
-                    config_options: config_options.clone(),
-                },
-            )?;
-            Ok::<_, BackendError>(StartSessionResponse {
-                session: contract_session(session),
-                available_commands,
-                config_options,
-            })
-        }
-        .await;
-
-        match result {
-            Ok(response) => {
-                release.commit();
-                Ok(response)
-            }
-            Err(error) => {
-                if persisted {
-                    let _ = SqliteSessionRepository::new(self.inner.pool.clone())
-                        .soft_delete_session(&session_id, self.inner.clock.now_timestamp_millis());
-                }
-                let _ = ora_history::remove_session_history(
-                    &self.inner.sessions_root,
-                    session_id.as_ref(),
-                );
-                if unpublished {
-                    self.unpublished_workflow_sessions_write()?
-                        .remove(&session_id);
-                }
-                Err(error)
-            }
-        }
+        self.start_session_with_visibility(
+            request,
+            SessionVisibility::UnpublishedWorkflow,
+            self.inner.session_mcp.with_selection(selection),
+        )
+        .await
     }
 
     /// Wakes every Live Session so it re-reads the current Desired MCP revision.
@@ -626,6 +544,10 @@ impl AgentRuntimeManager {
         request: SwitchSessionAgentRequest,
     ) -> Result<SwitchSessionAgentResponse, BackendError> {
         let session = self.find_session(&request.session_id)?;
+        let session_mcp = self
+            .inner
+            .session_mcp
+            .with_selection(self.inner.mcp_selections.selection_for(&session.id)?);
         let target = domain_agent_ref(request.agent_ref)?;
         if target == session.agent_ref {
             return Err(BackendError::new(
@@ -647,7 +569,13 @@ impl AgentRuntimeManager {
             mcp_revision,
             ..
         } = self
-            .create_provider_session(&session.id, &target, &cwd, request.model.as_deref())
+            .create_provider_session(
+                &session.id,
+                &target,
+                &cwd,
+                request.model.as_deref(),
+                &session_mcp,
+            )
             .await?;
         // Only now is the move certain, so the old binding can be released. Its
         // context is not reusable afterwards: work done on the new agent would be
@@ -663,6 +591,7 @@ impl AgentRuntimeManager {
             self.insert_actor(
                 session.clone(),
                 ActorSetup {
+                    session_mcp,
                     cwd,
                     connection: supervisor,
                     channel: Some(channel),
@@ -952,6 +881,10 @@ impl AgentRuntimeManager {
         }
         let cwd = self.workspace_cwd(&session.workspace_id)?;
         let connection = self.inner.connections.for_agent(&session.agent_ref)?;
+        let session_mcp = self
+            .inner
+            .session_mcp
+            .with_selection(self.inner.mcp_selections.selection_for(&session.id)?);
         let mut opened = self.open_recorder(&session)?;
         let session = match opened.failure.take() {
             Some(reason) => self.settle_record(session, RecordOutcome::JustFailed { reason }),
@@ -965,6 +898,7 @@ impl AgentRuntimeManager {
         self.insert_actor(
             session,
             ActorSetup {
+                session_mcp,
                 cwd,
                 connection,
                 channel: None,
@@ -1023,7 +957,7 @@ impl AgentRuntimeManager {
                 app_events: self.inner.app_events.clone(),
                 title_acquisition: setup.title_acquisition,
                 command_sender: commands.downgrade(),
-                session_mcp: self.inner.session_mcp.clone(),
+                session_mcp: setup.session_mcp,
                 barriers: self.inner.barriers.clone(),
                 live_mcp: setup.live_mcp,
                 #[cfg(test)]
@@ -1058,6 +992,7 @@ impl AgentRuntimeManager {
 
 /// Groups the provider and persistence state needed to start one session actor.
 struct ActorSetup {
+    session_mcp: SessionMcpHost,
     cwd: PathBuf,
     connection: ConnectionSupervisor,
     channel: Option<SessionChannel>,

--- a/crates/backend/src/agent_runtime/actor_mcp.rs
+++ b/crates/backend/src/agent_runtime/actor_mcp.rs
@@ -6,6 +6,7 @@ use super::super::SessionChannel;
 use super::super::events::settle_idle_event;
 use super::super::routing::SessionEvent;
 use super::super::scheduling::{ActiveInput, ActiveInputState};
+use super::super::start::log_session_mcp_request;
 use super::super::support::{
     agent_timed_out, contract_session, map_acp_error, protocol_violation, runtime_unavailable,
     session_event_overflow, session_stopped,
@@ -44,6 +45,7 @@ impl RuntimeActor {
         let desired = crate::session_setup::resolve_session_mcp_revision(
             &self.session_mcp,
             &self.session_mcp,
+            &self.session_mcp.selection,
         )
         .map_err(SessionMcpError::into_backend)?;
         let (state, refresh_now) = self
@@ -83,6 +85,7 @@ impl RuntimeActor {
         let desired = crate::session_setup::resolve_session_mcp_revision(
             &self.session_mcp,
             &self.session_mcp,
+            &self.session_mcp.selection,
         )
         .map_err(SessionMcpError::into_backend)?;
         match self.live_mcp.prompt_admission(&desired) {
@@ -217,6 +220,14 @@ impl RuntimeActor {
         let request =
             AcpLoadSessionRequest::new(AcpSessionId::new(agent_session_id.clone()), &self.cwd)
                 .mcp_servers(snapshot.servers().to_vec());
+        log_session_mcp_request(
+            &self.session.id,
+            &self.session.agent_ref,
+            Some(&agent_session_id),
+            AGENT_METHOD_NAMES.session_load,
+            &self.session_mcp.selection,
+            &snapshot,
+        );
         ora_debug!(session_id = %self.session.id, "session/load MCP refresh sent");
         let pending = match client
             .start_session_request::<_, LoadSessionResponse>(

--- a/crates/backend/src/agent_runtime/attach.rs
+++ b/crates/backend/src/agent_runtime/attach.rs
@@ -9,6 +9,7 @@ use super::handoff::HandoffDebt;
 use super::routing::{SessionChannel, SessionControl, SessionEvent};
 use super::start::{
     PendingProviderSession, ProviderSessionRelease, apply_model_intent, create_provider_session,
+    log_session_mcp_request,
 };
 use super::support::{agent_timed_out, map_acp_error, protocol_violation, session_event_overflow};
 use super::{RuntimeActor, SESSION_SETUP_TIMEOUT};
@@ -128,6 +129,14 @@ impl RuntimeActor {
         let request =
             AcpLoadSessionRequest::new(AcpSessionId::new(agent_session_id.clone()), &self.cwd)
                 .mcp_servers(snapshot.servers().to_vec());
+        log_session_mcp_request(
+            &self.session.id,
+            &self.session.agent_ref,
+            Some(&agent_session_id),
+            AGENT_METHOD_NAMES.session_load,
+            &self.session_mcp.selection,
+            snapshot,
+        );
         ora_debug!(session_id = %self.session.id, "session/load sent");
         let pending = client
             .start_session_request::<_, LoadSessionResponse>(

--- a/crates/backend/src/agent_runtime/load_tests.rs
+++ b/crates/backend/src/agent_runtime/load_tests.rs
@@ -74,6 +74,7 @@ fn test_manager(root: &Path, pool: &RepositoryPool, scheduler: Scheduler) -> Age
         .expect("open plugin host"),
     );
     AgentRuntimeManager::new(AgentRuntimeSetup {
+        mcp_selections: Arc::new(crate::session_setup::SessionMcpSelection::Automatic),
         plugin_host,
         pool: pool.clone(),
         home_directory: root.to_path_buf(),

--- a/crates/backend/src/agent_runtime/plugin_agent/compat.rs
+++ b/crates/backend/src/agent_runtime/plugin_agent/compat.rs
@@ -1,0 +1,32 @@
+use ora_plugin_runtime::PluginRegistration;
+
+/// Legacy method names emitted by agent plugins built with SDK 0.7.
+pub(super) const LEGACY_AGENT_LIST_MODELS_METHOD: &str = "agent/listModels";
+/// Legacy Effect method name emitted by agent plugins built with SDK 0.7.
+pub(super) const LEGACY_EFFECT_VERIFY_READY_METHOD: &str = "effect/verifyReady";
+
+/// Returns whether a plugin declares either the current or legacy spelling of a method.
+pub(super) fn has_compatible_method(
+    registration: &PluginRegistration,
+    current: &str,
+    legacy: &str,
+) -> bool {
+    registration.methods.contains(current) || registration.methods.contains(legacy)
+}
+
+/// Selects the method spelling declared by one plugin, preferring the current protocol.
+pub(super) fn compatible_method(
+    registration: &PluginRegistration,
+    current: &'static str,
+    legacy: &'static str,
+) -> &'static str {
+    if registration.methods.contains(current) {
+        current
+    } else if registration.methods.contains(legacy) {
+        legacy
+    } else {
+        // Contract validation normally prevents this path; keeping the canonical name makes a
+        // later invocation report the precise missing-method error if a caller violates that seam.
+        current
+    }
+}

--- a/crates/backend/src/agent_runtime/replaced_sessions_tests.rs
+++ b/crates/backend/src/agent_runtime/replaced_sessions_tests.rs
@@ -64,6 +64,7 @@ fn test_manager(
         .expect("open plugin host"),
     );
     AgentRuntimeManager::new(AgentRuntimeSetup {
+        mcp_selections: Arc::new(crate::session_setup::SessionMcpSelection::Automatic),
         plugin_host,
         pool: pool.clone(),
         home_directory: root.to_path_buf(),

--- a/crates/backend/src/agent_runtime/start.rs
+++ b/crates/backend/src/agent_runtime/start.rs
@@ -1,13 +1,17 @@
 //! Creates provider sessions only when a caller is ready to persist and use them.
 
 use super::connection::ConnectionSupervisors;
+use super::history::RecordOutcome;
 use super::routing::SessionChannel;
 use super::support::{agent_timed_out, map_acp_error};
+use super::support::{contract_session, domain_agent_ref};
+use super::{ActorSetup, HandoffDebt, SessionVisibility, TitleAcquisition};
 use super::{AgentRuntimeManager, SESSION_SETUP_TIMEOUT, collect_setup_commands};
 use crate::BackendError;
 use crate::session_setup::{
     AgentSessionMcpCapabilities, SessionMcpHost, SessionMcpRevision, SessionSetup,
 };
+use crate::session_setup::{LiveMcpState, SessionMcpSelection};
 use agent_client_protocol_schema::v1::{
     AGENT_METHOD_NAMES, AvailableCommand, CloseSessionRequest, CloseSessionResponse,
     DeleteSessionRequest, DeleteSessionResponse, NewSessionRequest, NewSessionResponse,
@@ -15,8 +19,12 @@ use agent_client_protocol_schema::v1::{
     SessionConfigOptionValue, SessionConfigSelectOptions, SetSessionConfigOptionRequest,
     SetSessionConfigOptionResponse,
 };
+use ora_application::{Clock, SessionIdGenerator, SessionRepository, UuidSessionIdGenerator};
+use ora_contracts::{StartSessionRequest, StartSessionResponse};
+use ora_db::SqliteSessionRepository;
 use ora_domain::{AgentRef, SessionId};
-use ora_logging::{ora_debug, ora_warn};
+use ora_domain::{AuditFields, Session, SessionStatus, WorkspaceId};
+use ora_logging::{ora_debug, ora_info, ora_warn};
 use std::path::Path;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -78,6 +86,111 @@ impl Drop for ProviderSessionRelease {
 }
 
 impl AgentRuntimeManager {
+    /// Runs the only path allowed to create and persist a provider session.
+    pub(super) async fn start_session_with_visibility(
+        &self,
+        request: StartSessionRequest,
+        visibility: SessionVisibility,
+        session_mcp: SessionMcpHost,
+    ) -> Result<StartSessionResponse, BackendError> {
+        let workspace_id = WorkspaceId::new(request.workspace_id);
+        let agent_ref = domain_agent_ref(request.agent_ref)?;
+        let cwd = self.workspace_cwd(&workspace_id)?;
+        let session_id = UuidSessionIdGenerator::new().generate_session_id();
+        let PendingProviderSession {
+            release,
+            agent_session_id,
+            list_session_supported,
+            channel,
+            available_commands,
+            config_options,
+            mcp_revision,
+        } = self
+            .create_provider_session(
+                &session_id,
+                &agent_ref,
+                &cwd,
+                request.model.as_deref(),
+                &session_mcp,
+            )
+            .await?;
+        let mut persisted = false;
+        let unpublished = matches!(visibility, SessionVisibility::UnpublishedWorkflow);
+
+        if unpublished {
+            self.unpublished_workflow_sessions_write()?
+                .insert(session_id.clone());
+        }
+        let result = async {
+            let _lifecycle = self.inner.lifecycle.lock().await;
+            let supervisor = self.inner.connections.for_agent(&agent_ref)?;
+            let now = self.inner.clock.now_timestamp_millis();
+            let session = Session::new(
+                session_id.clone(),
+                workspace_id,
+                agent_ref,
+                agent_session_id,
+                SessionStatus::Running,
+                AuditFields::new(now, now, false),
+            );
+            let mut opened = self.open_recorder(&session)?;
+            let outcome = match opened.failure.take() {
+                Some(reason) => RecordOutcome::JustFailed { reason },
+                None => opened.recorder.record_meta(&session, &cwd),
+            };
+            SqliteSessionRepository::new(self.inner.pool.clone())
+                .create_session(session.clone())
+                .map_err(|source| {
+                    BackendError::internal("failed to persist agent CLI session", source)
+                })?;
+            persisted = true;
+            let session = self.settle_record(session, outcome);
+            let title_acquisition = TitleAcquisition::awaiting_first_prompt(list_session_supported);
+            self.insert_actor(
+                session.clone(),
+                ActorSetup {
+                    session_mcp,
+                    cwd,
+                    connection: supervisor,
+                    channel: Some(channel),
+                    recorder: opened.recorder,
+                    handoff: HandoffDebt::Settled,
+                    title_acquisition,
+                    live_mcp: LiveMcpState::Active(mcp_revision),
+                    config_options: config_options.clone(),
+                },
+            )?;
+            Ok::<_, BackendError>(StartSessionResponse {
+                session: contract_session(session),
+                available_commands,
+                config_options,
+            })
+        }
+        .await;
+
+        match result {
+            Ok(response) => {
+                release.commit();
+                Ok(response)
+            }
+            Err(error) => {
+                if persisted {
+                    let _ = SqliteSessionRepository::new(self.inner.pool.clone())
+                        .soft_delete_session(&session_id, self.inner.clock.now_timestamp_millis());
+                }
+                let _ = ora_history::remove_session_history(
+                    &self.inner.sessions_root,
+                    session_id.as_ref(),
+                );
+                if unpublished {
+                    self.unpublished_workflow_sessions_write()?
+                        .remove(&session_id);
+                }
+                Err(error)
+            }
+        }
+    }
+
     /// Creates a provider session and keeps it unpublished until the caller persists ownership.
     pub(super) async fn create_provider_session(
         &self,
@@ -85,10 +198,11 @@ impl AgentRuntimeManager {
         agent_ref: &AgentRef,
         cwd: &Path,
         model: Option<&str>,
+        session_mcp: &SessionMcpHost,
     ) -> Result<PendingProviderSession, BackendError> {
         create_provider_session(
             &self.inner.connections,
-            &self.inner.session_mcp,
+            session_mcp,
             ora_session_id,
             agent_ref,
             cwd,
@@ -118,6 +232,14 @@ pub(super) async fn create_provider_session(
         ),
     )
     .map_err(crate::session_setup::SessionMcpError::into_backend)?;
+    log_session_mcp_request(
+        ora_session_id,
+        agent_ref,
+        None,
+        AGENT_METHOD_NAMES.session_new,
+        &session_mcp.selection,
+        &setup.mcp,
+    );
     let mcp_revision = setup.mcp.revision().clone();
     let _setup_registration = supervisor.begin_session_setup();
     let response = timeout(
@@ -169,6 +291,58 @@ pub(super) async fn create_provider_session(
         config_options,
         mcp_revision,
     })
+}
+
+/// One selected MCP member rendered for logs without executable configuration or credentials.
+struct SessionMcpLogMember {
+    plugin_id: String,
+    package_version: String,
+    configuration_revision: u64,
+    transport: &'static str,
+}
+
+impl std::fmt::Debug for SessionMcpLogMember {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SessionMcpLogMember")
+            .field("plugin_id", &self.plugin_id)
+            .field("package_version", &self.package_version)
+            .field("configuration_revision", &self.configuration_revision)
+            .field("transport", &self.transport)
+            .finish()
+    }
+}
+
+/// Logs the exact secret-free MCP identity sent at an ACP session boundary.
+pub(super) fn log_session_mcp_request(
+    ora_session_id: &SessionId,
+    agent_ref: &AgentRef,
+    agent_session_id: Option<&str>,
+    acp_method: &str,
+    selection: &SessionMcpSelection,
+    snapshot: &crate::session_setup::SessionMcpSnapshot,
+) {
+    let members = snapshot
+        .revision()
+        .members()
+        .iter()
+        .map(|member| SessionMcpLogMember {
+            plugin_id: member.plugin_id.canonical(),
+            package_version: member.package_version.to_string(),
+            configuration_revision: member.configuration_revision,
+            transport: member.transport.as_str(),
+        })
+        .collect::<Vec<_>>();
+    ora_info!(
+        session_id = %ora_session_id,
+        agent = %agent_ref,
+        agent_session_id,
+        acp_method,
+        mcp_selection = selection.mode(),
+        mcp_server_count = snapshot.servers().len(),
+        mcp_members = ?members,
+        "sending ACP session configuration"
+    );
 }
 
 /// Applies a model only when the session authoritatively offers that value.
@@ -299,13 +473,25 @@ async fn release_provider_session(
 
 #[cfg(test)]
 mod tests {
-    use super::model_config_id;
-    use agent_client_protocol_schema::v1::{
-        SessionConfigGroupId, SessionConfigId, SessionConfigKind, SessionConfigOption,
-        SessionConfigOptionCategory, SessionConfigSelect, SessionConfigSelectGroup,
-        SessionConfigSelectOption, SessionConfigSelectOptions, SessionConfigValueId,
+    use super::{log_session_mcp_request, model_config_id};
+    use crate::session_setup::{
+        SessionMcpMemberRevision, SessionMcpRevision, SessionMcpSelection, SessionMcpSnapshot,
+        SessionMcpTransportKind,
     };
+    use agent_client_protocol_schema::v1::{
+        HttpHeader, McpServer, McpServerHttp, SessionConfigGroupId, SessionConfigId,
+        SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelect,
+        SessionConfigSelectGroup, SessionConfigSelectOption, SessionConfigSelectOptions,
+        SessionConfigValueId,
+    };
+    use ora_domain::{AgentRef, PluginId, SessionId};
+    use ora_logging::with_recorded_trace_logging;
     use pretty_assertions::assert_eq;
+    use semver::Version;
+    use std::collections::BTreeSet;
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::layer::{Context, Layer};
 
     fn select_option(value: &str, name: &str) -> SessionConfigSelectOption {
         SessionConfigSelectOption::new(
@@ -417,5 +603,117 @@ mod tests {
         ];
 
         assert_eq!(model_config_id(&options, "retired-model"), None);
+    }
+
+    /// ACP boundary diagnostics identify the selection without serializing server credentials.
+    #[test]
+    fn session_mcp_log_contains_revision_identity_and_omits_secrets() {
+        let plugin_id = PluginId::parse("official/tavily").expect("plugin id");
+        let snapshot = SessionMcpSnapshot::new(
+            vec![McpServer::Http(
+                McpServerHttp::new(plugin_id.canonical(), "https://secret.example.test/mcp")
+                    .headers(vec![HttpHeader::new(
+                        "Authorization",
+                        "Bearer super-secret",
+                    )]),
+            )],
+            SessionMcpRevision::new(vec![SessionMcpMemberRevision {
+                plugin_id: plugin_id.clone(),
+                package_version: Version::new(1, 2, 3),
+                configuration_revision: 7,
+                transport: SessionMcpTransportKind::Http,
+            }]),
+        );
+        let selection = SessionMcpSelection::Explicit(BTreeSet::from([plugin_id.canonical()]));
+        let recorder = EventTextRecorder::default();
+
+        with_recorded_trace_logging(recorder.layer(), || {
+            log_session_mcp_request(
+                &SessionId::new("ora-session"),
+                &AgentRef::parse("official/opencode").expect("agent ref"),
+                Some("provider-session"),
+                "session/new",
+                &selection,
+                &snapshot,
+            );
+        });
+
+        let recorded = recorder.text();
+        assert!(
+            recorded.contains("sending ACP session configuration"),
+            "{recorded}"
+        );
+        assert!(recorded.contains("official/tavily"), "{recorded}");
+        assert!(recorded.contains("1.2.3"), "{recorded}");
+        assert!(recorded.contains("configuration_revision: 7"), "{recorded}");
+        assert!(recorded.contains("explicit"), "{recorded}");
+        assert!(!recorded.contains("super-secret"));
+        assert!(!recorded.contains("secret.example.test"));
+        assert!(!recorded.contains("Authorization"));
+    }
+
+    /// Captures the rendered fields from one test-scoped logging event.
+    #[derive(Clone, Debug, Default)]
+    struct EventTextRecorder {
+        text: Arc<Mutex<String>>,
+    }
+
+    impl EventTextRecorder {
+        /// Builds a subscriber layer sharing this recorder's output.
+        fn layer(&self) -> EventTextLayer {
+            EventTextLayer {
+                text: self.text.clone(),
+            }
+        }
+
+        /// Returns every field rendered by the captured event.
+        fn text(&self) -> String {
+            self.text.lock().expect("recorded event lock").clone()
+        }
+    }
+
+    /// Records field names and values without using the production formatter.
+    #[derive(Clone, Debug)]
+    struct EventTextLayer {
+        text: Arc<Mutex<String>>,
+    }
+
+    impl<S> Layer<S> for EventTextLayer
+    where
+        S: tracing::Subscriber,
+    {
+        /// Appends each event field under the test-scoped TRACE subscriber.
+        fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
+            event.record(&mut EventTextVisitor {
+                text: self.text.clone(),
+            });
+        }
+    }
+
+    /// Renders structured values so the test can assert the complete leak boundary.
+    struct EventTextVisitor {
+        text: Arc<Mutex<String>>,
+    }
+
+    impl Visit for EventTextVisitor {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            let mut text = self.text.lock().expect("recorded event lock");
+            text.push_str(field.name());
+            text.push('=');
+            text.push_str(value);
+            text.push('\n');
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.record_debug(field, &value);
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            let mut text = self.text.lock().expect("recorded event lock");
+            text.push_str(field.name());
+            text.push('=');
+            text.push_str(&format!("{value:?}"));
+            text.push('\n');
+        }
     }
 }

--- a/crates/backend/src/bootstrap.rs
+++ b/crates/backend/src/bootstrap.rs
@@ -150,6 +150,9 @@ impl Backend {
         let relative_path_base = paths.relative_path_base;
         let agent_runtime = Arc::new(
             AgentRuntimeManager::new(AgentRuntimeSetup {
+                mcp_selections: Arc::new(
+                    crate::workflow::run::WorkflowSessionMcpSelectionSource::new(pool.clone()),
+                ),
                 plugin_host: plugin.clone(),
                 pool: pool.clone(),
                 home_directory: paths.home_directory,

--- a/crates/backend/src/plugin/operations/install_tests.rs
+++ b/crates/backend/src/plugin/operations/install_tests.rs
@@ -46,6 +46,7 @@ fn test_plugin_api(root: &Path, pool: &RepositoryPool) -> Plugins {
     );
     let runtime = Arc::new(
         AgentRuntimeManager::new(AgentRuntimeSetup {
+            mcp_selections: Arc::new(crate::session_setup::SessionMcpSelection::Automatic),
             plugin_host: host.clone(),
             pool: pool.clone(),
             home_directory: root.to_path_buf(),

--- a/crates/backend/src/session_setup.rs
+++ b/crates/backend/src/session_setup.rs
@@ -9,9 +9,12 @@ mod mcp;
 pub(crate) use barrier::{AgentSessionBarriers, BarrierGuard, BarrierReason};
 pub(crate) use mcp::{
     AgentSessionMcpCapabilities, LiveMcpEvent, LiveMcpPromptAdmission, LiveMcpState,
-    SessionMcpError, SessionMcpHost, SessionMcpRevision, SessionMcpSnapshot, resolve_session_mcp,
+    SessionMcpError, SessionMcpHost, SessionMcpRevision, SessionMcpSelection,
+    SessionMcpSelectionSource, SessionMcpSnapshot, resolve_session_mcp,
     resolve_session_mcp_revision,
 };
+#[cfg(test)]
+pub(crate) use mcp::{SessionMcpMemberRevision, SessionMcpTransportKind};
 
 use crate::plugin::PluginApi;
 use std::path::Path;
@@ -31,7 +34,7 @@ impl SessionSetup {
         capabilities: AgentSessionMcpCapabilities,
     ) -> Result<Self, SessionMcpError> {
         Ok(Self {
-            mcp: resolve_session_mcp(host, host, cwd, capabilities)?,
+            mcp: resolve_session_mcp(host, host, cwd, capabilities, &host.selection)?,
         })
     }
 }

--- a/crates/backend/src/session_setup/mcp.rs
+++ b/crates/backend/src/session_setup/mcp.rs
@@ -4,7 +4,11 @@ mod error;
 mod host;
 mod live;
 mod resolve;
+mod selection;
+pub(crate) use selection::{SessionMcpSelection, SessionMcpSelectionSource};
 
+#[cfg(test)]
+mod selection_tests;
 #[cfg(test)]
 mod tests;
 

--- a/crates/backend/src/session_setup/mcp/error.rs
+++ b/crates/backend/src/session_setup/mcp/error.rs
@@ -17,6 +17,8 @@ pub(crate) enum SessionMcpErrorCode {
     RevisionChanged,
     ConfigurationUnavailable,
     CatalogUnavailable,
+    SelectedPluginUnavailable,
+    ConfigurationIncomplete,
 }
 
 impl SessionMcpErrorCode {
@@ -32,6 +34,8 @@ impl SessionMcpErrorCode {
             Self::RevisionChanged => "mcp_revision_changed",
             Self::ConfigurationUnavailable => "mcp_configuration_unavailable",
             Self::CatalogUnavailable => "mcp_catalog_unavailable",
+            Self::SelectedPluginUnavailable => "mcp_selected_plugin_unavailable",
+            Self::ConfigurationIncomplete => "mcp_configuration_incomplete",
         }
     }
 }
@@ -85,6 +89,10 @@ pub(crate) enum SessionMcpError {
     ConfigurationUnavailable { plugin_id: PluginId },
     #[error("installed MCP catalog could not be read")]
     CatalogUnavailable,
+    #[error("selected MCP plugin `{plugin_id}` is not installed or is invalid")]
+    SelectedPluginUnavailable { plugin_id: String },
+    #[error("selected MCP plugin `{plugin_id}` configuration is incomplete")]
+    ConfigurationIncomplete { plugin_id: PluginId },
 }
 
 impl SessionMcpError {
@@ -100,19 +108,25 @@ impl SessionMcpError {
             Self::RevisionChanged { .. } => SessionMcpErrorCode::RevisionChanged,
             Self::ConfigurationUnavailable { .. } => SessionMcpErrorCode::ConfigurationUnavailable,
             Self::CatalogUnavailable => SessionMcpErrorCode::CatalogUnavailable,
+            Self::SelectedPluginUnavailable { .. } => {
+                SessionMcpErrorCode::SelectedPluginUnavailable
+            }
+            Self::ConfigurationIncomplete { .. } => SessionMcpErrorCode::ConfigurationIncomplete,
         }
     }
 
-    fn plugin_id(&self) -> Option<&PluginId> {
+    fn plugin_id(&self) -> Option<String> {
         match self {
             Self::LoadCapabilityMissing | Self::CatalogUnavailable => None,
-            Self::HttpCapabilityMissing { plugin_id }
+            Self::SelectedPluginUnavailable { plugin_id } => Some(plugin_id.clone()),
+            Self::ConfigurationIncomplete { plugin_id }
+            | Self::HttpCapabilityMissing { plugin_id }
             | Self::SettingMissing { plugin_id, .. }
             | Self::IllegalRuntimeText { plugin_id, .. }
             | Self::CommandNotInPackage { plugin_id }
             | Self::WorkspaceCwdUnresolved { plugin_id }
-            | Self::ConfigurationUnavailable { plugin_id } => Some(plugin_id),
-            Self::RevisionChanged { plugin_id } => plugin_id.as_ref(),
+            | Self::ConfigurationUnavailable { plugin_id } => Some(plugin_id.canonical()),
+            Self::RevisionChanged { plugin_id } => plugin_id.as_ref().map(PluginId::canonical),
         }
     }
 
@@ -126,7 +140,9 @@ impl SessionMcpError {
             | Self::WorkspaceCwdUnresolved { .. }
             | Self::RevisionChanged { .. }
             | Self::ConfigurationUnavailable { .. }
-            | Self::CatalogUnavailable => None,
+            | Self::CatalogUnavailable
+            | Self::SelectedPluginUnavailable { .. }
+            | Self::ConfigurationIncomplete { .. } => None,
         }
     }
 
@@ -141,7 +157,9 @@ impl SessionMcpError {
             | Self::WorkspaceCwdUnresolved { .. }
             | Self::RevisionChanged { .. }
             | Self::ConfigurationUnavailable { .. }
-            | Self::CatalogUnavailable => None,
+            | Self::CatalogUnavailable
+            | Self::SelectedPluginUnavailable { .. }
+            | Self::ConfigurationIncomplete { .. } => None,
         }
     }
 
@@ -152,7 +170,7 @@ impl SessionMcpError {
         }
         PublicError::SessionMcpSetupFailed(Box::new(SessionMcpSetupFailedParams {
             error_code: self.code().as_str().to_string(),
-            plugin_id: self.plugin_id().map(PluginId::canonical),
+            plugin_id: self.plugin_id(),
             setting_id: self.setting_id().map(str::to_string),
             transport: self.transport().map(|kind| kind.as_str().to_string()),
         }))

--- a/crates/backend/src/session_setup/mcp/host.rs
+++ b/crates/backend/src/session_setup/mcp/host.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::SessionMcpError;
+use super::{SessionMcpError, SessionMcpSelection};
 
 /// One statically valid installed MCP package version.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -59,11 +59,23 @@ pub(crate) trait SessionMcpConfigurationSource {
 #[derive(Clone)]
 pub(crate) struct SessionMcpHost {
     plugin_host: Arc<PluginApi>,
+    pub(crate) selection: SessionMcpSelection,
 }
 
 impl SessionMcpHost {
     pub(crate) fn new(plugin_host: Arc<PluginApi>) -> Self {
-        Self { plugin_host }
+        Self {
+            plugin_host,
+            selection: SessionMcpSelection::Automatic,
+        }
+    }
+
+    /// Creates a session-local view without mutating the shared installed plugin source.
+    pub(crate) fn with_selection(&self, selection: SessionMcpSelection) -> Self {
+        Self {
+            plugin_host: self.plugin_host.clone(),
+            selection,
+        }
     }
 
     /// Translates a Session's persisted agent identity into the plugin that owns its barrier.

--- a/crates/backend/src/session_setup/mcp/resolve.rs
+++ b/crates/backend/src/session_setup/mcp/resolve.rs
@@ -3,7 +3,7 @@
 use super::{
     AgentSessionMcpCapabilities, InstalledMcpCandidate, McpConfigurationEligibility,
     SessionMcpCatalog, SessionMcpConfigurationSource, SessionMcpError, SessionMcpMemberRevision,
-    SessionMcpRevision, SessionMcpSnapshot, SessionMcpTransportKind,
+    SessionMcpRevision, SessionMcpSelection, SessionMcpSnapshot, SessionMcpTransportKind,
 };
 use agent_client_protocol_schema::v1::{
     EnvVariable, HttpHeader, McpServer, McpServerHttp, McpServerStdio,
@@ -22,8 +22,9 @@ const MAX_REVISION_RETRIES: usize = 3;
 pub(crate) fn resolve_session_mcp_revision(
     catalog: &impl SessionMcpCatalog,
     configurations: &impl SessionMcpConfigurationSource,
+    selection: &SessionMcpSelection,
 ) -> Result<SessionMcpRevision, SessionMcpError> {
-    let selected = select_effective_set(catalog, configurations)?;
+    let selected = select_effective_set(catalog, configurations, selection)?;
     Ok(revision_from_selected(&selected))
 }
 
@@ -37,11 +38,12 @@ pub(crate) fn resolve_session_mcp(
     configurations: &impl SessionMcpConfigurationSource,
     cwd: &Path,
     capabilities: AgentSessionMcpCapabilities,
+    selection: &SessionMcpSelection,
 ) -> Result<SessionMcpSnapshot, SessionMcpError> {
     for _ in 0..MAX_REVISION_RETRIES {
-        let selected = select_effective_set(catalog, configurations)?;
+        let selected = select_effective_set(catalog, configurations, selection)?;
         let snapshot = build_snapshot(&selected, cwd, capabilities)?;
-        let current = select_effective_set(catalog, configurations)?;
+        let current = select_effective_set(catalog, configurations, selection)?;
         if identities_match(&selected, &current) {
             return Ok(snapshot);
         }
@@ -59,15 +61,39 @@ struct SelectedMcp {
 fn select_effective_set(
     catalog: &impl SessionMcpCatalog,
     configurations: &impl SessionMcpConfigurationSource,
+    selection: &SessionMcpSelection,
 ) -> Result<Vec<SelectedMcp>, SessionMcpError> {
+    // An explicit empty set must work even when unrelated installed plugins are broken.
+    if matches!(selection, SessionMcpSelection::Explicit(ids) if ids.is_empty()) {
+        return Ok(Vec::new());
+    }
     let mut candidates = catalog
         .installed_mcps()
         .map_err(|_| SessionMcpError::CatalogUnavailable)?;
+    if let SessionMcpSelection::Explicit(ids) = selection {
+        for id in ids {
+            if !candidates
+                .iter()
+                .any(|candidate| candidate.plugin_id.canonical() == *id)
+            {
+                return Err(SessionMcpError::SelectedPluginUnavailable {
+                    plugin_id: id.clone(),
+                });
+            }
+        }
+        candidates.retain(|candidate| ids.contains(&candidate.plugin_id.canonical()));
+    }
     candidates.sort_by_key(|candidate| candidate.plugin_id.canonical());
     let mut selected = Vec::new();
     for candidate in candidates {
         match configurations.eligibility(&candidate)? {
-            McpConfigurationEligibility::Incomplete => {}
+            McpConfigurationEligibility::Incomplete => {
+                if matches!(selection, SessionMcpSelection::Explicit(_)) {
+                    return Err(SessionMcpError::ConfigurationIncomplete {
+                        plugin_id: candidate.plugin_id,
+                    });
+                }
+            }
             McpConfigurationEligibility::NoSettings => selected.push(SelectedMcp {
                 candidate,
                 configuration_revision: 0,

--- a/crates/backend/src/session_setup/mcp/selection.rs
+++ b/crates/backend/src/session_setup/mcp/selection.rs
@@ -1,0 +1,45 @@
+//! A session's selection restricts both MCP delivery and live revision observation.
+
+use std::collections::BTreeSet;
+
+/// Ordinary chats discover eligible plugins; workflows supply a frozen, explicit allowlist.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) enum SessionMcpSelection {
+    #[default]
+    Automatic,
+    Explicit(BTreeSet<String>),
+}
+
+impl SessionMcpSelection {
+    /// Stable diagnostic label that reveals no MCP configuration values.
+    pub(crate) const fn mode(&self) -> &'static str {
+        match self {
+            Self::Automatic => "automatic",
+            Self::Explicit(_) => "explicit",
+        }
+    }
+}
+
+/// Supplies durable session intent without making the runtime depend on its owning use case.
+///
+/// Implementations must return an error for unreadable ownership metadata, rather than widening
+/// an explicit selection to automatic discovery. The shared, nongeneric actor manager stores
+/// this injected policy behind an Arc so replacement runtimes need no workflow implementation.
+pub(crate) trait SessionMcpSelectionSource: Send + Sync {
+    /// Resolves the selection owned by an existing session before attaching or rebinding it.
+    fn selection_for(
+        &self,
+        session_id: &ora_domain::SessionId,
+    ) -> Result<SessionMcpSelection, crate::BackendError>;
+}
+
+#[cfg(test)]
+impl SessionMcpSelectionSource for SessionMcpSelection {
+    /// Keeps runtime-only fixtures independent of external ownership repositories.
+    fn selection_for(
+        &self,
+        _session_id: &ora_domain::SessionId,
+    ) -> Result<SessionMcpSelection, crate::BackendError> {
+        Ok(self.clone())
+    }
+}

--- a/crates/backend/src/session_setup/mcp/selection_tests.rs
+++ b/crates/backend/src/session_setup/mcp/selection_tests.rs
@@ -1,0 +1,193 @@
+//! Explicit workflow policies must restrict delivery, validation, and revision observation alike.
+
+use super::tests::{
+    FakeCatalog, FakeConfigurations, Fixture, candidate, capabilities, plugin, stdio_config,
+};
+use super::{
+    McpConfigurationEligibility, SessionMcpError, SessionMcpRevision, SessionMcpSelection,
+    resolve_session_mcp, resolve_session_mcp_revision,
+};
+use pretty_assertions::assert_eq;
+use semver::Version;
+use std::collections::BTreeMap;
+
+/// Builds canonical allowlists just as frozen workflow bindings do.
+fn explicit(names: &[&str]) -> SessionMcpSelection {
+    SessionMcpSelection::Explicit(names.iter().map(|name| plugin(name).canonical()).collect())
+}
+
+/// An unrelated broken plugin cannot block a workflow, and empty selections need no capabilities.
+#[test]
+fn explicit_selection_filters_before_configuration_and_capability_checks() {
+    let fixture = Fixture::new();
+    let first = candidate(
+        "first",
+        Version::new(1, 0, 0),
+        &fixture.package_root,
+        stdio_config(),
+    );
+    let second = candidate(
+        "second",
+        Version::new(1, 0, 0),
+        &fixture.package_root,
+        stdio_config(),
+    );
+    let catalog = FakeCatalog::new(vec![first.clone(), second]);
+    let configurations = FakeConfigurations {
+        by_id: BTreeMap::from([(
+            first.plugin_id.canonical(),
+            McpConfigurationEligibility::NoSettings,
+        )]),
+    };
+    let empty = resolve_session_mcp(
+        &catalog,
+        &configurations,
+        &fixture.package_root,
+        capabilities(/*load_session*/ false, /*http*/ false),
+        &explicit(&[]),
+    )
+    .unwrap();
+    assert_eq!(
+        (empty.servers(), empty.revision()),
+        (&[][..], &SessionMcpRevision::default())
+    );
+    let selected = resolve_session_mcp(
+        &catalog,
+        &configurations,
+        &fixture.package_root,
+        capabilities(/*load_session*/ true, /*http*/ false),
+        &explicit(&["first"]),
+    )
+    .unwrap();
+    let isolated = resolve_session_mcp(
+        &FakeCatalog::new(vec![first]),
+        &configurations,
+        &fixture.package_root,
+        capabilities(/*load_session*/ true, /*http*/ false),
+        &SessionMcpSelection::Automatic,
+    )
+    .unwrap();
+    assert_eq!(
+        (selected.servers(), selected.revision()),
+        (isolated.servers(), isolated.revision())
+    );
+    assert_eq!(
+        resolve_session_mcp_revision(&catalog, &configurations, &explicit(&["second"])),
+        Err(SessionMcpError::ConfigurationUnavailable {
+            plugin_id: plugin("second")
+        })
+    );
+}
+
+/// Explicit dependencies fail closed while automatic chat discovery still omits incomplete ones.
+#[test]
+fn selected_missing_or_incomplete_plugins_fail_without_a_partial_set() {
+    let fixture = Fixture::new();
+    let catalog = FakeCatalog::new(vec![candidate(
+        "first",
+        Version::new(1, 0, 0),
+        &fixture.package_root,
+        stdio_config(),
+    )]);
+    let configurations = FakeConfigurations {
+        by_id: BTreeMap::from([(
+            plugin("first").canonical(),
+            McpConfigurationEligibility::Incomplete,
+        )]),
+    };
+    for selection in [explicit(&["first"]), explicit(&["missing"])] {
+        let expected = if selection == explicit(&["first"]) {
+            SessionMcpError::ConfigurationIncomplete {
+                plugin_id: plugin("first"),
+            }
+        } else {
+            SessionMcpError::SelectedPluginUnavailable {
+                plugin_id: plugin("missing").canonical(),
+            }
+        };
+        assert_eq!(
+            resolve_session_mcp_revision(&catalog, &configurations, &selection),
+            Err(expected.clone())
+        );
+        assert_eq!(
+            resolve_session_mcp(
+                &catalog,
+                &configurations,
+                &fixture.package_root,
+                capabilities(/*load_session*/ true, /*http*/ true),
+                &selection
+            )
+            .err(),
+            Some(expected)
+        );
+    }
+    assert_eq!(
+        resolve_session_mcp_revision(&catalog, &configurations, &SessionMcpSelection::Automatic),
+        Ok(SessionMcpRevision::default())
+    );
+}
+
+/// Changes outside the allowlist cannot schedule a refresh or prevent a prompt.
+#[test]
+fn unselected_package_changes_do_not_change_the_desired_revision() {
+    let fixture = Fixture::new();
+    let selected = candidate(
+        "first",
+        Version::new(1, 0, 0),
+        &fixture.package_root,
+        stdio_config(),
+    );
+    let catalog = FakeCatalog::new(vec![selected.clone()]);
+    let configurations = FakeConfigurations {
+        by_id: BTreeMap::from([(
+            plugin("first").canonical(),
+            McpConfigurationEligibility::NoSettings,
+        )]),
+    };
+    let before =
+        resolve_session_mcp_revision(&catalog, &configurations, &explicit(&["first"])).unwrap();
+    catalog.then(vec![
+        selected,
+        candidate(
+            "unrelated",
+            Version::new(2, 0, 0),
+            &fixture.package_root,
+            stdio_config(),
+        ),
+    ]);
+    // Consume the previous catalog page before inspecting the updated installation.
+    let _ = resolve_session_mcp_revision(&catalog, &configurations, &explicit(&["first"])).unwrap();
+    assert_eq!(
+        resolve_session_mcp_revision(&catalog, &configurations, &explicit(&["first"])),
+        Ok(before)
+    );
+}
+
+/// Selecting a plugin never bypasses the provider's required session-load capability.
+#[test]
+fn selected_plugins_require_agent_capabilities() {
+    let fixture = Fixture::new();
+    let catalog = FakeCatalog::new(vec![candidate(
+        "first",
+        Version::new(1, 0, 0),
+        &fixture.package_root,
+        stdio_config(),
+    )]);
+    let configurations = FakeConfigurations {
+        by_id: BTreeMap::from([(
+            plugin("first").canonical(),
+            McpConfigurationEligibility::NoSettings,
+        )]),
+    };
+    assert_eq!(
+        resolve_session_mcp(
+            &catalog,
+            &configurations,
+            &fixture.package_root,
+            capabilities(/*load_session*/ false, /*http*/ false),
+            &explicit(&["first"]),
+        )
+        .err(),
+        Some(SessionMcpError::LoadCapabilityMissing)
+    );
+}

--- a/crates/backend/src/session_setup/mcp/tests.rs
+++ b/crates/backend/src/session_setup/mcp/tests.rs
@@ -26,14 +26,14 @@ use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use url::Url;
 
-struct Fixture {
+pub(super) struct Fixture {
     _dir: TempDir,
-    package_root: PathBuf,
+    pub(super) package_root: PathBuf,
     command: PathBuf,
 }
 
 impl Fixture {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         let dir = TempDir::new().expect("tempdir");
         let package_root = dir.path().join("pkg");
         let command = package_root.join("assets").join("server");
@@ -54,18 +54,18 @@ impl Fixture {
 }
 
 #[derive(Clone)]
-struct FakeCatalog {
+pub(super) struct FakeCatalog {
     inner: Arc<Mutex<Vec<Vec<InstalledMcpCandidate>>>>,
 }
 
 impl FakeCatalog {
-    fn new(candidates: Vec<InstalledMcpCandidate>) -> Self {
+    pub(super) fn new(candidates: Vec<InstalledMcpCandidate>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(vec![candidates])),
         }
     }
 
-    fn then(&self, candidates: Vec<InstalledMcpCandidate>) {
+    pub(super) fn then(&self, candidates: Vec<InstalledMcpCandidate>) {
         self.inner.lock().expect("catalog").push(candidates);
     }
 }
@@ -81,8 +81,8 @@ impl SessionMcpCatalog for FakeCatalog {
     }
 }
 
-struct FakeConfigurations {
-    by_id: BTreeMap<String, McpConfigurationEligibility>,
+pub(super) struct FakeConfigurations {
+    pub(super) by_id: BTreeMap<String, McpConfigurationEligibility>,
 }
 
 impl SessionMcpConfigurationSource for FakeConfigurations {
@@ -98,11 +98,11 @@ impl SessionMcpConfigurationSource for FakeConfigurations {
     }
 }
 
-fn plugin(name: &str) -> PluginId {
+pub(super) fn plugin(name: &str) -> PluginId {
     PluginId::new("ora-space", name).expect("plugin id")
 }
 
-fn stdio_config() -> CompiledMcpConfiguration {
+pub(super) fn stdio_config() -> CompiledMcpConfiguration {
     CompiledMcpConfiguration {
         schema_version: 1,
         settings: None,
@@ -135,7 +135,7 @@ fn http_config() -> CompiledMcpConfiguration {
     }
 }
 
-fn candidate(
+pub(super) fn candidate(
     name: &str,
     version: Version,
     package_root: &Path,
@@ -149,7 +149,7 @@ fn candidate(
     }
 }
 
-fn capabilities(load_session: bool, http: bool) -> AgentSessionMcpCapabilities {
+pub(super) fn capabilities(load_session: bool, http: bool) -> AgentSessionMcpCapabilities {
     AgentSessionMcpCapabilities::new(load_session, http)
 }
 
@@ -209,6 +209,7 @@ fn maps_stdio_and_http_in_canonical_plugin_id_order_with_exact_revisions() {
         &configurations,
         &cwd,
         capabilities(/*load_session*/ true, /*http*/ true),
+        &super::SessionMcpSelection::Automatic,
     )
     .expect("snapshot");
 
@@ -284,6 +285,7 @@ fn omits_incomplete_mcp_without_failing_complete_peers() {
         &configurations,
         &fixture.package_root,
         capabilities(/*load_session*/ true, /*http*/ false),
+        &super::SessionMcpSelection::Automatic,
     )
     .expect("snapshot");
     assert_eq!(snapshot.servers().len(), 1);
@@ -317,6 +319,7 @@ fn fails_closed_when_http_capability_is_missing() {
         &configurations,
         &fixture.package_root,
         capabilities(/*load_session*/ true, /*http*/ false),
+        &super::SessionMcpSelection::Automatic,
     )
     .expect_err("http capability");
     assert_eq!(error.code().as_str(), "mcp_http_capability_missing");
@@ -347,6 +350,7 @@ fn fails_before_send_when_load_capability_is_missing_for_a_non_empty_set() {
         &configurations,
         &fixture.package_root,
         capabilities(/*load_session*/ false, /*http*/ false),
+        &super::SessionMcpSelection::Automatic,
     )
     .expect_err("load capability");
     assert!(matches!(error, SessionMcpError::LoadCapabilityMissing));
@@ -363,6 +367,7 @@ fn empty_set_does_not_require_load_capability() {
         &configurations,
         Path::new("/tmp"),
         capabilities(/*load_session*/ false, /*http*/ false),
+        &super::SessionMcpSelection::Automatic,
     )
     .expect("empty snapshot");
     assert!(snapshot.servers().is_empty());
@@ -398,6 +403,7 @@ fn regenerates_when_package_version_changes_during_resolve() {
         &configurations,
         &fixture.package_root,
         capabilities(/*load_session*/ true, /*http*/ false),
+        &super::SessionMcpSelection::Automatic,
     )
     .expect("retry snapshot");
     assert_eq!(
@@ -428,7 +434,12 @@ fn desired_revision_excludes_setting_values() {
         )]),
     };
 
-    let revision = resolve_session_mcp_revision(&catalog, &configurations).expect("revision");
+    let revision = resolve_session_mcp_revision(
+        &catalog,
+        &configurations,
+        &super::SessionMcpSelection::Automatic,
+    )
+    .expect("revision");
     let debug = format!("{revision:?}");
     assert!(!debug.contains("never-in-revision"));
     assert_eq!(revision.members()[0].configuration_revision, 3);
@@ -562,6 +573,7 @@ fn resolver_does_not_create_workspace_files() {
         },
         workspace.path(),
         capabilities(/*load_session*/ true, /*http*/ false),
+        &super::SessionMcpSelection::Automatic,
     )
     .expect("snapshot");
     assert_eq!(snapshot.servers().len(), 1);

--- a/crates/backend/src/workflow/run.rs
+++ b/crates/backend/src/workflow/run.rs
@@ -8,6 +8,8 @@ mod operations;
 mod prerequisites;
 mod prompt;
 mod recovery;
+mod session_mcp;
+pub(crate) use session_mcp::WorkflowSessionMcpSelectionSource;
 #[cfg(test)]
 mod test_fixture;
 mod worktree;

--- a/crates/backend/src/workflow/run/executor.rs
+++ b/crates/backend/src/workflow/run/executor.rs
@@ -246,11 +246,21 @@ async fn drive_agent_node(
     // admission before workflow UI loads can discover the session; failures in the preparation
     // block below stop this session so cancellation cannot leave an unbound actor behind.
     let started = agent_runtime
-        .start_workflow_node_session(StartSessionRequest {
-            workspace_id: context.run.workspace_id.to_string(),
-            agent_ref,
-            model: Some(config.executor.model_id.clone()),
-        })
+        .start_workflow_node_session(
+            StartSessionRequest {
+                workspace_id: context.run.workspace_id.to_string(),
+                agent_ref,
+                model: Some(config.executor.model_id.clone()),
+            },
+            crate::session_setup::SessionMcpSelection::Explicit(
+                config
+                    .mcps
+                    .iter()
+                    .filter(|mcp| mcp.enabled)
+                    .map(|mcp| mcp.mcp_id.clone())
+                    .collect(),
+            ),
+        )
         .await?;
     let session_id = SessionId::new(started.session.id);
 

--- a/crates/backend/src/workflow/run/prompt.rs
+++ b/crates/backend/src/workflow/run/prompt.rs
@@ -551,6 +551,7 @@ mod tests {
             instruction: None,
             input_variables: Vec::new(),
             agent_config: Some(AgentConfig {
+                mcps: Vec::new(),
                 executor: AgentExecutor {
                     agent_cli: "open_code".to_string(),
                     model_id: "m".to_string(),
@@ -643,6 +644,7 @@ mod tests {
             instruction: None,
             input_variables: Vec::new(),
             agent_config: Some(AgentConfig {
+                mcps: Vec::new(),
                 executor: AgentExecutor {
                     agent_cli: "open_code".to_string(),
                     model_id: "m".to_string(),

--- a/crates/backend/src/workflow/run/session_mcp.rs
+++ b/crates/backend/src/workflow/run/session_mcp.rs
@@ -1,0 +1,122 @@
+//! Restores node-local MCP intent from the existing durable workflow/session relationship.
+
+use crate::BackendError;
+use crate::session_setup::{SessionMcpSelection, SessionMcpSelectionSource};
+use ora_application::{WorkflowGraph, WorkflowRunEngineRepository};
+use ora_db::{RepositoryPool, SqliteWorkflowRunEngineRepository};
+use ora_domain::SessionId;
+
+/// Reads node-local intent without introducing workflow dependencies into the generic runtime.
+pub(crate) struct WorkflowSessionMcpSelectionSource {
+    repository: SqliteWorkflowRunEngineRepository,
+}
+
+impl WorkflowSessionMcpSelectionSource {
+    /// Captures the durable repository used when a session actor is recreated or rebound.
+    pub(crate) fn new(pool: RepositoryPool) -> Self {
+        Self {
+            repository: SqliteWorkflowRunEngineRepository::new(pool),
+        }
+    }
+}
+
+impl SessionMcpSelectionSource for WorkflowSessionMcpSelectionSource {
+    /// Uses the frozen run graph, so editing a draft never changes an existing conversation.
+    fn selection_for(&self, session_id: &SessionId) -> Result<SessionMcpSelection, BackendError> {
+        let repository = &self.repository;
+        let node_run = repository
+            .find_node_run_by_session_id(session_id)
+            .map_err(|source| {
+                BackendError::internal("failed to resolve workflow session ownership", source)
+            })?;
+        let Some(node_run) = node_run else {
+            return Ok(SessionMcpSelection::Automatic);
+        };
+        let context = repository
+            .find_execution_context(&node_run.run_id)
+            .map_err(|source| {
+                BackendError::internal("failed to load frozen workflow context", source)
+            })?
+            .ok_or_else(|| {
+                BackendError::internal(
+                    "workflow session has no execution context",
+                    std::io::Error::other("missing workflow context"),
+                )
+            })?;
+        let graph = WorkflowGraph::parse(&context.graph_json)
+            .map_err(|source| BackendError::internal("invalid frozen workflow graph", source))?;
+        let config = graph
+            .node(&node_run.node_id)
+            .and_then(|node| node.agent_config.as_ref())
+            .ok_or_else(|| {
+                BackendError::internal(
+                    "workflow session has no agent configuration",
+                    std::io::Error::other("missing workflow node"),
+                )
+            })?;
+        let ids = config
+            .mcps
+            .iter()
+            .filter(|mcp| mcp.enabled)
+            .map(|mcp| mcp.mcp_id.clone())
+            .collect();
+        Ok(SessionMcpSelection::Explicit(ids))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::run::test_fixture::{
+        AGENT_GRAPH, bind_and_park, bootstrap, run_test, started_run,
+    };
+    use ora_application::WorkflowRepository;
+    use ora_db::SqliteWorkflowRepository;
+    use ora_domain::WorkflowId;
+    use pretty_assertions::assert_eq;
+
+    /// Recreating runtime state uses the bound published snapshot, never the mutable draft.
+    #[test]
+    fn restores_frozen_node_selection_and_keeps_ordinary_sessions_automatic() {
+        run_test(async {
+            let (temp, pool) = bootstrap();
+            let graph = AGENT_GRAPH.replace("\"prompt\":\"do\"", "\"mcps\":[{\"mcpId\":\"official/first\",\"enabled\":true},{\"mcpId\":\"official/second\",\"enabled\":false}],\"prompt\":\"do\"");
+            let (_, nodes) = started_run(&temp, &pool, &graph);
+            let agent = nodes.iter().find(|node| node.node_id == "agent").unwrap();
+            let (session_id, _) = bind_and_park(&pool, agent);
+            let source = WorkflowSessionMcpSelectionSource::new(pool.clone());
+            SqliteWorkflowRepository::new(pool)
+                .update_draft(&WorkflowId::new("workflow-1"), AGENT_GRAPH.to_string(), 60)
+                .unwrap();
+            assert_eq!(
+                source.selection_for(&session_id).unwrap(),
+                SessionMcpSelection::Explicit(["official/first".to_string()].into_iter().collect())
+            );
+            assert_eq!(
+                source.selection_for(&SessionId::new("ordinary")).unwrap(),
+                SessionMcpSelection::Automatic
+            );
+        });
+    }
+
+    /// Disabled legacy or missing IDs remain persisted but cannot widen the restored selection.
+    #[test]
+    fn all_disabled_bindings_restore_an_explicit_empty_selection() {
+        run_test(async {
+            let (temp, pool) = bootstrap();
+            let graph = AGENT_GRAPH.replace(
+                "\"prompt\":\"do\"",
+                "\"mcps\":[{\"mcpId\":\"old-example\",\"enabled\":false}],\"prompt\":\"do\"",
+            );
+            let (_, nodes) = started_run(&temp, &pool, &graph);
+            let agent = nodes.iter().find(|node| node.node_id == "agent").unwrap();
+            let (session_id, _) = bind_and_park(&pool, agent);
+            assert_eq!(
+                WorkflowSessionMcpSelectionSource::new(pool)
+                    .selection_for(&session_id)
+                    .unwrap(),
+                SessionMcpSelection::Explicit(Default::default())
+            );
+        });
+    }
+}

--- a/docs/session-mcp.md
+++ b/docs/session-mcp.md
@@ -1,5 +1,7 @@
 # Session MCP
 
+English | [中文](session-mcp.zh.md)
+
 Ora delivers configured MCP plugins as **Session Runtime Input**, not as Effect Resources and not
 as Workspace files. Every ACP `session/new` and `session/load` — `startSession`, the attach a prompt performs, the
 rebuild that replaces a provider session Ora could not restore, agent switch, workflow start, and
@@ -7,8 +9,12 @@ live refresh — shares one Session Setup snapshot.
 
 ## ACP injection
 
-The Effective MCP Set is every currently installed, statically valid MCP plugin whose
-configuration is complete. Incomplete plugins are omitted without failing the rest of the set.
+Ordinary chats automatically select every currently installed, statically valid MCP plugin whose
+configuration is complete. Incomplete plugins are omitted without failing the rest of that set.
+Workflow Agent nodes instead use their frozen `mcps` bindings as an explicit allowlist: only
+`enabled: true` IDs are delivered, and an empty list delivers no MCP servers. Missing, invalid,
+or incompletely configured selected plugins fail setup; unselected plugins are filtered before
+configuration and capability checks. Old graphs without `mcps` use an empty allowlist.
 Server names are canonical Plugin IDs (`<namespace>/<identifier>`), sorted by that ID. A snapshot
 is all-or-nothing: the runtime never sends a partial `mcpServers` list.
 
@@ -32,16 +38,40 @@ Success advances Active revision; a newer Desired that arrives during load stays
 blocks only that Session, and the next prompt retries instead of using the old configuration.
 Stopped Sessions do not refresh in the background.
 
+A workflow Session retains its node-local selection through creation, restore, provider rebuild,
+and live refresh. After an actor is recreated, its selection comes from the existing node-run
+Session relationship and the run's published snapshot. Missing or invalid associated execution
+metadata fails closed rather than reverting to automatic discovery. Editing a draft cannot change
+an existing run's selection. Plugin package versions and configuration values remain live inputs;
+changes outside the allowlist do not change that Session's Desired revision. The editor switches
+configure later runs; they are not controls for changing a running Session.
+
 MCP refresh, Skill Effect mutation, and Agent replacement share one Agent Session Barrier so new
 prompts wait for a safe point. They do not share Effect state: MCP never becomes an Effect
 Resource, Desired, or readiness signal.
+
+## Diagnostics and agent conformance
+
+Immediately before each ACP `session/new` or `session/load`, Ora emits an INFO event named
+`sending ACP session configuration`. It includes the Ora Session ID, Agent, provider Session ID
+when one exists, ACP method, selection mode, server count, and the selected Plugin IDs with package
+version, configuration revision, and transport. It deliberately excludes commands, arguments,
+environment variables, HTTP URLs, headers, and Setting values.
+
+Agent adapters are expected to treat the supplied `mcpServers` list as the complete set for that
+Session. Ora keeps the shared Agent process model and does not create one OpenCode process per
+Session. OpenCode through version 1.18.30 retains ACP-supplied MCP registrations at process scope,
+so an empty list is delivered correctly but may not remove a server registered by an earlier
+Session in the same OpenCode process. This provider conformance gap is tracked upstream in
+[OpenCode issue #32371](https://github.com/anomalyco/opencode/issues/32371).
 
 ## Security and compatibility
 
 Setting values may exist in the Configuration Store, a short-lived in-memory Snapshot, and the
 ACP frame sent to a trusted Agent. They must not enter Effect, SQLite, Workspace files, logs,
-errors, UI DTOs, revision digests, or Agent environment variables. Errors name Plugin ID, Setting
-ID, transport, and a stable code only.
+errors, UI DTOs, revision digests, or Agent environment variables. Logs may contain only the
+secret-free revision identity described above. Errors name Plugin ID, Setting ID, transport, and a
+stable code only.
 
 Ora does not create, modify, or delete `.mcp.json`, OpenCode JSON/JSONC, ownership sidecars, Git
 exclude files, or any other Workspace path for MCP. Existing user-authored MCP configuration is

--- a/docs/session-mcp.zh.md
+++ b/docs/session-mcp.zh.md
@@ -1,0 +1,39 @@
+# Session MCP
+
+[English](session-mcp.md) | 中文
+
+Ora 将已配置的 MCP 插件作为会话运行时输入交付。它们不属于 Effect Resource，也不通过工作区文件交付。所有 ACP `session/new` 与 `session/load` 路径共用 Session Setup 快照，包括首次启动、发送时恢复、恢复失败后的会话重建、切换 Agent、工作流执行和运行时刷新。
+
+## ACP 注入
+
+普通聊天自动选择当前已安装、静态声明有效且配置完整的 MCP 插件。配置未完成的插件被跳过，不影响其余插件。
+
+工作流 Agent 节点采用冻结的 `mcps` 绑定作为显式白名单，只交付 `enabled: true` 的插件。空列表或缺少 `mcps` 的旧图均表示不使用 MCP。已选插件未安装、声明无效或配置不完整时，整个设置过程失败；未选择的插件在配置读取和能力检查之前就被过滤。
+
+服务名称使用规范插件 ID（`<namespace>/<identifier>`），并按 ID 排序。快照必须整体成功，运行时不会发送部分 `mcpServers` 列表。
+
+Stdio 映射为 ACP `McpServer::Stdio`，并重新检查命令是否为当前插件版本目录内的普通文件。HTTP 映射为 `McpServer::Http`，要求 Agent 声明 HTTP MCP 能力。`{ "context": "workspace" }` 被替换为会话的绝对工作目录，字面量 `"."` 保持不变。环境变量和请求头使用 ACP 名称/值列表。
+
+非空集合要求 Agent 支持 `session/load`，因为运行中变更 MCP 集合只能通过这一消息交付。不支持时，在发送任何设置消息之前失败；恢复失败后的 `session/new` 重建也遵循相同要求。Agent 的自有重放机制或 Ora 注入的历史文本不能代替 MCP 快照。
+
+## 运行时刷新
+
+运行中的会话仅在内存中保存 Desired 与 Active MCP 版本。安装、更新、卸载插件，以及保存、清除、恢复插件设置时，都会发送不包含凭据的唤醒通知。空闲会话立即通过 `session/load` 刷新；正在处理请求的会话在当前轮次结束后刷新。刷新期间阻止新请求进入。成功后推进 Active；刷新中出现更新的 Desired 时保留待处理状态。失败只阻塞当前会话，下次发送时重试，不继续使用过期配置。已停止的会话不在后台刷新。
+
+工作流会话在首次创建、恢复、重建和刷新时均保留节点选择。Actor 重新创建后，通过现有节点运行与会话的关联，读取运行所引用的发布快照。关联的执行数据缺失或无效时直接报错，不回退为自动发现。修改草稿不会影响已有运行的选择。
+
+选中插件的版本和设置仍是实时输入，继续使用现有安全刷新边界。白名单以外的插件变化不会改变当前会话的 Desired 版本。编辑器开关用于配置后续运行，不用于即时修改正在运行的会话。
+
+MCP 刷新、Skill Effect 变更和 Agent 替换共用 Agent Session Barrier，确保新请求等待安全时机。它们不共用 Effect 状态：MCP 不会变成 Effect Resource、Desired 或就绪信号。
+
+## 诊断日志与 Agent 一致性
+
+每次发送 ACP `session/new` 或 `session/load` 前，Ora 都会写入一条名为 `sending ACP session configuration` 的 INFO 日志。日志包含 Ora 会话 ID、Agent、已有时的提供方会话 ID、ACP 方法、选择模式、服务数量，以及所选插件的 ID、包版本、配置修订号和传输类型。命令、参数、环境变量、HTTP URL、请求头和设置值不会写入日志。
+
+Agent 适配器应把传入的 `mcpServers` 列表视为该会话的完整集合。Ora 保留共享 Agent 进程模型，不为每个会话创建独立 OpenCode 进程。OpenCode 截至 1.18.30 仍会在进程范围保留通过 ACP 注入的 MCP 注册，因此 Ora 虽然正确发送空列表，OpenCode 仍可能向当前会话暴露同一进程中较早会话注册的服务。该 provider 一致性缺口由 [OpenCode issue #32371](https://github.com/anomalyco/opencode/issues/32371) 跟踪。
+
+## 安全与兼容
+
+设置值只能存在于配置存储、短暂的内存快照和发送给可信 Agent 的 ACP 消息中。不得进入 Effect、SQLite、工作区文件、日志、错误、UI DTO、版本摘要或 Agent 进程环境变量。日志只能包含上述不含秘密的版本身份信息。工作流只保存插件 ID 和开关。错误仅包含插件 ID、设置 ID、传输类型和稳定错误码。
+
+Ora 不会为 MCP 创建、修改或删除 `.mcp.json`、OpenCode JSON/JSONC、所有权旁文件、Git 排除文件或其他工作区路径。已有用户 MCP 文件保持原样。本实现没有从未发布的文件物化方案迁移的步骤。

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,5 +1,7 @@
 # Workflow
 
+English | [中文](workflow.zh.md)
+
 `ora-application` owns the workflow definition use cases, with persistence in `ora-db` and public contracts in `ora-contracts`. Workflows manage editable agent orchestration graphs with draft-as-workspace semantics and immutable published snapshots.
 
 ## Entities and tables
@@ -34,6 +36,26 @@ Snapshot versions are strings. The draft is identified by the reserved string `"
 ## Graph storage
 
 The `graph` column stores the complete React Flow JSON document. Workflow definition CRUD treats it as an opaque string. The [workflow run engine](../crates/application/src/workflow_run/engine/README.md) parses and validates the frozen snapshot when a run starts.
+
+## Agent-node MCP bindings
+
+The Agent inspector reads installed `kind: "mcp"` plugins, displaying their names, canonical IDs,
+and configuration availability. Authors can add, enable, disable, and remove bindings independently
+for each node. Adding enables the binding. Loading failures offer retry and preserve existing
+bindings; missing plugins remain visible by ID and can still be disabled or removed.
+
+Bindings use `mcps: [{ mcpId, enabled }]` in the graph, where `mcpId` is the full installed plugin
+ID. Draft save, publish, duplicate, and import/export retain these values, including disabled
+bindings. No selection (including old graphs without `mcps`) means no MCP servers for that node.
+Legacy demo IDs are retained without guessing a replacement. Empty IDs, duplicate IDs, and invalid
+field types are rejected when parsing the executable graph.
+
+Execution uses the frozen run's enabled IDs throughout Session creation, restore, rebuild, and
+refresh. Editing a draft affects later runs only. An unavailable enabled dependency fails the node
+with an explicit error; it is never silently skipped. Unselected plugins cannot block the node.
+Ordinary chats keep automatic discovery. Package and configuration updates for selected plugins
+still use the existing safe refresh boundary; no credentials are persisted in the graph. See
+[Session MCP](session-mcp.md) for runtime delivery and refresh behavior.
 
 ## Handlers
 

--- a/docs/workflow.zh.md
+++ b/docs/workflow.zh.md
@@ -1,0 +1,115 @@
+# 工作流
+
+[English](workflow.md) | 中文
+
+`ora-application` 负责工作流定义用例，`ora-db` 负责持久化，`ora-contracts` 定义公共契约。工作流管理可编辑的 Agent 编排图，以草稿作为编辑工作区，以不可变发布快照作为运行版本。
+
+## 实体与数据表
+
+| 领域类型           | 数据表               |
+| ------------------ | -------------------- |
+| `Workflow`         | `workflows`          |
+| `WorkflowSnapshot` | `workflow_snapshots` |
+
+`Workflow` 保存稳定身份、名称、发布快照指针和审计字段；`WorkflowSnapshot` 保存版本化的 React Flow 图。详情、摘要和版本读模型分离，列表响应不包含图数据。列表按创建时间倒序排列。
+
+## 草稿、发布与版本生命周期
+
+创建工作流时原子创建唯一 `draft` 快照。`UpdateDraft` 就地更新草稿图，不生成新快照。
+
+复制工作流时，从源工作流的当前草稿创建新的身份和草稿，不复制发布快照、当前发布指针或已有运行。副本从未发布状态开始。
+
+发布将草稿复制为新的不可变快照，并更新 `workflows.published_snapshot_id`，供后续运行使用。发布快照的 `updated_at` 始终为 `NULL`，包括软删除之后；只有草稿编辑会更新该字段。
+
+- 回滚：把历史快照复制到草稿，不改变发布指针。
+- 激活：切换发布指针，并将该快照同步到草稿。
+- 删除快照：可删除单个发布快照，但不能删除草稿或当前激活版本。
+
+## 标识符与版本号
+
+`WorkflowId` 和 `WorkflowSnapshotId` 使用基于 UUID 的新类型，遵循仓库的 `define_id!` 约定。
+
+版本号是字符串，`draft` 为保留值。发布版本可由用户指定，也可通过注入时钟生成 `v{timestamp_millis}`；同毫秒冲突时追加数字后缀。用户版本不能为空，不能超过 128 字节，必须适合作为单个 URL 路径片段，且不能为 `.` 或 `..`。部分唯一索引约束同一工作流的可见版本，已软删除的版本号可以重用。
+
+## 图存储
+
+`graph` 字段保存完整 React Flow JSON。工作流定义 CRUD 将其视为不透明字符串；[工作流运行引擎](../crates/application/src/workflow_run/engine/README.md)在启动时解析和校验冻结快照。
+
+## Agent 节点 MCP 绑定
+
+节点配置读取已安装的 `kind: "mcp"` 插件，展示名称、完整 ID 和配置可用性。每个节点独立添加、启用、禁用和移除绑定，添加后默认启用。加载失败时提供重试并保留现有配置；插件缺失时仍显示 ID，允许禁用或移除。
+
+图中使用 `mcps: [{ mcpId, enabled }]` 保存绑定，其中 `mcpId` 是完整插件 ID。草稿保存、发布、复制和导入导出均保留绑定，包括已禁用项。空列表或旧图缺少 `mcps` 时表示节点不使用 MCP。旧示例 ID 原样保留，不猜测替代插件。执行图解析会拒绝空 ID、重复 ID 和非法字段类型。
+
+会话创建、恢复、重建和刷新始终使用冻结运行中的已启用 ID。草稿修改只影响后续运行。已启用的依赖不可用时明确报告节点失败，不静默跳过；未选择的插件不阻塞节点。普通聊天仍自动发现可用插件。选中插件的版本和配置更新继续使用现有安全刷新边界，图中不保存凭据。详见 [Session MCP](session-mcp.zh.md)。
+
+## 处理器
+
+处理器采用端口与适配器模式，共用 `WorkflowRepository`、`WorkflowIdGenerator` 和 `Clock`。
+
+| 处理器                    | 用途                   |
+| ------------------------- | ---------------------- |
+| `CreateWorkflowHandler`   | 创建工作流与草稿       |
+| `GetWorkflowHandler`      | 获取完整详情           |
+| `ListWorkflowsHandler`    | 列出摘要               |
+| `UpdateWorkflowHandler`   | 更新名称               |
+| `DeleteWorkflowHandler`   | 软删除工作流与快照     |
+| `UpdateDraftHandler`      | 更新草稿图             |
+| `PublishWorkflowHandler`  | 发布并激活新快照       |
+| `RollbackWorkflowHandler` | 将历史快照复制到草稿   |
+| `ActivateWorkflowHandler` | 激活快照并同步草稿     |
+| `ListVersionsHandler`     | 列出发布版本           |
+| `GetVersionHandler`       | 按版本获取快照         |
+| `DeleteSnapshotHandler`   | 在约束范围内软删除快照 |
+
+工作流定义删除使用普通 CRUD 处理器，不采用项目和任务的独立级联仓库；运行引用的保护规则另见下文。
+
+## 工作流运行
+
+运行通过 `workspace_id` 绑定现有工作区。Agent 节点在选定工作区执行，每个节点创建独立会话，冻结的执行配置决定 Agent、模型、角色、Skill、MCP 和提示词。
+
+Skill 在部署时校验并物化，运行保存包含调用名称和包路径的物化回执。调用名称和落点来自该回执，执行节点不再按名称重新读取可变的全局目录。Skill 交付通过 `AgentSkillDeliveryProvider` 隔离，发现根目录的数量和位置可随 Agent 实现变化，不必改变工作流创建或提示词组装逻辑。
+
+节点完整对话以会话历史为唯一来源。`workflow_node_runs.output` 保存最终助手文本，用于展示、审计及 `agent-1.output` 访问；即使结构化解析或校验失败也保留原文。成功校验的结构化对象才写入 `agent-1.structured_output`。
+
+运行变量池保存在 `workflow_runs.payload`。它包含有类型的 Start 输入和产出数据节点的稳定输出，`variablePool.values` 只保存已赋值变量。Condition 不公开输出变量，其分支选择单独保存在 `conditionDecisions`，能够跨重启恢复。完成节点的变量写入与状态切换在同一 SQLite 事务中提交。
+
+运行的启动指令保存在 `workflow_runs.input`，不会作为普通工作流变量供选择。Start 输入可以在定义中暂不赋值，部署前填写。自定义全局变量必须包含显式点分名称与类型正确的初始值；系统全局变量由运行时拥有。每个节点可使用全局变量与直接前驱变量，Condition 对变量作用域透明，连续 Condition 会传递原始前驱变量。其他间接祖先变量必须通过直接前驱转发。结构化字段路径进入同一变量目录，Condition 和 Output 无需手写自由文本选择器。各终端 Output 独立构建结果对象，结果名只需在同一 Output 内唯一。
+
+变量类型在图解析、编辑器输入和变量写入时检查。`array` 与 `array[any]` 允许异构数组；有类型数组检查每个元素。文件使用工作区相对引用 `{ "kind": "workspace_file", "path": "relative/path" }`，文件数组使用该对象数组。旧路径字符串会被规范化；绝对路径、父目录穿越、空路径和平台保留路径被拒绝。结构化 Agent Schema 递归校验，并在提示词中生成有效示例。Agent 输出的文件字段必须遵循该对象形式。
+
+Start 表单控件与变量类型分离：文本、段落、选择框、数字、复选框、单文件、文件列表和 JSON 分别产出 `string`、`string`、`string`、`number`、`boolean`、`file`、`array[file]`、`object`。展示名称、选项、必填项和文本长度限制随快照冻结，并在部署边界重新校验。旧快照按变量类型推导兼容控件。
+
+### 实体与状态
+
+| 领域类型          | 数据表               |
+| ----------------- | -------------------- |
+| `WorkflowRun`     | `workflow_runs`      |
+| `WorkflowNodeRun` | `workflow_node_runs` |
+
+`WorkflowRun` 固定引用发布版本的 `snapshot_id`，保存运行名称与工作区。`WorkflowNodeRun` 只为实际开始的节点创建记录，未开始状态由前端对比图与记录推导。
+
+运行与节点均使用 `Pending | Running | Succeeded | Failed | Cancelled`。交互节点等待后续输入时持久化为 `Pending`；公共契约将存在等待节点的运行投影为 `AwaitingInput`。终态节点会话只读，后端拒绝新提示词。节点会话可按 ID 读取，但不会出现在普通聊天列表中。
+
+### 创建与快照固定
+
+创建处理器验证指定工作区和快照归属，使用显式 `snapshot_id` 或工作流当前发布版本，并校验角色与 Skill 绑定。运行初始为 `Pending`，`current_nodes` 为空。变量池从冻结图编译，并以启动文本初始化保留的 `{start_id}.input`。未提供启动文本时，使用冻结 Start 指令作为默认值。
+
+部署界面收集运行名称、可编辑的启动指令和 Start 输入。工作区由打开工作流选择器的项目或任务明确提供，后端不推断分支，也不额外创建 worktree。
+
+### 读取、删除与保护
+
+详情返回运行与节点，列表按项目提供摘要。此层只读取节点历史，节点写入和状态机由引擎负责。
+
+删除会拒绝活动运行、等待人工输入且含非终态节点的运行，以及拥有运行中节点会话的运行。尚未启动且没有节点记录的 `Pending` 运行可以直接删除。删除会软删除运行、节点及其会话，绝不删除共享工作区。软删除记录不可重新激活。
+
+活动运行引用的发布快照不能软删除（`SnapshotInUse`），其工作流也不能删除（`ActiveRuns`），确保冻结图始终可读取。
+
+## 职责边界
+
+- 运行 CRUD 负责持久化，`ora-application` 引擎负责调度、节点写入和状态机，后端 `WorkflowRunNodeExecutor` 驱动会话。
+- 变量池使用已有 JSON 字段，不引入新的变量表；MCP 选择使用已有图和会话关联，不增加文件布局或数据库迁移。
+- 执行图验证属于运行引擎，不属于定义 CRUD。
+- Tauri 命令和服务器路由属于传输适配器。
+
+另见[领域模型](domain-models.md)、[应用与契约边界](application-contracts-boundary.md)、[数据库仓库](database-repositories.md)、[运行引擎](../crates/application/src/workflow_run/engine/README.md)和[后端](../crates/backend/README.md)。

--- a/e2e/fake-agent/acp.rs
+++ b/e2e/fake-agent/acp.rs
@@ -164,6 +164,7 @@ impl FakeAcpAgent {
                 },
             );
             record_acp_call(method, &session_id);
+            record_mcp_call(method, &session_id, &request.mcp_servers);
             return success(
                 NewSessionResponse::new(session_id).config_options(config_options(&model)),
             );
@@ -172,6 +173,7 @@ impl FakeAcpAgent {
             let request: LoadSessionRequest = parse_params(method, params)?;
             let session_id = request.session_id.to_string();
             record_acp_call(method, &session_id);
+            record_mcp_call(method, &session_id, &request.mcp_servers);
             if Path::new(LOAD_REFUSAL_MARKER).exists() {
                 return Err(AcpError::unknown_session(&session_id));
             }
@@ -393,4 +395,28 @@ fn success<Response: Serialize>(response: Response) -> Result<AcpCallResult, Acp
         notifications: Vec::new(),
         result,
     })
+}
+
+/// Records only server identities so integration assertions never journal MCP credentials.
+fn record_mcp_call(method: &str, session_id: &str, servers: &[McpServer]) {
+    let names: Vec<_> = servers
+        .iter()
+        .map(|server| match server {
+            McpServer::Stdio(server) => server.name.clone(),
+            McpServer::Http(server) => server.name.clone(),
+            McpServer::Sse(server) => server.name.clone(),
+            _ => panic!("unsupported fixture MCP transport"),
+        })
+        .collect();
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("mcp_calls.jsonl")
+        .expect("MCP journal");
+    writeln!(
+        file,
+        "{}",
+        json!({"method": method, "sessionId": session_id, "servers": names})
+    )
+    .expect("record MCP call");
 }

--- a/e2e/tests/desktop/core/session.rs
+++ b/e2e/tests/desktop/core/session.rs
@@ -2,6 +2,7 @@
 
 mod tests {
     mod lifecycle;
+    mod workflow_mcp;
 
     use crate::setup::DesktopTestSetup;
     use agent_client_protocol_schema::v1::{

--- a/e2e/tests/desktop/core/session/tests/workflow_mcp.rs
+++ b/e2e/tests/desktop/core/session/tests/workflow_mcp.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::setup::DesktopTestSetup;
 use agent_client_protocol_schema::v1::{ContentBlock, TextContent};
-use ora_backend::Backend;
+use ora_backend::{Backend, BackendError};
 use ora_contracts::*;
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
@@ -31,7 +31,14 @@ fn install_mcp(home: &Path, name: &str) -> Result<PathBuf, std::io::Error> {
             "resolver = 1\nidentifier = \"{name}\"\nkind = \"mcp\"\nversion = \"1.0.0\"\ndescription = \"MCP fixture\"\n"
         ),
     )?;
-    fs::write(root.join("assets").join("server"), "fixture")?;
+    let command = root.join("assets").join("server");
+    fs::write(&command, "#!/bin/sh\n")?;
+    // Unix discovery refuses a stdio command without an executable mode bit, and CI runs there.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&command, fs::Permissions::from_mode(0o755))?;
+    }
     fs::write(root.join("assets").join("config.json"), json!({"schemaVersion": 1, "transport": {"type": "stdio", "command": "assets/server", "args": [], "env": {}}}).to_string())?;
     Ok(root)
 }
@@ -158,7 +165,39 @@ fn workflow_mcp_allowlists_survive_restore_rebuild_and_refresh() -> TestResult {
         let updated = first.with_file_name("1.0.1");
         fs::rename(&first, &updated)?;
         backend.plugins().scan(ScanPluginsRequest {}).await?;
-        follow_up(&backend, left).await?;
+        // The scan wakes the live actor into an MCP refresh that holds the session exclusively;
+        // a prompt reaching it mid-refresh is answered with SessionBusy while the parked node
+        // rolls back to Pending. Waiting for the refresh's own journal entry closes the wide
+        // window, and a bounded retry settles the instant where the refresh response and the
+        // queued prompt are ready together inside the actor's select.
+        tokio::time::timeout(Duration::from_secs(15), async {
+            while !mcp_calls(&package_root).is_ok_and(|calls| {
+                calls.iter().any(|call| {
+                    call["method"] == "session/load"
+                        && call["sessionId"] == rebuilt_provider
+                        && call["servers"] == json!(["official/first"])
+                })
+            }) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await?;
+        for attempt in 0..5 {
+            match follow_up(&backend, left).await {
+                Ok(()) => break,
+                Err(error)
+                    if attempt < 4
+                        && error
+                            .downcast_ref::<BackendError>()
+                            .is_some_and(|error| {
+                                matches!(error.public_error(), PublicError::SessionBusy(_))
+                            }) =>
+                {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
         parked_nodes(&backend, &run.id).await?;
         let left_provider = rebuilt_provider;
         assert!(mcp_calls(&package_root)?.iter().any(|call| call["method"] == "session/load" && call["sessionId"] == left_provider && call["servers"] == json!(["official/first"])));

--- a/e2e/tests/desktop/core/session/tests/workflow_mcp.rs
+++ b/e2e/tests/desktop/core/session/tests/workflow_mcp.rs
@@ -1,0 +1,171 @@
+//! Node allowlists must survive actual ACP creation, restore, rebuild, and plugin wakeups.
+
+use super::{
+    agent_ref, current_thread_runtime, drain_prompt, install_fake_opencode_plugin,
+    open_ready_backend, seed_workspace,
+};
+use crate::setup::DesktopTestSetup;
+use agent_client_protocol_schema::v1::{ContentBlock, TextContent};
+use ora_backend::Backend;
+use ora_contracts::*;
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// Installs a declarative stdio MCP; the fake agent records delivery without launching its command.
+fn install_mcp(home: &Path, name: &str) -> Result<PathBuf, std::io::Error> {
+    let root = home
+        .join("plugins")
+        .join("installed")
+        .join("official")
+        .join(name)
+        .join("1.0.0");
+    fs::create_dir_all(root.join("assets"))?;
+    fs::write(
+        root.join("orax.toml"),
+        format!(
+            "resolver = 1\nidentifier = \"{name}\"\nkind = \"mcp\"\nversion = \"1.0.0\"\ndescription = \"MCP fixture\"\n"
+        ),
+    )?;
+    fs::write(root.join("assets").join("server"), "fixture")?;
+    fs::write(root.join("assets").join("config.json"), json!({"schemaVersion": 1, "transport": {"type": "stdio", "command": "assets/server", "args": [], "env": {}}}).to_string())?;
+    Ok(root)
+}
+
+/// Produces two independent nodes, one with a mixed allowlist and one with no MCP bindings.
+fn graph() -> String {
+    let agent = |id, mcps| {
+        json!({"id": id, "data": {"kind": "agent", "agentConfig": {
+            "executor": {"agentCli": "official/ora-space.opencode", "modelId": "anthropic/claude-sonnet-4"},
+            "prompt": "hello", "interactive": true, "mcps": mcps
+        }}})
+    };
+    json!({"nodes": [
+        {"id": "start", "data": {"kind": "start"}},
+        agent("left", json!([{"mcpId": "official/first", "enabled": true}, {"mcpId": "official/second", "enabled": false}])),
+        agent("right", json!([]))
+    ], "edges": [{"source": "start", "target": "left"}, {"source": "start", "target": "right"}]}).to_string()
+}
+
+/// Waits for both first turns to park, reporting node errors instead of hiding setup failures.
+async fn parked_nodes(
+    backend: &Backend,
+    run_id: &str,
+) -> Result<Vec<WorkflowNodeRun>, Box<dyn std::error::Error>> {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let detail = backend.workflow_runs().get(GetWorkflowRunRequest {
+                run_id: run_id.to_string(),
+            })?;
+            if let Some(error) = detail.nodes.iter().find_map(|node| node.error.as_ref()) {
+                return Err(std::io::Error::other(error.clone()).into());
+            }
+            let nodes: Vec<_> = detail
+                .nodes
+                .into_iter()
+                .filter(|node| node.node_type == "agent")
+                .collect();
+            if nodes.len() == 2
+                && nodes.iter().all(|node| {
+                    node.status == WorkflowNodeStatus::Pending && node.session_id.is_some()
+                })
+            {
+                return Ok(nodes);
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await?
+}
+
+/// Reads complete request observations after the corresponding response has been consumed.
+fn mcp_calls(package_root: &Path) -> Result<Vec<Value>, serde_json::Error> {
+    fs::read_to_string(package_root.join("mcp_calls.jsonl"))
+        .unwrap_or_default()
+        .lines()
+        .map(serde_json::from_str)
+        .collect()
+}
+
+/// Sends a human continuation through the workflow-owned session's ordinary prompt boundary.
+async fn follow_up(backend: &Backend, session_id: &str) -> TestResult {
+    drain_prompt(backend.sessions().prompt(PromptSessionRequest {
+        session_id: session_id.to_string(),
+        model: None,
+        record_prompt: None,
+        prompt: vec![ContentBlock::Text(TextContent::new("continue"))],
+    }))
+    .await
+}
+
+/// The frozen choice, including an empty choice, must win over all installed plugins on every path.
+#[test]
+fn workflow_mcp_allowlists_survive_restore_rebuild_and_refresh() -> TestResult {
+    ora_logging::with_trace_logging(|| {
+        current_thread_runtime()?.block_on(async {
+        let setup = DesktopTestSetup::new()?;
+        let home = &setup.backend_paths().home_directory;
+        let package_root = install_fake_opencode_plugin(home)?;
+        let first = install_mcp(home, "first")?;
+        install_mcp(home, "second")?;
+        let backend = open_ready_backend(&setup)?;
+        let workspace_id = seed_workspace(&setup, &backend)?;
+        // Interactive completion snapshots require a committed checkout.
+        for args in [vec!["init"], vec!["-c", "user.name=Test", "-c", "user.email=test@example.test", "commit", "--allow-empty", "-m", "initial"]] {
+            let output = std::process::Command::new("git").args(args).current_dir(setup.root().join("workspace")).output()?;
+            assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+        }
+        let workflow = backend.workflows().create(CreateWorkflowRequest { name: "MCP workflow".into(), graph: Some(graph()) })?;
+        backend.workflows().publish(PublishWorkflowRequest { workflow_id: workflow.workflow.id.clone(), version: Some("v1".into()) })?;
+        let run = backend.workflow_runs().create(CreateWorkflowRunRequest {
+            workspace_id: workspace_id.clone(), workflow_id: workflow.workflow.id.clone(), locale: WorkflowRunLocale::EnUs,
+            snapshot_id: None, kickoff_input: None, name: None,
+        })?.run;
+        backend.workflow_runs().start(StartWorkflowRunRequest { run_id: run.id.clone() })?;
+        let nodes = parked_nodes(&backend, &run.id).await?;
+        let left = nodes.iter().find(|node| node.node_id == "left").and_then(|node| node.session_id.as_ref()).ok_or("left session missing")?;
+        let calls = mcp_calls(&package_root)?;
+        assert_eq!(calls.len(), 2);
+        let left_provider = calls.iter().find(|call| call["servers"] == json!(["official/first"])).ok_or("left MCP selection missing")?["sessionId"].clone();
+        let right_provider = calls.iter().find(|call| call["servers"] == json!([])).ok_or("right MCP selection not empty")?["sessionId"].clone();
+
+        let ordinary = backend.sessions().start(StartSessionRequest { workspace_id, agent_ref: agent_ref(), model: None }).await?;
+        assert_eq!(mcp_calls(&package_root)?.last().ok_or("MCP journal is empty")?["servers"], json!(["official/first", "official/second"]));
+        backend.workflows().update_draft(UpdateDraftRequest { workflow_id: workflow.workflow.id, graph: graph().replace("official/first", "official/second") })?;
+        backend.sessions().stop(StopSessionRequest { session_id: left.clone() }).await?;
+        follow_up(&backend, left).await?;
+        parked_nodes(&backend, &run.id).await?;
+        assert_eq!(mcp_calls(&package_root)?.last().ok_or("MCP journal is empty")?, &json!({"method": "session/load", "sessionId": left_provider, "servers": ["official/first"]}));
+
+        fs::write(package_root.join("refuse_session_load"), "refuse")?;
+        backend.sessions().stop(StopSessionRequest { session_id: left.clone() }).await?;
+        follow_up(&backend, left).await?;
+        parked_nodes(&backend, &run.id).await?;
+        let calls = mcp_calls(&package_root)?;
+        assert_eq!(calls[calls.len()-2]["method"], "session/load");
+        assert_eq!(calls.last().ok_or("MCP journal is empty")?["method"], "session/new");
+        assert_eq!(calls.last().ok_or("MCP journal is empty")?["servers"], json!(["official/first"]));
+        let rebuilt_provider = calls.last().ok_or("MCP journal is empty")?["sessionId"].clone();
+        fs::remove_file(package_root.join("refuse_session_load"))?;
+
+        // An actual selected package revision wakes the live actor, still using its frozen IDs.
+        let manifest = first.join("orax.toml");
+        fs::write(&manifest, fs::read_to_string(&manifest)?.replace("1.0.0", "1.0.1"))?;
+        let updated = first.with_file_name("1.0.1");
+        fs::rename(&first, &updated)?;
+        backend.plugins().scan(ScanPluginsRequest {}).await?;
+        follow_up(&backend, left).await?;
+        parked_nodes(&backend, &run.id).await?;
+        let left_provider = rebuilt_provider;
+        assert!(mcp_calls(&package_root)?.iter().any(|call| call["method"] == "session/load" && call["sessionId"] == left_provider && call["servers"] == json!(["official/first"])));
+        assert!(mcp_calls(&package_root)?.iter().filter(|call| call["sessionId"] == right_provider).all(|call| call["servers"] == json!([])));
+        backend.workflow_runs().cancel(CancelWorkflowRunRequest { run_id: run.id }).await?;
+        backend.sessions().stop(StopSessionRequest { session_id: ordinary.session.id }).await?;
+        Ok(())
+    })
+    })
+}

--- a/packages/app-shell/src/features/workflow-editor/README.md
+++ b/packages/app-shell/src/features/workflow-editor/README.md
@@ -24,7 +24,10 @@ category.
 - `WorkflowEditorList` replaces the project tree in the app sidebar for that mode.
 - Selection and flush-before-switch actions live in `workflow-editor-store`.
 - `useWorkflowLibrary` is also consumed by the workspace create menu to start runs.
-- Agent-node MCP attachments read `MCP_CATALOG` from this feature, not Settings.
+- Agent-node MCP choices derive from `useInstalledPlugins` (`kind: "mcp"`) and share plugin-query
+  invalidation with Settings. Canonical IDs and enabled flags persist in the graph; availability
+  is display metadata. Missing or unavailable bindings stay editable, and discovery failure
+  offers retry without claiming that installed plugins disappeared.
 
 ## Key invariants
 

--- a/packages/app-shell/src/features/workflow-editor/mcp-catalog.ts
+++ b/packages/app-shell/src/features/workflow-editor/mcp-catalog.ts
@@ -1,45 +1,33 @@
-/**
- * Static MCP catalog for workflow Agent node attachments.
- * Authors pick zero or more entries; runtime session wiring stays out of scope.
- */
-export interface McpCatalogEntry {
-  id: string;
-  name: string;
-  description: string;
+import type { InstalledPlugin } from "@ora/contracts";
+import type { WorkflowMcpChoice } from "@ora/workflow-mock";
+
+/** Maps installed identities and secret-free readiness to the authoring catalog. */
+export function workflowMcpChoices(
+  plugins: readonly InstalledPlugin[],
+): WorkflowMcpChoice[] {
+  return plugins
+    .filter((plugin) => plugin.kind === "mcp")
+    .map((plugin) => {
+      const choice = { value: plugin.id, label: plugin.displayName };
+      if (plugin.installationValidity.validity !== "valid") {
+        return { ...choice, unavailableReason: "invalidDeclaration" };
+      }
+      if (plugin.configuration.state === "unavailable") {
+        return { ...choice, unavailableReason: "configurationUnavailable" };
+      }
+      if (
+        plugin.configuration.state === "available" &&
+        plugin.configuration.completeness !== "complete"
+      ) {
+        return { ...choice, unavailableReason: "configurationIncomplete" };
+      }
+      return choice;
+    });
 }
 
-/** Seeded MCP servers available in the workflow designer. */
-export const MCP_CATALOG: readonly McpCatalogEntry[] = [
-  {
-    id: "filesystem",
-    name: "Filesystem",
-    description:
-      "Read and write project files through a sandboxed workspace MCP.",
-  },
-  {
-    id: "github",
-    name: "GitHub",
-    description:
-      "Inspect pull requests, issues, and repository metadata via GitHub MCP.",
-  },
-  {
-    id: "browser",
-    name: "Browser",
-    description: "Navigate pages and capture snapshots for UI verification.",
-  },
-  {
-    id: "postgres",
-    name: "Postgres",
-    description: "Query and inspect PostgreSQL schemas and rows.",
-  },
-  {
-    id: "notion",
-    name: "Notion",
-    description: "Search and update Notion pages used as project knowledge.",
-  },
-  {
-    id: "slack",
-    name: "Slack",
-    description: "Post updates and read channel context from Slack workspaces.",
-  },
-];
+/** Loading failures must not turn persisted bindings into allegedly uninstalled plugins. */
+export interface WorkflowMcpCatalogStatus {
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+}

--- a/packages/app-shell/src/features/workflow-editor/translations.ts
+++ b/packages/app-shell/src/features/workflow-editor/translations.ts
@@ -275,6 +275,14 @@ export const workflowEditorTranslations = {
     "settings.workflow.removeSkill": "移除 {{name}}",
     "settings.workflow.field.mcps": "MCP",
     "settings.workflow.addMcp": "添加 MCP",
+    "settings.workflow.mcp.loading": "正在加载已安装的 MCP…",
+    "settings.workflow.mcp.loadError": "无法加载已安装的 MCP，已有配置已保留。",
+    "settings.workflow.mcp.retry": "重新加载 MCP",
+    "settings.workflow.mcp.installHint": "请先在插件设置中安装 MCP 插件。",
+    "settings.workflow.mcp.missing": "插件未安装或不可用",
+    "settings.workflow.mcp.configurationIncomplete": "插件配置未完成",
+    "settings.workflow.mcp.configurationUnavailable": "无法读取插件配置",
+    "settings.workflow.mcp.invalidDeclaration": "插件声明无效",
     "settings.workflow.searchAvailableMcps": "搜索可添加的 MCP",
     "settings.workflow.noAvailableMcps": "没有可添加的 MCP",
     "settings.workflow.noConfiguredMcps": "暂未配置 MCP（可选）",
@@ -638,6 +646,18 @@ export const workflowEditorTranslations = {
     "settings.workflow.removeSkill": "Remove {{name}}",
     "settings.workflow.field.mcps": "MCP",
     "settings.workflow.addMcp": "Add MCP",
+    "settings.workflow.mcp.loading": "Loading installed MCPs…",
+    "settings.workflow.mcp.loadError":
+      "Could not load installed MCPs. Existing bindings are preserved.",
+    "settings.workflow.mcp.retry": "Reload MCPs",
+    "settings.workflow.mcp.installHint":
+      "Install an MCP plugin in plugin settings first.",
+    "settings.workflow.mcp.missing": "Plugin is not installed or unavailable",
+    "settings.workflow.mcp.configurationIncomplete":
+      "Plugin configuration is incomplete",
+    "settings.workflow.mcp.configurationUnavailable":
+      "Plugin configuration could not be read",
+    "settings.workflow.mcp.invalidDeclaration": "Plugin declaration is invalid",
     "settings.workflow.searchAvailableMcps": "Search available MCPs",
     "settings.workflow.noAvailableMcps": "No available MCPs",
     "settings.workflow.noConfiguredMcps": "No MCPs configured (optional)",

--- a/packages/app-shell/src/features/workflow-editor/workflow-editor.tsx
+++ b/packages/app-shell/src/features/workflow-editor/workflow-editor.tsx
@@ -82,7 +82,8 @@ import { organizeWorkflowNodes } from "./workflow-flow/layout";
 import type { WorkflowCanvasNode } from "./workflow-flow/types";
 import { WorkflowInspector } from "./workflow-inspector";
 import { WorkflowGlobalVariablesDialog } from "./workflow-global-variables-dialog";
-import { MCP_CATALOG } from "./mcp-catalog";
+import { workflowMcpChoices } from "./mcp-catalog";
+import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
 import {
   useWorkflowEditorStore,
   type WorkflowEditorLibraryActions,
@@ -268,6 +269,7 @@ function WorkflowEditorContent({
   const client = useContractsClient();
   const agentsQuery = useAgents();
   const skillsQuery = useSkills();
+  const pluginsQuery = useInstalledPlugins();
   const agentModelsCatalog = useWorkflowAgentModels();
   const { deleteElements, toObject } = useReactFlow<WorkflowCanvasNode, Edge>();
   const locale =
@@ -291,10 +293,7 @@ function WorkflowEditorContent({
       value: skill.name,
       label: skill.name,
     }));
-    const mcps = MCP_CATALOG.map((mcp) => ({
-      value: mcp.id,
-      label: mcp.name,
-    }));
+    const mcps = workflowMcpChoices(pluginsQuery.data ?? []);
     const agentModels = agentModelsCatalog.agentModels;
     const defaultExecutor = agentModels[0];
     return {
@@ -324,6 +323,7 @@ function WorkflowEditorContent({
     capabilitiesOverride,
     locale,
     skillsQuery.data,
+    pluginsQuery.data,
   ]);
   const agentModelsLoading =
     capabilitiesOverride === undefined && agentModelsCatalog.isLoading;
@@ -1916,6 +1916,17 @@ function WorkflowEditorContent({
                 node={selectedNode}
                 capabilities={capabilities}
                 variableCatalog={variableCatalog}
+                mcpCatalog={
+                  capabilitiesOverride === undefined
+                    ? {
+                        isLoading: pluginsQuery.isPending,
+                        isError: pluginsQuery.isError,
+                        onRetry: () => {
+                          void pluginsQuery.refetch();
+                        },
+                      }
+                    : undefined
+                }
                 agentModelsLoading={agentModelsLoading}
                 agentModelsError={agentModelsError}
                 onRetryAgentModels={agentModelsCatalog.refetch}

--- a/packages/app-shell/src/features/workflow-editor/workflow-flow/node-parameter-summary.tsx
+++ b/packages/app-shell/src/features/workflow-editor/workflow-flow/node-parameter-summary.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../workflow-node-chrome";
 import { useAgents } from "../../../state/hooks/use-agents";
 import { useSkills } from "../../../state/hooks/use-skills";
-import { MCP_CATALOG } from "../mcp-catalog";
+import { useInstalledPlugins } from "../../../state/hooks/use-installed-plugins";
 
 interface NodeParameter {
   label: string;
@@ -25,6 +25,7 @@ export function WorkflowNodeParameterSummary({
   const { i18n, t } = useTranslation();
   const agentsQuery = useAgents();
   const skillsQuery = useSkills();
+  const pluginsQuery = useInstalledPlugins();
   // The workflow JSON stores role/skill by name, so name-keyed lookups resolve directly.
   const agentNameById = new Map(
     (agentsQuery.data ?? []).map((agent) => [agent.name, agent.name]),
@@ -32,7 +33,11 @@ export function WorkflowNodeParameterSummary({
   const skillNameById = new Map(
     (skillsQuery.data ?? []).map((skill) => [skill.name, skill.name]),
   );
-  const mcpNameById = new Map(MCP_CATALOG.map((mcp) => [mcp.id, mcp.name]));
+  const mcpNameById = new Map(
+    (pluginsQuery.data ?? [])
+      .filter((plugin) => plugin.kind === "mcp")
+      .map((plugin) => [plugin.id, plugin.displayName]),
+  );
   const locale =
     i18n.resolvedLanguage === "en-US" ? ("en-US" as const) : ("zh-CN" as const);
   const labels = createWorkflowSummaryLabels(locale);

--- a/packages/app-shell/src/features/workflow-editor/workflow-inspector.tsx
+++ b/packages/app-shell/src/features/workflow-editor/workflow-inspector.tsx
@@ -1,3 +1,5 @@
+import { WorkflowMcpFields } from "./workflow-mcp-fields";
+import type { WorkflowMcpCatalogStatus } from "./mcp-catalog";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -61,6 +63,7 @@ import {
 interface WorkflowInspectorProps {
   node: Node<WorkflowNodeData, "workflow"> | null;
   capabilities: WorkflowCapabilities;
+  mcpCatalog?: WorkflowMcpCatalogStatus;
   variableCatalog: WorkflowVariableCatalogEntry[];
   agentModelsLoading?: boolean;
   agentModelsError?: boolean;
@@ -85,6 +88,7 @@ export function WorkflowInspector(props: WorkflowInspectorProps) {
     <WorkflowNodeInspector
       node={props.node}
       capabilities={props.capabilities}
+      mcpCatalog={props.mcpCatalog}
       variableCatalog={props.variableCatalog}
       agentModelsLoading={props.agentModelsLoading ?? false}
       agentModelsError={props.agentModelsError ?? false}
@@ -134,6 +138,7 @@ function WorkflowInspectorEmpty() {
 function WorkflowNodeInspector({
   node,
   capabilities,
+  mcpCatalog,
   variableCatalog,
   agentModelsLoading,
   agentModelsError,
@@ -150,6 +155,7 @@ function WorkflowNodeInspector({
 }: {
   node: Node<WorkflowNodeData, "workflow">;
   capabilities: WorkflowCapabilities;
+  mcpCatalog?: WorkflowMcpCatalogStatus;
   variableCatalog: WorkflowVariableCatalogEntry[];
   agentModelsLoading: boolean;
   agentModelsError: boolean;
@@ -213,6 +219,7 @@ function WorkflowNodeInspector({
                   key={node.id}
                   config={agentConfig}
                   capabilities={capabilities}
+                  mcpCatalog={mcpCatalog}
                   modelsLoading={agentModelsLoading}
                   modelsError={agentModelsError}
                   onRetryModels={onRetryAgentModels}
@@ -394,6 +401,7 @@ function WorkflowNodeInspector({
 function AgentConfigurationFields({
   config: rawConfig,
   capabilities,
+  mcpCatalog,
   modelsLoading,
   modelsError,
   onRetryModels,
@@ -408,6 +416,7 @@ function AgentConfigurationFields({
 }: {
   config: WorkflowAgentConfig;
   capabilities: WorkflowCapabilities;
+  mcpCatalog?: WorkflowMcpCatalogStatus;
   modelsLoading: boolean;
   modelsError: boolean;
   onRetryModels?: () => void;
@@ -424,7 +433,6 @@ function AgentConfigurationFields({
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [rolePickerOpen, setRolePickerOpen] = useState(false);
   const [skillPickerOpen, setSkillPickerOpen] = useState(false);
-  const [mcpPickerOpen, setMcpPickerOpen] = useState(false);
   const [structuredOutputDialogOpen, setStructuredOutputDialogOpen] =
     useState(false);
   // Older drafts may omit `mcps`; normalize before any list access.
@@ -470,11 +478,6 @@ function AgentConfigurationFields({
   const enabledSkillCount = config.skills.filter(
     (skill) => skill.enabled,
   ).length;
-  const configuredMcpIds = new Set(config.mcps.map((mcp) => mcp.mcpId));
-  const availableMcps = (capabilities.mcps ?? []).filter(
-    (mcp) => !configuredMcpIds.has(mcp.value),
-  );
-  const enabledMcpCount = config.mcps.filter((mcp) => mcp.enabled).length;
   const configuredRole = capabilities.roles.find(
     (role) => role.value === config.roleId,
   );
@@ -514,33 +517,6 @@ function AgentConfigurationFields({
     onChange({
       ...config,
       skills: config.skills.filter((skill) => skill.skillId !== skillId),
-    });
-  }
-
-  /** Adds a new MCP in its enabled state, preserving configuration order. */
-  function addMcp(mcpId: string): void {
-    onChange({
-      ...config,
-      mcps: [...config.mcps, { mcpId, enabled: true }],
-    });
-    setMcpPickerOpen(false);
-  }
-
-  /** Updates only the enabled state of a configured MCP. */
-  function setMcpEnabled(mcpId: string, enabled: boolean): void {
-    onChange({
-      ...config,
-      mcps: config.mcps.map((mcp) =>
-        mcp.mcpId === mcpId ? { ...mcp, enabled } : mcp,
-      ),
-    });
-  }
-
-  /** Removes a configured MCP without affecting the remaining selection order. */
-  function removeMcp(mcpId: string): void {
-    onChange({
-      ...config,
-      mcps: config.mcps.filter((mcp) => mcp.mcpId !== mcpId),
     });
   }
 
@@ -927,105 +903,12 @@ function AgentConfigurationFields({
           )}
         </div>
       </fieldset>
-      <fieldset className="min-w-0 space-y-2">
-        <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
-          <legend className="min-w-0 text-[11px] font-medium">
-            {t("settings.workflow.field.mcps")}
-          </legend>
-          <div className="flex shrink-0 items-center gap-1">
-            <span className="whitespace-nowrap text-[10px] text-muted-foreground">
-              {t("settings.workflow.enabledMcpCount", {
-                enabled: enabledMcpCount,
-                total: config.mcps.length,
-              })}
-            </span>
-            <Popover open={mcpPickerOpen} onOpenChange={setMcpPickerOpen}>
-              <PopoverTrigger
-                render={
-                  <Button
-                    id="workflow-add-mcp"
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    disabled={(capabilities.mcps ?? []).length === 0}
-                    aria-label={t("settings.workflow.addMcp")}
-                  />
-                }
-              >
-                <IconPlus />
-              </PopoverTrigger>
-              <PopoverContent align="end" className="w-72 p-0">
-                <Command>
-                  <CommandInput
-                    aria-label={t("settings.workflow.searchAvailableMcps")}
-                    placeholder={t("settings.workflow.searchAvailableMcps")}
-                    className="text-sm"
-                  />
-                  <CommandList className="max-h-60">
-                    <CommandEmpty className="py-6 text-center text-xs">
-                      {t("settings.workflow.noAvailableMcps")}
-                    </CommandEmpty>
-                    <CommandGroup>
-                      {availableMcps.map((mcp) => (
-                        <CommandItem
-                          key={mcp.value}
-                          value={`${mcp.label} ${mcp.value}`}
-                          onSelect={() => addMcp(mcp.value)}
-                        >
-                          {mcp.label}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
-                </Command>
-              </PopoverContent>
-            </Popover>
-          </div>
-        </div>
-        <div className="min-w-0 divide-y overflow-hidden rounded-md border border-border">
-          {config.mcps.map((configuredMcp) => {
-            const mcp = (capabilities.mcps ?? []).find(
-              (candidate) => candidate.value === configuredMcp.mcpId,
-            ) ?? { value: configuredMcp.mcpId, label: configuredMcp.mcpId };
-            return (
-              <div
-                key={configuredMcp.mcpId}
-                className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 px-2.5 py-2"
-              >
-                <span className="min-w-0 truncate text-xs">{mcp.label}</span>
-                <Switch
-                  size="sm"
-                  className="shrink-0 data-checked:bg-blue-600 hover:data-checked:bg-blue-700"
-                  checked={configuredMcp.enabled}
-                  aria-label={t("settings.workflow.toggleMcp", {
-                    name: mcp.label,
-                  })}
-                  onCheckedChange={(enabled) =>
-                    setMcpEnabled(configuredMcp.mcpId, enabled)
-                  }
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="shrink-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                  aria-label={t("settings.workflow.removeMcp", {
-                    name: mcp.label,
-                  })}
-                  onClick={() => removeMcp(configuredMcp.mcpId)}
-                >
-                  <IconTrash />
-                </Button>
-              </div>
-            );
-          })}
-          {config.mcps.length === 0 && (
-            <p className="px-2.5 py-3 text-xs text-muted-foreground">
-              {t("settings.workflow.noConfiguredMcps")}
-            </p>
-          )}
-        </div>
-      </fieldset>
+      <WorkflowMcpFields
+        config={config}
+        choices={capabilities.mcps ?? []}
+        catalog={mcpCatalog}
+        onChange={onChange}
+      />
       <InspectorField
         label={t("settings.workflow.field.interactive")}
         htmlFor="workflow-agent-interactive"

--- a/packages/app-shell/src/features/workflow-editor/workflow-mcp-fields.test.tsx
+++ b/packages/app-shell/src/features/workflow-editor/workflow-mcp-fields.test.tsx
@@ -1,0 +1,218 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { InstalledPlugin } from "@ora/contracts";
+import {
+  createMockWorkflowCapabilities,
+  type WorkflowAgentConfig,
+  type WorkflowMcpChoice,
+} from "@ora/workflow-mock";
+import { appI18n } from "../../i18n/i18n-instance";
+import { AppI18nProvider } from "../../i18n/i18n";
+import {
+  workflowMcpChoices,
+  type WorkflowMcpCatalogStatus,
+} from "./mcp-catalog";
+import { WorkflowMcpFields } from "./workflow-mcp-fields";
+
+/** Creates installed metadata without starting a plugin process. */
+function plugin(
+  id: string,
+  overrides: Partial<
+    Pick<InstalledPlugin, "configuration" | "installationValidity">
+  > = {},
+): InstalledPlugin {
+  return {
+    id,
+    namespace: "official",
+    name: "tools",
+    displayName: "Tools",
+    version: "1.0.0",
+    description: "Project tools",
+    homepage: null,
+    license: null,
+    logo: null,
+    installationValidity: { validity: "valid" },
+    configuration: { state: "not_declared" },
+    runtime: "stopped",
+    kind: "mcp",
+    ...overrides,
+  };
+}
+
+/** Keeps state updates on React's actual interaction boundary and exposes the persisted contract. */
+function Harness({
+  choices,
+  initial = [],
+  catalog,
+}: {
+  choices: WorkflowMcpChoice[];
+  initial?: WorkflowAgentConfig["mcps"];
+  catalog?: WorkflowMcpCatalogStatus;
+}) {
+  const [config, setConfig] = useState({
+    ...createMockWorkflowCapabilities("en-US").defaultAgentConfig,
+    mcps: initial,
+  });
+  return (
+    <AppI18nProvider>
+      <WorkflowMcpFields
+        config={config}
+        choices={choices}
+        catalog={catalog}
+        onChange={setConfig}
+      />
+      <output data-testid="bindings">{JSON.stringify(config.mcps)}</output>
+    </AppI18nProvider>
+  );
+}
+
+describe("workflow MCP catalog", () => {
+  it("uses installed MCP identities and readiness, regardless of process runtime", () => {
+    expect(
+      workflowMcpChoices([
+        plugin("official/tools"),
+        plugin("local/tools", {
+          configuration: { state: "available", completeness: "incomplete" },
+        }),
+        plugin("other/invalid", {
+          installationValidity: {
+            validity: "invalid_declaration",
+            errorCode: "invalid",
+          },
+        }),
+        plugin("other/unreadable", {
+          configuration: { state: "unavailable", errorCode: "read" },
+        }),
+        { ...plugin("official/skill"), kind: "skill" },
+      ]),
+    ).toEqual([
+      { value: "official/tools", label: "Tools" },
+      {
+        value: "local/tools",
+        label: "Tools",
+        unavailableReason: "configurationIncomplete",
+      },
+      {
+        value: "other/invalid",
+        label: "Tools",
+        unavailableReason: "invalidDeclaration",
+      },
+      {
+        value: "other/unreadable",
+        label: "Tools",
+        unavailableReason: "configurationUnavailable",
+      },
+    ]);
+  });
+});
+
+describe("workflow MCP bindings", () => {
+  it("adds same-name plugins by ID, prevents duplicates, toggles, and removes", async () => {
+    await appI18n.changeLanguage("en-US");
+    const user = userEvent.setup();
+    render(
+      <Harness
+        choices={workflowMcpChoices([
+          plugin("official/tools"),
+          plugin("local/tools"),
+        ])}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Add MCP" }));
+    await user.click(
+      await screen.findByRole("option", { name: /Tools official\/tools/ }),
+    );
+    expect(screen.getByTestId("bindings")).toHaveTextContent(
+      '[{"mcpId":"official/tools","enabled":true}]',
+    );
+    await user.click(screen.getByRole("button", { name: "Add MCP" }));
+    expect(
+      screen.queryByRole("option", { name: /Tools official\/tools/ }),
+    ).not.toBeInTheDocument();
+    await user.click(
+      await screen.findByRole("option", { name: /Tools local\/tools/ }),
+    );
+    await user.click(
+      screen.getAllByRole("switch", { name: "Enable or disable Tools" })[0],
+    );
+    expect(
+      JSON.parse(screen.getByTestId("bindings").textContent ?? ""),
+    ).toEqual([
+      { mcpId: "official/tools", enabled: false },
+      { mcpId: "local/tools", enabled: true },
+    ]);
+    await user.click(
+      screen.getAllByRole("button", { name: "Remove Tools" })[0],
+    );
+    expect(
+      JSON.parse(screen.getByTestId("bindings").textContent ?? ""),
+    ).toEqual([{ mcpId: "local/tools", enabled: true }]);
+  });
+
+  it("retains missing bindings and lets authors disable them", async () => {
+    await appI18n.changeLanguage("en-US");
+    const user = userEvent.setup();
+    render(
+      <Harness
+        choices={[]}
+        initial={[{ mcpId: "missing/tools", enabled: true }]}
+      />,
+    );
+    expect(
+      screen.getByText("Plugin is not installed or unavailable"),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("switch", { name: "Enable or disable missing/tools" }),
+    );
+    expect(
+      JSON.parse(screen.getByTestId("bindings").textContent ?? ""),
+    ).toEqual([{ mcpId: "missing/tools", enabled: false }]);
+  });
+
+  it("shows retry instead of claiming a plugin was uninstalled when discovery fails", async () => {
+    await appI18n.changeLanguage("en-US");
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(
+      <Harness
+        choices={[]}
+        initial={[{ mcpId: "official/tools", enabled: true }]}
+        catalog={{ isLoading: false, isError: true, onRetry }}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Existing bindings are preserved",
+    );
+    expect(
+      screen.queryByText("Plugin is not installed or unavailable"),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Reload MCPs" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("allows incomplete plugins to be selected and shows their status", async () => {
+    await appI18n.changeLanguage("en-US");
+    const user = userEvent.setup();
+    render(
+      <Harness
+        choices={workflowMcpChoices([
+          plugin("local/tools", {
+            configuration: { state: "available", completeness: "incomplete" },
+          }),
+        ])}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Add MCP" }));
+    await user.click(
+      await screen.findByRole("option", { name: /Tools local\/tools/ }),
+    );
+    expect(
+      screen.getByText("Plugin configuration is incomplete"),
+    ).toBeInTheDocument();
+    expect(
+      JSON.parse(screen.getByTestId("bindings").textContent ?? ""),
+    ).toEqual([{ mcpId: "local/tools", enabled: true }]);
+  });
+});

--- a/packages/app-shell/src/features/workflow-editor/workflow-mcp-fields.tsx
+++ b/packages/app-shell/src/features/workflow-editor/workflow-mcp-fields.tsx
@@ -1,0 +1,230 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { IconPlus, IconTrash } from "@tabler/icons-react";
+import {
+  Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Switch,
+} from "@ora/ui";
+import type {
+  WorkflowAgentConfig,
+  WorkflowMcpChoice,
+} from "@ora/workflow-mock";
+import type { WorkflowMcpCatalogStatus } from "./mcp-catalog";
+
+/** Edits node-local intent while preserving bindings whose installed plugin is unavailable. */
+export function WorkflowMcpFields({
+  config,
+  choices,
+  catalog,
+  onChange,
+}: {
+  config: WorkflowAgentConfig;
+  choices: WorkflowMcpChoice[];
+  catalog?: WorkflowMcpCatalogStatus;
+  onChange: (config: WorkflowAgentConfig) => void;
+}) {
+  const { t } = useTranslation();
+  const [mcpPickerOpen, setMcpPickerOpen] = useState(false);
+  const configuredMcpIds = new Set(config.mcps.map((mcp) => mcp.mcpId));
+  const availableMcps = choices.filter(
+    (mcp) => !configuredMcpIds.has(mcp.value),
+  );
+  const enabledMcpCount = config.mcps.filter((mcp) => mcp.enabled).length;
+  /** Adds a new MCP in its enabled state, preserving configuration order. */
+  function addMcp(mcpId: string): void {
+    if (config.mcps.some((mcp) => mcp.mcpId === mcpId)) return;
+    onChange({
+      ...config,
+      mcps: [...config.mcps, { mcpId, enabled: true }],
+    });
+    setMcpPickerOpen(false);
+  }
+
+  /** Updates only the enabled state of a configured MCP. */
+  function setMcpEnabled(mcpId: string, enabled: boolean): void {
+    onChange({
+      ...config,
+      mcps: config.mcps.map((mcp) =>
+        mcp.mcpId === mcpId ? { ...mcp, enabled } : mcp,
+      ),
+    });
+  }
+
+  /** Removes a configured MCP without affecting the remaining selection order. */
+  function removeMcp(mcpId: string): void {
+    onChange({
+      ...config,
+      mcps: config.mcps.filter((mcp) => mcp.mcpId !== mcpId),
+    });
+  }
+
+  return (
+    <fieldset className="min-w-0 space-y-2">
+      <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+        <legend className="min-w-0 text-[11px] font-medium">
+          {t("settings.workflow.field.mcps")}
+        </legend>
+        <div className="flex shrink-0 items-center gap-1">
+          <span className="whitespace-nowrap text-[10px] text-muted-foreground">
+            {t("settings.workflow.enabledMcpCount", {
+              enabled: enabledMcpCount,
+              total: config.mcps.length,
+            })}
+          </span>
+          <Popover open={mcpPickerOpen} onOpenChange={setMcpPickerOpen}>
+            <PopoverTrigger
+              render={
+                <Button
+                  id="workflow-add-mcp"
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  disabled={
+                    choices.length === 0 ||
+                    catalog?.isLoading === true ||
+                    catalog?.isError === true
+                  }
+                  aria-label={t("settings.workflow.addMcp")}
+                />
+              }
+            >
+              <IconPlus />
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-72 p-0">
+              <Command>
+                <CommandInput
+                  aria-label={t("settings.workflow.searchAvailableMcps")}
+                  placeholder={t("settings.workflow.searchAvailableMcps")}
+                  className="text-sm"
+                />
+                <CommandList className="max-h-60">
+                  <CommandEmpty className="py-6 text-center text-xs">
+                    {t("settings.workflow.noAvailableMcps")}
+                  </CommandEmpty>
+                  <CommandGroup>
+                    {availableMcps.map((mcp) => (
+                      <CommandItem
+                        key={mcp.value}
+                        aria-label={`${mcp.label} ${mcp.value}`}
+                        value={`${mcp.label} ${mcp.value}`}
+                        onSelect={() => addMcp(mcp.value)}
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate">{mcp.label}</span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {mcp.value}
+                          </span>
+                          {mcp.unavailableReason && (
+                            <span className="block text-xs text-destructive">
+                              {t(
+                                `settings.workflow.mcp.${mcp.unavailableReason}`,
+                              )}
+                            </span>
+                          )}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+      <div className="min-w-0 divide-y overflow-hidden rounded-md border border-border">
+        {catalog?.isLoading && (
+          <p role="status" className="p-2.5 text-xs">
+            {t("settings.workflow.mcp.loading")}
+          </p>
+        )}
+        {catalog?.isError && (
+          <div role="alert" className="p-2.5 text-xs">
+            <p>{t("settings.workflow.mcp.loadError")}</p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={catalog.onRetry}
+            >
+              {t("settings.workflow.mcp.retry")}
+            </Button>
+          </div>
+        )}
+        {!catalog?.isLoading && !catalog?.isError && choices.length === 0 && (
+          <p className="p-2.5 text-xs text-muted-foreground">
+            {t("settings.workflow.mcp.installHint")}
+          </p>
+        )}
+        {config.mcps.map((configuredMcp) => {
+          const installed = choices.find(
+            (candidate) => candidate.value === configuredMcp.mcpId,
+          );
+          const mcp = installed ?? {
+            value: configuredMcp.mcpId,
+            label: configuredMcp.mcpId,
+          };
+          const reason =
+            catalog?.isLoading || catalog?.isError
+              ? undefined
+              : (installed?.unavailableReason ??
+                (installed === undefined ? "missing" : undefined));
+          return (
+            <div
+              key={configuredMcp.mcpId}
+              className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 px-2.5 py-2"
+            >
+              <div className="min-w-0 text-xs">
+                <span className="block truncate">{mcp.label}</span>
+                <span className="block truncate text-muted-foreground">
+                  {mcp.value}
+                </span>
+                {reason && (
+                  <span className="block text-destructive">
+                    {t(`settings.workflow.mcp.${reason}`)}
+                  </span>
+                )}
+              </div>
+              <Switch
+                size="sm"
+                className="shrink-0 data-checked:bg-blue-600 hover:data-checked:bg-blue-700"
+                checked={configuredMcp.enabled}
+                aria-label={t("settings.workflow.toggleMcp", {
+                  name: mcp.label,
+                })}
+                onCheckedChange={(enabled) =>
+                  setMcpEnabled(configuredMcp.mcpId, enabled)
+                }
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                aria-label={t("settings.workflow.removeMcp", {
+                  name: mcp.label,
+                })}
+                onClick={() => removeMcp(configuredMcp.mcpId)}
+              >
+                <IconTrash />
+              </Button>
+            </div>
+          );
+        })}
+        {config.mcps.length === 0 && (
+          <p className="px-2.5 py-3 text-xs text-muted-foreground">
+            {t("settings.workflow.noConfiguredMcps")}
+          </p>
+        )}
+      </div>
+    </fieldset>
+  );
+}

--- a/packages/app-shell/src/features/workflow-run/run-act-agent-config.tsx
+++ b/packages/app-shell/src/features/workflow-run/run-act-agent-config.tsx
@@ -5,6 +5,7 @@ import { IconRobot } from "@tabler/icons-react";
 import { PluginLogoMark } from "../settings/plugin-logo";
 import { useAgentCatalog } from "../../state/hooks/use-agent-catalog";
 import { useAgents } from "../../state/hooks/use-agents";
+import { useInstalledPlugins } from "../../state/hooks/use-installed-plugins";
 import { useSkills } from "../../state/hooks/use-skills";
 import { formatAgentExecutorLabel } from "./agent-config-display";
 import { RunBriefPopover } from "./run-brief-popover";
@@ -25,6 +26,12 @@ export function RunActAgentConfig({ config }: RunActAgentConfigProps) {
   const agentCatalog = useAgentCatalog();
   const agentsQuery = useAgents();
   const skillsQuery = useSkills();
+  const pluginsQuery = useInstalledPlugins();
+  const mcpById = new Map(
+    (pluginsQuery.data ?? [])
+      .filter((plugin) => plugin.kind === "mcp")
+      .map((plugin) => [plugin.id, plugin]),
+  );
   // The workflow JSON stores role/skill by name, so resolve catalog descriptions by name.
   const agentByName = new Map(
     (agentsQuery.data ?? []).map((agent) => [agent.name, agent]),
@@ -149,14 +156,20 @@ export function RunActAgentConfig({ config }: RunActAgentConfigProps) {
             {enabledMcps.map((mcp) => (
               <li key={mcp.mcpId}>
                 <RunBriefPopover
-                  title={mcp.mcpId}
-                  body={t("workflowRun.inspector.catalogNoDescription")}
+                  title={mcpById.get(mcp.mcpId)?.displayName ?? mcp.mcpId}
+                  body={
+                    mcpById.get(mcp.mcpId)?.description ||
+                    t("workflowRun.inspector.catalogNoDescription")
+                  }
                   openLabel={t("workflowRun.inspector.mcpOpen", {
-                    name: mcp.mcpId,
+                    name: mcpById.get(mcp.mcpId)?.displayName ?? mcp.mcpId,
                   })}
                 >
                   <span className="line-clamp-2 text-xs leading-4">
-                    {mcp.mcpId}
+                    {mcpById.get(mcp.mcpId)?.displayName ?? mcp.mcpId}
+                    <span className="block text-muted-foreground">
+                      {mcp.mcpId}
+                    </span>
                   </span>
                 </RunBriefPopover>
               </li>

--- a/packages/workflow-mock/src/capabilities.ts
+++ b/packages/workflow-mock/src/capabilities.ts
@@ -6,6 +6,14 @@ export interface WorkflowChoice {
   label: string;
 }
 
+/** Availability is descriptive: authors can save bindings before configuring the plugin. */
+export interface WorkflowMcpChoice extends WorkflowChoice {
+  unavailableReason?:
+    | "configurationIncomplete"
+    | "configurationUnavailable"
+    | "invalidDeclaration";
+}
+
 export type WorkflowConfigField =
   | "agent"
   | "initialPrompt"
@@ -30,7 +38,7 @@ export interface WorkflowCapabilities {
   roles: WorkflowChoice[];
   skills: WorkflowChoice[];
   /** MCP catalog choices for Agent node attachments (optional per node). */
-  mcps: WorkflowChoice[];
+  mcps: WorkflowMcpChoice[];
   tools: WorkflowChoice[];
   /** Comparison operators offered by Condition nodes, keyed by stable value. */
   conditionOperators: WorkflowChoice[];

--- a/packages/workflow-runtime/src/graph-codec.test.ts
+++ b/packages/workflow-runtime/src/graph-codec.test.ts
@@ -155,3 +155,36 @@ describe("workflow timestamp projection", () => {
     expect(workflowTimestampToIso(isoToWorkflowTimestamp(iso))).toBe(iso);
   });
 });
+
+// Saved drafts, published snapshots, and exported graphs share this envelope codec.
+it("preserves canonical MCP IDs and disabled bindings across graph round trips", () => {
+  const agent: WorkflowDefinitionNode = {
+    id: "agent-1",
+    type: "workflow",
+    position: { x: 0, y: 0 },
+    data: {
+      kind: "agent",
+      title: "Agent",
+      description: "",
+      agentConfig: {
+        schemaVersion: 3,
+        executor: { agentCli: "official/agent", modelId: "model" },
+        roleId: "",
+        skills: [],
+        prompt: "",
+        mcps: [
+          { mcpId: "official/tools", enabled: true },
+          { mcpId: "local/tools", enabled: false },
+        ],
+      },
+    },
+  };
+  const input = {
+    nodes: [agent],
+    edges: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+    annotations: [],
+    globalVariables: [],
+  };
+  expect(parseWorkflowGraph(serializeWorkflowGraph(input))).toEqual(input);
+});

--- a/xtask/rust-size-baseline.json
+++ b/xtask/rust-size-baseline.json
@@ -2,13 +2,13 @@
   "modules": {
     "crates/application/src/workflow_run/engine/graph.rs": {
       "owner": "ora-application",
-      "lines": 879,
-      "split_plan": "Extract graph parsing/validation and indexed traversal into private modules, keeping accepted graph schemas and readiness rules covered by their existing tests."
+      "lines": 833,
+      "split_plan": "Extract graph parsing/validation and indexed traversal into private modules. Agent execution types now live in engine/agent_config.rs. Keep accepted graph schemas and readiness rules covered by their existing tests."
     },
     "crates/backend/src/agent_runtime.rs": {
       "owner": "ora-backend",
-      "lines": 1072,
-      "split_plan": "Extract runtime command admission from manager ownership. Preserve the single scheduler, supervisor map and session actors; move the corresponding lifecycle tests with each responsibility. Durable record ownership now lives in agent_runtime/record.rs, and load/attach in agent_runtime/load.rs and agent_runtime/attach.rs."
+      "lines": 1010,
+      "split_plan": "Extract runtime command admission from manager ownership. Preserve the single scheduler, supervisor map and session actors; move the corresponding lifecycle tests with each responsibility. Session creation now lives in agent_runtime/start.rs. Durable record ownership lives in agent_runtime/record.rs, and load/attach in agent_runtime/load.rs and agent_runtime/attach.rs."
     },
     "crates/db/src/repository/workflow_run_engine.rs": {
       "owner": "ora-db",


### PR DESCRIPTION
## 背景与解决的问题

工作流 Agent 节点此前展示的是静态 MCP 目录，节点保存的启用状态没有完整接入会话运行时。实际结果是：即使用户在节点中取消勾选 Tavily，工作流会话仍可能沿用普通聊天的自动选择规则，把 Tavily 传给 Agent。

MCP（Model Context Protocol，模型上下文协议）用于把搜索、数据库等外部工具能力提供给 Agent。本 PR 将节点配置改为明确的 MCP 允许列表：只有该节点显式添加且启用的插件才能进入会话；未选择或全部禁用时传递空集合。

## 提交的功能

### 编辑器与持久化

- 复用已安装插件查询，只展示 `kind: "mcp"` 的插件，移除生产界面的静态目录。
- 每个 Agent 节点可以独立添加、启用、禁用和移除 MCP；新增绑定默认启用，并按完整插件 ID 去重。
- 同时展示插件名称和完整 ID，以区分同名插件；无法匹配名称时保留并展示 ID。
- 已卸载、声明无效或配置不完整的绑定仍可保存、禁用和移除；目录查询失败提供重试，避免把查询故障误判为插件已卸载。
- 保留 `mcps: [{ mcpId, enabled }]` 数据格式，使配置随工作流保存、发布和导入导出；旧工作流缺少 `mcps` 时按空数组处理。
- 编辑器、画布摘要和运行详情统一使用真实插件名称，并同步更新相关 README 及中英文文档。

### 会话运行时

- 新增内部 `SessionMcpSelection` 类型，明确区分普通聊天的自动选择与工作流的显式插件 ID 集合。
- 工作流启动时冻结节点配置。“冻结”是指本次运行保存启动时的配置副本，因此之后修改草稿只影响后续运行，不会改变已经开始的运行。
- MCP 解析先按节点选择过滤，再读取配置并检查 Agent 能力。空集合直接生成空快照；“快照”是本次会话实际使用的 MCP 配置副本。
- 已启用插件缺失、配置不完整、声明无效或 Agent 不支持所需能力时，通过现有节点失败通道返回具体错误，不静默跳过。
- 会话首次创建、恢复、重建、刷新以及发送消息前始终使用同一选择策略。恢复关联数据异常时采用关闭式失败，即直接报错并收紧能力，不回退到全部 MCP。
- 普通聊天继续沿用原有自动选择行为，不增加全局开关，也不增加运行中的动态切换。

### 可诊断日志

在统一的 ACP 会话边界增加 INFO 日志，覆盖：

- `session/new`；
- 恢复会话时的 `session/load`；
- MCP 刷新时的 `session/load`；
- Agent 无法恢复旧会话后重建时的新会话创建。

ACP（Agent Client Protocol，Agent 客户端协议）是 Ora 与 Agent 进程之间创建、恢复和驱动会话的通信协议。日志记录会话 ID、操作阶段、MCP 插件 ID、配置修订号、版本标识和传输类型，用于判断 Ora 实际向 Agent 传递了哪些 MCP。日志不会记录 URL、环境变量、请求头、命令、参数、插件设置或凭据。

## 为什么采用该方案

MCP 选择属于单个工作流节点的运行输入，因此应在会话边界显式传递，而不是借用普通聊天的全局自动发现规则。工作流只保存插件 ID 和开关，凭据继续由现有插件配置解析器提供；这样既能冻结能力范围，也不会把秘密信息复制进工作流定义或运行记录。

选择集合由会话运行组件持有，使创建、恢复、刷新和重建共享同一来源，避免某条恢复路径意外退回自动加载全部 MCP。解析时先过滤再检查，也保证未选中插件的安装、卸载或配置变化不会影响该节点。

## 考虑与取舍

- 保留现有共享 Agent 进程架构，没有采用“每个会话启动一个 OpenCode 进程”的规避方案。独立进程可以隔离提供方内部状态，但并发会话会按数量增加内存占用和进程生命周期管理成本，并改变当前系统的资源模型。
- OpenCode 1.18.30 存在进程内 MCP 移除未完全生效的提供方问题：Ora 即使在 ACP 请求中传递了新的空集合，OpenCode 仍可能保留此前加载的工具。本 PR 保证 Ora 的选择、校验和传输正确，并通过安全日志提供证据，但不通过多进程方案掩盖该兼容性缺口。
- 配置不完整的插件允许提前绑定并保存，便于先设计工作流、后补凭据；执行时严格失败，以免用户误以为节点已经获得该工具能力。
- 已有运行使用冻结配置，保证可复现性；代价是草稿中的紧急开关不会追溯改变正在运行的节点，本次也不引入运行中切换机制。

## 测试与验证

- `task format`
- `task test`
  - 前端、TypeScript 类型检查和 lint；
  - Rust workspace lint、单元测试和文档测试；
  - Tauri 桌面层测试；
  - 12 个端到端测试，包括工作流 MCP 允许列表在恢复、重建和刷新后的隔离，以及普通聊天与两个工作流节点之间互不影响。
- 日志测试确认诊断字段存在，且秘密字段不会进入日志。

## 文档与规范

- 更新工作流编辑器 README。
- 更新英文工作流文档，并新增对应中文版本和双向链接。
- 更新 Session MCP 英文文档，并新增对应中文版本和双向链接。
- 对应规范变更：ora-space/specs#17。

